### PR TITLE
scylla: avoid panic when removing a non-sharded connection from the pool

### DIFF
--- a/scylla.go
+++ b/scylla.go
@@ -107,7 +107,12 @@ func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
 func (p *scyllaConnPicker) Remove(conn *Conn) {
 	s := parseSupported(conn.supported)
 	if s.nrShards == 0 {
-		panic(fmt.Sprintf("scylla: %s not a sharded connection", conn.Address()))
+		// It is possible for Remove to be called before the connection is added to the pool.
+		// Ignoring these connections here is safe.
+		if gocqlDebug {
+			Logger.Printf("scylla: %s has unknown sharding state, ignoring it", conn.Address())
+		}
+		return
 	}
 	if gocqlDebug {
 		Logger.Printf("scylla: %s remove shard %d connection", conn.Address(), s.shard)


### PR DESCRIPTION
We simply log and ignore a connection that does not have the proper sharding info attached.

Fixes: #10 