### PR TITLE
Do not choose less busy connection if query is LWT

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -329,7 +329,7 @@ func newHostConnPool(session *Session, host *HostInfo, port, size int,
 }
 
 // Pick a connection from this connection pool for the given query.
-func (pool *hostConnPool) Pick(token Token, keyspace string, table string) *Conn {
+func (pool *hostConnPool) Pick(token Token, qry ExecutableQuery) *Conn {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 
@@ -347,7 +347,7 @@ func (pool *hostConnPool) Pick(token Token, keyspace string, table string) *Conn
 		}
 	}
 
-	return pool.connPicker.Pick(token, keyspace, table)
+	return pool.connPicker.Pick(token, qry)
 }
 
 // Size returns the number of connections currently active in the pool

--- a/connpicker.go
+++ b/connpicker.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ConnPicker interface {
-	Pick(Token, string, string) *Conn
+	Pick(Token, ExecutableQuery) *Conn
 	Put(*Conn)
 	Remove(conn *Conn)
 	InFlight() int
@@ -71,7 +71,7 @@ func (p *defaultConnPicker) Size() (int, int) {
 	return size, p.size - size
 }
 
-func (p *defaultConnPicker) Pick(Token, string, string) *Conn {
+func (p *defaultConnPicker) Pick(Token, ExecutableQuery) *Conn {
 	pos := int(atomic.AddUint32(&p.pos, 1) - 1)
 	size := len(p.conns)
 
@@ -110,7 +110,7 @@ func (*defaultConnPicker) NextShard() (shardID, nrShards int) {
 // to the point where we have first connection.
 type nopConnPicker struct{}
 
-func (nopConnPicker) Pick(Token, string, string) *Conn {
+func (nopConnPicker) Pick(Token, ExecutableQuery) *Conn {
 	return nil
 }
 

--- a/query_executor.go
+++ b/query_executor.go
@@ -125,7 +125,7 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 			continue
 		}
 
-		conn := pool.Pick(selectedHost.Token(), qry.Keyspace(), qry.Table())
+		conn := pool.Pick(selectedHost.Token(), qry)
 		if conn == nil {
 			selectedHost = hostIter()
 			continue

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -24,7 +24,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{{
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(Token(nil), "", "") != s.conns[0] {
+		if s.Pick(Token(nil), nil) != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
@@ -33,7 +33,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{{
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(Token(nil), "", "") != s.conns[0] {
+		if s.Pick(Token(nil), nil) != s.conns[0] {
 			t.Fatal("expected connection")
 		}
 	})
@@ -42,20 +42,20 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 		s.conns = []*Conn{nil, {
 			streams: streams.New(protoVersion4),
 		}}
-		if s.Pick(Token(nil), "", "") != s.conns[1] {
+		if s.Pick(Token(nil), nil) != s.conns[1] {
 			t.Fatal("expected connection")
 		}
-		if s.Pick(Token(nil), "", "") != s.conns[1] {
+		if s.Pick(Token(nil), nil) != s.conns[1] {
 			t.Fatal("expected connection")
 		}
 	})
 
 	t.Run("multiple shards no conns", func(t *testing.T) {
 		s.conns = []*Conn{nil, nil}
-		if s.Pick(Token(nil), "", "") != nil {
+		if s.Pick(Token(nil), nil) != nil {
 			t.Fatal("expected nil")
 		}
-		if s.Pick(Token(nil), "", "") != nil {
+		if s.Pick(Token(nil), nil) != nil {
 			t.Fatal("expected nil")
 		}
 	})
@@ -64,7 +64,7 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 func hammerConnPicker(t *testing.T, wg *sync.WaitGroup, s *scyllaConnPicker, loops int) {
 	t.Helper()
 	for i := 0; i < loops; i++ {
-		if c := s.Pick(nil, "", ""); c == nil {
+		if c := s.Pick(nil, nil); c == nil {
 			t.Error("unexpected nil")
 		}
 	}
@@ -163,7 +163,7 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 			conns:     []*Conn{nil, mockConn(1)},
 		}
 
-		if s.Pick(Token(nil), "", "") == nil {
+		if s.Pick(Token(nil), nil) == nil {
 			t.Fatal("expected connection")
 		}
 	})
@@ -187,7 +187,7 @@ func TestScyllaRandomConnPIcker(t *testing.T) {
 				defer wg.Done()
 				for i := 0; i < 3; i++ {
 					select {
-					case connCh <- s.Pick(Token(nil), "", ""):
+					case connCh <- s.Pick(Token(nil), nil):
 					case <-ctx.Done():
 					}
 				}

--- a/session.go
+++ b/session.go
@@ -608,7 +608,7 @@ func (s *Session) getConn() *Conn {
 		pool, ok := s.pool.getPool(host)
 		if !ok {
 			continue
-		} else if conn := pool.Pick(nil, "", ""); conn != nil {
+		} else if conn := pool.Pick(nil, nil); conn != nil {
 			return conn
 		}
 	}


### PR DESCRIPTION
There is a code in gocql that selects another connection to a node if chosen connection is too busy (has less than half available stream ids).

We should not do this with LWT.