### PR TITLE
scylla: lwt optimization to use primary replicas constistently

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -213,7 +213,6 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		dialer = d
 	}
 
-
 	conn, err := dialer.DialContext(ctx, "tcp", host.HostnameAndPort())
 	if err != nil {
 		return nil, err

--- a/frame.go
+++ b/frame.go
@@ -161,6 +161,7 @@ const (
 
 	// prepare flags
 	flagWithPreparedKeyspace uint32 = 0x01
+	flagLWT                  int    = 0x80000000
 
 	// header flags
 	flagCompress      byte = 0x01
@@ -934,6 +935,9 @@ func (f *framer) readTypeInfo() TypeInfo {
 type preparedMetadata struct {
 	resultMetadata
 
+	// LWT query detected
+	lwt bool
+
 	// proto v4+
 	pkeyColumns []int
 }
@@ -961,6 +965,8 @@ func (f *framer) parsePreparedMetadata() preparedMetadata {
 		}
 		meta.pkeyColumns = pkeys
 	}
+
+	meta.lwt = meta.flags&flagLWT == flagLWT
 
 	if meta.flags&flagHasMorePages == flagHasMorePages {
 		meta.pagingState = copyBytes(f.readBytes())

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049
+	github.com/google/go-cmp v0.4.0
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049 h1:K9KHZbXKpGydfDN0aZrsoHpLJlZsBrGMFWbgLDGnPZk=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -18,5 +20,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/policies.go
+++ b/policies.go
@@ -601,7 +601,7 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		replicas = []*HostInfo{host}
 	} else {
 		replicas = ht.hosts
-		if t.shuffleReplicas {
+		if t.shuffleReplicas && !qry.IsLWT() {
 			replicas = shuffleHosts(replicas)
 		}
 	}

--- a/policies_test.go
+++ b/policies_test.go
@@ -729,17 +729,16 @@ func TestHostPolicy_TokenAware_NetworkStrategy(t *testing.T) {
 	iterCheck(t, iter, "8")
 }
 
-
 func TestHostPolicy_TokenAware_Issue1274(t *testing.T) {
 	policy := TokenAwareHostPolicy(DCAwareRoundRobinPolicy("local"))
 	policyInternal := policy.(*tokenAwareHostPolicy)
-	policyInternal.getKeyspaceName = func() string {return "myKeyspace"}
+	policyInternal.getKeyspaceName = func() string { return "myKeyspace" }
 	policyInternal.getKeyspaceMetadata = func(ks string) (*KeyspaceMetadata, error) {
 		return nil, errors.New("not initialized")
 	}
 
 	query := &Query{}
-	query.getKeyspace = func() string {return "myKeyspace"}
+	query.getKeyspace = func() string { return "myKeyspace" }
 
 	iter := policy.Pick(nil)
 	if iter == nil {
@@ -773,11 +772,11 @@ func TestHostPolicy_TokenAware_Issue1274(t *testing.T) {
 			return nil, fmt.Errorf("unknown keyspace: %s", keyspaceName)
 		}
 		return &KeyspaceMetadata{
-			Name: "myKeyspace",
+			Name:          "myKeyspace",
 			StrategyClass: "NetworkTopologyStrategy",
-			StrategyOptions: map[string]interface{} {
-				"class": "NetworkTopologyStrategy",
-				"local": 1,
+			StrategyOptions: map[string]interface{}{
+				"class":   "NetworkTopologyStrategy",
+				"local":   1,
 				"remote1": 1,
 				"remote2": 1,
 			},

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -2,8 +2,9 @@ package gocql
 
 import (
 	"bytes"
-	"github.com/gocql/gocql/internal/lru"
 	"sync"
+
+	"github.com/gocql/gocql/internal/lru"
 )
 
 const defaultMaxPreparedStmts = 1000

--- a/query_executor.go
+++ b/query_executor.go
@@ -13,6 +13,7 @@ type ExecutableQuery interface {
 	GetRoutingKey() ([]byte, error)
 	Keyspace() string
 	IsIdempotent() bool
+	IsLWT() bool
 
 	withContext(context.Context) ExecutableQuery
 

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -145,8 +145,8 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 		s := &scyllaConnPicker{
 			nrShards:  4,
 			msbIgnore: 12,
-			pos: math.MaxUint64,
-			conns: []*Conn{nil, mockConn("1")},
+			pos:       math.MaxUint64,
+			conns:     []*Conn{nil, mockConn("1")},
 		}
 
 		if s.Pick(token(nil)) == nil {
@@ -158,8 +158,8 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 		s := &scyllaConnPicker{
 			nrShards:  4,
 			msbIgnore: 12,
-			pos: math.MaxUint64,
-			conns: []*Conn{nil, mockConn("1")},
+			pos:       math.MaxUint64,
+			conns:     []*Conn{nil, mockConn("1")},
 		}
 
 		var wg sync.WaitGroup

--- a/session.go
+++ b/session.go
@@ -373,6 +373,7 @@ func (s *Session) Query(stmt string, values ...interface{}) *Query {
 	qry.stmt = stmt
 	qry.values = values
 	qry.defaultsFromSession()
+	qry.lwt = false
 	return qry
 }
 
@@ -395,6 +396,7 @@ func (s *Session) Bind(stmt string, b func(q *QueryInfo) ([]interface{}, error))
 	qry.stmt = stmt
 	qry.binding = b
 	qry.defaultsFromSession()
+	qry.lwt = false
 	return qry
 }
 
@@ -559,6 +561,7 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string) (*routingKeyI
 		routingKeyInfo := &routingKeyInfo{
 			indexes: info.request.pkeyColumns,
 			types:   types,
+			lwt:     info.request.lwt,
 		}
 
 		inflight.value = routingKeyInfo
@@ -593,6 +596,7 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string) (*routingKeyI
 	routingKeyInfo := &routingKeyInfo{
 		indexes: make([]int, size),
 		types:   make([]TypeInfo, size),
+		lwt:     info.request.lwt,
 	}
 
 	for keyIndex, keyColumn := range partitionKey {
@@ -826,6 +830,11 @@ type Query struct {
 	// used by control conn queries to prevent triggering a write to systems
 	// tables in AWS MCS see
 	skipPrepare bool
+
+	// lwt denotes the query being an LWT/CAS operation
+	// In effect if the query is of the form "INSERT/UPDATE ... IF ..."
+	// For more details see https://docs.scylladb.com/using-scylla/lwt/
+	lwt bool
 }
 
 func (q *Query) defaultsFromSession() {
@@ -1043,7 +1052,9 @@ func (q *Query) GetRoutingKey() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	if routingKeyInfo != nil {
+		q.lwt = routingKeyInfo.lwt
+	}
 	return createRoutingKey(routingKeyInfo, q.values)
 }
 
@@ -1096,6 +1107,10 @@ func (q *Query) speculativeExecutionPolicy() SpeculativeExecutionPolicy {
 
 func (q *Query) IsIdempotent() bool {
 	return q.idempotent
+}
+
+func (q *Query) IsLWT() bool {
+	return q.lwt
 }
 
 // Idempotent marks the query as being idempotent or not depending on
@@ -1549,6 +1564,13 @@ type Batch struct {
 	cancelBatch           func()
 	keyspace              string
 	metrics               *queryMetrics
+
+	// lwt denotes the query being an LWT/CAS operation
+	// In effect if the query is of the form "INSERT/UPDATE ... IF ..."
+	// For more details see https://docs.scylladb.com/using-scylla/lwt/
+	// It is sufficient that one batch entry is a conditional query for the
+	// whole batch to be considered for LWT optimization.
+	lwt bool
 }
 
 // NewBatch creates a new batch operation without defaults from the cluster
@@ -1637,6 +1659,10 @@ func (b *Batch) IsIdempotent() bool {
 		}
 	}
 	return true
+}
+
+func (b *Batch) IsLWT() bool {
+	return b.lwt
 }
 
 func (b *Batch) speculativeExecutionPolicy() SpeculativeExecutionPolicy {
@@ -1775,6 +1801,9 @@ func (b *Batch) GetRoutingKey() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if routingKeyInfo != nil {
+		b.lwt = routingKeyInfo.lwt
+	}
 
 	return createRoutingKey(routingKeyInfo, entry.Args)
 }
@@ -1851,6 +1880,7 @@ type routingKeyInfoLRU struct {
 type routingKeyInfo struct {
 	indexes []int
 	types   []TypeInfo
+	lwt     bool
 }
 
 func (r *routingKeyInfo) String() string {

--- a/session.go
+++ b/session.go
@@ -702,7 +702,7 @@ func (s *Session) MapExecuteBatchCAS(batch *Batch, dest map[string]interface{}) 
 type hostMetrics struct {
 	// Attempts is count of how many times this query has been attempted for this host.
 	// An attempt is either a retry or fetching next page of results.
-	Attempts     int
+	Attempts int
 
 	// TotalLatency is the sum of attempt latencies for this host in nanoseconds.
 	TotalLatency int64
@@ -881,7 +881,7 @@ func (q *Query) Latency() int64 {
 }
 
 func (q *Query) AddLatency(l int64, host *HostInfo) {
-	q.metrics.attempt(0, time.Duration(l) * time.Nanosecond, host, false)
+	q.metrics.attempt(0, time.Duration(l)*time.Nanosecond, host, false)
 }
 
 // Consistency sets the consistency level for this query. If no consistency
@@ -1630,7 +1630,7 @@ func (b *Batch) Latency() int64 {
 }
 
 func (b *Batch) AddLatency(l int64, host *HostInfo) {
-	b.metrics.attempt(0, time.Duration(l) * time.Nanosecond, host, false)
+	b.metrics.attempt(0, time.Duration(l)*time.Nanosecond, host, false)
 }
 
 // GetConsistency returns the currently configured consistency level for the batch


### PR DESCRIPTION
The driver now ensures that replicas are never shuffled for LWT type queries.

Fixes: #40 