### PR TITLE
marshal: blob support for map[string]interface{}

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -259,15 +259,20 @@ func unmarshalVarchar(info TypeInfo, data []byte, value interface{}) error {
 	case k == reflect.String:
 		rv.SetString(string(data))
 		return nil
-	case k == reflect.Slice && t.Elem().Kind() == reflect.Uint8:
+	case k == reflect.Slice && t.Elem().Kind() == reflect.Uint8, k == reflect.Interface:
 		var dataCopy []byte
 		if data != nil {
 			dataCopy = make([]byte, len(data))
 			copy(dataCopy, data)
 		}
-		rv.SetBytes(dataCopy)
+		if k == reflect.Slice {
+			rv.SetBytes(dataCopy)
+		} else {
+			rv.Set(reflect.ValueOf(dataCopy))
+		}
 		return nil
 	}
+
 	return unmarshalErrorf("can not unmarshal %s into %T", info, value)
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -432,6 +432,19 @@ var marshalTests = []struct {
 	},
 	{
 		CollectionType{
+			NativeType: NativeType{proto: 2, typ: TypeMap},
+			Key:        NativeType{proto: 2, typ: TypeVarchar},
+			Elem:       NativeType{proto: 2, typ: TypeBlob},
+		},
+		[]byte("\x00\x01\x00\x03foo\x00\x05\x01\x02\x03\x04\x05"),
+		map[string]interface{}{
+			"foo": []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+		},
+		nil,
+		nil,
+	},
+	{
+		CollectionType{
 			NativeType: NativeType{proto: 2, typ: TypeList},
 			Elem:       NativeType{proto: 2, typ: TypeVarchar},
 		},


### PR DESCRIPTION
Map collections with blob values weren't marshalled into
map[string]interface{}.
This patch allows to store []byte in such map.