### PR TITLE
Fix string condition in tracing

### DIFF
--- a/session.go
+++ b/session.go
@@ -2320,7 +2320,7 @@ func (t *traceWriter) Trace(traceId []byte) {
 			WHERE session_id = ?`, traceId)
 
 		for iter.Scan(&timestamp, &activity, &source, &elapsed, &thread) {
-			if strings.Contains(activity, "Done processing") {
+			if strings.Contains(activity, "preparing a result") {
 				isDone = true
 				break
 			}


### PR DESCRIPTION
Previously the condition deciding if tracing is ready was correct only for select queries, but for insert queries it was always false. Because of that there was a possiblility of quering control connection for tracing more times than it was needed.