### PR TITLE
Parse scyllaSupported metadata once

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -154,6 +154,7 @@ type Conn struct {
 	currentKeyspace string
 	host            *HostInfo
 	supported       map[string][]string
+	scyllaSupported scyllaSupported
 
 	session *Session
 
@@ -395,7 +396,9 @@ func (s *startupCoordinator) options(ctx context.Context) error {
 	if !ok {
 		return NewErrProtocol("Unknown type of response to startup frame: %T", frame)
 	}
+	// Keep raw supported multimap for debug purposes
 	s.conn.supported = v.supported
+	s.conn.scyllaSupported = parseSupported(s.conn.supported)
 
 	return s.startup(ctx)
 }

--- a/scylla.go
+++ b/scylla.go
@@ -10,9 +10,11 @@ import (
 // scyllaSupported represents Scylla connection options as sent in SUPPORTED
 // frame.
 type scyllaSupported struct {
-	shard     int
-	nrShards  int
-	msbIgnore uint64
+	shard             int
+	nrShards          int
+	msbIgnore         uint64
+	partitioner       string
+	shardingAlgorithm string
 }
 
 func parseSupported(supported map[string][]string) scyllaSupported {
@@ -51,20 +53,17 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 		}
 	}
 
-	var (
-		partitioner string
-		algorithm   string
-	)
 	if s, ok := supported[scyllaPartitioner]; ok {
-		partitioner = s[0]
+		si.partitioner = s[0]
 	}
 	if s, ok := supported[scyllaShardingAlgorithm]; ok {
-		algorithm = s[0]
+		si.shardingAlgorithm = s[0]
 	}
 
-	if partitioner != "org.apache.cassandra.dht.Murmur3Partitioner" || algorithm != "biased-token-round-robin" || si.nrShards == 0 || si.msbIgnore == 0 {
+	if si.partitioner != "org.apache.cassandra.dht.Murmur3Partitioner" || si.shardingAlgorithm != "biased-token-round-robin" || si.nrShards == 0 || si.msbIgnore == 0 {
 		if gocqlDebug {
-			Logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d", partitioner, algorithm, si.nrShards, si.msbIgnore)
+			Logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d",
+				si.partitioner, si.shardingAlgorithm, si.nrShards, si.msbIgnore)
 		}
 		return scyllaSupported{}
 	}
@@ -74,8 +73,7 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 
 // isScyllaConn checks if conn is suitable for scyllaConnPicker.
 func isScyllaConn(conn *Conn) bool {
-	s := parseSupported(conn.supported)
-	return s.nrShards != 0
+	return conn.scyllaSupported.nrShards != 0
 }
 
 // scyllaConnPicker is a specialised ConnPicker that selects connections based
@@ -94,24 +92,24 @@ type scyllaConnPicker struct {
 }
 
 func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
-	s := parseSupported(conn.supported)
-	if s.nrShards == 0 {
+	if conn.scyllaSupported.nrShards == 0 {
 		panic(fmt.Sprintf("scylla: %s not a sharded connection", conn.Address()))
 	}
 
 	if gocqlDebug {
-		Logger.Printf("scylla: %s sharding options %+v", conn.Address(), s)
+		Logger.Printf("scylla: %s sharding options %+v", conn.Address(), conn.scyllaSupported)
 	}
 
 	return &scyllaConnPicker{
-		nrShards:  s.nrShards,
-		msbIgnore: s.msbIgnore,
+		nrShards:  conn.scyllaSupported.nrShards,
+		msbIgnore: conn.scyllaSupported.msbIgnore,
 	}
 }
 
 func (p *scyllaConnPicker) Remove(conn *Conn) {
-	s := parseSupported(conn.supported)
-	if s.nrShards == 0 {
+	shard := conn.scyllaSupported.shard
+
+	if conn.scyllaSupported.nrShards == 0 {
 		// It is possible for Remove to be called before the connection is added to the pool.
 		// Ignoring these connections here is safe.
 		if gocqlDebug {
@@ -120,11 +118,11 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
 		return
 	}
 	if gocqlDebug {
-		Logger.Printf("scylla: %s remove shard %d connection", conn.Address(), s.shard)
+		Logger.Printf("scylla: %s remove shard %d connection", conn.Address(), shard)
 	}
 
-	if p.conns[s.shard] != nil {
-		p.conns[s.shard] = nil
+	if p.conns[shard] != nil {
+		p.conns[shard] = nil
 		p.nrConns--
 	}
 }
@@ -181,20 +179,22 @@ func (p *scyllaConnPicker) shardOf(token murmur3Token) int {
 func (p *scyllaConnPicker) Put(conn *Conn) {
 	const maxExcessConnsFactor = 10
 
-	s := parseSupported(conn.supported)
-	if s.nrShards == 0 {
+	nrShards := conn.scyllaSupported.nrShards
+	shard := conn.scyllaSupported.shard
+
+	if nrShards == 0 {
 		panic(fmt.Sprintf("scylla: %s not a sharded connection", conn.Address()))
 	}
 
-	if s.nrShards != len(p.conns) {
-		if s.nrShards != p.nrShards {
+	if nrShards != len(p.conns) {
+		if nrShards != p.nrShards {
 			panic(fmt.Sprintf("scylla: %s invalid number of shards", conn.Address()))
 		}
 		conns := p.conns
-		p.conns = make([]*Conn, s.nrShards, s.nrShards)
+		p.conns = make([]*Conn, nrShards, nrShards)
 		copy(p.conns, conns)
 	}
-	if c := p.conns[s.shard]; c != nil {
+	if c := p.conns[shard]; c != nil {
 		p.excessConns = append(p.excessConns, conn)
 		if len(p.excessConns) > maxExcessConnsFactor*p.nrShards {
 			if gocqlDebug {
@@ -204,7 +204,7 @@ func (p *scyllaConnPicker) Put(conn *Conn) {
 		}
 		return
 	}
-	p.conns[s.shard] = conn
+	p.conns[shard] = conn
 	p.nrConns++
 	if p.nrConns >= p.nrShards {
 		// We have reached one connection to each shard and
@@ -212,7 +212,7 @@ func (p *scyllaConnPicker) Put(conn *Conn) {
 		p.closeExcessConns()
 	}
 	if gocqlDebug {
-		Logger.Printf("scylla: %s put shard %d connection total: %d missing: %d", conn.Address(), s.shard, p.nrConns, p.nrShards-p.nrConns)
+		Logger.Printf("scylla: %s put shard %d connection total: %d missing: %d", conn.Address(), shard, p.nrConns, p.nrShards-p.nrConns)
 	}
 }
 

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -94,9 +94,9 @@ func TestScyllaConnPickerRemove(t *testing.T) {
 		msbIgnore: 12,
 	}
 
-	conn := mockConn("0")
+	conn := mockConn(0)
 	s.Put(conn)
-	s.Put(mockConn("1"))
+	s.Put(mockConn(1))
 
 	if s.nrConns != 2 {
 		t.Error("added 2 connections, expected connection count to be 2")
@@ -112,14 +112,14 @@ func TestScyllaConnPickerRemove(t *testing.T) {
 	}
 }
 
-func mockConn(shard string) *Conn {
+func mockConn(shard int) *Conn {
 	return &Conn{
-		supported: map[string][]string{
-			"SCYLLA_SHARD":               {shard},
-			"SCYLLA_NR_SHARDS":           {"4"},
-			"SCYLLA_SHARDING_IGNORE_MSB": {"12"},
-			"SCYLLA_PARTITIONER":         {"org.apache.cassandra.dht.Murmur3Partitioner"},
-			"SCYLLA_SHARDING_ALGORITHM":  {"biased-token-round-robin"},
+		scyllaSupported: scyllaSupported{
+			shard:             shard,
+			nrShards:          4,
+			msbIgnore:         12,
+			partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
+			shardingAlgorithm: "biased-token-round-robin",
 		},
 	}
 }
@@ -145,8 +145,8 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 		s := &scyllaConnPicker{
 			nrShards:  4,
 			msbIgnore: 12,
-			pos: math.MaxUint64,
-			conns: []*Conn{nil, mockConn("1")},
+			pos:       math.MaxUint64,
+			conns:     []*Conn{nil, mockConn(1)},
 		}
 
 		if s.Pick(token(nil)) == nil {
@@ -158,8 +158,8 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 		s := &scyllaConnPicker{
 			nrShards:  4,
 			msbIgnore: 12,
-			pos: math.MaxUint64,
-			conns: []*Conn{nil, mockConn("1")},
+			pos:       math.MaxUint64,
+			conns:     []*Conn{nil, mockConn(1)},
 		}
 
 		var wg sync.WaitGroup


### PR DESCRIPTION
Get rid of unnecessary repeated parsing of "SCYLLA" connection
options.

Parse only once and save in the connection object as
`scyllaSupported` field.

Save raw "supported" field for debugging purposes.

Fix `mockConn` function in scylla tests to accept int as shard
number and initialize `scyllaSupported` field directly.

Tests: unit

Signed-off-by: Pavel Solodovnikov <pa.solodovnikov@scylladb.com>