### PR TITLE
Fix nil pointer dereference in event handling node removal

### DIFF
--- a/events.go
+++ b/events.go
@@ -240,8 +240,8 @@ func (s *Session) handleRemovedNode(ip net.IP, port int) {
 
 	// we remove all nodes but only add ones which pass the filter
 	host, ok := s.ring.getHostByIP(ip.String())
-	hostID := host.HostID()
 	if ok {
+		hostID := host.HostID()
 		s.ring.removeHost(hostID)
 
 		host.setState(NodeDown)


### PR DESCRIPTION
For the moment we have unsafe coding where we try to use 'host' object
before checking the success of it's 'get' operation.
    
When a Scylla node gets forcibly terminated we have a race condition
and to some probability to get the following panic:
```    
      panic: runtime error: invalid memory address or nil pointer dereference
      [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x632814]
    
      goroutine 1723 [running]:
      github.com/gocql/gocql.(*HostInfo).HostID(0xc0001500b8)
        %full-path%/gocql@v1.7.1/host_source.go:271 +0x34
      github.com/gocql/gocql.(*Session).handleRemovedNode(
            0xc000150000, {0xc0134c10d8, 0xc0093d69b0, 0xa}, 0x45264d)
        %full-path%/gocql@v1.7.1/events.go:243 +0x5f
      github.com/gocql/gocql.(*Session).handleNodeEvent(
            0xc000150000, {0xc01701a000, 0x1, 0x43e305})
        %full-path%/gocql@v1.7.1/events.go:176 +0x28e
      created by github.com/gocql/gocql.(*eventDebouncer).flush
        %full-path%/gocql@v1.7.1/events.go:67 +0xb5
``` 

So, fix it by checking the result first and only then use 'host' object.