### PR TITLE
Bug fix: Add matching case for unmarshalling nil uuid column

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1865,6 +1865,8 @@ func unmarshalUUID(info TypeInfo, data []byte, value interface{}) error {
 			*v = ""
 		case *[]byte:
 			*v = nil
+		case *[16]byte:
+			*v = [16]byte{}
 		case *UUID:
 			*v = UUID{}
 		default:


### PR DESCRIPTION
Schemagen generates structs as [16]byte for uuid and timeuuid columns. 

when a time/uuid column has nil value, the switch case will not match with *[]byte and returns the following error:

`can not unmarshal X timeuuid into *[16]uint8`

to solve this we can change Schemagen, or add the case here. personally I belive changing Schemagen has more cost and mapping UUIDs to [16]byte is better than mapping to []byte.