### PR TITLE
Replace gocql/gocql imports with scylladb/gocql

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -19,8 +19,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gocql/gocql/internal/lru"
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/scylladb/gocql/internal/lru"
+	"github.com/scylladb/gocql/internal/streams"
 )
 
 var (

--- a/conn_test.go
+++ b/conn_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/streams"
+	"github.com/scylladb/gocql/internal/streams"
 )
 
 const (

--- a/doc.go
+++ b/doc.go
@@ -4,6 +4,6 @@
 
 // Package gocql implements a fast and robust Cassandra driver for the
 // Go programming language.
-package gocql // import "github.com/gocql/gocql"
+package gocql // import "github.com/scylladb/gocql"
 
 // TODO(tux21b): write more docs.

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocql/gocql/internal/ccm"
+	"github.com/scylladb/gocql/internal/ccm"
 )
 
 func TestEventDiscovery(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gocql/gocql
+module github.com/scylladb/gocql
 
 require (
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049

--- a/host_source_gen.go
+++ b/host_source_gen.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/gocql/gocql"
+	"github.com/scylladb/gocql"
 )
 
 func gen(clause, field string) {

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -1,7 +1,7 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/scylladb/gocql/internal/lru"
 	"sync"
 )
 

--- a/session.go
+++ b/session.go
@@ -18,7 +18,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/gocql/gocql/internal/lru"
+	"github.com/scylladb/gocql/internal/lru"
 )
 
 // Session is the interface used by users to interact with the database.

--- a/token.go
+++ b/token.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gocql/gocql/internal/murmur"
+	"github.com/scylladb/gocql/internal/murmur"
 )
 
 // a token partitioner


### PR DESCRIPTION
Also rename the go.mod to scylladb/gocql to make installable with go
modules.
This is needed for a fork as you want to use internal modules within the
package  - in case you modify any of them and also have the possibility
to install both fork and the original upstream version.


It seems like issues are turned off so I couldn't create an issue for this. We are using go modules and with these I wasn't able to install your fork version.

```
 $ go get -u github.com/scylladb/gocql/
go: finding github.com/scylladb/gocql latest
go: github.com/scylladb/gocql@v0.0.0-20181115114908-435701b4f3c0: parsing go.mod: unexpected module path "github.com/gocql/gocql"
go get: error loading module requirements
```

I would expect the fork to carry a different module names as somebody might want to have installed both fork version and also the original one. And also, I would expect in within the package to import its modules.