### PR TITLE
Make public interfaces implementable

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -329,7 +329,7 @@ func newHostConnPool(session *Session, host *HostInfo, port, size int,
 }
 
 // Pick a connection from this connection pool for the given query.
-func (pool *hostConnPool) Pick(token token, keyspace string, table string) *Conn {
+func (pool *hostConnPool) Pick(token Token, keyspace string, table string) *Conn {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 

--- a/connpicker.go
+++ b/connpicker.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ConnPicker interface {
-	Pick(token, string, string) *Conn
+	Pick(Token, string, string) *Conn
 	Put(*Conn)
 	Remove(conn *Conn)
 	InFlight() int
@@ -71,7 +71,7 @@ func (p *defaultConnPicker) Size() (int, int) {
 	return size, p.size - size
 }
 
-func (p *defaultConnPicker) Pick(token, string, string) *Conn {
+func (p *defaultConnPicker) Pick(Token, string, string) *Conn {
 	pos := int(atomic.AddUint32(&p.pos, 1) - 1)
 	size := len(p.conns)
 
@@ -110,7 +110,7 @@ func (*defaultConnPicker) NextShard() (shardID, nrShards int) {
 // to the point where we have first connection.
 type nopConnPicker struct{}
 
-func (nopConnPicker) Pick(token, string, string) *Conn {
+func (nopConnPicker) Pick(Token, string, string) *Conn {
 	return nil
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -435,10 +435,10 @@ func (h *HostInfo) Hostname() string {
 }
 
 func (h *HostInfo) ConnectAddressAndPort() string {
-        h.mu.Lock()
-        defer h.mu.Unlock()
-        addr, _ := h.connectAddressLocked()
-        return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	addr, _ := h.connectAddressLocked()
+	return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
 }
 
 func (h *HostInfo) String() string {
@@ -596,7 +596,7 @@ func addTabletToTabletsList(tablets []*TabletInfo, tablet *TabletInfo) []*Tablet
 }
 
 // Search for place in tablets table for token starting from index l to index r
-func findTabletForToken(tablets []*TabletInfo, token token, l int, r int) *TabletInfo {
+func findTabletForToken(tablets []*TabletInfo, token Token, l int, r int) *TabletInfo {
 	for l < r {
 		var m int
 		if r*l > 0 {

--- a/host_source.go
+++ b/host_source.go
@@ -435,10 +435,10 @@ func (h *HostInfo) Hostname() string {
 }
 
 func (h *HostInfo) ConnectAddressAndPort() string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	addr, _ := h.connectAddressLocked()
-	return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
+        h.mu.Lock()
+        defer h.mu.Unlock()
+        addr, _ := h.connectAddressLocked()
+        return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
 }
 
 func (h *HostInfo) String() string {

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -244,7 +244,7 @@ type schemaDescriber struct {
 	session *Session
 	mu      sync.Mutex
 
-	cache        map[string]*KeyspaceMetadata
+	cache map[string]*KeyspaceMetadata
 
 	// Experimental, this interface and use may change
 	tabletsCache *TabletsMetadata

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -244,7 +244,7 @@ type schemaDescriber struct {
 	session *Session
 	mu      sync.Mutex
 
-	cache map[string]*KeyspaceMetadata
+	cache        map[string]*KeyspaceMetadata
 
 	// Experimental, this interface and use may change
 	tabletsCache *TabletsMetadata

--- a/policies.go
+++ b/policies.go
@@ -323,20 +323,20 @@ type HostSelectionPolicy interface {
 // selection policy.
 type SelectedHost interface {
 	Info() *HostInfo
-	Token() token
+	Token() Token
 	Mark(error)
 }
 
 type selectedHost struct {
 	info  *HostInfo
-	token token
+	token Token
 }
 
 func (host selectedHost) Info() *HostInfo {
 	return host.info
 }
 
-func (host selectedHost) Token() token {
+func (host selectedHost) Token() Token {
 	return host.token
 }
 
@@ -928,7 +928,7 @@ func (host selectedHostPoolHost) Info() *HostInfo {
 	return host.info
 }
 
-func (host selectedHostPoolHost) Token() token {
+func (host selectedHostPoolHost) Token() Token {
 	return nil
 }
 

--- a/query_executor.go
+++ b/query_executor.go
@@ -18,7 +18,7 @@ type ExecutableQuery interface {
 	Table() string
 	IsIdempotent() bool
 	IsLWT() bool
-	GetCustomPartitioner() partitioner
+	GetCustomPartitioner() Partitioner
 
 	withContext(context.Context) ExecutableQuery
 

--- a/scylla.go
+++ b/scylla.go
@@ -353,7 +353,7 @@ func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
 	}
 }
 
-func (p *scyllaConnPicker) Pick(t token, keyspace string, table string) *Conn {
+func (p *scyllaConnPicker) Pick(t Token, keyspace string, table string) *Conn {
 	if len(p.conns) == 0 {
 		return nil
 	}
@@ -378,13 +378,13 @@ func (p *scyllaConnPicker) Pick(t token, keyspace string, table string) *Conn {
 		conn.mu.Lock()
 		if conn.tabletsRoutingV1 {
 			tablets := conn.session.getTablets()
-	
+
 			// Search for tablets with Keyspace and Table from the Query
 			l, r := findTablets(tablets, keyspace, table)
-	
+
 			if l != -1 {
 				tablet := findTabletForToken(tablets, mmt, l, r)
-	
+
 				for _, replica := range tablet.replicas {
 					if replica.hostId.String() == p.hostId {
 						idx = replica.shardId
@@ -396,7 +396,7 @@ func (p *scyllaConnPicker) Pick(t token, keyspace string, table string) *Conn {
 
 		break
 	}
-	
+
 	if idx == -1 {
 		idx = p.shardOf(mmt)
 	}
@@ -415,7 +415,7 @@ func (p *scyllaConnPicker) maybeReplaceWithLessBusyConnection(c *Conn) *Conn {
 		return c
 	}
 	alternative := p.leastBusyConn()
-	if alternative == nil || alternative.AvailableStreams() * 120 > c.AvailableStreams() * 100 {
+	if alternative == nil || alternative.AvailableStreams()*120 > c.AvailableStreams()*100 {
 		return c
 	} else {
 		return alternative
@@ -423,7 +423,7 @@ func (p *scyllaConnPicker) maybeReplaceWithLessBusyConnection(c *Conn) *Conn {
 }
 
 func isHeavyLoaded(c *Conn) bool {
-    return c.streams.NumStreams / 2 > c.AvailableStreams();
+	return c.streams.NumStreams/2 > c.AvailableStreams()
 }
 
 func (p *scyllaConnPicker) leastBusyConn() *Conn {

--- a/scylla.go
+++ b/scylla.go
@@ -378,13 +378,13 @@ func (p *scyllaConnPicker) Pick(t Token, keyspace string, table string) *Conn {
 		conn.mu.Lock()
 		if conn.tabletsRoutingV1 {
 			tablets := conn.session.getTablets()
-
+	
 			// Search for tablets with Keyspace and Table from the Query
 			l, r := findTablets(tablets, keyspace, table)
-
+	
 			if l != -1 {
 				tablet := findTabletForToken(tablets, mmt, l, r)
-
+	
 				for _, replica := range tablet.replicas {
 					if replica.hostId.String() == p.hostId {
 						idx = replica.shardId
@@ -396,7 +396,7 @@ func (p *scyllaConnPicker) Pick(t Token, keyspace string, table string) *Conn {
 
 		break
 	}
-
+	
 	if idx == -1 {
 		idx = p.shardOf(mmt)
 	}
@@ -415,7 +415,7 @@ func (p *scyllaConnPicker) maybeReplaceWithLessBusyConnection(c *Conn) *Conn {
 		return c
 	}
 	alternative := p.leastBusyConn()
-	if alternative == nil || alternative.AvailableStreams()*120 > c.AvailableStreams()*100 {
+	if alternative == nil || alternative.AvailableStreams() * 120 > c.AvailableStreams() * 100 {
 		return c
 	} else {
 		return alternative
@@ -423,7 +423,7 @@ func (p *scyllaConnPicker) maybeReplaceWithLessBusyConnection(c *Conn) *Conn {
 }
 
 func isHeavyLoaded(c *Conn) bool {
-	return c.streams.NumStreams/2 > c.AvailableStreams()
+    return c.streams.NumStreams / 2 > c.AvailableStreams();
 }
 
 func (p *scyllaConnPicker) leastBusyConn() *Conn {
@@ -860,7 +860,7 @@ func ScyllaGetSourcePort(ctx context.Context) uint16 {
 
 // Returns a partitioner specific to the table, or "nil"
 // if the cluster-global partitioner should be used
-func scyllaGetTablePartitioner(session *Session, keyspaceName, tableName string) (partitioner, error) {
+func scyllaGetTablePartitioner(session *Session, keyspaceName, tableName string) (Partitioner, error) {
 	isCdc, err := scyllaIsCdcTable(session, keyspaceName, tableName)
 	if err != nil {
 		return nil, err

--- a/scylla_cdc.go
+++ b/scylla_cdc.go
@@ -30,7 +30,7 @@ func (p scyllaCDCPartitioner) Name() string {
 	return scyllaCDCPartitionerName
 }
 
-func (p scyllaCDCPartitioner) Hash(partitionKey []byte) token {
+func (p scyllaCDCPartitioner) Hash(partitionKey []byte) Token {
 	if len(partitionKey) < 8 {
 		// The key is too short to extract any sensible token,
 		// so return the min token instead
@@ -68,7 +68,7 @@ func (p scyllaCDCPartitioner) Hash(partitionKey []byte) token {
 	return int64Token(upperQword)
 }
 
-func (p scyllaCDCPartitioner) ParseString(str string) token {
+func (p scyllaCDCPartitioner) ParseString(str string) Token {
 	return parseInt64Token(str)
 }
 

--- a/scylla_cdc.go
+++ b/scylla_cdc.go
@@ -24,7 +24,7 @@ const (
 
 type scyllaCDCPartitioner struct{}
 
-var _ partitioner = scyllaCDCPartitioner{}
+var _ Partitioner = scyllaCDCPartitioner{}
 
 func (p scyllaCDCPartitioner) Name() string {
 	return scyllaCDCPartitionerName

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -24,7 +24,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{{
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(token(nil), "", "") != s.conns[0] {
+		if s.Pick(Token(nil), "", "") != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
@@ -33,7 +33,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{{
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(token(nil), "", "") != s.conns[0] {
+		if s.Pick(Token(nil), "", "") != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
@@ -42,20 +42,20 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{nil, {
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(token(nil), "", "") != s.conns[1] {
+		if s.Pick(Token(nil), "", "") != s.conns[1] {
 			t.Fatal("expected connection")
 		}
-		if s.Pick(token(nil), "", "") != s.conns[1] {
+		if s.Pick(Token(nil), "", "") != s.conns[1] {
 			t.Fatal("expected connection")
 		}
 	})
 
 	t.Run("multiple shards no conns", func(t *testing.T) {
 		s.conns = []*Conn{nil, nil}
-		if s.Pick(token(nil), "", "") != nil {
+		if s.Pick(Token(nil), "", "") != nil {
 			t.Fatal("expected nil")
 		}
-		if s.Pick(token(nil), "", "") != nil {
+		if s.Pick(Token(nil), "", "") != nil {
 			t.Fatal("expected nil")
 		}
 	})
@@ -163,7 +163,7 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 			conns:     []*Conn{nil, mockConn(1)},
 		}
 
-		if s.Pick(token(nil), "", "") == nil {
+		if s.Pick(Token(nil), "", "") == nil {
 			t.Fatal("expected connection")
 		}
 	})
@@ -187,7 +187,7 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 				defer wg.Done()
 				for i := 0; i < 3; i++ {
 					select {
-					case connCh <- s.Pick(token(nil), "", ""):
+					case connCh <- s.Pick(Token(nil), "", ""):
 					case <-ctx.Done():
 					}
 				}

--- a/session.go
+++ b/session.go
@@ -2171,10 +2171,10 @@ type routingKeyInfoLRU struct {
 }
 
 type routingKeyInfo struct {
-	indexes  []int
-	types    []TypeInfo
-	keyspace string
-	table    string
+	indexes     []int
+	types       []TypeInfo
+	keyspace    string
+	table       string
 	lwt         bool
 	partitioner partitioner
 }

--- a/session.go
+++ b/session.go
@@ -986,7 +986,7 @@ type queryRoutingInfo struct {
 	lwt bool
 
 	// If not nil, represents a custom partitioner for the table.
-	partitioner partitioner
+	partitioner Partitioner
 
 	keyspace string
 
@@ -999,7 +999,7 @@ func (qri *queryRoutingInfo) isLWT() bool {
 	return qri.lwt
 }
 
-func (qri *queryRoutingInfo) getPartitioner() partitioner {
+func (qri *queryRoutingInfo) getPartitioner() Partitioner {
 	qri.mu.RLock()
 	defer qri.mu.RUnlock()
 	return qri.partitioner
@@ -1310,7 +1310,7 @@ func (q *Query) IsLWT() bool {
 	return q.routingInfo.isLWT()
 }
 
-func (q *Query) GetCustomPartitioner() partitioner {
+func (q *Query) GetCustomPartitioner() Partitioner {
 	return q.routingInfo.getPartitioner()
 }
 
@@ -1933,7 +1933,7 @@ func (b *Batch) IsLWT() bool {
 	return b.routingInfo.isLWT()
 }
 
-func (b *Batch) GetCustomPartitioner() partitioner {
+func (b *Batch) GetCustomPartitioner() Partitioner {
 	return b.routingInfo.getPartitioner()
 }
 
@@ -2171,12 +2171,12 @@ type routingKeyInfoLRU struct {
 }
 
 type routingKeyInfo struct {
-	indexes     []int
-	types       []TypeInfo
-	keyspace    string
-	table       string
+	indexes  []int
+	types    []TypeInfo
+	keyspace string
+	table    string
 	lwt         bool
-	partitioner partitioner
+	partitioner Partitioner
 }
 
 func (r *routingKeyInfo) String() string {

--- a/token.go
+++ b/token.go
@@ -17,7 +17,7 @@ import (
 )
 
 // a token partitioner
-type partitioner interface {
+type Partitioner interface {
 	Name() string
 	Hash([]byte) Token
 	ParseString(string) Token
@@ -135,7 +135,7 @@ func (ht hostToken) String() string {
 
 // a data structure for organizing the relationship between tokens and hosts
 type tokenRing struct {
-	partitioner partitioner
+	partitioner Partitioner
 
 	// tokens map token range to primary replica.
 	// The elements in tokens are sorted by token ascending.

--- a/token_test.go
+++ b/token_test.go
@@ -133,7 +133,7 @@ func TestRandomToken(t *testing.T) {
 type intToken int
 
 func (i intToken) String() string        { return strconv.Itoa(int(i)) }
-func (i intToken) Less(token token) bool { return i < token.(intToken) }
+func (i intToken) Less(token Token) bool { return i < token.(intToken) }
 
 // Test of the token ring implementation based on example at the start of this
 // page of documentation:

--- a/topology.go
+++ b/topology.go
@@ -9,7 +9,7 @@ import (
 
 type hostTokens struct {
 	// token is end (inclusive) of token range these hosts belong to
-	token token
+	token Token
 	hosts []*HostInfo
 }
 
@@ -24,7 +24,7 @@ func (h tokenRingReplicas) Less(i, j int) bool { return h[i].token.Less(h[j].tok
 func (h tokenRingReplicas) Len() int           { return len(h) }
 func (h tokenRingReplicas) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
 
-func (h tokenRingReplicas) replicasFor(t token) *hostTokens {
+func (h tokenRingReplicas) replicasFor(t Token) *hostTokens {
 	if len(h) == 0 {
 		return nil
 	}


### PR DESCRIPTION
currently private interface `token` directly or indirectly present in lot's of interfaces and therefore makes them unimplementable: `SelectedHost`, `ExecutableQuery`, `HostSelectionPolicy`, `NextHost`

To fix it we need to make all parts of interfaces be public
Closes #183 