### PR TITLE
Fix tokenAwareHostPolicy host selection

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -558,12 +558,12 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		return t.fallback.Pick(qry)
 	}
 
-	primaryEndpoint, token := tr.GetHostForPartitionKey(routingKey)
-	if primaryEndpoint == nil || token == nil {
+	primaryEndpoint, token, endToken := tr.GetHostForPartitionKey(routingKey)
+	if primaryEndpoint == nil || endToken == nil {
 		return t.fallback.Pick(qry)
 	}
 
-	replicas, ok := t.getReplicas(qry.Keyspace(), token)
+	replicas, ok := t.getReplicas(qry.Keyspace(), endToken)
 	if !ok {
 		replicas = []*HostInfo{primaryEndpoint}
 	} else if t.shuffleReplicas {

--- a/token.go
+++ b/token.go
@@ -192,14 +192,18 @@ func (t *tokenRing) String() string {
 	return string(buf.Bytes())
 }
 
-func (t *tokenRing) GetHostForPartitionKey(partitionKey []byte) (host *HostInfo, token token) {
+// GetHostForPartitionKey finds host information for given partition key.
+//
+// It returns two tokens. First is token that exactly corresponds to the partition key (and could be used to
+// determine shard, for example), second token is the endToken that corresponds to the host.
+func (t *tokenRing) GetHostForPartitionKey(partitionKey []byte) (host *HostInfo, token token, endToken token) {
 	if t == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	token = t.partitioner.Hash(partitionKey)
-	host, _ = t.GetHostForToken(token)
-	return host, token
+	host, endToken = t.GetHostForToken(token)
+	return host, token, endToken
 }
 
 func (t *tokenRing) GetHostForToken(token token) (host *HostInfo, endToken token) {

--- a/token_test.go
+++ b/token_test.go
@@ -204,7 +204,7 @@ func TestTokenRing_Nil(t *testing.T) {
 	if host, endToken := ring.GetHostForToken(nil); host != nil || endToken != nil {
 		t.Error("Expected nil for nil token ring")
 	}
-	if host, token := ring.GetHostForPartitionKey(nil); host != nil || token != nil {
+	if host, token, endToken := ring.GetHostForPartitionKey(nil); host != nil || token != nil || endToken != nil {
 		t.Error("Expected nil for nil token ring")
 	}
 }


### PR DESCRIPTION
`tokenAwareHostPolicy` always selects a primary replica of a token.
When using `tokenAwareHostPolicy` backed by `dcAwareRR`, for tokens
with primary replica in a different DC, this results in selecting
a RANDOM host in a given DC.

This bug was previously fixed in commit
scylladb/gocql@39cb625a5f6c96219b1f810cce34b14d034b3681 and
gocql/gocql@ec4793573d1447b6f92a1b359a0594566fad9d0e,
but was reintroduced in the scylla branch by commit
scylladb/gocql@1469a13d9cdd60e2bec9ea38eb7b3bcd4c78d5de.

The test for token aware policy is updated so that
the regression does not happen again.