### PR TITLE
Mark node as down if unable to dial control conn

### DIFF
--- a/control.go
+++ b/control.go
@@ -401,6 +401,9 @@ func (c *controlConn) attemptReconnectToAnyOfHosts(hosts []*HostInfo) (*Conn, er
 	for _, host := range hosts {
 		conn, err = c.session.connect(c.session.ctx, host, c)
 		if err != nil {
+			if c.session.cfg.ConvictionPolicy.AddFailure(err, host) {
+				c.session.handleNodeDown(host.ConnectAddress(), host.Port())
+			}
 			c.session.logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
 			continue
 		}


### PR DESCRIPTION
Previously if connection to the node failed, information about that was logged, but it was not handled in any other way. The node down handling has had been there, but it has had been deleted in https://github.com/gocql/gocql/commit/56d43d598ab6e840b2a49c9e1bedb1c8210f3472.
If during restart the resources assigned to node change, the driver does not update this. That could lead to outdated information about shards.
In Scylla without this when restarting node with increased assigned resources happen, there was a panic due to wrong number of shards.
I added previously removed marking node as down.

Fixes: https://github.com/scylladb/gocql/issues/145