### PR TITLE
Introduce support for tablets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
           DOCKER_COMPOSE_VERSION: 2.20.0
         run: sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
+      - run: sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
       - run: ./integration.sh cassandra scylla
       - run: ./integration.sh integration scylla
       - run: ./integration.sh ccm
+      - run: ./integration.sh tablet

--- a/common_test.go
+++ b/common_test.go
@@ -13,17 +13,18 @@ import (
 )
 
 var (
-	flagCluster      = flag.String("cluster", "127.0.0.1", "a comma-separated list of host:port tuples")
-	flagProto        = flag.Int("proto", 0, "protcol version")
-	flagCQL          = flag.String("cql", "3.0.0", "CQL version")
-	flagRF           = flag.Int("rf", 1, "replication factor for test keyspace")
-	clusterSize      = flag.Int("clusterSize", 1, "the expected size of the cluster")
-	flagRetry        = flag.Int("retries", 5, "number of times to retry queries")
-	flagAutoWait     = flag.Duration("autowait", 1000*time.Millisecond, "time to wait for autodiscovery to fill the hosts poll")
-	flagRunSslTest   = flag.Bool("runssl", false, "Set to true to run ssl test")
-	flagRunAuthTest  = flag.Bool("runauth", false, "Set to true to run authentication test")
-	flagCompressTest = flag.String("compressor", "", "compressor to use")
-	flagTimeout      = flag.Duration("gocql.timeout", 5*time.Second, "sets the connection `timeout` for all operations")
+	flagCluster          = flag.String("cluster", "127.0.0.1", "a comma-separated list of host:port tuples")
+	flagMultiNodeCluster = flag.String("multiCluster", "127.0.0.2", "a comma-separated list of host:port tuples")
+	flagProto            = flag.Int("proto", 0, "protcol version")
+	flagCQL              = flag.String("cql", "3.0.0", "CQL version")
+	flagRF               = flag.Int("rf", 1, "replication factor for test keyspace")
+	clusterSize          = flag.Int("clusterSize", 1, "the expected size of the cluster")
+	flagRetry            = flag.Int("retries", 5, "number of times to retry queries")
+	flagAutoWait         = flag.Duration("autowait", 1000*time.Millisecond, "time to wait for autodiscovery to fill the hosts poll")
+	flagRunSslTest       = flag.Bool("runssl", false, "Set to true to run ssl test")
+	flagRunAuthTest      = flag.Bool("runauth", false, "Set to true to run authentication test")
+	flagCompressTest     = flag.String("compressor", "", "compressor to use")
+	flagTimeout          = flag.Duration("gocql.timeout", 5*time.Second, "sets the connection `timeout` for all operations")
 
 	flagCassVersion cassVersion
 )
