### PR TITLE
Add host failure handling

### DIFF
--- a/control.go
+++ b/control.go
@@ -401,6 +401,9 @@ func (c *controlConn) attemptReconnectToAnyOfHosts(hosts []*HostInfo) (*Conn, er
 	for _, host := range hosts {
 		conn, err = c.session.connect(c.session.ctx, host, c)
 		if err != nil {
+			if c.session.cfg.ConvictionPolicy.AddFailure(err, host) {
+				c.session.handleNodeDown(host.ConnectAddress(), host.Port())
+			}
 			c.session.logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
 			continue
 		}


### PR DESCRIPTION
Previously when restarting node with increased assigned resources happen there was a panic due to wrong number of shards.

Added host failure handling to fix that.

Fixes: #145 