### PR TITLE
Switch tests from SimpleStrategy to NetworkTopologyStrategy

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2112,15 +2112,15 @@ func TestGetKeyspaceMetadata(t *testing.T) {
 	if keyspaceMetadata.Name != "gocql_test" {
 		t.Errorf("Expected keyspace name to be 'gocql' but was '%s'", keyspaceMetadata.Name)
 	}
-	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.SimpleStrategy" {
-		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.SimpleStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
+	if keyspaceMetadata.StrategyClass != "org.apache.cassandra.locator.NetworkTopologyStrategy" {
+		t.Errorf("Expected replication strategy class to be 'org.apache.cassandra.locator.NetworkTopologyStrategy' but was '%s'", keyspaceMetadata.StrategyClass)
 	}
 	if keyspaceMetadata.StrategyOptions == nil {
 		t.Error("Expected replication strategy options map but was nil")
 	}
-	rfStr, ok := keyspaceMetadata.StrategyOptions["replication_factor"]
+	rfStr, ok := keyspaceMetadata.StrategyOptions["datacenter1"]
 	if !ok {
-		t.Fatalf("Expected strategy option 'replication_factor' but was not found in %v", keyspaceMetadata.StrategyOptions)
+		t.Fatalf("Expected strategy option 'datacenter1' but was not found in %v", keyspaceMetadata.StrategyOptions)
 	}
 	rfInt, err := strconv.Atoi(rfStr.(string))
 	if err != nil {

--- a/common_test.go
+++ b/common_test.go
@@ -154,7 +154,7 @@ func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string) {
 
 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
 	WITH replication = {
-		'class' : 'SimpleStrategy',
+		'class' : 'NetworkTopologyStrategy',
 		'replication_factor' : %d
 	}`, keyspace, *flagRF))
 

--- a/control_integration_test.go
+++ b/control_integration_test.go
@@ -62,7 +62,7 @@ func TestUnixSockets(t *testing.T) {
 
 	err = createTable(sess, fmt.Sprintf(`CREATE KEYSPACE %s
 	WITH replication = {
-		'class' : 'SimpleStrategy',
+		'class' : 'NetworkTopologyStrategy',
 		'replication_factor' : 1
 	}`, keyspace))
 	if err != nil {

--- a/keyspace_table_test.go
+++ b/keyspace_table_test.go
@@ -33,7 +33,7 @@ func TestKeyspaceTable(t *testing.T) {
 
 	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
 	WITH replication = {
-		'class' : 'SimpleStrategy',
+		'class' : 'NetworkTopologyStrategy',
 		'replication_factor' : 1
 	}`, keyspace))
 

--- a/testdata/recreate/aggregates.cql
+++ b/testdata/recreate/aggregates.cql
@@ -1,5 +1,5 @@
 CREATE KEYSPACE gocqlx_aggregates WITH replication = {
-  'class': 'SimpleStrategy',
+  'class': 'NetworkTopologyStrategy',
   'replication_factor': '2'
 };
 

--- a/testdata/recreate/aggregates_golden.cql
+++ b/testdata/recreate/aggregates_golden.cql
@@ -1,33 +1,25 @@
-CREATE KEYSPACE gocqlx_aggregates WITH replication = {
-    'class': 'SimpleStrategy',
-    'replication_factor': '2'
-};
-
-CREATE FUNCTION gocqlx_aggregates.avgstate (state
-    tuple<int, double>, val
-    double)
-    CALLED ON NULL INPUT
-    RETURNS frozen<tuple<int, double>>
-    LANGUAGE lua
-    AS $$
-  return { state[1]+1, state[2]+val }
-  $$;
-
-CREATE FUNCTION gocqlx_aggregates.avgfinal (state
-    tuple<int, double>)
-    CALLED ON NULL INPUT
-    RETURNS double
-    LANGUAGE lua
-    AS $$
+CREATE KEYSPACE gocqlx_aggregates WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'} AND durable_writes = true;
+CREATE FUNCTION gocqlx_aggregates.avgfinal(state frozen<tuple<int, double>>)
+CALLED ON NULL INPUT
+RETURNS double
+LANGUAGE lua
+AS $$
   r=0
   r=state[2]
   r=r/state[1]
   return r
-  $$;
-
-CREATE AGGREGATE gocqlx_aggregates.average(
-    double)
-    SFUNC avgstate
-    STYPE tuple<int, double>
-    FINALFUNC avgfinal
-    INITCOND (0, 0);
+  
+$$;
+CREATE FUNCTION gocqlx_aggregates.avgstate(state frozen<tuple<int, double>>, val double)
+CALLED ON NULL INPUT
+RETURNS frozen<tuple<int, double>>
+LANGUAGE lua
+AS $$
+  return { state[1]+1, state[2]+val }
+  
+$$;
+CREATE AGGREGATE gocqlx_aggregates.average(double)
+SFUNC avgstate
+STYPE frozen<tuple<int, double>>
+FINALFUNC avgfinal
+INITCOND (0, 0);

