### PR TITLE
Fix ErrNoConnections from defaultConnectionPicker.Remove code

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -551,4 +551,5 @@ func (pool *hostConnPool) HandleError(conn *Conn, err error, closed bool) {
 	}
 
 	pool.connPicker.Remove(conn)
+	go pool.fill()
 }

--- a/connpicker.go
+++ b/connpicker.go
@@ -42,8 +42,9 @@ func (p *defaultConnPicker) Remove(conn *Conn) {
 
 	for i, candidate := range p.conns {
 		if candidate == conn {
-			p.conns[i] = nil
-			return
+			last := len(p.conns) - 1
+			p.conns[i], p.conns = p.conns[last], p.conns[:last]
+			break
 		}
 	}
 }


### PR DESCRIPTION
i use this driver to interact with an apache Cassandra cluster : the [defaultConnPicker](https://github.com/scylladb/gocql/blob/c33cb5219995f721fc2978b01188f72cf879e3b5/connectionpool.go#L590-L595) is used

the application queries eventually fail with the error [`ErrNoConnections`](https://github.com/scylladb/gocql/blob/c33cb5219995f721fc2978b01188f72cf879e3b5/query_executor.go#L197), without any recovery

all connPicker connections eventually are set to `nil` by handling of sporadic network errors over time:
 - `Conn.closeWithError` ([code](https://github.com/scylladb/gocql/blob/3a1e987b9cb437b62f85f190466926d9d84107fe/conn.go#L1158))
 - `hostConnPool.HandleError` ([code](https://github.com/scylladb/gocql/blob/3a1e987b9cb437b62f85f190466926d9d84107fe/conn.go#L599-L600))
 - `defaultConnPicker.Remove` ([code](https://github.com/scylladb/gocql/blob/3a1e987b9cb437b62f85f190466926d9d84107fe/connectionpool.go#L553))

the query executor loop over [nil connections](https://github.com/scylladb/gocql/blob/3a1e987b9cb437b62f85f190466926d9d84107fe/query_executor.go#L132) , and the recovery ( pool filling ) does not occur because the pool is full of connections

the [old implementation of hostPool](https://github.com/glutamatt/gocql/commit/a088a2587c1c6d69d06f5fb06b3e05b466de7b1d#diff-fff1b739e54a76fd5e6a22675f7aa73ddc2a4987f82af014ee4aa8dea926cd82L575), before connPicker , actually remove the failed connection and shorten the slice of connections

i propose the patch to the upstream (i already [patched the fork](https://github.com/glutamatt/gocql/compare/3418a09662b73b5bc870a763cf6b8778a77248da..5de89f97882b) i use in my production code)