### PR TITLE
rate limit CQL extension support

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -196,3 +196,28 @@ type RequestErrCASWriteUnknown struct {
 	Received    int
 	BlockFor    int
 }
+
+type OpType uint8
+
+const (
+	OpTypeRead  OpType = 0
+	OpTypeWrite OpType = 1
+)
+
+type RequestErrRateLimitReached struct {
+	errorFrame
+	OpType                OpType
+	RejectedByCoordinator bool
+}
+
+func (e *RequestErrRateLimitReached) String() string {
+	var opType string
+	if e.OpType == OpTypeRead {
+		opType = "Read"
+	} else if e.OpType == OpTypeWrite {
+		opType = "Write"
+	} else {
+		opType = "Other"
+	}
+	return fmt.Sprintf("[request_error_rate_limit_reached OpType=%s RejectedByCoordinator=%t]", opType, e.RejectedByCoordinator)
+}

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -197,6 +197,38 @@ func pickLoop(t *testing.T, s *scyllaConnPicker, c int, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
+func TestScyllaRateLimitingExtParsing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("init framer without cql extensions", func(t *testing.T) {
+		t.Parallel()
+		// mock connection without cql extensions, expected to have the `rateLimitingErrorCode`
+		// field set to 0 (default, signifying no code)
+		conn := mockConn(0)
+		f := newFramerWithExts(conn, conn, conn.compressor, conn.version, conn.cqlProtoExts)
+		if f.rateLimitingErrorCode != 0 {
+			t.Error("expected to have rateLimitingErrorCode set to 0 (no code) after framer init")
+		}
+	})
+
+	const mockCode = 42
+	t.Run("init framer with cql extensions", func(t *testing.T) {
+		t.Parallel()
+		// create a mock connection, add `lwt` cql protocol extension to it,
+		// ensure that framer recognizes this extension and adjusts appropriately
+		conn := mockConn(0)
+		conn.cqlProtoExts = []cqlProtocolExtension{
+			&rateLimitExt{
+				rateLimitErrorCode: mockCode,
+			},
+		}
+		framerWithRateLimitExt := newFramerWithExts(conn, conn, conn.compressor, conn.version, conn.cqlProtoExts)
+		if framerWithRateLimitExt.rateLimitingErrorCode != mockCode {
+			t.Error("expected to have rateLimitingErrorCode set to mockCode after framer init")
+		}
+	})
+}
+
 func TestScyllaLWTExtParsing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Since recently, Scylla has begun to support a new CQL error type, RateLimitError. For this error to be recognised by the driver properly, a proper negotiation is needed. It was implemented similarly to the already-present LWT optimisation extension negotiation.