### PR TITLE
Remove locks for tablets flag on Conn

### DIFF
--- a/scylla.go
+++ b/scylla.go
@@ -375,8 +375,7 @@ func (p *scyllaConnPicker) Pick(t Token, keyspace string, table string) *Conn {
 			continue
 		}
 
-		conn.mu.Lock()
-		if conn.tabletsRoutingV1 {
+		if conn.isTabletSupported() {
 			tablets := conn.session.getTablets()
 
 			// Search for tablets with Keyspace and Table from the Query
@@ -392,7 +391,6 @@ func (p *scyllaConnPicker) Pick(t Token, keyspace string, table string) *Conn {
 				}
 			}
 		}
-		conn.mu.Unlock()
 
 		break
 	}

--- a/session.go
+++ b/session.go
@@ -230,7 +230,7 @@ func (s *Session) init() error {
 			return err
 		}
 		s.control.getConn().conn.mu.Lock()
-		s.tabletsRoutingV1 = s.control.getConn().conn.tabletsRoutingV1
+		s.tabletsRoutingV1 = s.control.getConn().conn.isTabletSupported()
 		s.control.getConn().conn.mu.Unlock()
 
 		if !s.cfg.DisableInitialHostLookup {


### PR DESCRIPTION
Removes unnecessary `Conn.mu` locking on accessing `tabletsRoutingV1` flag.
`Conn.mu` is overused, less it is used less contention is yielded along with more performance. 