### PR TITLE
Retract tags taken by mistake from kiwicom/gocql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,11 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+retract (
+    v1.8.0  // tag from kiwicom/gocql added by mistake to scylladb/gocql
+    v1.8.1  // tag from kiwicom/gocql added by mistake to scylladb/gocql
+    v1.9.0  // tag from kiwicom/gocql added by mistake to scylladb/gocql
+    v1.10.0 // tag from kiwicom/gocql added by mistake to scylladb/gocql
+)
+
 go 1.13


### PR DESCRIPTION
Retract `v1.8.0`, `v1.8.1`, `v1.9.0`, `v1.10.0` - tags mistakenly taken from `kiwicom/gocql`, which are not actual releases made in `scylladb/gocql`.

Even though those tags were removed from `scylladb/gocql` (see #110), some Go module mirrors have already fetched them:

```
$ go list -m --versions github.com/scylladb/gocql
github.com/scylladb/gocql v1.0.0 v1.0.1 v1.0.2 v1.0.3 v1.0.4 v1.1.0 v1.2.0 v1.2.1 v1.3.0-rc.1 v1.3.0 v1.3.1 v1.3.2 v1.3.3 v1.3.4 v1.4.0 v1.4.1 v1.4.2 v1.4.3 v1.5.0 v1.6.0 v1.7.0 v1.7.1 v1.7.2 v1.7.3 v1.8.0 v1.8.1 v1.9.0 v1.10.0
```

As we can't control those mirrors, they will always return an incorrect version of gocql, even if we release "new" `v1.9.0`, `v1.10.0`.

Subsequent to merging of this patch, version `v1.11.0` of `scylladb/gocql` will be released.

Fixes #132 