### PR TITLE
Add healthchecks, switch from Docker Compose V1 to V2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Docker compose
         env:
-          DOCKER_COMPOSE_VERSION: 1.27.4
+          DOCKER_COMPOSE_VERSION: 2.20.0
         run: sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
       - run: ./integration.sh cassandra scylla

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,11 @@ services:
     - type: bind
       source: ./testdata/pki/cassandra.key
       target: /etc/scylla/db.key
+    healthcheck:
+      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 18
 networks:
   public:
     driver: bridge

--- a/integration.sh
+++ b/integration.sh
@@ -12,17 +12,7 @@ function scylla_up() {
 
   echo "==> Running Scylla ${SCYLLA_IMAGE}"
   docker pull ${SCYLLA_IMAGE}
-  docker compose up -d
-
-  echo "==> Waiting for CQL port"
-  for s in $(docker-compose ps --services); do
-    until v=$(${exec} ${s} cqlsh -e "DESCRIBE SCHEMA"); do
-      echo ${v}
-      docker-compose logs --tail 10 ${s}
-      sleep 5
-    done
-  done
-  echo "==> Waiting for CQL port done"
+  docker compose up -d --wait
 }
 
 function scylla_down() {

--- a/integration.sh
+++ b/integration.sh
@@ -8,11 +8,11 @@ readonly SCYLLA_IMAGE=${SCYLLA_IMAGE}
 set -eu -o pipefail
 
 function scylla_up() {
-  local -r exec="docker-compose exec -T"
+  local -r exec="docker compose exec -T"
 
   echo "==> Running Scylla ${SCYLLA_IMAGE}"
   docker pull ${SCYLLA_IMAGE}
-  docker-compose up -d
+  docker compose up -d
 
   echo "==> Waiting for CQL port"
   for s in $(docker-compose ps --services); do
@@ -27,7 +27,7 @@ function scylla_up() {
 
 function scylla_down() {
   echo "==> Stopping Scylla"
-  docker-compose down
+  docker compose down
 }
 
 function scylla_restart() {


### PR DESCRIPTION
As per Docker documentation:

> From July 2023 Docker Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.

Therefore, the first patch replaces all uses of Docker Compose V1 (`docker-compose` command) with Docker Compose V2 (`docker compose` command) and changes installed version of Docker Compose in main.yml.

This gives a possibility to replace manual checking the health of the containers with healthchecks and using `--wait` flag in `docker compose`. `--wait flag` makes Docker wait for all healthchecks to be in "healthy" state. Since docker-compose.yml files in this repository use `cqlsh` to determine the health of a container, this means that Docker will wait for all nodes of the cluster to be fully bootstrapped and their CQL port ready.

All of this makes adding new nodes and making them boot in order easier, it is just adding new healthchecks and dependencies. 