### PR TITLE
Expose driver name/version configuration on cluster config level and change default driver name

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const defaultDriverName = "ScyllaDB GoCQL Driver"
+
 // PoolConfig configures the connection pool used by the driver, it defaults to
 // using a round-robin host selection policy and a round-robin connection selection
 // policy for each host.
@@ -144,6 +146,14 @@ type ClusterConfig struct {
 	// Sends a client side timestamp for all requests which overrides the timestamp at which it arrives at the server.
 	// Default: true, only enabled for protocol 3 and above.
 	DefaultTimestamp bool
+
+	// The name of the driver that is going to be reported to the server.
+	// Default: "ScyllaDB GoLang Driver"
+	DriverName string
+
+	// The version of the driver that is going to be reported to the server.
+	// Defaulted to current library version
+	DriverVersion string
 
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
@@ -289,6 +299,8 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		MaxRoutingKeyInfo:            1000,
 		PageSize:                     5000,
 		DefaultTimestamp:             true,
+		DriverName:                   defaultDriverName,
+		DriverVersion:                defaultDriverVersion,
 		MaxWaitSchemaAgreement:       60 * time.Second,
 		ReconnectInterval:            60 * time.Second,
 		ConvictionPolicy:             &SimpleConvictionPolicy{},

--- a/conn.go
+++ b/conn.go
@@ -470,8 +470,8 @@ func (s *startupCoordinator) options(ctx context.Context) error {
 func (s *startupCoordinator) startup(ctx context.Context) error {
 	m := map[string]string{
 		"CQL_VERSION":    s.conn.cfg.CQLVersion,
-		"DRIVER_NAME":    driverName,
-		"DRIVER_VERSION": driverVersion,
+		"DRIVER_NAME":    s.conn.session.cfg.DriverName,
+		"DRIVER_VERSION": s.conn.session.cfg.DriverVersion,
 	}
 
 	if s.conn.compressor != nil {

--- a/version.go
+++ b/version.go
@@ -6,20 +6,16 @@ const (
 	mainModule = "github.com/gocql/gocql"
 )
 
-var driverName string
-
-var driverVersion string
+var defaultDriverVersion string
 
 func init() {
 	buildInfo, ok := debug.ReadBuildInfo()
 	if ok {
 		for _, d := range buildInfo.Deps {
 			if d.Path == mainModule {
-				driverName = mainModule
-				driverVersion = d.Version
+				defaultDriverVersion = d.Version
 				if d.Replace != nil {
-					driverName = d.Replace.Path
-					driverVersion = d.Replace.Version
+					defaultDriverVersion = d.Replace.Version
 				}
 				break
 			}


### PR DESCRIPTION
Part of https://github.com/scylladb/scylla-drivers/issues/7

We want all drivers to report their names uniformly.