### PR TITLE
Add the datacenter name validation if provided

### DIFF
--- a/policies_integration_test.go
+++ b/policies_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration && scylla
+// +build integration,scylla
+
+package gocql
+
+import (
+	"testing"
+)
+
+// Check if session fail to start if DC name provided in the policy is wrong
+func TestDCValidationTokenAware(t *testing.T) {
+	cluster := createCluster()
+
+	fallback := DCAwareRoundRobinPolicy("WRONG_DC")
+	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(fallback)
+
+	_, err := cluster.CreateSession()
+	if err == nil {
+		t.Fatal("createSession was expected to fail with wrong DC name provided.")
+	}
+}
+
+func TestDCValidationDCAware(t *testing.T) {
+	cluster := createCluster()
+	cluster.PoolConfig.HostSelectionPolicy = DCAwareRoundRobinPolicy("WRONG_DC")
+
+	_, err := cluster.CreateSession()
+	if err == nil {
+		t.Fatal("createSession was expected to fail with wrong DC name provided.")
+	}
+}
+
+func TestDCValidationRackAware(t *testing.T) {
+	cluster := createCluster()
+	cluster.PoolConfig.HostSelectionPolicy = RackAwareRoundRobinPolicy("WRONG_DC", "RACK")
+
+	_, err := cluster.CreateSession()
+	if err == nil {
+		t.Fatal("createSession was expected to fail with wrong DC name provided.")
+	}
+}

--- a/session.go
+++ b/session.go
@@ -197,6 +197,10 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		}
 	}
 
+	if s.policy.IsOperational(s) != nil {
+		return nil, fmt.Errorf("gocql: unable to create session: %v", err)
+	}
+
 	return s, nil
 }
 


### PR DESCRIPTION
Previously there was no check if DC name provided in the policy (DCAware and RackAware) is correct. That could lead to e.g. making routing decisions based on the wrong DC name.

This PR introduces failing to connect if DC name is different in the topology than the one the user entered.

Fixes: #205 