### PR TITLE
recreate: fixed formatting of CQL output

### DIFF
--- a/recreate.go
+++ b/recreate.go
@@ -88,7 +88,7 @@ var tableCQLTemplate = template.Must(template.New("table").
 	}).
 	Parse(`
 CREATE TABLE {{ .KeyspaceName }}.{{ .Tm.Name }} (
-  {{ tableColumnToCQL .Tm }}
+    {{ tableColumnToCQL .Tm }}
 ) WITH {{ tablePropertiesToCQL .Tm.ClusteringColumns .Tm.Options .Tm.Flags .Tm.Extensions }};
 `))
 
@@ -110,14 +110,15 @@ var functionTemplate = template.Must(template.New("functions").
 	}).
 	Parse(`
 CREATE FUNCTION {{ escape .keyspaceName }}.{{ escape .fm.Name }} ( 
-  {{- range $i, $args := zip .fm.ArgumentNames .fm.ArgumentTypes }}
-  {{- if ne $i 0 }}, {{ end }}
-  {{- escape (index $args 0) }} {{ stripFrozen (index $args 1) }}
-  {{- end -}})
-  {{ if .fm.CalledOnNullInput }}CALLED{{ else }}RETURNS NULL{{ end }} ON NULL INPUT
-  RETURNS {{ .fm.ReturnType }}
-  LANGUAGE {{ .fm.Language }}
-  AS $${{ .fm.Body }}$$;
+    {{- range $i, $args := zip .fm.ArgumentNames .fm.ArgumentTypes }}
+    {{- if ne $i 0 }}, {{ end }}
+    {{- escape (index $args 0) }}
+    {{ stripFrozen (index $args 1) }}
+    {{- end -}})
+    {{ if .fm.CalledOnNullInput }}CALLED{{ else }}RETURNS NULL{{ end }} ON NULL INPUT
+    RETURNS {{ .fm.ReturnType }}
+    LANGUAGE {{ .fm.Language }}
+    AS $${{ .fm.Body }}$$;
 `))
 
 func (km *KeyspaceMetadata) functionToCQL(w io.Writer, keyspaceName string, fm *FunctionMetadata) error {
@@ -138,16 +139,16 @@ var viewTemplate = template.Must(template.New("views").
 	}).
 	Parse(`
 CREATE MATERIALIZED VIEW {{ .vm.KeyspaceName }}.{{ .vm.ViewName }} AS
-SELECT {{ if .vm.IncludeAllColumns }}*{{ else }}
-{{- range $i, $col := .vm.OrderedColumns }}
-{{- if ne $i 0 }}, {{ end }}
-{{- $col }}
-{{- end }}
-{{- end }}
-FROM {{ .vm.KeyspaceName }}.{{ .vm.BaseTableName }}
-WHERE {{ .vm.WhereClause }}
-PRIMARY KEY ({{ partitionKeyString .vm.PartitionKey .vm.ClusteringColumns }})
-WITH {{ tablePropertiesToCQL .vm.ClusteringColumns .vm.Options .flags .vm.Extensions }};
+    SELECT {{ if .vm.IncludeAllColumns }}*{{ else }}
+    {{- range $i, $col := .vm.OrderedColumns }}
+    {{- if ne $i 0 }}, {{ end }}
+    {{ $col }}
+    {{- end }}
+    {{- end }}
+    FROM {{ .vm.KeyspaceName }}.{{ .vm.BaseTableName }}
+    WHERE {{ .vm.WhereClause }}
+    PRIMARY KEY ({{ partitionKeyString .vm.PartitionKey .vm.ClusteringColumns }})
+    WITH {{ tablePropertiesToCQL .vm.ClusteringColumns .vm.Options .flags .vm.Extensions }};
 `))
 
 func (km *KeyspaceMetadata) viewToCQL(w io.Writer, vm *ViewMetadata) error {
@@ -166,18 +167,18 @@ var aggregatesTemplate = template.Must(template.New("aggregate").
 	}).
 	Parse(`
 CREATE AGGREGATE {{ .Keyspace }}.{{ .Name }}( 
-  {{- range $arg, $i := .ArgumentTypes }}
-  {{- if ne $i 0 }}, {{ end }}
-  {{- stripFrozen $arg }}
-  {{- end -}})
-  SFUNC {{ .StateFunc.Name }}
-  STYPE {{ stripFrozen .State }}
-  {{- if ne .FinalFunc.Name "" }}
-  FINALFUNC {{ .FinalFunc.Name }}
-  {{- end -}}
-  {{- if ne .InitCond "" }}
-  INITCOND {{ .InitCond }}
-  {{- end -}}
+    {{- range $arg, $i := .ArgumentTypes }}
+    {{- if ne $i 0 }}, {{ end }}
+    {{ stripFrozen $arg }}
+    {{- end -}})
+    SFUNC {{ .StateFunc.Name }}
+    STYPE {{ stripFrozen .State }}
+    {{- if ne .FinalFunc.Name "" }}
+    FINALFUNC {{ .FinalFunc.Name }}
+    {{- end -}}
+    {{- if ne .InitCond "" }}
+    INITCOND {{ .InitCond }}
+    {{- end -}}
 );
 `))
 
