### PR TITLE
Fixed race between Query.Release() and speculative executions in queryExecutor

### DIFF
--- a/query_executor.go
+++ b/query_executor.go
@@ -7,6 +7,8 @@ import (
 )
 
 type ExecutableQuery interface {
+	borrowForExecution()    // Used to ensure that the query stays alive for lifetime of a particular execution goroutine.
+	releaseAfterExecution() // Used when a goroutine finishes its execution attempts, either with ok result or an error.
 	execute(ctx context.Context, conn *Conn) *Iter
 	attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
 	retryPolicy() RetryPolicy
@@ -45,6 +47,7 @@ func (q *queryExecutor) speculate(ctx context.Context, qry ExecutableQuery, sp S
 	for i := 0; i < sp.Attempts(); i++ {
 		select {
 		case <-ticker.C:
+			qry.borrowForExecution() // ensure liveness in case of executing Query to prevent races with Query.Release().
 			go q.run(ctx, qry, hostIter, results)
 		case <-ctx.Done():
 			return &Iter{err: ctx.Err()}
@@ -82,6 +85,7 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 	results := make(chan *Iter, 1)
 
 	// Launch the main execution
+	qry.borrowForExecution() // ensure liveness in case of executing Query to prevent races with Query.Release().
 	go q.run(ctx, qry, hostIter, results)
 
 	// The speculative executions are launched _in addition_ to the main
@@ -173,4 +177,5 @@ func (q *queryExecutor) run(ctx context.Context, qry ExecutableQuery, hostIter N
 	case results <- q.do(ctx, qry, hostIter):
 	case <-ctx.Done():
 	}
+	qry.releaseAfterExecution()
 }


### PR DESCRIPTION
As described in https://github.com/scylladb/gocql/issues/88, there is a race condition when there is more than one concurrent execution (by means of speculative execution) and Query.Release() is called after one of them completes. Query.Release() calls Query.reset(), which in turns zeroes the whole Query. Then, after another execution completes, it tries to access metrics, but they are already set to nil by the call to Release(), so a segfault is triggered.

~~The solution is quite simple: a waitgroup is introduced into the Query (behind a pointer, as the Query is to be copiable). Every execution fiber (i.e. every execution goroutine) is added to that waitgroup, and Query.Release() waits with calling Query.reset() until all those goroutines complete.~~

~~Not to make Query.Release() block the caller while waiting for any stuck executions, waiting and reset are done on a separate goroutine.~~

**EDIT**: better approach using reference counting:

The solution is quite simple: a ref counter is introduced into the Query. It is obviously initially set to 1. Every execution fiber
(i.e. every execution goroutine) has the refcount atomically incremented before it is started, and decrements the refcount on completion. Query.Release() merely decrements the refcount. Query.reset() is called by whichever goroutine that decrements the refcount to 0.

Fixes: #88