### PR TITLE
session: conn, add possibility to cap the nr. of streams per TCP connection

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -51,6 +51,7 @@ type ClusterConfig struct {
 	Port               int                                      // port (default: 9042)
 	Keyspace           string                                   // initial keyspace (optional)
 	NumConns           int                                      // number of connections per host (default: 2), this option has no effect when working with Scylla - instead, one connection for each shard will be created
+	MaxStreams         int                                      // maximal number of streams per TCP connection
 	Consistency        Consistency                              // default consistency level (default: Quorum)
 	Compressor         Compressor                               // compression algorithm (default: nil)
 	Authenticator      Authenticator                            // authenticator (default: nil)

--- a/conn.go
+++ b/conn.go
@@ -289,7 +289,7 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		errorHandler:  errorHandler,
 		compressor:    cfg.Compressor,
 		session:       s,
-		streams:       streams.New(cfg.ProtoVersion),
+		streams:       s.streamIDGenerator(cfg.ProtoVersion),
 		host:          host,
 		frameObserver: s.frameObserver,
 		w: &deadlineWriter{
@@ -308,6 +308,13 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 	}
 
 	return c, nil
+}
+
+func (s *Session) streamIDGenerator(protocol int) *streams.IDGenerator {
+	if s.cfg.MaxStreams > 0 {
+		return streams.NewLimited(s.cfg.MaxStreams)
+	}
+	return streams.New(protocol)
 }
 
 func (c *Conn) init(ctx context.Context) error {

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -24,7 +24,13 @@ func New(protocol int) *IDGenerator {
 	if protocol > 2 {
 		maxStreams = 32768
 	}
+	return NewLimited(maxStreams)
+}
 
+func NewLimited(maxStreams int) *IDGenerator {
+	if maxStreams < 128 {
+		maxStreams = 128
+	}
 	buckets := maxStreams / 64
 	// reserve stream 0
 	streams := make([]uint64, buckets)


### PR DESCRIPTION
To cap the number add MaxStreams value to ClusterConfig when initializing the driver.