### PR TITLE
Revert "Print out logs of failed container"

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -12,7 +12,7 @@ function scylla_up() {
 
   echo "==> Running Scylla ${SCYLLA_IMAGE}"
   docker pull ${SCYLLA_IMAGE}
-  docker compose up -d --wait || docker compose ps --format json | jq -M 'select(.Health == "unhealthy") | .Service' | xargs docker compose logs && exit 1
+  docker compose up -d --wait
 }
 
 function scylla_down() {


### PR DESCRIPTION
Reverts scylladb/gocql#188

This change not only prints out the logs if container is unhealthy but also exits and manage to not run the tests when there is nothing wrong with the containers. 