### PR TITLE
Introduce initial reconnection policy

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -1289,6 +1289,22 @@ type ReconnectionPolicy interface {
 	GetMaxRetries() int
 }
 
+// NoReconnectionPolicy is a policy to have no retry.
+//
+// Examples of usage:
+//
+//	cluster.InitialReconnectionPolicy = &NoReconnectionPolicy{}
+type NoReconnectionPolicy struct {
+}
+
+func (c *NoReconnectionPolicy) GetInterval(currentRetry int) time.Duration {
+	return time.Duration(0)
+}
+
+func (c *NoReconnectionPolicy) GetMaxRetries() int {
+	return 1
+}
+
 // ConstantReconnectionPolicy has simple logic for returning a fixed reconnection interval.
 //
 // Examples of usage:


### PR DESCRIPTION
We would want to retry on initial connection to the cluster, in case if cluster is not ready yet.

This PR introduced new `InitialReconnectionPolicy` option to `ServerConfig`, by default it is `NoReconnectionPolicy`, to ensure old behavior.

Closes #230
