### PR TITLE
Expand cluster validation and move SSL initialization to the validation step

### DIFF
--- a/session.go
+++ b/session.go
@@ -120,9 +120,8 @@ func addrsToHosts(addrs []string, defaultPort int, logger StdLogger) ([]*HostInf
 // NewSession wraps an existing Node.
 func NewSession(cfg ClusterConfig) (*Session, error) {
 	if err := cfg.Validate(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("gocql: unable to create session: cluster config validation failed: %v", err)
 	}
-
 	// TODO: we should take a context in here at some point
 	ctx, cancel := context.WithCancel(context.TODO())
 


### PR DESCRIPTION
Let's expand cluster validation and move SSL initialization/validation to just before session is being created.