### PR TITLE
Mutex token aware sharding initializer

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -396,6 +396,8 @@ type tokenAwareHostPolicy struct {
 }
 
 func (t *tokenAwareHostPolicy) Init(s *Session) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.getKeyspaceMetadata = s.KeyspaceMetadata
 	t.getKeyspaceName = func() string { return s.cfg.Keyspace }
 	t.logger = s.logger


### PR DESCRIPTION
- Prevents data race when/if a schema update happens during an initialization.

I believe this addresses #94. 