### PR TITLE
Add new API for tracing

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -105,7 +105,7 @@ func TestTracing(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	trace := &traceWriter{session: session, w: buf}
+	trace := &TraceWriter{session: session, w: buf}
 	if err := session.Query(`INSERT INTO trace (id) VALUES (?)`, 42).Trace(trace).Exec(); err != nil {
 		t.Fatal("insert:", err)
 	} else if buf.Len() == 0 {

--- a/doc.go
+++ b/doc.go
@@ -359,4 +359,7 @@
 // system_traces.events tables. NewTraceWriter returns an implementation of Tracer that writes the events to a writer.
 // Gathering trace information might be essential for debugging and optimizing queries, but writing traces has overhead,
 // so this feature should not be used on production systems with very high load unless you know what you are doing.
+// There is also a new implementation of Tracer - TracerEnhanced, that is intended to be more reliable and convinient to use.
+// It has a funcionality to check if trace is ready to be extracted and only actually gets it if requested which makes
+// the impact on a performance smaller.
 package gocql // import "github.com/gocql/gocql"

--- a/session_test.go
+++ b/session_test.go
@@ -42,11 +42,11 @@ func TestSessionAPI(t *testing.T) {
 		t.Fatalf("expceted prefetch 0.75, got %v", s.prefetch)
 	}
 
-	trace := &traceWriter{}
+	trace := NewTracer(nil)
 
 	s.SetTrace(trace)
 	if s.trace != trace {
-		t.Fatalf("expected traceWriter '%v',got '%v'", trace, s.trace)
+		t.Fatalf("expected tracer '%v',got '%v'", trace, s.trace)
 	}
 
 	qry := s.Query("test", 1)
@@ -138,7 +138,7 @@ func TestQueryBasicAPI(t *testing.T) {
 		t.Fatalf("expected Query.GetConsistency to return 'LocalSerial', got '%s'", qry.GetConsistency())
 	}
 
-	trace := &traceWriter{}
+	trace := NewTracer(nil)
 	qry.Trace(trace)
 	if qry.trace != trace {
 		t.Fatalf("expected Query.Trace to be '%v', got '%v'", trace, qry.trace)
@@ -247,7 +247,7 @@ func TestBatchBasicAPI(t *testing.T) {
 		t.Fatalf("expected batch.GetConsistency() to return 'One', got '%s'", b.GetConsistency())
 	}
 
-	trace := &traceWriter{}
+	trace := NewTracer(nil)
 	b.Trace(trace)
 	if b.trace != trace {
 		t.Fatalf("expected batch.Trace to be '%v', got '%v'", trace, b.trace)

--- a/tracer.go
+++ b/tracer.go
@@ -1,0 +1,219 @@
+package gocql
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// Tracer is the interface implemented by query tracers. Tracers have the
+// ability to obtain a detailed event log of all events that happened during
+// the execution of a query from Cassandra. Gathering this information might
+// be essential for debugging and optimizing queries, but this feature should
+// not be used on production systems with very high load.
+type Tracer interface {
+	Trace(traceId []byte)
+}
+
+type TraceWriter struct {
+	session *Session
+	w       io.Writer
+	mu      sync.Mutex
+
+	maxAttempts   int
+	sleepInterval time.Duration
+}
+
+// NewTraceWriter returns a simple Tracer implementation that outputs
+// the event log in a textual format.
+func NewTraceWriter(session *Session, w io.Writer) *TraceWriter {
+	return &TraceWriter{session: session, w: w, maxAttempts: 5, sleepInterval: 3 * time.Millisecond}
+}
+
+func (t *TraceWriter) SetMaxAttempts(maxAttempts int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.maxAttempts = maxAttempts
+}
+
+func (t *TraceWriter) SetSleepInterval(sleepInterval time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.sleepInterval = sleepInterval
+}
+
+func (t *TraceWriter) Trace(traceId []byte) {
+	var (
+		timestamp time.Time
+		activity  string
+		source    string
+		elapsed   int
+		thread    string
+	)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	fetchAttempts := 1
+	if t.maxAttempts > 0 {
+		fetchAttempts = t.maxAttempts
+	}
+
+	isDone := false
+	for i := 0; i < fetchAttempts; i++ {
+		var duration int
+
+		iter := t.session.control.query(`SELECT duration
+			FROM system_traces.sessions
+			WHERE session_id = ?`, traceId)
+		iter.Scan(&duration)
+		if duration > 0 {
+			isDone = true
+		}
+
+		if err := iter.Close(); err != nil {
+			fmt.Fprintln(t.w, "Error:", err)
+			return
+		}
+
+		if isDone || i == fetchAttempts-1 {
+			break
+		}
+
+		time.Sleep(t.sleepInterval)
+	}
+	if !isDone {
+		fmt.Fprintln(t.w, "Error: failed to wait tracing to complete. !!! Tracing is incomplete !!!")
+	}
+
+	var (
+		coordinator string
+		duration    int
+	)
+
+	iter := t.session.control.query(`SELECT coordinator, duration
+		FROM system_traces.sessions
+		WHERE session_id = ?`, traceId)
+
+	iter.Scan(&coordinator, &duration)
+	if err := iter.Close(); err != nil {
+		fmt.Fprintln(t.w, "Error:", err)
+		return
+	}
+
+	fmt.Fprintf(t.w, "Tracing session %016x (coordinator: %s, duration: %v):\n",
+		traceId, coordinator, time.Duration(duration)*time.Microsecond)
+
+	iter = t.session.control.query(`SELECT event_id, activity, source, source_elapsed, thread
+			FROM system_traces.events
+			WHERE session_id = ?`, traceId)
+
+	for iter.Scan(&timestamp, &activity, &source, &elapsed, &thread) {
+		fmt.Fprintf(t.w, "%s: %s [%s] (source: %s, elapsed: %d)\n",
+			timestamp.Format("2006/01/02 15:04:05.999999"), activity, thread, source, elapsed)
+	}
+
+	if err := iter.Close(); err != nil {
+		fmt.Fprintln(t.w, "Error:", err)
+	}
+}
+
+type TracerEnhanced struct {
+	session  *Session
+	traceIDs [][]byte
+	mu       sync.Mutex
+}
+
+func NewTracer(session *Session) *TracerEnhanced {
+	return &TracerEnhanced{session: session}
+}
+
+func (t *TracerEnhanced) Trace(traceId []byte) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.traceIDs = append(t.traceIDs, traceId)
+}
+
+func (t *TracerEnhanced) AllTraceIDs() [][]byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.traceIDs
+}
+
+func (t *TracerEnhanced) IsReady(traceId []byte) (bool, error) {
+	isDone := false
+	var duration int
+
+	iter := t.session.control.query(`SELECT duration
+		FROM system_traces.sessions
+		WHERE session_id = ?`, traceId)
+	iter.Scan(&duration)
+	if duration > 0 {
+		isDone = true
+	}
+
+	if err := iter.Close(); err != nil {
+		return false, err
+	}
+
+	if isDone {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (t *TracerEnhanced) GetCoordinatorTime(traceId []byte) (string, time.Duration, error) {
+	var (
+		coordinator string
+		duration    int
+	)
+
+	iter := t.session.control.query(`SELECT coordinator, duration
+		FROM system_traces.sessions
+		WHERE session_id = ?`, traceId)
+
+	iter.Scan(&coordinator, &duration)
+	if err := iter.Close(); err != nil {
+		return coordinator, time.Duration(duration) * time.Microsecond, err
+	}
+
+	return coordinator, time.Duration(duration) * time.Microsecond, nil
+}
+
+type TraceEntry struct {
+	Timestamp time.Time
+	Activity  string
+	Source    string
+	Elapsed   int
+	Thread    string
+}
+
+func (t *TracerEnhanced) GetActivities(traceId []byte) ([]TraceEntry, error) {
+	iter := t.session.control.query(`SELECT event_id, activity, source, source_elapsed, thread
+		FROM system_traces.events
+		WHERE session_id = ?`, traceId)
+
+	var (
+		timestamp time.Time
+		activity  string
+		source    string
+		elapsed   int
+		thread    string
+	)
+
+	var activities []TraceEntry
+
+	for iter.Scan(&timestamp, &activity, &source, &elapsed, &thread) {
+		activities = append(activities, TraceEntry{Timestamp: timestamp, Activity: activity, Source: source, Elapsed: elapsed, Thread: thread})
+	}
+
+	if err := iter.Close(); err != nil {
+		return nil, err
+	}
+
+	return activities, nil
+}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -1,0 +1,53 @@
+//go:build all || cassandra || scylla
+// +build all cassandra scylla
+
+package gocql
+
+import "testing"
+
+func TestTracingNewAPI(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	if err := createTable(session, `CREATE TABLE gocql_test.trace2 (id int primary key)`); err != nil {
+		t.Fatal("create:", err)
+	}
+
+	trace := NewTracer(session)
+	if err := session.Query(`INSERT INTO trace2 (id) VALUES (?)`, 42).Trace(trace).Exec(); err != nil {
+		t.Fatal("insert:", err)
+	}
+
+	var value int
+	if err := session.Query(`SELECT id FROM trace2 WHERE id = ?`, 42).Trace(trace).Scan(&value); err != nil {
+		t.Fatal("select:", err)
+	} else if value != 42 {
+		t.Fatalf("value: expected %d, got %d", 42, value)
+	}
+
+	for _, traceID := range trace.AllTraceIDs() {
+		var (
+			isReady bool
+			err     error
+		)
+		for !isReady {
+			isReady, err = trace.IsReady(traceID)
+			if err != nil {
+				t.Fatal("Error: ", err)
+			}
+		}
+		activities, err := trace.GetActivities(traceID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		coordinator, _, err := trace.GetCoordinatorTime(traceID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(activities) == 0 {
+			t.Fatal("Failed to obtain any tracing for tradeID: ", traceID)
+		} else if coordinator == "" {
+			t.Fatal("Failed to obtain coordinator for traceID: ", traceID)
+		}
+	}
+}


### PR DESCRIPTION
Reading of tracing info should be done asynchronously, otherwise enabling tracing will lead to query processing slow down. Current implementation of Tracer - traceWriter has this flaw and is actually not exactly useful, it just write custom formatted messages into a buffer.

This commit adds new implementation of Tracer - tracer which address that problems.

Fixes: #227