### PR TITLE
Bump scylla version to 5.4.6 and use fixed version for all of the nodes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env:
-      SCYLLA_IMAGE: scylladb/scylla:5.2.9
+      SCYLLA_IMAGE: scylladb/scylla:5.4.6
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       timeout: 5s
       retries: 18
   node_2:
-    image: scylladb/scylla-nightly
+    image: scylladb/scylla-nightly:6.0.0-rc2-0.20240602.cbf47319c1f7
     command: |
       --experimental-features consistent-topology-changes
       --experimental-features tablets
@@ -49,7 +49,7 @@ services:
       timeout: 5s
       retries: 18
   node_3:
-    image: scylladb/scylla-nightly
+    image: scylladb/scylla-nightly:6.0.0-rc2-0.20240602.cbf47319c1f7
     command: |
       --experimental-features consistent-topology-changes
       --experimental-features tablets
@@ -68,7 +68,7 @@ services:
       node_2:
         condition: service_healthy
   node_4:
-    image: scylladb/scylla-nightly
+    image: scylladb/scylla-nightly:6.0.0-rc2-0.20240602.cbf47319c1f7
     command: |
       --experimental-features consistent-topology-changes
       --experimental-features tablets

--- a/testdata/config/scylla.yaml
+++ b/testdata/config/scylla.yaml
@@ -8,3 +8,5 @@ client_encryption_options:
   keyfile: /etc/scylla/db.key
   truststore: /etc/scylla/ca.crt
   require_client_auth: true
+# when using 5.4.x we have to specify force_schema_commit_log option
+force_schema_commit_log: true


### PR DESCRIPTION
Previously scylla integration tests used scylla 5.2.9 and tablet tests used `scylladb/scylla-nightly`.

This PR changes scylla version to `scylladb/scylla:5.4.6` for node used to integration test and to fixed version of scylla-nightly for tablet tests.