### PR TITLE
HostSelectionPolicy: add Reset method, Session.Close: call HostSelect…

### DIFF
--- a/session.go
+++ b/session.go
@@ -522,6 +522,10 @@ func (s *Session) Close() {
 		s.cancel()
 	}
 
+	if s.policy != nil {
+		s.policy.Reset()
+	}
+
 	s.sessionStateMu.Lock()
 	s.isClosed = true
 	s.sessionStateMu.Unlock()


### PR DESCRIPTION
I'm not entirely sure this is even the right idea but in some cases panic in our application (shared policy) caused us inconvenience. In my opinion if one session is closed, another session can start working with host policy (because the condition is fulfilled that there is only one session working with token aware host policy).

I propose to consider this request)
