### PR TITLE
Add support for establishing per-shard connections using Scylla shard-aware ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ If you are using a custom Dialer and if your nodes expose the shard-aware port, 
   }
   ```
 
-
-
 ---
 
 Package gocql implements a fast and robust Cassandra client for the

--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ if localDC != "" {
 
 ### Shard-aware port
 
-This version of gocql supports a more robust method of establishing connection for each shard by using _shard aware port_ for native transport. It greatly reduces time and the number of connections that need to be opened in some specific cases, e.g. when many clients connect at once, or when there are other non-shard-aware clients connected to the same node.
+This version of gocql supports a more robust method of establishing connection for each shard by using _shard aware port_ for native transport.
+It greatly reduces time and the number of connections that need to be opened in some specific cases, ex. when many clients connect at once, or when there are other non-shard-aware clients connected to the same node.
 
-For this feature to work correctly, the shard-aware port on the nodes that expose it should be reachable from the client. If it's not, gocql will establish only one connection for each such host and will get stuck trying to establish connection for each remaining shard through the shard-aware port. If you can neither fix your network nor disable shard-aware port on your cluster, you can use `ClusterConfig.DisableShardAwarePort` to disable it.
+For this feature to work correctly, the shard-aware port on the nodes that expose it should be reachable from the client.
+If it's not, gocql will establish only one connection for each such host and will get stuck trying to establish connection for each remaining shard through the shard-aware port.
+If you can neither fix your network nor disable shard-aware port on your cluster, you can use `ClusterConfig.DisableShardAwarePort` to disable it.
 
 If you are using a custom Dialer and if your nodes expose the shard-aware port, it is highly recommended to update it so that it uses a specific source port when connecting.
 

--- a/cluster.go
+++ b/cluster.go
@@ -149,6 +149,17 @@ type ClusterConfig struct {
 	// If not provided, a default dialer configured with ConnectTimeout will be used.
 	Dialer Dialer
 
+	// DisableShardAwarePort will prevent the driver from connecting to Scylla's shard-aware port,
+	// even if there are nodes in the cluster that support it.
+	//
+	// It is generally recommended to leave this option turned off because gocql can use
+	// the shard-aware port to make the process of establishing more robust.
+	// However, if you have a cluster with nodes which expose shard-aware port
+	// but the port is unreachable due to network configuration issues, you can use
+	// this option to work around the issue. Set it to true only if you neither can fix
+	// your network nor disable shard-aware port on your nodes.
+	DisableShardAwarePort bool
+
 	// internal config for testing
 	disableControlConn bool
 }

--- a/conn.go
+++ b/conn.go
@@ -992,7 +992,7 @@ type inflightPrepare struct {
 }
 
 func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer) (*preparedStatment, error) {
-	stmtCacheKey := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, stmt)
+	stmtCacheKey := c.session.stmtsLRU.keyFor(c.host.HostnameAndPort(), c.currentKeyspace, stmt)
 	flight, ok := c.session.stmtsLRU.execIfMissing(stmtCacheKey, func(lru *lru.Cache) *inflightPrepare {
 		flight := &inflightPrepare{
 			done: make(chan struct{}),
@@ -1226,7 +1226,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		// is not consistent with regards to its schema.
 		return iter
 	case *RequestErrUnprepared:
-		stmtCacheKey := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, qry.stmt)
+		stmtCacheKey := c.session.stmtsLRU.keyFor(c.host.HostnameAndPort(), c.currentKeyspace, qry.stmt)
 		c.session.stmtsLRU.evictPreparedID(stmtCacheKey, x.StatementId)
 		return c.executeQuery(ctx, qry)
 	case error:
@@ -1377,7 +1377,7 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) *Iter {
 	case *RequestErrUnprepared:
 		stmt, found := stmts[string(x.StatementId)]
 		if found {
-			key := c.session.stmtsLRU.keyFor(c.addr, c.currentKeyspace, stmt)
+			key := c.session.stmtsLRU.keyFor(c.host.HostnameAndPort(), c.currentKeyspace, stmt)
 			c.session.stmtsLRU.evictPreparedID(key, x.StatementId)
 		}
 		return c.executeBatch(ctx, batch)

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -463,8 +463,10 @@ func (pool *hostConnPool) connectMany(count int) error {
 
 // create a new connection to the host and add it to the pool
 func (pool *hostConnPool) connect() (err error) {
-	dialer, ok := pool.connPicker.(Dialer)
-	if !ok {
+	pool.mu.Lock()
+	dialer := pool.connPicker.GetCustomDialer()
+	pool.mu.Unlock()
+	if dialer == nil {
 		dialer = pool.session.cfg.Dialer
 	}
 

--- a/connpicker.go
+++ b/connpicker.go
@@ -12,6 +12,8 @@ type ConnPicker interface {
 	Remove(conn *Conn)
 	Size() (int, int)
 	Close()
+
+	GetCustomDialer() Dialer
 }
 
 type defaultConnPicker struct {
@@ -90,6 +92,10 @@ func (p *defaultConnPicker) Put(conn *Conn) {
 	p.mu.Unlock()
 }
 
+func (*defaultConnPicker) GetCustomDialer() Dialer {
+	return nil
+}
+
 // nopConnPicker is a no-operation implementation of ConnPicker, it's used when
 // hostConnPool is created to allow deferring creation of the actual ConnPicker
 // to the point where we have first connection.
@@ -113,4 +119,8 @@ func (nopConnPicker) Size() (int, int) {
 }
 
 func (nopConnPicker) Close() {
+}
+
+func (nopConnPicker) GetCustomDialer() Dialer {
+	return nil
 }

--- a/frame.go
+++ b/frame.go
@@ -2106,18 +2106,18 @@ func (f *framer) writeStringMap(m map[string]string) {
 	}
 }
 
-func (f *framer) writeBytesMap(m map[string][]byte) {
-	f.writeShort(uint16(len(m)))
-	for k, v := range m {
-		f.writeString(k)
-		f.writeBytes(v)
-	}
-}
-
 func (f *framer) writeStringMultiMap(m map[string][]string) {
 	f.writeShort(uint16(len(m)))
 	for k, v := range m {
 		f.writeString(k)
 		f.writeStringList(v)
+	}
+}
+
+func (f *framer) writeBytesMap(m map[string][]byte) {
+	f.writeShort(uint16(len(m)))
+	for k, v := range m {
+		f.writeString(k)
+		f.writeBytes(v)
 	}
 }

--- a/frame.go
+++ b/frame.go
@@ -2113,3 +2113,11 @@ func (f *framer) writeBytesMap(m map[string][]byte) {
 		f.writeBytes(v)
 	}
 }
+
+func (f *framer) writeStringMultiMap(m map[string][]string) {
+	f.writeShort(uint16(len(m)))
+	for k, v := range m {
+		f.writeString(k)
+		f.writeStringList(v)
+	}
+}

--- a/scylla.go
+++ b/scylla.go
@@ -17,6 +17,8 @@ type scyllaSupported struct {
 	msbIgnore         uint64
 	partitioner       string
 	shardingAlgorithm string
+	shardAwarePort    uint16
+	shardAwarePortSSL uint16
 	lwtFlagMask       int
 }
 
@@ -105,6 +107,8 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 		scyllaPartitioner       = "SCYLLA_PARTITIONER"
 		scyllaShardingAlgorithm = "SCYLLA_SHARDING_ALGORITHM"
 		scyllaShardingIgnoreMSB = "SCYLLA_SHARDING_IGNORE_MSB"
+		scyllaShardAwarePort    = "SCYLLA_SHARD_AWARE_PORT"
+		scyllaShardAwarePortSSL = "SCYLLA_SHARD_AWARE_PORT_SSL"
 	)
 
 	var (
@@ -139,6 +143,24 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	}
 	if s, ok := supported[scyllaShardingAlgorithm]; ok {
 		si.shardingAlgorithm = s[0]
+	}
+	if s, ok := supported[scyllaShardAwarePort]; ok {
+		if shardAwarePort, err := strconv.ParseUint(s[0], 10, 16); err != nil {
+			if gocqlDebug {
+				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePort, s, err)
+			}
+		} else {
+			si.shardAwarePort = uint16(shardAwarePort)
+		}
+	}
+	if s, ok := supported[scyllaShardAwarePortSSL]; ok {
+		if shardAwarePortSSL, err := strconv.ParseUint(s[0], 10, 16); err != nil {
+			if gocqlDebug {
+				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePortSSL, s, err)
+			}
+		} else {
+			si.shardAwarePortSSL = uint16(shardAwarePortSSL)
+		}
 	}
 
 	if si.partitioner != "org.apache.cassandra.dht.Murmur3Partitioner" || si.shardingAlgorithm != "biased-token-round-robin" || si.nrShards == 0 || si.msbIgnore == 0 {

--- a/scylla.go
+++ b/scylla.go
@@ -446,7 +446,7 @@ func (p *scyllaConnPicker) DialContext(ctx context.Context, network, addr string
 		iter := newScyllaPortIterator(shardID, p.nrShards)
 
 		for {
-			port, ok := iter.nextPort()
+			port, ok := iter.Next()
 			if !ok {
 				return nil, errors.New("could not allocate port")
 			}
@@ -529,7 +529,7 @@ func newScyllaPortIterator(shardID, shardCount int) *scyllaPortIterator {
 	}
 }
 
-func (spi *scyllaPortIterator) nextPort() (uint16, bool) {
+func (spi *scyllaPortIterator) Next() (uint16, bool) {
 	if spi == nil {
 		return 0, false
 	}

--- a/scylla_shard_aware_port_common_test.go
+++ b/scylla_shard_aware_port_common_test.go
@@ -1,0 +1,324 @@
+// +build integration unit
+
+package gocql
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+type makeClusterTestFunc func() *ClusterConfig
+
+func testShardAwarePortNoReconnections(t *testing.T, makeCluster makeClusterTestFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+
+	// Initialize 10 sessions in parallel.
+	// If shard-aware port is used and configured properly, we should get
+	// a connection to each shard without any retries.
+	// For each host, there should be N-1 connections to the special port.
+
+	// Run 10 sessions in parallel
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Each session gets a separate configuration, because we need to have
+			// separate connection listeners - we need to differentiate connections
+			// made for each session separately
+			dialer := newLoggingTestDialer()
+			cluster := makeCluster()
+			cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
+			cluster.Dialer = dialer
+
+			useTLS := cluster.SslOpts != nil
+
+			sess, err := cluster.CreateSession()
+			if err != nil {
+				cancel()
+				return
+			}
+			defer sess.Close()
+
+			if err := waitUntilPoolsStopFilling(ctx, sess, 10*time.Second); err != nil {
+				cancel()
+				return
+			}
+
+			hosts := sess.ring.allHosts()
+			for _, host := range hosts {
+				t.Logf("checking host %s", host.hostname)
+				hostPool, _ := sess.pool.getPool(host)
+
+				shardAwarePort := getShardAwarePort(hostPool, useTLS)
+				if shardAwarePort == 0 {
+					// Shard aware port was not exposed by the host
+					t.Log("the host does not expose a shard-aware port, skipping")
+					continue
+				}
+
+				// Verify that we have a sharded connPicker
+				shardedPicker, ok := hostPool.connPicker.(*scyllaConnPicker)
+				if !ok {
+					t.Errorf("not a sharded connection")
+					continue
+				}
+
+				numberOfShards := shardedPicker.nrShards
+
+				// Verify that there were no duplicate connections to the same shard
+				// Make sure that we didn't connect to the same shard twice
+				// There should be numberOfShards-1 connections to the new port
+				events := dialer.events[host.hostname]
+				shardAwareConnectionCount := 0
+				shardsConnected := make(map[int]testConnectionEvent)
+				for _, evt := range events {
+					if evt.destinationPort != shardAwarePort {
+						continue
+					}
+
+					shardAwareConnectionCount++
+
+					shard := scyllaShardForSourcePort(evt.sourcePort, numberOfShards)
+					if oldPort, hasShard := shardsConnected[shard]; hasShard {
+						t.Errorf("there was more than one connection to the shard aware port from the same shard (shard %d, port %d and %d)",
+							shard, oldPort, evt.sourcePort)
+					}
+				}
+
+				if shardAwareConnectionCount != numberOfShards-1 {
+					t.Errorf("expected %d connections to the shard aware port, but got %d", numberOfShards-1, shardAwareConnectionCount)
+				}
+			}
+
+			return
+		}()
+	}
+
+	wg.Wait()
+}
+
+func testShardAwarePortMaliciousNAT(t *testing.T, makeCluster makeClusterTestFunc) {
+	cluster := makeCluster()
+	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
+	cluster.Dialer = &sourcePortOffByOneTestDialer{}
+
+	sess, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("an error occurred while creating a session: %s", err)
+	}
+	defer sess.Close()
+
+	// In this situation we are guaranteed that the connection will miss one
+	// shard at this point. The first connection receives a random shard,
+	// then we establish N-1 connections, targeting remaining shards.
+	// Because the malicious port translator shifts the port by one,
+	// one shard will be missed (if the host has more than one shard).
+
+	// Retry until we establish one connection per shard
+
+	for {
+		if err := waitUntilPoolsStopFilling(context.Background(), sess, 10*time.Second); err != nil {
+			t.Fatal(err)
+		}
+
+		if checkIfPoolsAreFull(sess) {
+			break
+		}
+
+		triggerPoolsRefill(sess)
+	}
+}
+
+func testShardAwarePortUnusedIfNotEnabled(t *testing.T, makeCluster makeClusterTestFunc) {
+	dialer := newLoggingTestDialer()
+	cluster := makeCluster()
+	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
+
+	// Explicitly disable the shard aware port
+	cluster.DisableShardAwarePort = true
+	cluster.Dialer = dialer
+
+	useTLS := cluster.SslOpts != nil
+
+	sess, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("an error occurred while creating a session: %s", err)
+	}
+	defer sess.Close()
+
+	if err := waitUntilPoolsStopFilling(context.Background(), sess, 10*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	hosts := sess.ring.allHosts()
+	for _, host := range hosts {
+		t.Logf("checking host %s", host.hostname)
+		hostPool, _ := sess.pool.getPool(host)
+
+		shardAwarePort := getShardAwarePort(hostPool, useTLS)
+		if shardAwarePort == 0 {
+			// Shard aware port was not exposed by the host
+			t.Log("the host does not expose a shard-aware port, skipping")
+			continue
+		}
+
+		events, _ := dialer.events[host.hostname]
+
+		for _, evt := range events {
+			if evt.destinationPort == shardAwarePort {
+				t.Error("there was an attempt to connect to a shard aware port, but the configuration does not allow that")
+			}
+		}
+	}
+}
+
+func checkIfShardAwarePortIsExposed(pool *hostConnPool, useTLS bool) bool {
+	return getShardAwareAddress(pool, useTLS) != ""
+}
+
+func getShardAwarePort(pool *hostConnPool, useTLS bool) uint16 {
+	addr := getShardAwareAddress(pool, useTLS)
+	if addr == "" {
+		return 0
+	}
+
+	_, portS, _ := net.SplitHostPort(addr)
+	port, _ := strconv.Atoi(portS)
+	return uint16(port)
+}
+
+func getShardAwareAddress(pool *hostConnPool, useTLS bool) string {
+	picker, ok := pool.connPicker.(*scyllaConnPicker)
+	if !ok {
+		return ""
+	}
+	return picker.shardAwareAddress
+}
+
+func triggerPoolsRefill(sess *Session) {
+	hosts := sess.ring.allHosts()
+	for _, host := range hosts {
+		hostPool, _ := sess.pool.getPool(host)
+		go hostPool.fill()
+	}
+}
+
+func waitUntilPoolsStopFilling(ctx context.Context, sess *Session, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	for !checkIfPoolsStoppedFilling(sess) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-deadline:
+			return fmt.Errorf("failed to fill all connection pools in %s", timeout)
+
+		case <-time.After(250 * time.Millisecond):
+			continue
+		}
+	}
+
+	return nil
+}
+
+func checkIfPoolsStoppedFilling(sess *Session) bool {
+	hosts := sess.ring.allHosts()
+	for _, host := range hosts {
+		hostPool, _ := sess.pool.getPool(host)
+
+		hostPool.mu.Lock()
+		isFilling := hostPool.filling
+		hostPool.mu.Unlock()
+
+		if isFilling {
+			return false
+		}
+	}
+
+	return true
+}
+
+func checkIfPoolsAreFull(sess *Session) bool {
+	hosts := sess.ring.allHosts()
+	for _, host := range hosts {
+		hostPool, _ := sess.pool.getPool(host)
+
+		hostPool.mu.Lock()
+		_, remaining := hostPool.connPicker.Size()
+		hostPool.mu.Unlock()
+
+		if remaining > 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+type sourcePortOffByOneTestDialer struct {
+	ScyllaShardAwareDialer
+}
+
+func (spobo *sourcePortOffByOneTestDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	// Simulate a NAT that always increases the source port by 1
+	// This should always result in wrong shard being assigned if host
+	// has more than one shard.
+
+	sourcePort := ScyllaGetSourcePort(ctx)
+	if sourcePort > 0 {
+		sourcePort++
+	}
+	newCtx := context.WithValue(ctx, scyllaSourcePortCtx{}, sourcePort)
+	return spobo.ScyllaShardAwareDialer.DialContext(newCtx, network, addr)
+}
+
+type loggingTestDialer struct {
+	ScyllaShardAwareDialer
+
+	events map[string][]testConnectionEvent
+	mu     sync.Mutex
+}
+
+type testConnectionEvent struct {
+	sourcePort, destinationPort uint16
+}
+
+func newLoggingTestDialer() *loggingTestDialer {
+	return &loggingTestDialer{
+		events: make(map[string][]testConnectionEvent),
+	}
+}
+
+func (ltd *loggingTestDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	sourcePort := ScyllaGetSourcePort(ctx)
+
+	hostname, destinationPortStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	destinationPort, err := strconv.ParseUint(destinationPortStr, 10, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := ltd.ScyllaShardAwareDialer.DialContext(ctx, network, addr)
+
+	if err == nil {
+		ltd.mu.Lock()
+		defer ltd.mu.Unlock()
+
+		evt := testConnectionEvent{
+			sourcePort:      sourcePort,
+			destinationPort: uint16(destinationPort),
+		}
+		ltd.events[hostname] = append(ltd.events[hostname], evt)
+	}
+
+	return conn, err
+}

--- a/scylla_shard_aware_port_integration_test.go
+++ b/scylla_shard_aware_port_integration_test.go
@@ -1,0 +1,24 @@
+// +build integration
+// +build scylla
+
+package gocql
+
+import "testing"
+
+func TestShardAwarePortIntegrationNoReconnections(t *testing.T) {
+	testShardAwarePortNoReconnections(t, func() *ClusterConfig {
+		return createCluster()
+	})
+}
+
+func TestShardAwarePortIntegrationMaliciousNAT(t *testing.T) {
+	testShardAwarePortMaliciousNAT(t, func() *ClusterConfig {
+		return createCluster()
+	})
+}
+
+func TestShardAwarePortIntegrationUnusedIfNotEnabled(t *testing.T) {
+	testShardAwarePortUnusedIfNotEnabled(t, func() *ClusterConfig {
+		return createCluster()
+	})
+}

--- a/scylla_shard_aware_port_integration_test.go
+++ b/scylla_shard_aware_port_integration_test.go
@@ -17,6 +17,12 @@ func TestShardAwarePortIntegrationMaliciousNAT(t *testing.T) {
 	})
 }
 
+func TestShardAwarePortIntegrationUnreachable(t *testing.T) {
+	testShardAwarePortUnreachable(t, func() *ClusterConfig {
+		return createCluster()
+	})
+}
+
 func TestShardAwarePortIntegrationUnusedIfNotEnabled(t *testing.T) {
 	testShardAwarePortUnusedIfNotEnabled(t, func() *ClusterConfig {
 		return createCluster()

--- a/scylla_shard_aware_port_mocked_test.go
+++ b/scylla_shard_aware_port_mocked_test.go
@@ -22,6 +22,10 @@ func TestShardAwarePortMockedMaliciousNAT(t *testing.T) {
 	testWithAndWithoutTLS(t, testShardAwarePortMaliciousNAT)
 }
 
+func TestShardAwarePortMockedUnreachable(t *testing.T) {
+	testWithAndWithoutTLS(t, testShardAwarePortUnreachable)
+}
+
 func TestShardAwarePortMockedUnusedIfNotEnabled(t *testing.T) {
 	testWithAndWithoutTLS(t, testShardAwarePortUnusedIfNotEnabled)
 }

--- a/scylla_shard_aware_port_mocked_test.go
+++ b/scylla_shard_aware_port_mocked_test.go
@@ -1,0 +1,141 @@
+// +build unit
+
+package gocql
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const testShardCount = 3
+
+func TestShardAwarePortMockedNoReconnections(t *testing.T) {
+	testWithAndWithoutTLS(t, testShardAwarePortNoReconnections)
+}
+
+func TestShardAwarePortMockedMaliciousNAT(t *testing.T) {
+	testWithAndWithoutTLS(t, testShardAwarePortMaliciousNAT)
+}
+
+func TestShardAwarePortMockedUnusedIfNotEnabled(t *testing.T) {
+	testWithAndWithoutTLS(t, testShardAwarePortUnusedIfNotEnabled)
+}
+
+func testWithAndWithoutTLS(t *testing.T, test func(t *testing.T, makeCluster makeClusterTestFunc)) {
+	t.Run("without TLS", func(t *testing.T) {
+		makeCluster, stop := startServerWithShardAwarePort(t, false)
+		defer stop()
+		test(t, makeCluster)
+	})
+
+	t.Run("with TLS", func(t *testing.T) {
+		makeCluster, stop := startServerWithShardAwarePort(t, true)
+		defer stop()
+		test(t, makeCluster)
+	})
+}
+
+func startServerWithShardAwarePort(t testing.TB, useTLS bool) (makeCluster func() *ClusterConfig, stop func()) {
+	var shardAwarePort uint32
+
+	shardAwarePortKey := "SCYLLA_SHARD_AWARE_PORT"
+	if useTLS {
+		shardAwarePortKey = "SCYLLA_SHARD_AWARE_PORT_SSL"
+	}
+
+	regularSupportedFactory := func(conn net.Conn) map[string][]string {
+		// Assign a random shard. Although Scylla uses a deterministic algorithm
+		// for assigning shards, the driver doesn't have enough information
+		// to determine which shard will be assigned - therefore, from its
+		// perspective, it's practically random.
+		saPort := int(atomic.LoadUint32(&shardAwarePort))
+
+		t.Log("Connecting to the regular port")
+
+		shardID := rand.Intn(testShardCount)
+
+		supported := getStandardScyllaExtensions(shardID, testShardCount)
+		supported[shardAwarePortKey] = []string{strconv.Itoa(saPort)}
+		return supported
+	}
+
+	shardAwareSupportedFactory := func(conn net.Conn) map[string][]string {
+		// Shard ID depends on the source port.
+		saPort := int(atomic.LoadUint32(&shardAwarePort))
+
+		t.Log("Connecting to the shard-aware port")
+
+		port := mustParsePortFromAddr(conn.RemoteAddr().String())
+		shardID := scyllaShardForSourcePort(port, testShardCount)
+
+		supported := getStandardScyllaExtensions(shardID, testShardCount)
+		supported[shardAwarePortKey] = []string{strconv.Itoa(saPort)}
+		return supported
+	}
+
+	makeServer := func(factory testSupportedFactory) *TestServer {
+		if useTLS {
+			return NewSSLTestServerWithSupportedFactory(t,
+				defaultProto, context.Background(), factory)
+		}
+		return NewTestServerWithAddressAndSupportedFactory("127.0.0.1:0", t,
+			defaultProto, context.Background(), factory)
+	}
+
+	srvRegular := makeServer(regularSupportedFactory)
+	srvShardAware := makeServer(shardAwareSupportedFactory)
+
+	saPort := mustParsePortFromAddr(srvShardAware.Address)
+	atomic.StoreUint32(&shardAwarePort, uint32(saPort))
+
+	t.Logf("regular port address: %s, shard aware port address: %s",
+		srvRegular.Address, srvShardAware.Address)
+
+	makeCluster = func() *ClusterConfig {
+		var cluster *ClusterConfig
+		if useTLS {
+			cluster = createTestSslCluster(srvRegular.Address, defaultProto, false)
+
+			// Give a long timeout. For some reason, closing tls connections
+			// result in an i/o timeout error, and this mitigates this problem.
+			cluster.Timeout = 1 * time.Minute
+		} else {
+			cluster = testCluster(defaultProto, srvRegular.Address)
+		}
+		return cluster
+	}
+
+	stop = func() {
+		srvRegular.Stop()
+		srvShardAware.Stop()
+	}
+
+	return makeCluster, stop
+}
+
+func mustParsePortFromAddr(addr string) uint16 {
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		panic(err)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		panic(err)
+	}
+	return uint16(port)
+}
+
+func getStandardScyllaExtensions(shardID, shardCount int) map[string][]string {
+	return map[string][]string{
+		"SCYLLA_SHARD":               []string{strconv.Itoa(shardID)},
+		"SCYLLA_NR_SHARDS":           []string{strconv.Itoa(shardCount)},
+		"SCYLLA_PARTITIONER":         []string{"org.apache.cassandra.dht.Murmur3Partitioner"},
+		"SCYLLA_SHARDING_ALGORITHM":  []string{"biased-token-round-robin"},
+		"SCYLLA_SHARDING_IGNORE_MSB": []string{"12"},
+	}
+}

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -239,7 +239,7 @@ func TestScyllaPortIterator(t *testing.T) {
 				previousPort := 0
 
 				for {
-					portU16, ok := iterator.nextPort()
+					portU16, ok := iterator.Next()
 					if !ok {
 						break
 					}


### PR DESCRIPTION
In commit [1572b9e41cd02e8b676404ba72a549398d281a66](https://github.com/scylladb/scylla/commit/1572b9e41cd02e8b676404ba72a549398d281a66), Scylla gained
support for so-called "shard-aware" ports. These ports support the same
Cassandra native protocol as the regular native transport ports.
However, unlike the regular ports, shard-aware ports allow the driver to
choose the shard that will handle the connection by choosing an
appropriate source port.

Currently, regular native transport ports employ a load-balancing
strategy that assigns, for an incoming connection, the shard that has
the least amount of connections assigned. Until now, the driver worked
by opening new connections until a single connection per shard is
established. When a connection to an already connected shard is opened,
it is not immediately closed - only after the number of opened
connections exceeds 10x the number of shards. This behavior does not
work well in some realistic scenarios:

1. When many shard-aware clients connect at once, the load-balancing
   strategy will not work well. Clients will open a very large number of
   connections before reaching all of the shards.
2. When there are non-shard-aware clients connected to a node, the
   distribution of their connections per shard may be uneven. If one
   shard is occupied by many more connections than the others, it will
   prevent the current load-balancing strategy from assigning a
   connection to that shard, unless a large number of connections to
   other shards is established first.

Shard-aware ports allow the driver to completely avoid those problems by
choosing towards which shard it wishes to connect to. The first
connection is still established towards a regular native transport port,
and the following connections for remaining shards can be established
towards shard-aware ports.

This PR adds support for establishing per-shard connections using
the shard-aware ports.