### PR TITLE
Run go vet and tests in all subpackages in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - run: go vet
+      - run: go vet ./...
 
       - name: Run unit tests
-        run: go test -tags unit -race
+        run: go test -tags unit -race ./...
 
       - name: Install Docker compose
         env:


### PR DESCRIPTION
`go vet` and `go test` without any package arguments runs only
on the go files in the repo root directory. It should run on all
non-vendored packages.

Fixes following go vet failure:
* `./scylla_test.go:180:4: call to (*T).Fatal from a non-test goroutine`