### PR TITLE
Change default behavior with skipping metadata

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -465,6 +465,10 @@ func (cfg *ClusterConfig) Validate() error {
 		return errors.New("ProtoVersion should be positive number or zero")
 	}
 
+	if !cfg.DisableSkipMetadata {
+		Logger.Println("warning: enabling skipping metadata can lead to unpredictible results when executing query and altering columns involved in the query.")
+	}
+
 	return cfg.ValidateAndInitSSL()
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -216,6 +216,9 @@ type ClusterConfig struct {
 	// statement.
 	//
 	// See https://issues.apache.org/jira/browse/CASSANDRA-10786
+	// See https://github.com/scylladb/scylladb/issues/20860
+	//
+	// Default: true
 	DisableSkipMetadata bool
 
 	// QueryObserver will set the provided query observer on all queries created from this session.
@@ -318,6 +321,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		SocketKeepalive:              15 * time.Second,
 		WriteCoalesceWaitTime:        200 * time.Microsecond,
 		MetadataSchemaRequestTimeout: 60 * time.Second,
+		DisableSkipMetadata:          true,
 	}
 
 	return cfg


### PR DESCRIPTION
As enabling skipping metadata can lead to correctness problems (https://github.com/scylladb/scylladb/issues/20860) it has to be disabled by default. 

This PR implements that change and adds a warning when someone enables this optimization.

