### PR TITLE
policies: Fix getting replicas in TestHostPolicy_TokenAware_DCAwareRR2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,3 +109,4 @@ Jacob Greenleaf <jacob@jacobgreenleaf.com>
 Alex Lourie <alex@instaclustr.com>; <djay.il@gmail.com>
 Marco Cadetg <cadetg@gmail.com>
 Martin Sucha <martin.sucha@kiwi.com>; <git@mm.ms47.eu>
+Ivan Boyarkin <ivan.boyarkin@kiwi.com>; <mr.vanboy@gmail.com>

--- a/policies_test.go
+++ b/policies_test.go
@@ -675,7 +675,7 @@ func TestHostPolicy_TokenAware_DCAwareRR2(t *testing.T) {
 			orderedToken("55"): {hosts[10], hosts[11], hosts[0], hosts[1], hosts[2], hosts[3]},
 			orderedToken("60"): {hosts[11], hosts[0], hosts[1], hosts[2], hosts[3], hosts[4]},
 		},
-	}, policyInternal.keyspaces.Load().(*keyspaceMeta).replicas)
+	}, policyInternal.getMetadataReadOnly().replicas)
 
 	// now the token ring is configured
 	query.RoutingKey([]byte("23"))


### PR DESCRIPTION
This commit fixes error:
```
type *tokenAwareHostPolicy has no field or method keyspaces
```

which was introduced with 47e14727 after merging https://github.com/scylladb/gocql/pull/22

Commit 9867ae96 removed field used in the test and this change later was
not reflected during ongoing merges.