### PR TITLE
fix: race on createSession

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -400,6 +400,8 @@ type tokenAwareHostPolicy struct {
 }
 
 func (t *tokenAwareHostPolicy) Init(s *Session) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.getKeyspaceMetadata = s.KeyspaceMetadata
 	t.getKeyspaceName = func() string { return s.cfg.Keyspace }
 }


### PR DESCRIPTION
Creating multiple session in parallel will data race on init if the schema change, for exemple if you create different keyspace in different goroutine you'll get an error

github.com/gocql/gocql.(*tokenAwareHostPolicy).Init()
      /Users/sacha/go/pkg/mod/github.com/scylladb/gocql@v1.5.0/policies.go:436 +0xac
  github.com/gocql/gocql.NewSession()
      /Users/sacha/go/pkg/mod/github.com/scylladb/gocql@v1.5.0/session.go:154 +0xf98
  github.com/gocql/gocql.(*ClusterConfig).CreateSession()
      /Users/sacha/go/pkg/mod/github.com/scylladb/gocql@v1.5.0/cluster.go:205 +0xf7
  XXX.com/org/repo/internal/link.Test_mapper_Map()
      /Users/sacha/go/src/XXX.com/org/repo/internal/link/mapper_test.go:115 +0x56
  testing.tRunner()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1193 +0x202

Previous write at 0x00c0000e61d0 by goroutine 105:
  github.com/gocql/gocql.(*tokenAwareHostPolicy).Init()
      /Users/sacha/go/pkg/mod/github.com/scylladb/gocql@v1.5.0/policies.go:436 +0xac
  github.com/gocql/gocql.NewSession()
      /Users/sacha/go/pkg/mod/github.com/scylladb/gocql@v1.5.0/session.go:154 +0xf98
  github.com/gocql/gocql.(*ClusterConfig).CreateSession()
      /Users/sacha/go/pkg/mod/github.com/scylladb/gocql@v1.5.0/cluster.go:205 +0xf7
  XXX.com/org/repo/internal/mypkg.Test_mapper_GetLinkAdID()
      /Users/sacha/go/src/XXX.com/org/repo/internal/link/mapper_test.go:197 +0x56
  testing.tRunner()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1193 +0x202

Goroutine 52 (running) created at:
  testing.(*T).Run()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1417 +0x3b3
  XXX.com/org/repo/common/test.MultipleSetUpTearDown()
      /Users/sacha/go/src/XXX.com/org/repo/common/test/setupteardown.go:50 +0x129
  XXX.com/org/repo/internal/mypkg.TestMain()
      /Users/sacha/go/src/XXX.com/org/repo/internal/link/mapper_test.go:35 +0x119
  main.main()
      _testmain.go:109 +0x371

Goroutine 105 (running) created at:
  testing.(*T).Run()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /Users/sacha/.gimme/versions/go1.16.4.darwin.amd64/src/testing/testing.go:1417 +0x3b3
  XXX.com/org/repo/common/test.MultipleSetUpTearDown()
      /Users/sacha/go/src/XXX.com/org/repo/common/test/setupteardown.go:50 +0x129
  XXX.com/org/repo/internal/mypkg.TestMain()
      /Users/sacha/go/src/XXX.com/org/repo/internal/link/mapper_test.go:35 +0x119
  main.main()
      _testmain.go:109 +0x371
