### PR TITLE
Open both encrypted and unencrypted Scylla in integration suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env:
-      SCYLLA_IMAGE: scylladb/scylla:4.2.0
+      SCYLLA_IMAGE: scylladb/scylla:4.6.3
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/common_test.go
+++ b/common_test.go
@@ -40,6 +40,7 @@ func getClusterHosts() []string {
 
 func addSslOptions(cluster *ClusterConfig) *ClusterConfig {
 	if *flagRunSslTest {
+		cluster.Port = 9142
 		cluster.SslOpts = &SslOptions{
 			CertPath:               "testdata/pki/gocql.crt",
 			KeyPath:                "testdata/pki/gocql.key",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,19 @@ services:
     networks:
       public:
         ipv4_address: 192.168.100.11
-
+    volumes:
+    - type: bind
+      source: ./testdata/config/scylla.yaml
+      target: /etc/scylla/scylla.yaml
+    - type: bind
+      source: ./testdata/pki/ca.crt
+      target: /etc/scylla/ca.crt
+    - type: bind
+      source: ./testdata/pki/cassandra.crt
+      target: /etc/scylla/db.crt
+    - type: bind
+      source: ./testdata/pki/cassandra.key
+      target: /etc/scylla/db.key
 networks:
   public:
     driver: bridge

--- a/testdata/config/scylla.yaml
+++ b/testdata/config/scylla.yaml
@@ -1,0 +1,10 @@
+native_transport_port_ssl: 9142
+native_transport_port: 9042
+native_shard_aware_transport_port: 19042
+native_shard_aware_transport_port_ssl: 19142
+client_encryption_options:
+  enabled: true
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+  truststore: /etc/scylla/ca.crt
+  require_client_auth: true


### PR DESCRIPTION
It allows to run tls and non-tls test suits without tearing up and down test environment