### PR TITLE
Add support for the CDC partitioner

### DIFF
--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -56,6 +56,7 @@ type TableMetadataOptions struct {
 	SpeculativeRetry        string
 	CDC                     map[string]string
 	InMemory                bool
+	Partitioner             string
 	Version                 string
 }
 
@@ -520,12 +521,14 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 
 		table := TableMetadata{}
 		if iter.MapScan(map[string]interface{}{
-			"cdc":       &table.Options.CDC,
-			"in_memory": &table.Options.InMemory,
-			"version":   &table.Options.Version,
+			"cdc":         &table.Options.CDC,
+			"in_memory":   &table.Options.InMemory,
+			"partitioner": &table.Options.Partitioner,
+			"version":     &table.Options.Version,
 		}) {
 			tables[i].Options.CDC = table.Options.CDC
 			tables[i].Options.Version = table.Options.Version
+			tables[i].Options.Partitioner = table.Options.Partitioner
 			tables[i].Options.InMemory = table.Options.InMemory
 		}
 		if err := iter.Close(); err != nil && err != ErrNotFound {

--- a/policies.go
+++ b/policies.go
@@ -592,7 +592,12 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		return t.fallback.Pick(qry)
 	}
 
-	token := meta.tokenRing.partitioner.Hash(routingKey)
+	partitioner := qry.GetCustomPartitioner()
+	if partitioner == nil {
+		partitioner = meta.tokenRing.partitioner
+	}
+
+	token := partitioner.Hash(routingKey)
 	ht := meta.replicas[qry.Keyspace()].replicasFor(token)
 
 	var replicas []*HostInfo

