### PR TITLE
Fix data race accessing lwt/partitioner in Query/Batch

### DIFF
--- a/cass1batch_test.go
+++ b/cass1batch_test.go
@@ -52,7 +52,7 @@ func TestShouldPrepareFunction(t *testing.T) {
 	}
 
 	for _, test := range shouldPrepareTests {
-		q := &Query{stmt: test.Stmt}
+		q := &Query{stmt: test.Stmt, routingInfo: &queryRoutingInfo{}}
 		if got := q.shouldPrepare(); got != test.Result {
 			t.Fatalf("%q: got %v, expected %v\n", test.Stmt, got, test.Result)
 		}

--- a/conn.go
+++ b/conn.go
@@ -1156,7 +1156,9 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) *Iter {
 		}
 
 		// Set "lwt" property in the query if it is present in preparedMetadata
-		qry.lwt = info.request.lwt
+		qry.routingInfo.mu.Lock()
+		qry.routingInfo.lwt = info.request.lwt
+		qry.routingInfo.mu.Unlock()
 	} else {
 		frame = &writeQueryFrame{
 			statement:     qry.stmt,
@@ -1358,7 +1360,9 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) *Iter {
 
 	// The batch is considered to be conditional if even one of the
 	// statements is conditional.
-	batch.lwt = hasLwtEntries
+	batch.routingInfo.mu.Lock()
+	batch.routingInfo.lwt = hasLwtEntries
+	batch.routingInfo.mu.Unlock()
 
 	// TODO: should batch support tracing?
 	framer, err := c.exec(batch.Context(), req, nil)

--- a/policies_test.go
+++ b/policies_test.go
@@ -53,7 +53,7 @@ func TestHostPolicy_TokenAware_SimpleStrategy(t *testing.T) {
 		return nil, errors.New("not initalized")
 	}
 
-	query := &Query{}
+	query := &Query{routingInfo: &queryRoutingInfo{}}
 	query.getKeyspace = func() string { return keyspace }
 
 	iter := policy.Pick(nil)
@@ -176,8 +176,8 @@ func TestHostPolicy_TokenAware_LWT_DisablesHostShuffling(t *testing.T) {
 				policy.AddHost(host)
 			}
 			query := &Query{
-				lwt:        tc.lwt,
-				routingKey: []byte(tc.routingKey),
+				routingKey:  []byte(tc.routingKey),
+				routingInfo: &queryRoutingInfo{lwt: tc.lwt},
 			}
 			query.getKeyspace = func() string { return keyspace }
 			iter := policy.Pick(query)
@@ -304,7 +304,7 @@ func TestHostPolicy_TokenAware_NilHostInfo(t *testing.T) {
 	}
 	policy.SetPartitioner("OrderedPartitioner")
 
-	query := &Query{}
+	query := &Query{routingInfo: &queryRoutingInfo{}}
 	query.getKeyspace = func() string { return "myKeyspace" }
 	query.RoutingKey([]byte("20"))
 
@@ -362,7 +362,7 @@ func TestCOWList_Add(t *testing.T) {
 
 // TestSimpleRetryPolicy makes sure that we only allow 1 + numRetries attempts
 func TestSimpleRetryPolicy(t *testing.T) {
-	q := &Query{}
+	q := &Query{routingInfo: &queryRoutingInfo{}}
 
 	// this should allow a total of 3 tries.
 	rt := &SimpleRetryPolicy{NumRetries: 2}
@@ -420,7 +420,7 @@ func TestExponentialBackoffPolicy(t *testing.T) {
 
 func TestDowngradingConsistencyRetryPolicy(t *testing.T) {
 
-	q := &Query{cons: LocalQuorum}
+	q := &Query{cons: LocalQuorum, routingInfo: &queryRoutingInfo{}}
 
 	rewt0 := &RequestErrWriteTimeout{
 		Received:  0,
@@ -547,7 +547,7 @@ func TestHostPolicy_TokenAware(t *testing.T) {
 		return nil, errors.New("not initialized")
 	}
 
-	query := &Query{}
+	query := &Query{routingInfo: &queryRoutingInfo{}}
 	query.getKeyspace = func() string { return keyspace }
 
 	iter := policy.Pick(nil)
@@ -647,7 +647,7 @@ func TestHostPolicy_TokenAware_NetworkStrategy(t *testing.T) {
 		return nil, errors.New("not initialized")
 	}
 
-	query := &Query{}
+	query := &Query{routingInfo: &queryRoutingInfo{}}
 	query.getKeyspace = func() string { return keyspace }
 
 	iter := policy.Pick(nil)
@@ -737,7 +737,7 @@ func TestHostPolicy_TokenAware_Issue1274(t *testing.T) {
 		return nil, errors.New("not initialized")
 	}
 
-	query := &Query{}
+	query := &Query{routingInfo: &queryRoutingInfo{}}
 	query.getKeyspace = func() string { return "myKeyspace" }
 
 	iter := policy.Pick(nil)

--- a/session_test.go
+++ b/session_test.go
@@ -98,7 +98,7 @@ func (f funcQueryObserver) ObserveQuery(ctx context.Context, o ObservedQuery) {
 }
 
 func TestQueryBasicAPI(t *testing.T) {
-	qry := &Query{}
+	qry := &Query{routingInfo: &queryRoutingInfo{}}
 
 	// Initiate host
 	ip := "127.0.0.1"
@@ -172,7 +172,7 @@ func TestQueryBasicAPI(t *testing.T) {
 func TestQueryShouldPrepare(t *testing.T) {
 	toPrepare := []string{"select * ", "INSERT INTO", "update table", "delete from", "begin batch"}
 	cantPrepare := []string{"create table", "USE table", "LIST keyspaces", "alter table", "drop table", "grant user", "revoke user"}
-	q := &Query{}
+	q := &Query{routingInfo: &queryRoutingInfo{}}
 
 	for i := 0; i < len(toPrepare); i++ {
 		q.stmt = toPrepare[i]


### PR DESCRIPTION
Query and Batch can be copied and we shouldn't modify them directly
during execution, this was not the case previously as lwt and
partitioner fields could be accessed by multiple goroutines when the
driver was speculatively executing the query.

Because Query and Batch are copied (and a few exported methods have
value receiver), we cannot embed the mutex directly into Query and
Batch and separate struct needs to be allocated.

Fixes: https://github.com/scylladb/gocql/issues/65