@@ -36,6 +37,10 @@ func init() {
 
 func getClusterHosts() []string {
 	return strings.Split(*flagCluster, ",")
+}
+
+func getMultiNodeClusterHosts() []string {
+	return strings.Split(*flagMultiNodeCluster, ",")
 }
 
 func addSslOptions(cluster *ClusterConfig) *ClusterConfig {
@@ -102,6 +107,35 @@ func createCluster(opts ...func(*ClusterConfig)) *ClusterConfig {
 	return cluster
 }
 
+func createMultiNodeCluster(opts ...func(*ClusterConfig)) *ClusterConfig {
+	clusterHosts := getMultiNodeClusterHosts()
+	cluster := NewCluster(clusterHosts...)
+	cluster.ProtoVersion = *flagProto
+	cluster.CQLVersion = *flagCQL
+	cluster.Timeout = *flagTimeout
+	cluster.Consistency = Quorum
+	cluster.MaxWaitSchemaAgreement = 2 * time.Minute // travis might be slow
+	if *flagRetry > 0 {
+		cluster.RetryPolicy = &SimpleRetryPolicy{NumRetries: *flagRetry}
+	}
+
+	switch *flagCompressTest {
+	case "snappy":
+		cluster.Compressor = &SnappyCompressor{}
+	case "":
+	default:
+		panic("invalid compressor: " + *flagCompressTest)
+	}
+
+	cluster = addSslOptions(cluster)
+
+	for _, opt := range opts {
+		opt(cluster)
+	}
+
+	return cluster
+}
+
 func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
 	// TODO: tb.Helper()
 	c := *cluster
@@ -141,6 +175,37 @@ func createSessionFromCluster(cluster *ClusterConfig, tb testing.TB) *Session {
 	if err != nil {
 		tb.Fatal("createSession:", err)
 	}
+
+	if err := session.control.awaitSchemaAgreement(); err != nil {
+		tb.Fatal(err)
+	}
+
+	return session
+}
+
+func createSessionFromMultiNodeCluster(cluster *ClusterConfig, tb testing.TB) *Session {
+	keyspace := "test1"
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		tb.Fatal("createSession:", err)
+	}
+
+	initOnce.Do(func() {
+		if err = createTable(session, `DROP KEYSPACE IF EXISTS `+keyspace); err != nil {
+			panic(fmt.Sprintf("unable to drop keyspace: %v", err))
+		}
+
+		if err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
+		WITH replication = {
+			'class': 'NetworkTopologyStrategy',
+			'replication_factor': 1,
+			'initial_tablets': 8
+		};`, keyspace)); err != nil {
+			panic(fmt.Sprintf("unable to create keyspace: %v", err))
+		}
+
+	})
 
 	if err := session.control.awaitSchemaAgreement(); err != nil {
 		tb.Fatal(err)

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -26,6 +26,12 @@ type SetPartitioner interface {
 	SetPartitioner(partitioner string)
 }
 
+// interface to implement to receive the tablets value
+// Experimental, this interface and use may change
+type SetTablets interface {
+	SetTablets(tablets []*TabletInfo)
+}
+
 func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 	//  Config.InsecureSkipVerify | EnableHostVerification | Result
 	//  Config is nil             | true                   | verify host
@@ -312,7 +318,7 @@ func newHostConnPool(session *Session, host *HostInfo, port, size int,
 }
 
 // Pick a connection from this connection pool for the given query.
-func (pool *hostConnPool) Pick(token token) *Conn {
+func (pool *hostConnPool) Pick(token token, keyspace string, table string) *Conn {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 
@@ -330,7 +336,7 @@ func (pool *hostConnPool) Pick(token token) *Conn {
 		}
 	}
 
-	return pool.connPicker.Pick(token)
+	return pool.connPicker.Pick(token, keyspace, table)
 }
 
 // Size returns the number of connections currently active in the pool

--- a/connpicker.go
+++ b/connpicker.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ConnPicker interface {
-	Pick(token) *Conn
+	Pick(token, string, string) *Conn
 	Put(*Conn)
 	Remove(conn *Conn)
 	Size() (int, int)
@@ -65,7 +65,7 @@ func (p *defaultConnPicker) Size() (int, int) {
 	return size, p.size - size
 }
 
-func (p *defaultConnPicker) Pick(token) *Conn {
+func (p *defaultConnPicker) Pick(token, string, string) *Conn {
 	pos := int(atomic.AddUint32(&p.pos, 1) - 1)
 	size := len(p.conns)
 
@@ -104,7 +104,7 @@ func (*defaultConnPicker) NextShard() (shardID, nrShards int) {
 // to the point where we have first connection.
 type nopConnPicker struct{}
 
-func (nopConnPicker) Pick(token) *Conn {
+func (nopConnPicker) Pick(token, string, string) *Conn {
 	return nil
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,60 @@ services:
       interval: 5s
       timeout: 5s
       retries: 18
+  node_2:
+    image: scylladb/scylla-nightly
+    command: |
+      --experimental-features consistent-topology-changes
+      --experimental-features tablets
+      --smp 2
+      --memory 1G
+      --seeds 192.168.100.12
+    networks:
+      public:
+        ipv4_address: 192.168.100.12
+    healthcheck:
+      test: [ "CMD", "cqlsh", "192.168.100.12", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 18
+  node_3:
+    image: scylladb/scylla-nightly
+    command: |
+      --experimental-features consistent-topology-changes
+      --experimental-features tablets
+      --smp 2
+      --memory 1G
+      --seeds 192.168.100.12
+    networks:
+      public:
+        ipv4_address: 192.168.100.13
+    healthcheck:
+      test: [ "CMD", "cqlsh", "192.168.100.13", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 18
+    depends_on:
+      node_2:
+        condition: service_healthy
+  node_4:
+    image: scylladb/scylla-nightly
+    command: |
+      --experimental-features consistent-topology-changes
+      --experimental-features tablets
+      --smp 2
+      --memory 1G
+      --seeds 192.168.100.12
+    networks:
+      public:
+        ipv4_address: 192.168.100.14
+    healthcheck:
+      test: [ "CMD", "cqlsh", "192.168.100.14", "-e", "select * from system.local" ]
+      interval: 5s
+      timeout: 5s
+      retries: 18
+    depends_on:
+      node_3:
+        condition: service_healthy
 networks:
   public:
     driver: bridge

--- a/frame.go
+++ b/frame.go
@@ -367,6 +367,7 @@ type framer struct {
 
 	flagLWT               int
 	rateLimitingErrorCode int
+	tabletsRoutingV1      bool
 }
 
 func newFramer(compressor Compressor, version byte) *framer {
@@ -397,6 +398,8 @@ func newFramer(compressor Compressor, version byte) *framer {
 
 	f.header = nil
 	f.traceID = nil
+
+	f.tabletsRoutingV1 = false
 
 	return f
 }
@@ -435,6 +438,7 @@ func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlPr
 					tabletsRoutingV1, tabletsRoutingV1Ext{}))
 			return f
 		}
+		f.tabletsRoutingV1 = true
 	}
 
 	return f

--- a/frame.go
+++ b/frame.go
@@ -427,6 +427,16 @@ func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlPr
 		f.rateLimitingErrorCode = castedExt.rateLimitErrorCode
 	}
 
+	if tabletsExt := findCQLProtoExtByName(cqlProtoExts, tabletsRoutingV1); tabletsExt != nil {
+		_, ok := tabletsExt.(*tabletsRoutingV1Ext)
+		if !ok {
+			Logger.Println(
+				fmt.Errorf("Failed to cast CQL protocol extension identified by name %s to type %T",
+					tabletsRoutingV1, tabletsRoutingV1Ext{}))
+			return f
+		}
+	}
+
 	return f
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -989,6 +989,8 @@ func addTablet(r *ringDescriber, tablet *TabletInfo) error {
 	r.session.ring.setTablets(tablets)
 	r.session.policy.SetTablets(tablets)
 
+	r.session.schemaDescriber.refreshTabletsSchema()
+
 	return nil
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -472,12 +472,151 @@ func (h *HostInfo) ScyllaShardAwarePortTLS() uint16 {
 	return h.scyllaShardAwarePortTLS
 }
 
+// Experimental, this interface and use may change
+type ReplicaInfo struct {
+	hostId  UUID
+	shardId int
+}
+
+// Experimental, this interface and use may change
+type TabletInfo struct {
+	mu           sync.RWMutex
+	keyspaceName string
+	tableName    string
+	firstToken   int64
+	lastToken    int64
+	replicas     []ReplicaInfo
+}
+
+func (t *TabletInfo) KeyspaceName() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.keyspaceName
+}
+
+func (t *TabletInfo) FirstToken() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.firstToken
+}
+
+func (t *TabletInfo) LastToken() int64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.lastToken
+}
+
+func (t *TabletInfo) TableName() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.tableName
+}
+
+func (t *TabletInfo) Replicas() []ReplicaInfo {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.replicas
+}
+
+// Search for place in tablets table with specific Keyspace and Table name
+func findTablets(tablets []*TabletInfo, k string, t string) (int, int) {
+	l := -1
+	r := -1
+	for i, tablet := range tablets {
+		if tablet.KeyspaceName() == k && tablet.TableName() == t {
+			if l == -1 {
+				l = i
+			}
+			r = i
+		} else if l != -1 {
+			break
+		}
+	}
+
+	return l, r
+}
+
+func addTabletToTabletsList(tablets []*TabletInfo, tablet *TabletInfo) []*TabletInfo {
+	l, r := findTablets(tablets, tablet.keyspaceName, tablet.tableName)
+	if l == -1 && r == -1 {
+		l = 0
+		r = 0
+	} else {
+		r = r + 1
+	}
+
+	l1, r1 := l, r
+	l2, r2 := l1, r1
+
+	// find first overlaping range
+	for l1 < r1 {
+		mid := (l1 + r1) / 2
+		if tablets[mid].FirstToken() < tablet.FirstToken() {
+			l1 = mid + 1
+		} else {
+			r1 = mid
+		}
+	}
+	start := l1
+
+	if start > l && tablets[start-1].LastToken() > tablet.FirstToken() {
+		start = start - 1
+	}
+
+	// find last overlaping range
+	for l2 < r2 {
+		mid := (l2 + r2) / 2
+		if tablets[mid].LastToken() < tablet.LastToken() {
+			l2 = mid + 1
+		} else {
+			r2 = mid
+		}
+	}
+	end := l2
+	if end < r && tablets[end].FirstToken() >= tablet.LastToken() {
+		end = end - 1
+	}
+	if end == len(tablets) {
+		end = end - 1
+	}
+
+	updated_tablets := tablets
+	if start <= end {
+		// Delete elements from index start to end
+		updated_tablets = append(tablets[:start], tablets[end+1:]...)
+	}
+	// Insert tablet element at index start
+	updated_tablets2 := append(updated_tablets[:start], append([]*TabletInfo{tablet}, updated_tablets[start:]...)...)
+	return updated_tablets2
+}
+
+// Search for place in tablets table for token starting from index l to index r
+func findTabletForToken(tablets []*TabletInfo, token token, l int, r int) *TabletInfo {
+	for l < r {
+		var m int
+		if r*l > 0 {
+			m = l + (r-l)/2
+		} else {
+			m = (r + l) / 2
+		}
+		if int64Token(tablets[m].LastToken()).Less(token) {
+			l = m + 1
+		} else {
+			r = m
+		}
+	}
+
+	return tablets[l]
+}
+
 // Polls system.peers at a specific interval to find new hosts
 type ringDescriber struct {
 	session         *Session
 	mu              sync.Mutex
 	prevHosts       []*HostInfo
 	prevPartitioner string
+	// Experimental, this interface and use may change
+	prevTablets []*TabletInfo
 }
 
 // Returns true if we are using system_schema.keyspaces instead of system.schema_keyspaces
@@ -835,6 +974,21 @@ func refreshRing(r *ringDescriber) error {
 
 	r.session.metadata.setPartitioner(partitioner)
 	r.session.policy.SetPartitioner(partitioner)
+
+	return nil
+}
+
+// Experimental, this interface and use may change
+func addTablet(r *ringDescriber, tablet *TabletInfo) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tablets := r.session.getTablets()
+	tablets = addTabletToTabletsList(tablets, tablet)
+
+	r.session.ring.setTablets(tablets)
+	r.session.policy.SetTablets(tablets)
+
 	return nil
 }
 

--- a/integration.sh
+++ b/integration.sh
@@ -28,10 +28,25 @@ function scylla_restart() {
 scylla_restart
 
 readonly clusterSize=1
+readonly multiNodeClusterSize=3
 readonly scylla_liveset="192.168.100.11"
+readonly scylla_tablet_liveset="192.168.100.12"
 readonly cversion="3.11.4"
 readonly proto=4
 readonly args="-gocql.timeout=60s -proto=${proto} -rf=${clusterSize} -clusterSize=${clusterSize} -autowait=2000ms -compressor=snappy -gocql.cversion=${cversion} -cluster=${scylla_liveset}"
+readonly tabletArgs="-gocql.timeout=60s -proto=${proto} -rf=1 -clusterSize=${multiNodeClusterSize} -autowait=2000ms -compressor=snappy -gocql.cversion=${cversion} -multiCluster=${scylla_tablet_liveset}"
 
-echo "==> Running $* tests with args: ${args}"
-go test -timeout=5m -race -tags="$*" ${args} ./...
+if [[ "$*" == *"tablet"* ]];
+then 
+  echo "==> Running tablet tests with args: ${tabletArgs}"
+  go test -timeout=5m -race -tags="tablet" ${tabletArgs} ./...
+fi
+
+TAGS=$*
+TAGS=${TAGS//"tablet"/}
+
+if [ ! -z "$TAGS" ];
+then
+	echo "==> Running ${TAGS} tests with args: ${args}"
+	go test -timeout=5m -race -tags="$TAGS" ${args} ./...
+fi

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -1,3 +1,4 @@
+//go:build !cassandra || scylla
 // +build !cassandra scylla
 
 // Copyright (c) 2015 The gocql Authors. All rights reserved.
@@ -132,6 +133,29 @@ type IndexMetadata struct {
 	Options      map[string]string
 }
 
+// TabletsMetadata holds metadata for tablet list
+// Experimental, this interface and use may change
+type TabletsMetadata struct {
+	Tablets []*TabletMetadata
+}
+
+// TabletMetadata holds metadata for single tablet
+// Experimental, this interface and use may change
+type TabletMetadata struct {
+	KeyspaceName string
+	TableName    string
+	FirstToken   int64
+	LastToken    int64
+	Replicas     []ReplicaMetadata
+}
+
+// TabletMetadata holds metadata for single replica
+// Experimental, this interface and use may change
+type ReplicaMetadata struct {
+	HostId  UUID
+	ShardId int
+}
+
 const (
 	IndexKindCustom = "CUSTOM"
 )
@@ -215,20 +239,24 @@ func columnKindFromSchema(kind string) (ColumnKind, error) {
 	}
 }
 
-// queries the cluster for schema information for a specific keyspace
+// queries the cluster for schema information for a specific keyspace and for tablets
 type schemaDescriber struct {
 	session *Session
 	mu      sync.Mutex
 
-	cache map[string]*KeyspaceMetadata
+	cache        map[string]*KeyspaceMetadata
+
+	// Experimental, this interface and use may change
+	tabletsCache *TabletsMetadata
 }
 
 // creates a session bound schema describer which will query and cache
-// keyspace metadata
+// keyspace metadata and tablets metadata
 func newSchemaDescriber(session *Session) *schemaDescriber {
 	return &schemaDescriber{
-		session: session,
-		cache:   map[string]*KeyspaceMetadata{},
+		session:      session,
+		cache:        map[string]*KeyspaceMetadata{},
+		tabletsCache: &TabletsMetadata{},
 	}
 }
 
@@ -250,6 +278,36 @@ func (s *schemaDescriber) getSchema(keyspaceName string) (*KeyspaceMetadata, err
 	}
 
 	return metadata, nil
+}
+
+// Experimental, this interface and use may change
+func (s *schemaDescriber) getTabletsSchema() *TabletsMetadata {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	metadata := s.tabletsCache
+
+	return metadata
+}
+
+// Experimental, this interface and use may change
+func (s *schemaDescriber) refreshTabletsSchema() {
+	tablets := s.session.getTablets()
+	s.tabletsCache.Tablets = []*TabletMetadata{}
+
+	for _, tablet := range tablets {
+		t := &TabletMetadata{}
+		t.KeyspaceName = tablet.KeyspaceName()
+		t.TableName = tablet.TableName()
+		t.FirstToken = tablet.FirstToken()
+		t.LastToken = tablet.LastToken()
+		t.Replicas = []ReplicaMetadata{}
+		for _, replica := range tablet.Replicas() {
+			t.Replicas = append(t.Replicas, ReplicaMetadata{replica.hostId, replica.shardId})
+		}
+
+		s.tabletsCache.Tablets = append(s.tabletsCache.Tablets, t)
+	}
 }
 
 // clears the already cached keyspace metadata

--- a/query_executor.go
+++ b/query_executor.go
@@ -23,6 +23,8 @@ type ExecutableQuery interface {
 	withContext(context.Context) ExecutableQuery
 
 	RetryableQuery
+
+	GetSession() *Session
 }
 
 type queryExecutor struct {
@@ -123,7 +125,7 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 			continue
 		}
 
-		conn := pool.Pick(selectedHost.Token())
+		conn := pool.Pick(selectedHost.Token(), qry.Keyspace(), qry.Table())
 		if conn == nil {
 			selectedHost = hostIter()
 			continue

--- a/ring.go
+++ b/ring.go
@@ -22,6 +22,9 @@ type ring struct {
 	hostList []*HostInfo
 	pos      uint32
 
+	// Experimental, this interface and use may change
+	tabletList []*TabletInfo
+
 	// TODO: we should store the ring metadata here also.
 }
 
@@ -140,4 +143,12 @@ func (c *clusterMetadata) setPartitioner(partitioner string) {
 		// TODO: update other things now
 		c.partitioner = partitioner
 	}
+}
+
+// Experimental, this interface and use may change
+func (r *ring) setTablets(newTablets []*TabletInfo) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.tabletList = newTablets
 }

--- a/scylla.go
+++ b/scylla.go
@@ -51,7 +51,37 @@ func findCQLProtoExtByName(exts []cqlProtocolExtension, name string) cqlProtocol
 const (
 	lwtAddMetadataMarkKey = "SCYLLA_LWT_ADD_METADATA_MARK"
 	rateLimitError        = "SCYLLA_RATE_LIMIT_ERROR"
+	tabletsRoutingV1      = "TABLETS_ROUTING_V1"
 )
+
+// "tabletsRoutingV1" CQL Protocol Extension.
+// This extension, if enabled (properly negotiated), allows Scylla server
+// to send a tablet information in `custom_payload`.
+//
+// Implements cqlProtocolExtension interface.
+type tabletsRoutingV1Ext struct {
+}
+
+var _ cqlProtocolExtension = &tabletsRoutingV1Ext{}
+
+// Factory function to deserialize and create an `tabletsRoutingV1Ext` instance
+// from SUPPORTED message payload.
+func newTabletsRoutingV1Ext(supported map[string][]string) *tabletsRoutingV1Ext {
+	if _, found := supported[tabletsRoutingV1]; found {
+		return &tabletsRoutingV1Ext{}
+	}
+	return nil
+}
+
+func (ext *tabletsRoutingV1Ext) serialize() map[string]string {
+	return map[string]string{
+		tabletsRoutingV1: "",
+	}
+}
+
+func (ext *tabletsRoutingV1Ext) name() string {
+	return tabletsRoutingV1
+}
 
 // "Rate limit" CQL Protocol Extension.
 // This extension, if enabled (properly negotiated), allows Scylla server
@@ -241,6 +271,11 @@ func parseCQLProtocolExtensions(supported map[string][]string) []cqlProtocolExte
 	rateLimitExt := newRateLimitExt(supported)
 	if rateLimitExt != nil {
 		exts = append(exts, rateLimitExt)
+	}
+
+	tabletsExt := newTabletsRoutingV1Ext(supported)
+	if tabletsExt != nil {
+		exts = append(exts, tabletsExt)
 	}
 
 	return exts

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -24,7 +24,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{{
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(token(nil)) != s.conns[0] {
+		if s.Pick(token(nil), "", "") != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
@@ -33,7 +33,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{{
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(token(nil)) != s.conns[0] {
+		if s.Pick(token(nil), "", "") != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
@@ -42,20 +42,20 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{nil, {
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(token(nil)) != s.conns[1] {
+		if s.Pick(token(nil), "", "") != s.conns[1] {
 			t.Fatal("expected connection")
 		}
-		if s.Pick(token(nil)) != s.conns[1] {
+		if s.Pick(token(nil), "", "") != s.conns[1] {
 			t.Fatal("expected connection")
 		}
 	})
 
 	t.Run("multiple shards no conns", func(t *testing.T) {
 		s.conns = []*Conn{nil, nil}
-		if s.Pick(token(nil)) != nil {
+		if s.Pick(token(nil), "", "") != nil {
 			t.Fatal("expected nil")
 		}
-		if s.Pick(token(nil)) != nil {
+		if s.Pick(token(nil), "", "") != nil {
 			t.Fatal("expected nil")
 		}
 	})
@@ -64,7 +64,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 func hammerConnPicker(t *testing.T, wg *sync.WaitGroup, s *scyllaConnPicker, loops int) {
 	t.Helper()
 	for i := 0; i < loops; i++ {
-		if c := s.Pick(nil); c == nil {
+		if c := s.Pick(nil, "", ""); c == nil {
 			t.Error("unexpected nil")
 		}
 	}
@@ -163,7 +163,7 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 			conns:     []*Conn{nil, mockConn(1)},
 		}
 
-		if s.Pick(token(nil)) == nil {
+		if s.Pick(token(nil), "", "") == nil {
 			t.Fatal("expected connection")
 		}
 	})
@@ -187,7 +187,7 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 				defer wg.Done()
 				for i := 0; i < 3; i++ {
 					select {
-					case connCh <- s.Pick(token(nil)):
+					case connCh <- s.Pick(token(nil), "", ""):
 					case <-ctx.Done():
 					}
 				}

--- a/tablet_integration_test.go
+++ b/tablet_integration_test.go
@@ -1,0 +1,134 @@
+//go:build tablet
+// +build tablet
+
+package gocql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Check if TokenAwareHostPolicy works correctly when using tablets
+func TestTablets(t *testing.T) {
+	cluster := createMultiNodeCluster()
+
+	fallback := RoundRobinHostPolicy()
+	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(fallback)
+
+	session := createSessionFromMultiNodeCluster(cluster, t)
+	defer session.Close()
+
+	if err := createTable(session, fmt.Sprintf(`CREATE TABLE %s.%s (pk int, ck int, v int, PRIMARY KEY (pk, ck));
+	`, "test1", "table1")); err != nil {
+		panic(fmt.Sprintf("unable to create table: %v", err))
+	}
+
+	hosts, _, err := session.hostSource.GetHosts()
+	assertTrue(t, "err == nil", err == nil)
+
+	hostAddresses := []string{}
+	for _, host := range hosts {
+		hostAddresses = append(hostAddresses, host.connectAddress.String())
+	}
+
+	ctx := context.Background()
+
+	i := 0
+	for i < 50 {
+		i = i + 1
+		err = session.Query(`INSERT INTO test1.table1 (pk, ck, v) VALUES (?, ?, ?);`, i, i%5, i%2).WithContext(ctx).Exec()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	i = 0
+	for i < 50 {
+		i = i + 1
+
+		var pk int
+		var ck int
+		var v int
+
+		buf := &bytes.Buffer{}
+		trace := NewTraceWriter(session, buf)
+
+		err = session.Query(`SELECT pk, ck, v FROM test1.table1 WHERE pk = ?;`, i).WithContext(ctx).Consistency(One).Trace(trace).Scan(&pk, &ck, &v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		queriedHosts := 0
+		for _, hostAddress := range hostAddresses {
+			if strings.Contains(buf.String(), hostAddress) {
+				queriedHosts = queriedHosts + 1
+			}
+		}
+
+		assertEqual(t, "queriedHosts", 1, queriedHosts)
+	}
+}
+
+// Check if shard awareness works correctly when using tablets
+func TestTabletsShardAwareness(t *testing.T) {
+	cluster := createMultiNodeCluster()
+
+	fallback := RoundRobinHostPolicy()
+	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(fallback)
+
+	session := createSessionFromMultiNodeCluster(cluster, t)
+	defer session.Close()
+
+	if err := createTable(session, fmt.Sprintf(`CREATE TABLE %s.%s (pk int, ck int, v int, PRIMARY KEY (pk, ck));
+	`, "test1", "table_shard")); err != nil {
+		panic(fmt.Sprintf("unable to create table: %v", err))
+	}
+
+	ctx := context.Background()
+
+	i := 0
+	for i < 50 {
+		i = i + 1
+		err := session.Query(`INSERT INTO test1.table_shard (pk, ck, v) VALUES (?, ?, ?);`, i, i%5, i%2).WithContext(ctx).Exec()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	i = 0
+	for i < 50 {
+		i = i + 1
+
+		var pk int
+		var ck int
+		var v int
+
+		buf := &bytes.Buffer{}
+		trace := NewTraceWriter(session, buf)
+
+		err := session.Query(`SELECT pk, ck, v FROM test1.table_shard WHERE pk = ?;`, i).WithContext(ctx).Consistency(One).Trace(trace).Scan(&pk, &ck, &v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		re := regexp.MustCompile(`\[shard .*\]`)
+
+		shards := re.FindAllString(buf.String(), -1)
+
+		// find duplicates to check how many shards are used
+		allShards := make(map[string]bool)
+		shardList := []string{}
+		for _, item := range shards {
+			if _, value := allShards[item]; !value {
+				allShards[item] = true
+				shardList = append(shardList, item)
+			}
+		}
+
+		assertEqual(t, "shardList", 1, len(shardList))
+	}
+}

--- a/tablet_test.go
+++ b/tablet_test.go
@@ -1,0 +1,375 @@
+//go:build all || unit
+// +build all unit
+
+package gocql
+
+import (
+	"sync"
+	"testing"
+)
+
+var tablets = []*TabletInfo{
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		-7917529027641081857,
+		-6917529027641081857,
+		[]ReplicaInfo{{TimeUUID(), 9}},
+	},
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{{TimeUUID(), 8}},
+	},
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		-4611686018427387905,
+		-2305843009213693953,
+		[]ReplicaInfo{{TimeUUID(), 9}},
+	},
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		-2305843009213693953,
+		-1,
+		[]ReplicaInfo{{TimeUUID(), 8}},
+	},
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		-1,
+		2305843009213693951,
+		[]ReplicaInfo{{TimeUUID(), 3}},
+	},
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		2305843009213693951,
+		4611686018427387903,
+		[]ReplicaInfo{{TimeUUID(), 3}},
+	},
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		4611686018427387903,
+		6917529027641081855,
+		[]ReplicaInfo{{TimeUUID(), 7}},
+	},
+	{
+		sync.RWMutex{},
+		"test1",
+		"table1",
+		6917529027641081855,
+		9223372036854775807,
+		[]ReplicaInfo{{TimeUUID(), 7}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		-7917529027641081857,
+		-6917529027641081857,
+		[]ReplicaInfo{{TimeUUID(), 9}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{{TimeUUID(), 8}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		-4611686018427387905,
+		-2305843009213693953,
+		[]ReplicaInfo{{TimeUUID(), 9}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		-2305843009213693953,
+		-1,
+		[]ReplicaInfo{{TimeUUID(), 8}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		-1,
+		2305843009213693951,
+		[]ReplicaInfo{{TimeUUID(), 3}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		2305843009213693951,
+		4611686018427387903,
+		[]ReplicaInfo{{TimeUUID(), 3}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		4611686018427387903,
+		6917529027641081855,
+		[]ReplicaInfo{{TimeUUID(), 7}},
+	},
+	{
+		sync.RWMutex{},
+		"test2",
+		"table1",
+		6917529027641081855,
+		9223372036854775807,
+		[]ReplicaInfo{{TimeUUID(), 7}},
+	},
+}
+
+func TestFindTablets(t *testing.T) {
+	id, id2 := findTablets(tablets, "test1", "table1")
+	assertEqual(t, "id", 0, id)
+	assertEqual(t, "id2", 7, id2)
+
+	id, id2 = findTablets(tablets, "test2", "table1")
+	assertEqual(t, "id", 8, id)
+	assertEqual(t, "id2", 15, id2)
+
+	id, id2 = findTablets(tablets, "test3", "table1")
+	assertEqual(t, "id", -1, id)
+	assertEqual(t, "id2", -1, id2)
+}
+
+func TestFindTabletForToken(t *testing.T) {
+	tablet := findTabletForToken(tablets, parseInt64Token("0"), 0, 7)
+	assertTrue(t, "tablet.lastToken == 2305843009213693951", tablet.lastToken == 2305843009213693951)
+
+	tablet = findTabletForToken(tablets, parseInt64Token("9223372036854775807"), 0, 7)
+	assertTrue(t, "tablet.lastToken == 9223372036854775807", tablet.lastToken == 9223372036854775807)
+
+	tablet = findTabletForToken(tablets, parseInt64Token("-4611686018427387904"), 0, 7)
+	assertTrue(t, "tablet.lastToken == -2305843009213693953", tablet.lastToken == -2305843009213693953)
+}
+
+func CompareRanges(tablets []*TabletInfo, ranges [][]int64) bool {
+	if len(tablets) != len(ranges) {
+		return false
+	}
+
+	for idx, tablet := range tablets {
+		if tablet.FirstToken() != ranges[idx][0] || tablet.LastToken() != ranges[idx][1] {
+			return false
+		}
+	}
+	return true
+}
+func TestAddTabletToEmptyTablets(t *testing.T) {
+	tablets := []*TabletInfo{}
+
+	tablets = addTabletToTabletsList(tablets, &TabletInfo{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{},
+	})
+
+	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905}}))
+}
+
+func TestAddTabletAtTheBeggining(t *testing.T) {
+	tablets := []*TabletInfo{{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{},
+	}}
+
+	tablets = addTabletToTabletsList(tablets, &TabletInfo{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-8611686018427387905,
+		-7917529027641081857,
+		[]ReplicaInfo{},
+	})
+
+	assertTrue(t, "Token range in tablets table not correct",
+		CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857}, {-6917529027641081857, -4611686018427387905}}))
+}
+
+func TestAddTabletAtTheEnd(t *testing.T) {
+	tablets := []*TabletInfo{{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{},
+	}}
+
+	tablets = addTabletToTabletsList(tablets, &TabletInfo{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-1,
+		2305843009213693951,
+		[]ReplicaInfo{},
+	})
+
+	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
+		{-1, 2305843009213693951}}))
+}
+
+func TestAddTabletInTheMiddle(t *testing.T) {
+	tablets := []*TabletInfo{{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{},
+	}, {
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-1,
+		2305843009213693951,
+		[]ReplicaInfo{},
+	}}
+
+	tablets = addTabletToTabletsList(tablets, &TabletInfo{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-4611686018427387905,
+		-2305843009213693953,
+		[]ReplicaInfo{},
+	})
+
+	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
+		{-4611686018427387905, -2305843009213693953},
+		{-1, 2305843009213693951}}))
+}
+
+func TestAddTabletIntersecting(t *testing.T) {
+	tablets := []*TabletInfo{{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{},
+	}, {
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-4611686018427387905,
+		-2305843009213693953,
+		[]ReplicaInfo{},
+	}, {
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-2305843009213693953,
+		-1,
+		[]ReplicaInfo{},
+	}, {
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-1,
+		2305843009213693951,
+		[]ReplicaInfo{},
+	}}
+
+	tablets = addTabletToTabletsList(tablets, &TabletInfo{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-3611686018427387905,
+		-6,
+		[]ReplicaInfo{},
+	})
+
+	assertTrue(t, "Token range in tablets table not correct",
+		CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
+			{-3611686018427387905, -6},
+			{-1, 2305843009213693951}}))
+}
+
+func TestAddTabletIntersectingWithFirst(t *testing.T) {
+	tablets := []*TabletInfo{{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-8611686018427387905,
+		-7917529027641081857,
+		[]ReplicaInfo{},
+	}, {
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{},
+	}}
+
+	tablets = addTabletToTabletsList(tablets, &TabletInfo{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-8011686018427387905,
+		-7987529027641081857,
+		[]ReplicaInfo{},
+	})
+
+	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8011686018427387905, -7987529027641081857},
+		{-6917529027641081857, -4611686018427387905}}))
+}
+
+func TestAddTabletIntersectingWithLast(t *testing.T) {
+	tablets := []*TabletInfo{{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-8611686018427387905,
+		-7917529027641081857,
+		[]ReplicaInfo{},
+	}, {
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-6917529027641081857,
+		-4611686018427387905,
+		[]ReplicaInfo{},
+	}}
+
+	tablets = addTabletToTabletsList(tablets, &TabletInfo{
+		sync.RWMutex{},
+		"test_ks",
+		"test_tb",
+		-5011686018427387905,
+		-2987529027641081857,
+		[]ReplicaInfo{},
+	})
+
+	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857},
+		{-5011686018427387905, -2987529027641081857}}))
+}


### PR DESCRIPTION
This PR introduces changes to the driver that are necessary for shard-awareness and token-awareness to work effectively with the tablets.

Now if driver send the request to the wrong node/shard it will get the correct tablet information from Scylla in `custom_payload`. It uses this information to obtain target replicas and shard numbers for tables managed by tablet replication. 

I also added parsing `TABLETS_ROUTING_V1` extension. In order for Scylla to send the tablet info, the driver must tell the database during connection handshake that it is able to interpret it. It was implemented similarly to the already-present LWT optimization extension negotiation.

The metadata for tablets are provided to the user.

To test this change I created both integration and unit tests.

Fixes: #155


 