### PR TITLE
Document that NumConns has no effect when working with Scylla

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Configuration
 In order to make shard-awareness work, token aware host selection policy has to be enabled.
 Please make sure that the gocql configuration has `PoolConfig.HostSelectionPolicy` properly set like in the example below. 
 
+__When working with a Scylla cluster, `PoolConfig.NumConns` option has no effect - the driver opens one connection for each shard and completely ignores this option.__
+
 ```go
 c := gocql.NewCluster(hosts...)
 
@@ -70,6 +72,9 @@ c.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(fallback)
 if localDC != "" {
 	c.Consistency = gocql.LocalQuorum
 }
+
+// When working with a Scylla cluster the driver always opens one connection per shard, so `NumConns` is ignored.
+// c.NumConns = 4
 ```
 
 ### Shard-aware port

--- a/cluster.go
+++ b/cluster.go
@@ -50,7 +50,7 @@ type ClusterConfig struct {
 	ConnectTimeout     time.Duration                            // initial connection timeout, used during initial dial to server (default: 600ms)
 	Port               int                                      // port (default: 9042)
 	Keyspace           string                                   // initial keyspace (optional)
-	NumConns           int                                      // number of connections per host (default: 2)
+	NumConns           int                                      // number of connections per host (default: 2), this option has no effect when working with Scylla - instead, one connection for each shard will be created
 	Consistency        Consistency                              // default consistency level (default: Quorum)
 	Compressor         Compressor                               // compression algorithm (default: nil)
 	Authenticator      Authenticator                            // authenticator (default: nil)


### PR DESCRIPTION
Adds information about `NumConn` not being used when working with Scylla cluster to README.md and `NumConn`'s comment.

Fixes #68