### PR TITLE
Add LOAD_BALANCING_POLICY_SLOW_AVOIDANCE funtionality

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -211,6 +211,17 @@ func (p *policyConnPool) SetHosts(hosts []*HostInfo) {
 	}
 }
 
+func (p *policyConnPool) InFlight() int {
+	p.mu.RLock()
+	count := 0
+	for _, pool := range p.hostConnPools {
+		count += pool.InFlight()
+	}
+	p.mu.RUnlock()
+
+	return count
+}
+
 func (p *policyConnPool) Size() int {
 	p.mu.RLock()
 	count := 0
@@ -345,6 +356,15 @@ func (pool *hostConnPool) Size() int {
 	defer pool.mu.RUnlock()
 
 	size, _ := pool.connPicker.Size()
+	return size
+}
+
+// Size returns the number of connections currently active in the pool
+func (pool *hostConnPool) InFlight() int {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	size := pool.connPicker.InFlight()
 	return size
 }
 

--- a/connpicker.go
+++ b/connpicker.go
@@ -10,6 +10,7 @@ type ConnPicker interface {
 	Pick(token, string, string) *Conn
 	Put(*Conn)
 	Remove(conn *Conn)
+	InFlight() int
 	Size() (int, int)
 	Close()
 
@@ -58,6 +59,11 @@ func (p *defaultConnPicker) Close() {
 			conn.Close()
 		}
 	}
+}
+
+func (p *defaultConnPicker) InFlight() int {
+	size := len(p.conns)
+	return size
 }
 
 func (p *defaultConnPicker) Size() (int, int) {
@@ -112,6 +118,10 @@ func (nopConnPicker) Put(*Conn) {
 }
 
 func (nopConnPicker) Remove(conn *Conn) {
+}
+
+func (nopConnPicker) InFlight() int {
+	return 0
 }
 
 func (nopConnPicker) Size() (int, int) {

--- a/host_source.go
+++ b/host_source.go
@@ -409,6 +409,11 @@ func (h *HostInfo) IsUp() bool {
 	return h != nil && h.State() == NodeUp
 }
 
+func (h *HostInfo) IsBusy(s *Session) bool {
+	pool, ok := s.pool.getPool(h)
+	return ok && h != nil && pool.InFlight() >= MAX_IN_FLIGHT_THRESHOLD
+}
+
 func (h *HostInfo) HostnameAndPort() string {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -145,3 +145,7 @@ func (s *IDGenerator) Clear(stream int) (inuse bool) {
 func (s *IDGenerator) Available() int {
 	return s.NumStreams - int(atomic.LoadInt32(&s.inuseStreams)) - 1
 }
+
+func (s *IDGenerator) InUse() int {
+	return int(atomic.LoadInt32(&s.inuseStreams))
+}

--- a/scylla.go
+++ b/scylla.go
@@ -544,6 +544,16 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
 	}
 }
 
+func (p *scyllaConnPicker) InFlight() int {
+	result := 0
+	for _, conn := range p.conns {
+		if conn != nil {
+			result = result + (conn.streams.InUse())
+		}
+	}
+	return result
+}
+
 func (p *scyllaConnPicker) Size() (int, int) {
 	return p.nrConns, p.nrShards - p.nrConns
 }


### PR DESCRIPTION
The java driver has the feature to automatically avoid slow replicas by doing simple heuristics (https://github.com/scylladb/java-driver/blob/scylla-4.x/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java#L104). This is one of the key feature to have a stable latency.

This PR adds additional field in tokenAwareHostPolicy to control if the feature is enabled and what is the maximum in flight threshold.

If feature is enabled driver sorts the replicas to first try those with less than specified maximum in flight requests.

Fixes: #154