### PR TITLE
Reformat ClusterConfig to have doc comments above fields

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -35,8 +35,10 @@ type ClusterConfig struct {
 	// address, which is used to index connected hosts. If the domain name specified
 	// resolves to more than 1 IP address then the driver may connect multiple times to
 	// the same host, and will not mark the node being down or up from events.
-	Hosts      []string
-	CQLVersion string // CQL version (default: 3.0.0)
+	Hosts []string
+
+	// CQL version (default: 3.0.0)
+	CQLVersion string
 
 	// ProtoVersion sets the version of the native protocol to use, this will
 	// enable features in the driver for specific protocol versions, generally this
@@ -45,26 +47,76 @@ type ClusterConfig struct {
 	// If it is 0 or unset (the default) then the driver will attempt to discover the
 	// highest supported protocol for the cluster. In clusters with nodes of different
 	// versions the protocol selected is not defined (ie, it can be any of the supported in the cluster)
-	ProtoVersion       int
-	Timeout            time.Duration                            // connection timeout (default: 600ms)
-	ConnectTimeout     time.Duration                            // initial connection timeout, used during initial dial to server (default: 600ms)
-	Port               int                                      // port (default: 9042)
-	Keyspace           string                                   // initial keyspace (optional)
-	NumConns           int                                      // number of connections per host (default: 2), this option has no effect when working with Scylla - instead, one connection for each shard will be created
-	Consistency        Consistency                              // default consistency level (default: Quorum)
-	Compressor         Compressor                               // compression algorithm (default: nil)
-	Authenticator      Authenticator                            // authenticator (default: nil)
-	AuthProvider       func(h *HostInfo) (Authenticator, error) // an authenticator factory. Can be used to create alternative authenticators (default: nil)
-	RetryPolicy        RetryPolicy                              // Default retry policy to use for queries (default: 0)
-	ConvictionPolicy   ConvictionPolicy                         // Decide whether to mark host as down based on the error and host info (default: SimpleConvictionPolicy)
-	ReconnectionPolicy ReconnectionPolicy                       // Default reconnection policy to use for reconnecting before trying to mark host as down (default: see below)
-	SocketKeepalive    time.Duration                            // The keepalive period to use, enabled if > 0 (default: 0)
-	MaxPreparedStmts   int                                      // Sets the maximum cache size for prepared statements globally for gocql (default: 1000)
-	MaxRoutingKeyInfo  int                                      // Sets the maximum cache size for query info about statements for each session (default: 1000)
-	PageSize           int                                      // Default page size to use for created sessions (default: 5000)
-	SerialConsistency  Consistency                              // Sets the consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL (default: unset)
-	SslOpts            *SslOptions
-	DefaultTimestamp   bool // Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server. (default: true, only enabled for protocol 3 and above)
+	ProtoVersion int
+
+	// Connection timeout (default: 600ms)
+	Timeout time.Duration
+
+	// Initial connection timeout, used during initial dial to server (default: 600ms)
+	ConnectTimeout time.Duration
+
+	// Port used when dialing.
+	// Default: 9042
+	Port int
+
+	// Initial keyspace. Optional.
+	Keyspace string
+
+	// Number of connections per host.
+	// Default: 2
+	NumConns int
+
+	// Default consistency level.
+	// Default: Quorum
+	Consistency Consistency
+
+	// Compression algorithm.
+	// Default: nil
+	Compressor Compressor
+
+	// Default: nil
+	Authenticator Authenticator
+
+	// An Authenticator factory. Can be used to create alternative authenticators.
+	// Default: nil
+	AuthProvider func(h *HostInfo) (Authenticator, error)
+
+	// Default retry policy to use for queries.
+	// Default: no retries.
+	RetryPolicy RetryPolicy
+
+	// ConvictionPolicy decides whether to mark host as down based on the error and host info.
+	// Default: SimpleConvictionPolicy
+	ConvictionPolicy ConvictionPolicy
+
+	// Default reconnection policy to use for reconnecting before trying to mark host as down.
+	ReconnectionPolicy ReconnectionPolicy
+
+	// The keepalive period to use, enabled if > 0 (default: 0)
+	SocketKeepalive time.Duration
+
+	// Maximum cache size for prepared statements globally for gocql.
+	// Default: 1000
+	MaxPreparedStmts int
+
+	// Maximum cache size for query info about statements for each session.
+	// Default: 1000
+	MaxRoutingKeyInfo int
+
+	// Default page size to use for created sessions.
+	// Default: 5000
+	PageSize int
+
+	// Consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL.
+	// Default: unset
+	SerialConsistency SerialConsistency
+
+	SslOpts *SslOptions
+
+	// Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server.
+	// Default: true, only enabled for protocol 3 and above.
+	DefaultTimestamp bool
+
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig


### PR DESCRIPTION
This change is to make maintanance easier.
With comments above the fields, each field is indented separately,
so we can insert new fields into the struct and update the documentation
comments without gofmt reformating the whole struct.

This should reduce diffs in commits and minimize conflicts when
merging to forks.