### PR TITLE
Add HostDialer interface

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -53,6 +53,7 @@ type ClusterConfig struct {
 	Timeout time.Duration
 
 	// Initial connection timeout, used during initial dial to server (default: 600ms)
+	// ConnectTimeout is used to set up the default dialer and is ignored if Dialer or HostDialer is provided.
 	ConnectTimeout time.Duration
 
 	// Port used when dialing.
@@ -93,6 +94,7 @@ type ClusterConfig struct {
 	ReconnectionPolicy ReconnectionPolicy
 
 	// The keepalive period to use, enabled if > 0 (default: 0)
+	// SocketKeepalive is used to set up the default dialer and is ignored if Dialer or HostDialer is provided.
 	SocketKeepalive time.Duration
 
 	// Maximum cache size for prepared statements globally for gocql.
@@ -111,6 +113,8 @@ type ClusterConfig struct {
 	// Default: unset
 	SerialConsistency SerialConsistency
 
+	// SslOpts configures TLS use when HostDialer is not set.
+	// SslOpts is ignored if HostDialer is set.
 	SslOpts *SslOptions
 
 	// Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server.
@@ -199,7 +203,14 @@ type ClusterConfig struct {
 
 	// Dialer will be used to establish all connections created for this Cluster.
 	// If not provided, a default dialer configured with ConnectTimeout will be used.
+	// Dialer is ignored if HostDialer is provided.
 	Dialer Dialer
+
+	// HostDialer will be used to establish all connections for this Cluster.
+	// Unlike Dialer, HostDialer is responsible for setting up the entire connection, including the TLS session.
+	// To support shard-aware port, HostDialer should implement ShardDialer.
+	// If not provided, Dialer will be used instead.
+	HostDialer HostDialer
 
 	// DisableShardAwarePort will prevent the driver from connecting to Scylla's shard-aware port,
 	// even if there are nodes in the cluster that support it.

--- a/connpicker.go
+++ b/connpicker.go
@@ -13,7 +13,10 @@ type ConnPicker interface {
 	Size() (int, int)
 	Close()
 
-	GetCustomDialer() Dialer
+	// NextShard returns the shardID to connect to.
+	// nrShard specifies how many shards the host has.
+	// If nrShards is zero, the caller shouldn't use shard-aware port.
+	NextShard() (shardID, nrShards int)
 }
 
 type defaultConnPicker struct {
@@ -92,8 +95,8 @@ func (p *defaultConnPicker) Put(conn *Conn) {
 	p.mu.Unlock()
 }
 
-func (*defaultConnPicker) GetCustomDialer() Dialer {
-	return nil
+func (*defaultConnPicker) NextShard() (shardID, nrShards int) {
+	return 0, 0
 }
 
 // nopConnPicker is a no-operation implementation of ConnPicker, it's used when
@@ -121,6 +124,6 @@ func (nopConnPicker) Size() (int, int) {
 func (nopConnPicker) Close() {
 }
 
-func (nopConnPicker) GetCustomDialer() Dialer {
-	return nil
+func (nopConnPicker) NextShard() (shardID, nrShards int) {
+	return 0, 0
 }

--- a/dial.go
+++ b/dial.go
@@ -1,0 +1,90 @@
+package gocql
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// HostDialer allows customizing connection to cluster nodes.
+type HostDialer interface {
+	// DialHost establishes a connection to the host.
+	// The returned connection must be directly usable for CQL protocol,
+	// specifically DialHost is responsible also for setting up the TLS session if needed.
+	// DialHost should disable write coalescing if the returned net.Conn does not support writev.
+	// As of Go 1.18, only plain TCP connections support writev, TLS sessions should disable coalescing.
+	// You can use WrapTLS helper function if you don't need to override the TLS setup.
+	DialHost(ctx context.Context, host *HostInfo) (*DialedHost, error)
+}
+
+// DialedHost contains information about established connection to a host.
+type DialedHost struct {
+	// Conn used to communicate with the server.
+	Conn net.Conn
+
+	// DisableCoalesce disables write coalescing for the Conn.
+	// If true, the effect is the same as if WriteCoalesceWaitTime was configured to 0.
+	DisableCoalesce bool
+}
+
+// defaultHostDialer dials host in a default way.
+type defaultHostDialer struct {
+	dialer    Dialer
+	tlsConfig *tls.Config
+}
+
+func (hd *defaultHostDialer) DialHost(ctx context.Context, host *HostInfo) (*DialedHost, error) {
+	ip := host.ConnectAddress()
+	port := host.Port()
+
+	if !validIpAddr(ip) {
+		return nil, fmt.Errorf("host missing connect ip address: %v", ip)
+	} else if port == 0 {
+		return nil, fmt.Errorf("host missing port: %v", port)
+	}
+
+	addr := host.HostnameAndPort()
+	conn, err := hd.dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return WrapTLS(ctx, conn, addr, hd.tlsConfig)
+}
+
+func tlsConfigForAddr(tlsConfig *tls.Config, addr string) *tls.Config {
+	// the TLS config is safe to be reused by connections but it must not
+	// be modified after being used.
+	if !tlsConfig.InsecureSkipVerify && tlsConfig.ServerName == "" {
+		colonPos := strings.LastIndex(addr, ":")
+		if colonPos == -1 {
+			colonPos = len(addr)
+		}
+		hostname := addr[:colonPos]
+		// clone config to avoid modifying the shared one.
+		tlsConfig = tlsConfig.Clone()
+		tlsConfig.ServerName = hostname
+	}
+	return tlsConfig
+}
+
+// WrapTLS optionally wraps a net.Conn connected to addr with the given tlsConfig.
+// If the tlsConfig is nil, conn is not wrapped into a TLS session, so is insecure.
+// If the tlsConfig does not have server name set, it is updated based on the default gocql rules.
+func WrapTLS(ctx context.Context, conn net.Conn, addr string, tlsConfig *tls.Config) (*DialedHost, error) {
+	if tlsConfig != nil {
+		tlsConfig := tlsConfigForAddr(tlsConfig, addr)
+		tconn := tls.Client(conn, tlsConfig)
+		if err := tconn.HandshakeContext(ctx); err != nil {
+			conn.Close()
+			return nil, err
+		}
+		conn = tconn
+	}
+
+	return &DialedHost{
+		Conn:            conn,
+		DisableCoalesce: tlsConfig != nil, // write coalescing can't use writev when the connection is wrapped.
+	}, nil
+}

--- a/host_source.go
+++ b/host_source.go
@@ -131,6 +131,9 @@ type HostInfo struct {
 	state                      nodeState
 	schemaVersion              string
 	tokens                     []string
+
+	scyllaShardAwarePort    uint16
+	scyllaShardAwarePortTLS uint16
 }
 
 func (h *HostInfo) Equal(host *HostInfo) bool {
@@ -399,6 +402,29 @@ func (h *HostInfo) String() string {
 		h.hostname, h.connectAddress, h.peer, h.rpcAddress, h.broadcastAddress, h.preferredIP,
 		connectAddr, source,
 		h.port, h.dataCenter, h.rack, h.hostId, h.version, h.state, len(h.tokens))
+}
+
+func (h *HostInfo) setScyllaSupported(s scyllaSupported) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.scyllaShardAwarePort = s.shardAwarePort
+	h.scyllaShardAwarePortTLS = s.shardAwarePortSSL
+}
+
+// ScyllaShardAwarePort returns the shard aware port of this host.
+// Returns zero if the shard aware port is not known.
+func (h *HostInfo) ScyllaShardAwarePort() uint16 {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.scyllaShardAwarePort
+}
+
+// ScyllaShardAwarePortTLS returns the TLS-enabled shard aware port of this host.
+// Returns zero if the shard aware port is not known.
+func (h *HostInfo) ScyllaShardAwarePortTLS() uint16 {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.scyllaShardAwarePortTLS
 }
 
 // Polls system.peers at a specific interval to find new hosts


### PR DESCRIPTION
There are multiple use cases where the Dialer interface is not
sufficient.

When using TLS, users need to control also TLS context per host.
For example, host certificates might be either UUID in common name,
some hostname, IP address per host, etc.

Hosted instances or instances deployed in Kubernetes cluster tend
to be behind proxies. A proxy might use TLS server name indication
to identify which database host to connect to.

This commit adds Scylla-specific ShardDialer interface,
so that HostDialer works with shards as well.