### PR TITLE
Use `newFramerWithExts` instead of `newFramer` to utilize protocol extensions

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -769,7 +769,7 @@ func (c *Conn) recv(ctx context.Context) error {
 		panic(fmt.Sprintf("call has incorrect streamID: got %d expected %d", call.streamID, head.stream))
 	}
 
-	framer := newFramer(c.compressor, c.version)
+	framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts)
 
 	err = framer.readFrame(c, &head)
 	if err != nil {


### PR DESCRIPTION
When LWT optimization was implemented in gocql (https://github.com/scylladb/gocql/pull/49), all `newFramer` calls were replaced with `newFramerWithExts` calls.

Previously, during the upstream merging the code using `newFramer` was added (https://github.com/scylladb/gocql/pull/109) and it was forgotten to replace it with `newFramerWithExts`. That way, the `flagLWT` field was set to `0` by default, causing the driver to consider every query executed as a LWT query.

The issue was not immediately noticed because the only difference in behavior occurs when we want to use `ShuffleReplicas()` in `TokenAwareHostPolicy`.

This PR fixes the issue by replacing `newFramer` with `newFramerWithExts`.

Fixes: #174 