--- a/testdata/recreate/index.cql
+++ b/testdata/recreate/index.cql
@@ -1,5 +1,5 @@
 CREATE KEYSPACE gocqlx_idx WITH replication = {
-  'class': 'SimpleStrategy',
+  'class': 'NetworkTopologyStrategy',
   'replication_factor': '2'
 };
 

--- a/testdata/recreate/index_golden.cql
+++ b/testdata/recreate/index_golden.cql
@@ -1,8 +1,4 @@
-CREATE KEYSPACE gocqlx_idx WITH replication = {
-    'class': 'SimpleStrategy',
-    'replication_factor': '2'
-};
-
+CREATE KEYSPACE gocqlx_idx WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'} AND durable_writes = true;
 CREATE TABLE gocqlx_idx.menus (
     location text,
     name text,
@@ -11,16 +7,17 @@ CREATE TABLE gocqlx_idx.menus (
     PRIMARY KEY (location, name)
 ) WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = ''
-    AND compaction = {'class':'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
-
-CREATE INDEX menus_name_idx ON gocqlx_idx.menus (name);
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
+CREATE INDEX menus_name_idx ON gocqlx_idx.menus(name);

--- a/testdata/recreate/keyspace.cql
+++ b/testdata/recreate/keyspace.cql
@@ -1,4 +1,4 @@
 CREATE KEYSPACE gocqlx_keyspace WITH replication = {
-  'class': 'SimpleStrategy',
+  'class': 'NetworkTopologyStrategy',
   'replication_factor': '2'
 };

--- a/testdata/recreate/keyspace_golden.cql
+++ b/testdata/recreate/keyspace_golden.cql
@@ -1,4 +1,1 @@
-CREATE KEYSPACE gocqlx_keyspace WITH replication = {
-    'class': 'SimpleStrategy',
-    'replication_factor': '2'
-};
+CREATE KEYSPACE gocqlx_keyspace WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'} AND durable_writes = true;

--- a/testdata/recreate/materialized_views.cql
+++ b/testdata/recreate/materialized_views.cql
@@ -1,5 +1,5 @@
 CREATE KEYSPACE gocqlx_mv WITH replication = {
-  'class': 'SimpleStrategy',
+  'class': 'NetworkTopologyStrategy',
   'replication_factor': '2'
 };
 

--- a/testdata/recreate/materialized_views_golden.cql
+++ b/testdata/recreate/materialized_views_golden.cql
@@ -1,63 +1,61 @@
-CREATE KEYSPACE gocqlx_mv WITH replication = {
-    'class': 'SimpleStrategy',
-    'replication_factor': '2'
-};
-
+CREATE KEYSPACE gocqlx_mv WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'} AND durable_writes = true;
 CREATE TABLE gocqlx_mv.mv_buildings (
-    name text PRIMARY KEY,
+    name text,
     built int,
     city text,
-    meters int
+    meters int,
+    PRIMARY KEY (name)
 ) WITH bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = ''
-    AND compaction = {'class':'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
-
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
 CREATE MATERIALIZED VIEW gocqlx_mv.mv_building_by_city AS
-    SELECT *
+    SELECT city, name, built, meters
     FROM gocqlx_mv.mv_buildings
     WHERE city IS NOT null
     PRIMARY KEY (city, name)
     WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = ''
-    AND compaction = {'class':'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
-
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
 CREATE MATERIALIZED VIEW gocqlx_mv.mv_building_by_city2 AS
-    SELECT 
-    city, 
-    name, 
-    meters
+    SELECT city, name, meters
     FROM gocqlx_mv.mv_buildings
     WHERE city IS NOT null
     PRIMARY KEY (city, name)
     WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = ''
-    AND compaction = {'class':'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};

--- a/testdata/recreate/secondary_index.cql
+++ b/testdata/recreate/secondary_index.cql
@@ -1,5 +1,5 @@
 CREATE KEYSPACE gocqlx_sec_idx WITH replication = {
-  'class': 'SimpleStrategy',
+  'class': 'NetworkTopologyStrategy',
   'replication_factor': '2'
 };
 

--- a/testdata/recreate/secondary_index_golden.cql
+++ b/testdata/recreate/secondary_index_golden.cql
@@ -1,8 +1,4 @@
-CREATE KEYSPACE gocqlx_sec_idx WITH replication = {
-    'class': 'SimpleStrategy',
-    'replication_factor': '2'
-};
-
+CREATE KEYSPACE gocqlx_sec_idx WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'} AND durable_writes = true;
 CREATE TABLE gocqlx_sec_idx.menus (
     location text,
     name text,
@@ -11,16 +7,17 @@ CREATE TABLE gocqlx_sec_idx.menus (
     PRIMARY KEY (location, name)
 ) WITH CLUSTERING ORDER BY (name ASC)
     AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = ''
-    AND compaction = {'class':'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
-
-CREATE INDEX menus_name_idx ON gocqlx_sec_idx.menus ((location), name);
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
+CREATE INDEX menus_name_idx ON gocqlx_sec_idx.menus((location), name);

--- a/testdata/recreate/table.cql
+++ b/testdata/recreate/table.cql
@@ -1,5 +1,5 @@
 CREATE KEYSPACE gocqlx_table WITH replication = {
-  'class': 'SimpleStrategy',
+  'class': 'NetworkTopologyStrategy',
   'replication_factor': '2'
 };
 

--- a/testdata/recreate/table_golden.cql
+++ b/testdata/recreate/table_golden.cql
@@ -1,8 +1,4 @@
-CREATE KEYSPACE gocqlx_table WITH replication = {
-    'class': 'SimpleStrategy',
-    'replication_factor': '2'
-};
-
+CREATE KEYSPACE gocqlx_table WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'} AND durable_writes = true;
 CREATE TABLE gocqlx_table.loads (
     machine inet,
     cpu int,
@@ -11,36 +7,39 @@ CREATE TABLE gocqlx_table.loads (
     PRIMARY KEY ((machine, cpu), mtime)
 ) WITH CLUSTERING ORDER BY (mtime DESC)
     AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'NONE'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
     AND comment = ''
-    AND compaction = {'class':'TimeWindowCompactionStrategy','compaction_window_size':'14','compaction_window_unit':'DAYS'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'TimeWindowCompactionStrategy', 'compaction_window_size': '14', 'compaction_window_unit': 'DAYS'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
-
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
 CREATE TABLE gocqlx_table.monkeyspecies (
-    species text PRIMARY KEY,
+    species text,
     average_size int,
     common_name text,
-    population varint
+    population varint,
+    PRIMARY KEY (species)
 ) WITH bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = 'Important biological records'
-    AND compaction = {'class':'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
-
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
 CREATE TABLE gocqlx_table.timeline (
     userid uuid,
     posted_month int,
@@ -50,34 +49,37 @@ CREATE TABLE gocqlx_table.timeline (
     PRIMARY KEY (userid, posted_month, posted_time)
 ) WITH CLUSTERING ORDER BY (posted_month ASC, posted_time ASC)
     AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = ''
-    AND compaction = {'class':'LeveledCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'LeveledCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
-
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
 CREATE TABLE gocqlx_table.users_picture (
     userid uuid,
     pictureid uuid,
     posted_by text,
-    body text static,
+    body text STATIC,
     PRIMARY KEY (userid, pictureid, posted_by)
 ) WITH CLUSTERING ORDER BY (pictureid ASC, posted_by ASC)
     AND bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL','rows_per_partition':'ALL'}
+    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
     AND comment = ''
-    AND compaction = {'class':'SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression':'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND crc_check_chance = 1
     AND default_time_to_live = 0
     AND gc_grace_seconds = 864000
     AND max_index_interval = 2048
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
-    AND speculative_retry = '99.0PERCENTILE';
+    AND speculative_retry = '99.0PERCENTILE'
+    AND paxos_grace_seconds = 864000
+    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};

--- a/testdata/recreate/udt.cql
+++ b/testdata/recreate/udt.cql
@@ -1,5 +1,5 @@
 CREATE KEYSPACE gocqlx_udt WITH replication = {
-  'class': 'SimpleStrategy',
+  'class': 'NetworkTopologyStrategy',
   'replication_factor': '2'
 };
 

--- a/testdata/recreate/udt_golden.cql
+++ b/testdata/recreate/udt_golden.cql
@@ -1,13 +1,8 @@
-CREATE KEYSPACE gocqlx_udt WITH replication = {
-    'class': 'SimpleStrategy',
-    'replication_factor': '2'
-};
-
+CREATE KEYSPACE gocqlx_udt WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'} AND durable_writes = true;
 CREATE TYPE gocqlx_udt.phone (
     country_code int,
     number text
 );
-
 CREATE TYPE gocqlx_udt.address (
     street text,
     city text,


### PR DESCRIPTION
SimpleStrategy is getting depricated, as replacement is it recomended to use NetworkTopologyStrategy instead. 

This PR switches tests to use NetworkTopologyStrategy. Tests that are specifically targeting SimpleStrategy stays as they are.

Fixes: #217 