--- a/query_executor.go
+++ b/query_executor.go
@@ -14,6 +14,7 @@ type ExecutableQuery interface {
 	Keyspace() string
 	IsIdempotent() bool
 	IsLWT() bool
+	GetCustomPartitioner() partitioner
 
 	withContext(context.Context) ExecutableQuery
 

--- a/scylla.go
+++ b/scylla.go
@@ -650,3 +650,17 @@ func ScyllaGetSourcePort(ctx context.Context) uint16 {
 	sourcePort, _ := ctx.Value(scyllaSourcePortCtx{}).(uint16)
 	return sourcePort
 }
+
+// Returns a partitioner specific to the table, or "nil"
+// if the cluster-global partitioner should be used
+func scyllaGetTablePartitioner(session *Session, keyspaceName, tableName string) (partitioner, error) {
+	isCdc, err := scyllaIsCdcTable(session, keyspaceName, tableName)
+	if err != nil {
+		return nil, err
+	}
+	if isCdc {
+		return scyllaCDCPartitioner{}, nil
+	}
+
+	return nil, nil
+}

--- a/scylla.go
+++ b/scylla.go
@@ -285,7 +285,7 @@ func (p *scyllaConnPicker) Pick(t token) *Conn {
 		return p.randomConn()
 	}
 
-	mmt, ok := t.(murmur3Token)
+	mmt, ok := t.(int64Token)
 	// double check if that's murmur3 token
 	if !ok {
 		return nil
@@ -310,7 +310,7 @@ func (p *scyllaConnPicker) randomConn() *Conn {
 	return nil
 }
 
-func (p *scyllaConnPicker) shardOf(token murmur3Token) int {
+func (p *scyllaConnPicker) shardOf(token int64Token) int {
 	shards := uint64(p.nrShards)
 	z := uint64(token+math.MinInt64) << p.msbIgnore
 	lo := z & 0xffffffff

--- a/scylla_cdc.go
+++ b/scylla_cdc.go
@@ -1,0 +1,69 @@
+package gocql
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// cdc partitioner
+
+const (
+	scyllaCDCPartitionerName = "CDCPartitioner"
+
+	scyllaCDCPartitionKeyLength  = 16
+	scyllaCDCVersionMask         = 0x0F
+	scyllaCDCMinSupportedVersion = 1
+	scyllaCDCMaxSupportedVersion = 1
+
+	scyllaCDCMinToken = int64Token(math.MinInt64)
+)
+
+type scyllaCDCPartitioner struct{}
+
+var _ partitioner = scyllaCDCPartitioner{}
+
+func (p scyllaCDCPartitioner) Name() string {
+	return scyllaCDCPartitionerName
+}
+
+func (p scyllaCDCPartitioner) Hash(partitionKey []byte) token {
+	if len(partitionKey) < 8 {
+		// The key is too short to extract any sensible token,
+		// so return the min token instead
+		if gocqlDebug {
+			Logger.Printf("scylla: cdc partition key too short: %d < 8", len(partitionKey))
+		}
+		return scyllaCDCMinToken
+	}
+
+	upperQword := binary.BigEndian.Uint64(partitionKey[0:])
+
+	if gocqlDebug {
+		// In debug mode, do some more checks
+
+		if len(partitionKey) != scyllaCDCPartitionKeyLength {
+			// The token has unrecognized format, but the first quadword
+			// should be the token value that we want
+			Logger.Printf("scylla: wrong size of cdc partition key: %d", len(partitionKey))
+		}
+
+		lowerQword := binary.BigEndian.Uint64(partitionKey[8:])
+		version := lowerQword & scyllaCDCVersionMask
+		if version < scyllaCDCMinSupportedVersion || version > scyllaCDCMaxSupportedVersion {
+			// We don't support this version yet,
+			// the token may be wrong
+			Logger.Printf(
+				"scylla: unsupported version: %d is not in range [%d, %d]",
+				version,
+				scyllaCDCMinSupportedVersion,
+				scyllaCDCMaxSupportedVersion,
+			)
+		}
+	}
+
+	return int64Token(upperQword)
+}
+
+func (p scyllaCDCPartitioner) ParseString(str string) token {
+	return parseInt64Token(str)
+}

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -133,7 +133,7 @@ func TestScyllaConnPickerShardOf(t *testing.T) {
 		msbIgnore: 12,
 	}
 	for _, test := range scyllaShardOfTests {
-		if shard := s.shardOf(murmur3Token(test.token)); shard != test.shard {
+		if shard := s.shardOf(int64Token(test.token)); shard != test.shard {
 			t.Errorf("wrong scylla shard calculated for token %d, expected %d, got %d", test.token, test.shard, shard)
 		}
 	}

--- a/token.go
+++ b/token.go
@@ -29,9 +29,8 @@ type token interface {
 	Less(token) bool
 }
 
-// murmur3 partitioner and token
+// murmur3 partitioner
 type murmur3Partitioner struct{}
-type murmur3Token int64
 
 func (p murmur3Partitioner) Name() string {
 	return "Murmur3Partitioner"
@@ -39,21 +38,28 @@ func (p murmur3Partitioner) Name() string {
 
 func (p murmur3Partitioner) Hash(partitionKey []byte) token {
 	h1 := murmur.Murmur3H1(partitionKey)
-	return murmur3Token(h1)
+	return int64Token(h1)
 }
 
 // murmur3 little-endian, 128-bit hash, but returns only h1
 func (p murmur3Partitioner) ParseString(str string) token {
-	val, _ := strconv.ParseInt(str, 10, 64)
-	return murmur3Token(val)
+	return parseInt64Token(str)
 }
 
-func (m murmur3Token) String() string {
+// int64 token
+type int64Token int64
+
+func parseInt64Token(str string) int64Token {
+	val, _ := strconv.ParseInt(str, 10, 64)
+	return int64Token(val)
+}
+
+func (m int64Token) String() string {
 	return strconv.FormatInt(int64(m), 10)
 }
 
-func (m murmur3Token) Less(token token) bool {
-	return m < token.(murmur3Token)
+func (m int64Token) Less(token token) bool {
+	return m < token.(int64Token)
 }
 
 // order preserving partitioner and token

--- a/token_test.go
+++ b/token_test.go
@@ -31,15 +31,15 @@ func TestMurmur3Partitioner(t *testing.T) {
 	}
 }
 
-// Tests of the murmur3Token
-func TestMurmur3Token(t *testing.T) {
-	if murmur3Token(42).Less(murmur3Token(42)) {
+// Tests of the int64Token
+func TestInt64Token(t *testing.T) {
+	if int64Token(42).Less(int64Token(42)) {
 		t.Errorf("Expected Less to return false, but was true")
 	}
-	if !murmur3Token(-42).Less(murmur3Token(42)) {
+	if !int64Token(-42).Less(int64Token(42)) {
 		t.Errorf("Expected Less to return true, but was false")
 	}
-	if murmur3Token(42).Less(murmur3Token(-42)) {
+	if int64Token(42).Less(int64Token(-42)) {
 		t.Errorf("Expected Less to return false, but was true")
 	}
 }


### PR DESCRIPTION
In https://github.com/scylladb/scylla/commit/6f1a8cfeeaaf775fd4935c22644b276b5780c6b8, Scylla started using a custom partitioner for CDC log tables. This partitioner, similarly to Murmur3Partitioner, generates int64 tokens, but uses a different algorithm to calculate them. This causes the drivers which are unaware of the custom partitioner to wrongly choose coordinators for prepared queries to CDC log tables, rendering token- and shard-awareness useless.

This PR implements support for the CDC custom partitioner, which fixes token- and shard-awareness for CDC log tables.

I did the following manual tests (3 node cluster, 4 shards, keyspace with RF=1, single table with cdc enabled):
- Read from a cdc log table with tracing enabled. Without this PR, tracing shows that the coordinator had to contact another node. With this PR, there are no such messages, everything is queried locally.
- Continuously read from a cdc log table and looked at the `scylla_storage_proxy_coordinator_reads_remote_node` metric. Without this PR, this metric grows continuously. Without it, the metric does not grow.
