### PR TITLE
Add SerialConsistency to Consistency

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -62,7 +62,7 @@ type ClusterConfig struct {
 	MaxPreparedStmts   int                                      // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
 	MaxRoutingKeyInfo  int                                      // Sets the maximum cache size for query info about statements for each session (default: 1000)
 	PageSize           int                                      // Default page size to use for created sessions (default: 5000)
-	SerialConsistency  SerialConsistency                        // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
+	SerialConsistency  Consistency                              // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
 	SslOpts            *SslOptions
 	DefaultTimestamp   bool // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
 	// PoolConfig configures the underlying connection pool, allowing the

--- a/session.go
+++ b/session.go
@@ -820,7 +820,7 @@ type Query struct {
 	rt                    RetryPolicy
 	spec                  SpeculativeExecutionPolicy
 	binding               func(q *QueryInfo) ([]interface{}, error)
-	serialCons            SerialConsistency
+	serialCons            Consistency
 	defaultTimestamp      bool
 	defaultTimestampValue int64
 	disableSkipMetadata   bool
@@ -1141,6 +1141,9 @@ func (q *Query) Bind(v ...interface{}) *Query {
 // SERIAL. This option will be ignored for anything else that a
 // conditional update/insert.
 func (q *Query) SerialConsistency(cons SerialConsistency) *Query {
+	if !cons.IsSerial() {
+		panic("Serial consistency can only be SERIAL or LOCAL_SERIAL got " + cons.String())
+	}
 	q.serialCons = cons
 	return q
 }
@@ -1564,7 +1567,7 @@ type Batch struct {
 	spec                  SpeculativeExecutionPolicy
 	observer              BatchObserver
 	session               *Session
-	serialCons            SerialConsistency
+	serialCons            Consistency
 	defaultTimestamp      bool
 	defaultTimestampValue int64
 	context               context.Context
@@ -1737,6 +1740,9 @@ func (b *Batch) Size() int {
 //
 // Only available for protocol 3 and above
 func (b *Batch) SerialConsistency(cons SerialConsistency) *Batch {
+	if !cons.IsSerial() {
+		panic("Serial consistency can only be SERIAL or LOCAL_SERIAL got " + cons.String())
+	}
 	b.serialCons = cons
 	return b
 }

--- a/session_test.go
+++ b/session_test.go
@@ -126,6 +126,16 @@ func TestQueryBasicAPI(t *testing.T) {
 		t.Fatalf("expected Query.GetConsistency to return 'All', got '%s'", qry.GetConsistency())
 	}
 
+	qry.Consistency(LocalSerial)
+	if qry.GetConsistency() != LocalSerial {
+		t.Fatalf("expected Query.GetConsistency to return 'LocalSerial', got '%s'", qry.GetConsistency())
+	}
+
+	qry.SerialConsistency(LocalSerial)
+	if qry.GetConsistency() != LocalSerial {
+		t.Fatalf("expected Query.GetConsistency to return 'LocalSerial', got '%s'", qry.GetConsistency())
+	}
+
 	trace := &traceWriter{}
 	qry.Trace(trace)
 	if qry.trace != trace {


### PR DESCRIPTION
- SerialConsistency values are moved to Consistency
- All SerialConsistency fields are changed to Consistency
- API is preserved, and SerialConsistency is alias type

Fixes #58