### PR TITLE
Use ScyllaShardAwareDialer as a default dialer

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -105,13 +105,13 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 
 		dialer := cfg.Dialer
 		if dialer == nil {
-			d := &net.Dialer{
+			d := net.Dialer{
 				Timeout: cfg.ConnectTimeout,
 			}
 			if cfg.SocketKeepalive > 0 {
 				d.KeepAlive = cfg.SocketKeepalive
 			}
-			dialer = d
+			dialer = &ScyllaShardAwareDialer{d}
 		}
 
 		hostDialer = &scyllaDialer{


### PR DESCRIPTION
PR #98 introduced a regression which changed default dialer
to bare net.Dialer, instead of wrapped one with ScyllaShardAwareDialer.
This resulted in dialer not being able to set local address
which are required for correct shard assignment.
Even though we have an integration test for that, test environment
has only 2 shards, so it's possible that random port assignment passes it.