### PR TITLE
Refactor awaitSchemaAgreement logic

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1895,7 +1895,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 	}
 
 	// not exported
-	return fmt.Errorf("gocql: cluster schema versions not consistent: %+v", schemas)
+	return &ErrSchemaMismatch{schemas: schemas}
 }
 
 var (
@@ -1905,3 +1905,11 @@ var (
 	ErrConnectionClosed  = errors.New("gocql: connection closed waiting for response")
 	ErrNoStreams         = errors.New("gocql: no streams available on connection")
 )
+
+type ErrSchemaMismatch struct {
+	schemas []string
+}
+
+func (e *ErrSchemaMismatch) Error() string {
+	return fmt.Sprintf("gocql: cluster schema versions not consistent: %+v", e.schemas)
+}

--- a/conn.go
+++ b/conn.go
@@ -1838,7 +1838,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) (err error) {
 		}
 
 		for _, row := range rows {
-			host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.ConnectAddress(), port: c.session.cfg.Port})
+			host, err := hostInfoFromMap(row, &HostInfo{connectAddress: c.host.ConnectAddress(), port: c.session.cfg.Port}, c.session.cfg.translateAddressPort)
 			if err != nil {
 				goto cont
 			}

--- a/conn.go
+++ b/conn.go
@@ -1828,6 +1828,8 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 	endDeadline := time.Now().Add(c.session.cfg.MaxWaitSchemaAgreement)
 
 	var err error
+	ticker := time.NewTicker(200 * time.Millisecond) // Create a ticker that ticks every 200ms
+	defer ticker.Stop()
 
 	for time.Now().Before(endDeadline) {
 		iter := c.querySystemPeers(ctx, c.host.version)
@@ -1879,7 +1881,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(200 * time.Millisecond):
+		case <-ticker.C:
 		}
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -6,6 +6,7 @@ package gocql
 // This file groups integration tests where Cassandra has to be set up with some special integration variables
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -232,4 +233,25 @@ func TestSessionAwaitSchemaAgreement(t *testing.T) {
 	if err := session.AwaitSchemaAgreement(context.Background()); err != nil {
 		t.Fatalf("expected session.AwaitSchemaAgreement to not return an error but got '%v'", err)
 	}
+}
+
+func TestSessionAwaitSchemaAgreementSessionClosed(t *testing.T) {
+	session := createSession(t)
+	session.Close()
+
+	if err := session.AwaitSchemaAgreement(context.Background()); !errors.Is(err, ErrConnectionClosed) {
+		t.Fatalf("expected session.AwaitSchemaAgreement to return ErrConnectionClosed but got '%v'", err)
+	}
+
+}
+
+func TestSessionAwaitSchemaAgreementContextCanceled(t *testing.T) {
+	session := createSession(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := session.AwaitSchemaAgreement(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected session.AwaitSchemaAgreement to return 'context canceled' but got '%v'", err)
+	}
+
 }


### PR DESCRIPTION
Previously due to the wrong re-declarations of one variable error handling logic in `awaitSchemaAgreement` was broken. This code has always had the same result because the `err` in the condition was the error declared in the function definition not the one used in the for loop above.
https://github.com/scylladb/gocql/blob/master/conn.go#L1879-L1881

This PR fixes error handling as well as refactors some pieces of the code.

Fixes: #70 