### PR TITLE
Merge shard awareness with original behaviour

### DIFF
--- a/scylla.go
+++ b/scylla.go
@@ -295,9 +295,26 @@ func (p *scyllaConnPicker) Pick(t token) *Conn {
 	if c := p.conns[idx]; c != nil {
 		// We have this shard's connection
 		// so let's give it to the caller.
-		return c
+		// But only if it's not loaded too much and load is well distributed.
+		return p.maybeReplaceWithLessBusyConnection(c)
 	}
 	return p.leastBusyConn()
+}
+
+func (p *scyllaConnPicker) maybeReplaceWithLessBusyConnection(c *Conn) *Conn {
+	if !isHeavyLoaded(c) {
+		return c
+	}
+	alternative := p.leastBusyConn()
+	if alternative == nil || alternative.AvailableStreams() * 120 > c.AvailableStreams() * 100 {
+		return c
+	} else {
+		return alternative
+	}
+}
+
+func isHeavyLoaded(c *Conn) bool {
+    return c.streams.NumStreams / 2 > c.AvailableStreams();
 }
 
 func (p *scyllaConnPicker) leastBusyConn() *Conn {

--- a/scylla.go
+++ b/scylla.go
@@ -282,7 +282,7 @@ func (p *scyllaConnPicker) Pick(t token) *Conn {
 	}
 
 	if t == nil {
-		return p.randomConn()
+		return p.leastBusyConn()
 	}
 
 	mmt, ok := t.(int64Token)
@@ -297,17 +297,25 @@ func (p *scyllaConnPicker) Pick(t token) *Conn {
 		// so let's give it to the caller.
 		return c
 	}
-	return p.randomConn()
+	return p.leastBusyConn()
 }
 
-func (p *scyllaConnPicker) randomConn() *Conn {
+func (p *scyllaConnPicker) leastBusyConn() *Conn {
+	var (
+		leastBusyConn    *Conn
+		streamsAvailable int
+	)
 	idx := int(atomic.AddUint64(&p.pos, 1))
-	for i := 0; i < len(p.conns); i++ {
+	// find the conn which has the most available streams, this is racy
+	for i := range p.conns {
 		if conn := p.conns[(idx+i)%len(p.conns)]; conn != nil {
-			return conn
+			if streams := conn.AvailableStreams(); streams > streamsAvailable {
+				leastBusyConn = conn
+				streamsAvailable = streams
+			}
 		}
 	}
-	return nil
+	return leastBusyConn
 }
 
 func (p *scyllaConnPicker) shardOf(token int64Token) int {

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+
+	"github.com/gocql/gocql/internal/streams"
 )
 
 func TestScyllaConnPickerPickNilToken(t *testing.T) {
@@ -17,21 +19,27 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 	}
 
 	t.Run("no conns", func(t *testing.T) {
-		s.conns = []*Conn{{}}
+		s.conns = []*Conn{{
+			streams: streams.New(protoVersion4),
+		}}
 		if s.Pick(token(nil)) != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
 
 	t.Run("one shard", func(t *testing.T) {
-		s.conns = []*Conn{{}}
+		s.conns = []*Conn{{
+			streams: streams.New(protoVersion4),
+		}}
 		if s.Pick(token(nil)) != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
 
 	t.Run("multiple shards", func(t *testing.T) {
-		s.conns = []*Conn{nil, {}}
+		s.conns = []*Conn{nil, {
+			streams: streams.New(protoVersion4),
+		}}
 		if s.Pick(token(nil)) != s.conns[1] {
 			t.Fatal("expected connection")
 		}
@@ -73,7 +81,9 @@ func TestScyllaConnPickerHammerPickNilToken(t *testing.T) {
 		if i%7 == 0 {
 			continue
 		}
-		s.conns[i] = &Conn{}
+		s.conns[i] = &Conn{
+			streams: streams.New(protoVersion4),
+		}
 	}
 
 	n := runtime.GOMAXPROCS(0)
@@ -115,6 +125,7 @@ func TestScyllaConnPickerRemove(t *testing.T) {
 
 func mockConn(shard int) *Conn {
 	return &Conn{
+		streams: streams.New(protoVersion4),
 		scyllaSupported: scyllaSupported{
 			shard:             shard,
 			nrShards:          4,


### PR DESCRIPTION
It turns out that shard awareness is a great optimisation but in case of extremely high load, the original behaviour of picking the least busy connection performs better. This is because original algorithm load-balances coordinator work more evenly among shards.

This PR brings back the old, non shard aware behaviour when the selected connection that targets the right shard is more than 50% busy and there is another connection that's at least 20% less busy. Then we use the least busy connection instead of the one that connects to the right shard.