### PR TITLE
fix(docker-compose.yaml): increase memory limit to avoid hitting #126

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   node_1:
     image: ${SCYLLA_IMAGE}
     privileged: true
-    command: --smp 2 --memory 512M --seeds 192.168.100.11 --overprovisioned 1
+    command: --smp 2 --memory 768M --seeds 192.168.100.11 --overprovisioned 1
     networks:
       public:
         ipv4_address: 192.168.100.11


### PR DESCRIPTION
Due to the #126, we need to increase memory limit for scylla to avoid prepared stmt eviction during tests
