### PR TITLE
gocql: match the module name with replace path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gocql/gocql
+module github.com/scylladb/gocql
 
 require (
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect


### PR DESCRIPTION
We advise users to replace the module with:

    go mod edit -replace=github.com/gocql/gocql=github.com/scylladb/gocql@v1.2.0

However this fails with:

    go: github.com/scylladb/gocql@v1.2.0: parsing go.mod: unexpected module path "github.com/gocql/gocql"
    go: error loading module requirements

Since go mod expects github.com/scylladb/gocql module and finds a
different name.

This PR fixes that.