### PR TITLE
scylla: ensure we use the correct token to determine shard

### DIFF
--- a/token.go
+++ b/token.go
@@ -192,12 +192,14 @@ func (t *tokenRing) String() string {
 	return string(buf.Bytes())
 }
 
-func (t *tokenRing) GetHostForPartitionKey(partitionKey []byte) (host *HostInfo, endToken token) {
+func (t *tokenRing) GetHostForPartitionKey(partitionKey []byte) (host *HostInfo, token token) {
 	if t == nil {
 		return nil, nil
 	}
 
-	return t.GetHostForToken(t.partitioner.Hash(partitionKey))
+	token = t.partitioner.Hash(partitionKey)
+	host, _ = t.GetHostForToken(token)
+	return host, token
 }
 
 func (t *tokenRing) GetHostForToken(token token) (host *HostInfo, endToken token) {

--- a/token_test.go
+++ b/token_test.go
@@ -204,7 +204,7 @@ func TestTokenRing_Nil(t *testing.T) {
 	if host, endToken := ring.GetHostForToken(nil); host != nil || endToken != nil {
 		t.Error("Expected nil for nil token ring")
 	}
-	if host, endToken := ring.GetHostForPartitionKey(nil); host != nil || endToken != nil {
+	if host, token := ring.GetHostForPartitionKey(nil); host != nil || token != nil {
 		t.Error("Expected nil for nil token ring")
 	}
 }


### PR DESCRIPTION
The driver silently replaced the current token with the closest one
from the token ring that it could find. This worked well enough
to route the request to the correct host but to pick the right shard
we need the actual token for the qiven query.