@@ -195,7 +196,7 @@ var typeCQLTemplate = template.Must(template.New("types").
 	Parse(`
 CREATE TYPE {{ .Keyspace }}.{{ .Name }} ( 
   {{- range $i, $fields := zip .FieldNames .FieldTypes }} {{- if ne $i 0 }},{{ end }}
-  {{ index $fields 0 }} {{ index $fields 1 }}
+    {{ index $fields 0 }} {{ index $fields 1 }}
   {{- end }}
 );
 `))
@@ -247,12 +248,11 @@ var keyspaceCQLTemplate = template.Must(template.New("keyspace").
 		"escape":      cqlHelpers.escape,
 		"fixStrategy": cqlHelpers.fixStrategy,
 	}).
-	Parse(`
-CREATE KEYSPACE {{ .Name }} WITH replication = {
-  'class': {{ escape ( fixStrategy .StrategyClass) }}
-  {{- range $key, $value := .StrategyOptions }},
-  {{ escape $key }}: {{ escape $value }}
-  {{- end }}
+	Parse(`CREATE KEYSPACE {{ .Name }} WITH replication = {
+    'class': {{ escape ( fixStrategy .StrategyClass) }}
+    {{- range $key, $value := .StrategyOptions }},
+    {{ escape $key }}: {{ escape $value }}
+    {{- end }}
 }{{ if not .DurableWrites }} AND durable_writes = 'false'{{ end }};
 `))
 
@@ -445,10 +445,10 @@ func (h toCQLHelpers) tableColumnToCQL(tm *TableMetadata) string {
 		columns[0] += " PRIMARY KEY"
 	}
 
-	sb.WriteString(strings.Join(columns, ",\n  "))
+	sb.WriteString(strings.Join(columns, ",\n    "))
 
 	if len(tm.PartitionKey) > 1 || len(tm.ClusteringColumns) > 0 {
-		sb.WriteString(",\n  PRIMARY KEY (")
+		sb.WriteString(",\n    PRIMARY KEY (")
 		sb.WriteString(h.partitionKeyString(tm.PartitionKey, tm.ClusteringColumns))
 		sb.WriteRune(')')
 	}

--- a/testdata/recreate/index_golden.cql
+++ b/testdata/recreate/index_golden.cql
@@ -1,14 +1,14 @@
 CREATE KEYSPACE gocqlx_idx WITH replication = {
-  'class': 'SimpleStrategy',
-  'replication_factor': '1'
+    'class': 'SimpleStrategy',
+    'replication_factor': '1'
 };
 
 CREATE TABLE gocqlx_idx.menus (
-  location text,
-  name text,
-  dish_type text,
-  price float,
-  PRIMARY KEY (location, name)
+    location text,
+    name text,
+    dish_type text,
+    price float,
+    PRIMARY KEY (location, name)
 ) WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}

--- a/testdata/recreate/keyspace_golden.cql
+++ b/testdata/recreate/keyspace_golden.cql
@@ -1,4 +1,4 @@
 CREATE KEYSPACE gocqlx_keyspace WITH replication = {
-  'class': 'SimpleStrategy',
-  'replication_factor': '1'
+    'class': 'SimpleStrategy',
+    'replication_factor': '1'
 };

--- a/testdata/recreate/materialized_views_golden.cql
+++ b/testdata/recreate/materialized_views_golden.cql
@@ -1,13 +1,13 @@
 CREATE KEYSPACE gocqlx_mv WITH replication = {
-  'class': 'SimpleStrategy',
-  'replication_factor': '1'
+    'class': 'SimpleStrategy',
+    'replication_factor': '1'
 };
 
 CREATE TABLE gocqlx_mv.mv_buildings (
-  name text PRIMARY KEY,
-  built int,
-  city text,
-  meters int
+    name text PRIMARY KEY,
+    built int,
+    city text,
+    meters int
 ) WITH bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
     AND comment = ''
@@ -24,11 +24,11 @@ CREATE TABLE gocqlx_mv.mv_buildings (
     AND speculative_retry = '99.0PERCENTILE';
 
 CREATE MATERIALIZED VIEW gocqlx_mv.mv_building_by_city AS
-SELECT *
-FROM gocqlx_mv.mv_buildings
-WHERE city IS NOT null
-PRIMARY KEY (city, name)
-WITH CLUSTERING ORDER BY (name ASC)
+    SELECT *
+    FROM gocqlx_mv.mv_buildings
+    WHERE city IS NOT null
+    PRIMARY KEY (city, name)
+    WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
     AND comment = ''
@@ -45,11 +45,14 @@ WITH CLUSTERING ORDER BY (name ASC)
     AND speculative_retry = '99.0PERCENTILE';
 
 CREATE MATERIALIZED VIEW gocqlx_mv.mv_building_by_city2 AS
-SELECT city, name, meters
-FROM gocqlx_mv.mv_buildings
-WHERE city IS NOT null
-PRIMARY KEY (city, name)
-WITH CLUSTERING ORDER BY (name ASC)
+    SELECT 
+    city, 
+    name, 
+    meters
+    FROM gocqlx_mv.mv_buildings
+    WHERE city IS NOT null
+    PRIMARY KEY (city, name)
+    WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
     AND comment = ''

--- a/testdata/recreate/secondary_index_golden.cql
+++ b/testdata/recreate/secondary_index_golden.cql
@@ -1,14 +1,14 @@
 CREATE KEYSPACE gocqlx_sec_idx WITH replication = {
-  'class': 'SimpleStrategy',
-  'replication_factor': '1'
+    'class': 'SimpleStrategy',
+    'replication_factor': '1'
 };
 
 CREATE TABLE gocqlx_sec_idx.menus (
-  location text,
-  name text,
-  dish_type text,
-  price float,
-  PRIMARY KEY (location, name)
+    location text,
+    name text,
+    dish_type text,
+    price float,
+    PRIMARY KEY (location, name)
 ) WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}

--- a/testdata/recreate/table_golden.cql
+++ b/testdata/recreate/table_golden.cql
@@ -1,14 +1,14 @@
 CREATE KEYSPACE gocqlx_table WITH replication = {
-  'class': 'SimpleStrategy',
-  'replication_factor': '1'
+    'class': 'SimpleStrategy',
+    'replication_factor': '1'
 };
 
 CREATE TABLE gocqlx_table.loads (
-  machine inet,
-  cpu int,
-  mtime timeuuid,
-  load float,
-  PRIMARY KEY ((machine, cpu), mtime)
+    machine inet,
+    cpu int,
+    mtime timeuuid,
+    load float,
+    PRIMARY KEY ((machine, cpu), mtime)
 ) WITH CLUSTERING ORDER BY (mtime DESC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
@@ -26,10 +26,10 @@ CREATE TABLE gocqlx_table.loads (
     AND speculative_retry = '99.0PERCENTILE';
 
 CREATE TABLE gocqlx_table.monkeyspecies (
-  species text PRIMARY KEY,
-  average_size int,
-  common_name text,
-  population varint
+    species text PRIMARY KEY,
+    average_size int,
+    common_name text,
+    population varint
 ) WITH bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
     AND comment = 'Important biological records'
@@ -46,12 +46,12 @@ CREATE TABLE gocqlx_table.monkeyspecies (
     AND speculative_retry = '99.0PERCENTILE';
 
 CREATE TABLE gocqlx_table.timeline (
-  userid uuid,
-  posted_month int,
-  posted_time uuid,
-  body text,
-  posted_by text,
-  PRIMARY KEY (userid, posted_month, posted_time)
+    userid uuid,
+    posted_month int,
+    posted_time uuid,
+    body text,
+    posted_by text,
+    PRIMARY KEY (userid, posted_month, posted_time)
 ) WITH CLUSTERING ORDER BY (posted_month ASC, posted_time ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
@@ -69,11 +69,11 @@ CREATE TABLE gocqlx_table.timeline (
     AND speculative_retry = '99.0PERCENTILE';
 
 CREATE TABLE gocqlx_table.users_picture (
-  userid uuid,
-  pictureid uuid,
-  posted_by text,
-  body text static,
-  PRIMARY KEY (userid, pictureid, posted_by)
+    userid uuid,
+    pictureid uuid,
+    posted_by text,
+    body text static,
+    PRIMARY KEY (userid, pictureid, posted_by)
 ) WITH CLUSTERING ORDER BY (pictureid ASC, posted_by ASC)
     AND bloom_filter_fp_chance = 0.01
     AND caching = {'keys':'ALL','rows_per_partition':'ALL'}

--- a/testdata/recreate/udt_golden.cql
+++ b/testdata/recreate/udt_golden.cql
@@ -1,16 +1,16 @@
 CREATE KEYSPACE gocqlx_udt WITH replication = {
-  'class': 'SimpleStrategy',
-  'replication_factor': '1'
+    'class': 'SimpleStrategy',
+    'replication_factor': '1'
 };
 
 CREATE TYPE gocqlx_udt.phone (
-  country_code int,
-  number text
+    country_code int,
+    number text
 );
 
 CREATE TYPE gocqlx_udt.address (
-  street text,
-  city text,
-  zip text,
-  phones map<text, frozen<phone>>
+    street text,
+    city text,
+    zip text,
+    phones map<text, frozen<phone>>
 );


### PR DESCRIPTION
Table fields where misaligned with table options.
MV fields where used different indentations, now it's aligned with rest.
Removed first empty line.

Fixes #46