### PR TITLE
Send heartbeat OPTIONS message less frequent and enable keep alive

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -117,7 +117,7 @@ type ClusterConfig struct {
 	// Default reconnection policy to use for reconnecting before trying to mark host as down.
 	ReconnectionPolicy ReconnectionPolicy
 
-	// The keepalive period to use, enabled if > 0 (default: 0)
+	// The keepalive period to use, enabled if > 0 (default: 15 seconds)
 	// SocketKeepalive is used to set up the default dialer and is ignored if Dialer or HostDialer is provided.
 	SocketKeepalive time.Duration
 
@@ -290,6 +290,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		ReconnectInterval:      60 * time.Second,
 		ConvictionPolicy:       &SimpleConvictionPolicy{},
 		ReconnectionPolicy:     &ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second},
+		SocketKeepalive:        15 * time.Second,
 		WriteCoalesceWaitTime:  200 * time.Microsecond,
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -680,7 +680,7 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		switch resp.(type) {
 		case *supportedFrame:
 			// Everything ok
-			sleepTime = 5 * time.Second
+			sleepTime = 30 * time.Second
 			failures = 0
 		case error:
 			// TODO: should we do something here?

--- a/control.go
+++ b/control.go
@@ -87,7 +87,7 @@ func (c *controlConn) heartBeat() {
 		switch resp.(type) {
 		case *supportedFrame:
 			// Everything ok
-			sleepTime = 5 * time.Second
+			sleepTime = 30 * time.Second
 			continue
 		case error:
 			goto reconn


### PR DESCRIPTION
Now we are sending OPTIONS message on every connection every 5 seconds.

This PR changes that to 30 seconds (this is the number used in python-driver - https://github.com/scylladb/python-driver/blob/7cdc1ca25ffa2194a0772e46ccd89645f8514c1b/cassandra/cluster.py#L893) and enables the keepalive - with 15s by default (matches Golang's default).

Fixes: #162 