### PR TITLE
Fix marshal smallint

### DIFF
--- a/marshal/smallint/marshal.go
+++ b/marshal/smallint/marshal.go
@@ -1,0 +1,74 @@
+package smallint
+
+import (
+	"math/big"
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case int8:
+		return EncInt8(v)
+	case int32:
+		return EncInt32(v)
+	case int16:
+		return EncInt16(v)
+	case int64:
+		return EncInt64(v)
+	case int:
+		return EncInt(v)
+
+	case uint8:
+		return EncUint8(v)
+	case uint16:
+		return EncUint16(v)
+	case uint32:
+		return EncUint32(v)
+	case uint64:
+		return EncUint64(v)
+	case uint:
+		return EncUint(v)
+
+	case big.Int:
+		return EncBigInt(v)
+	case string:
+		return EncString(v)
+
+	case *int8:
+		return EncInt8R(v)
+	case *int16:
+		return EncInt16R(v)
+	case *int32:
+		return EncInt32R(v)
+	case *int64:
+		return EncInt64R(v)
+	case *int:
+		return EncIntR(v)
+
+	case *uint8:
+		return EncUint8R(v)
+	case *uint16:
+		return EncUint16R(v)
+	case *uint32:
+		return EncUint32R(v)
+	case *uint64:
+		return EncUint64R(v)
+	case *uint:
+		return EncUintR(v)
+
+	case *big.Int:
+		return EncBigIntR(v)
+	case *string:
+		return EncStringR(v)
+	default:
+		// Custom types (type MyInt int) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/marshal/smallint/marshal_utils.go
+++ b/marshal/smallint/marshal_utils.go
@@ -1,0 +1,200 @@
+package smallint
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+)
+
+var (
+	maxBigInt = big.NewInt(math.MaxInt16)
+	minBigInt = big.NewInt(math.MinInt16)
+)
+
+func EncInt8(v int8) ([]byte, error) {
+	return encInt16(int16(v)), nil
+}
+
+func EncInt8R(v *int8) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt8(*v)
+}
+
+func EncInt16(v int16) ([]byte, error) {
+	return encInt16(v), nil
+}
+
+func EncInt16R(v *int16) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt16(*v)
+}
+
+func EncInt32(v int32) ([]byte, error) {
+	if v > math.MaxInt16 || v < math.MinInt16 {
+		return nil, fmt.Errorf("failed to marshal smallint: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 8), byte(v)}, nil
+}
+
+func EncInt32R(v *int32) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt32(*v)
+}
+
+func EncInt64(v int64) ([]byte, error) {
+	if v > math.MaxInt16 || v < math.MinInt16 {
+		return nil, fmt.Errorf("failed to marshal smallint: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 8), byte(v)}, nil
+}
+
+func EncInt64R(v *int64) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt64(*v)
+}
+
+func EncInt(v int) ([]byte, error) {
+	if v > math.MaxInt16 || v < math.MinInt16 {
+		return nil, fmt.Errorf("failed to marshal smallint: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 8), byte(v)}, nil
+}
+
+func EncIntR(v *int) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt(*v)
+}
+
+func EncUint8(v uint8) ([]byte, error) {
+	return []byte{0, v}, nil
+}
+
+func EncUint8R(v *uint8) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint8(*v)
+}
+
+func EncUint16(v uint16) ([]byte, error) {
+	return []byte{byte(v >> 8), byte(v)}, nil
+}
+
+func EncUint16R(v *uint16) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint16(*v)
+}
+
+func EncUint32(v uint32) ([]byte, error) {
+	if v > math.MaxUint16 {
+		return nil, fmt.Errorf("failed to marshal smallint: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 8), byte(v)}, nil
+}
+
+func EncUint32R(v *uint32) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint32(*v)
+}
+
+func EncUint64(v uint64) ([]byte, error) {
+	if v > math.MaxUint16 {
+		return nil, fmt.Errorf("failed to marshal smallint: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 8), byte(v)}, nil
+}
+
+func EncUint64R(v *uint64) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint64(*v)
+}
+
+func EncUint(v uint) ([]byte, error) {
+	if v > math.MaxUint16 {
+		return nil, fmt.Errorf("failed to marshal smallint: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 8), byte(v)}, nil
+}
+
+func EncUintR(v *uint) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint(*v)
+}
+
+func EncBigInt(v big.Int) ([]byte, error) {
+	if v.Cmp(maxBigInt) == 1 || v.Cmp(minBigInt) == -1 {
+		return nil, fmt.Errorf("failed to marshal smallint: value (%T)(%s) out of range", v, v.String())
+	}
+	iv := v.Int64()
+	return []byte{byte(iv >> 8), byte(iv)}, nil
+}
+
+func EncBigIntR(v *big.Int) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncBigInt(*v)
+}
+
+func EncString(v string) ([]byte, error) {
+	if v == "" {
+		return nil, nil
+	}
+
+	n, err := strconv.ParseInt(v, 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal smallint: can not marshal %#v %s", v, err)
+	}
+	return []byte{byte(n >> 8), byte(n)}, nil
+}
+
+func EncStringR(v *string) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncString(*v)
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Type().Kind() {
+	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
+		return EncInt64(v.Int())
+	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+		return EncUint64(v.Uint())
+	case reflect.String:
+		return EncString(v.String())
+	default:
+		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%#[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encInt16(v int16) []byte {
+	return []byte{byte(v >> 8), byte(v)}
+}

--- a/marshal/smallint/unmarshal.go
+++ b/marshal/smallint/unmarshal.go
@@ -1,0 +1,81 @@
+package smallint
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+
+	case *int8:
+		return DecInt8(data, v)
+	case *int16:
+		return DecInt16(data, v)
+	case *int32:
+		return DecInt32(data, v)
+	case *int64:
+		return DecInt64(data, v)
+	case *int:
+		return DecInt(data, v)
+
+	case *uint8:
+		return DecUint8(data, v)
+	case *uint16:
+		return DecUint16(data, v)
+	case *uint32:
+		return DecUint32(data, v)
+	case *uint64:
+		return DecUint64(data, v)
+	case *uint:
+		return DecUint(data, v)
+
+	case *big.Int:
+		return DecBigInt(data, v)
+	case *string:
+		return DecString(data, v)
+
+	case **int8:
+		return DecInt8R(data, v)
+	case **int16:
+		return DecInt16R(data, v)
+	case **int32:
+		return DecInt32R(data, v)
+	case **int64:
+		return DecInt64R(data, v)
+	case **int:
+		return DecIntR(data, v)
+
+	case **uint8:
+		return DecUint8R(data, v)
+	case **uint16:
+		return DecUint16R(data, v)
+	case **uint32:
+		return DecUint32R(data, v)
+	case **uint64:
+		return DecUint64R(data, v)
+	case **uint:
+		return DecUintR(data, v)
+
+	case **big.Int:
+		return DecBigIntR(data, v)
+	case **string:
+		return DecStringR(data, v)
+	default:
+
+		// Custom types (type MyInt int) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%#[1]v)", value)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/marshal/smallint/unmarshal_utils.go
+++ b/marshal/smallint/unmarshal_utils.go
@@ -1,0 +1,385 @@
+package smallint
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+)
+
+var errWrongDataLen = fmt.Errorf("failed to unmarshal smallint: the length of the data should be 0 or 2")
+
+func DecInt8(p []byte, v *int8) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		val := decInt16(p)
+		if val > math.MaxInt8 || val < math.MinInt8 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into int8, the data should be in the int8 range")
+		}
+		*v = int8(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt8R(p []byte, v **int8) error {
+	if p != nil {
+		*v = new(int8)
+		return DecInt8(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt16(p []byte, v *int16) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = decInt16(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt16R(p []byte, v **int16) error {
+	if p != nil {
+		*v = new(int16)
+		return DecInt16(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt32(p []byte, v *int32) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = int32(decInt16(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt32R(p []byte, v **int32) error {
+	if p != nil {
+		*v = new(int32)
+		return DecInt32(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt64(p []byte, v *int64) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = int64(decInt16(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt64R(p []byte, v **int64) error {
+	if p != nil {
+		*v = new(int64)
+		return DecInt64(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt(p []byte, v *int) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = int(decInt16(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecIntR(p []byte, v **int) error {
+	if p != nil {
+		*v = new(int)
+		return DecInt(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint8(p []byte, v *uint8) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		if p[0] != 0 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint8, the data should be in the uint8 range")
+		}
+		*v = p[1]
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint8R(p []byte, v **uint8) error {
+	if p != nil {
+		*v = new(uint8)
+		return DecUint8(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint16(p []byte, v *uint16) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = uint16(p[0])<<8 | uint16(p[1])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint16R(p []byte, v **uint16) error {
+	if p != nil {
+		*v = new(uint16)
+		return DecUint16(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint32(p []byte, v *uint32) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = uint32(p[0])<<8 | uint32(p[1])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint32R(p []byte, v **uint32) error {
+	if p != nil {
+		*v = new(uint32)
+		return DecUint32(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint64(p []byte, v *uint64) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = decUint64(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint64R(p []byte, v **uint64) error {
+	if p != nil {
+		*v = new(uint64)
+		return DecUint64(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint(p []byte, v *uint) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 2:
+		*v = uint(p[0])<<8 | uint(p[1])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUintR(p []byte, v **uint) error {
+	if p != nil {
+		*v = new(uint)
+		return DecUint(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecString(p []byte, v *string) error {
+	switch len(p) {
+	case 0:
+		if p != nil {
+			*v = "0"
+		} else {
+			*v = ""
+		}
+	case 2:
+		*v = strconv.FormatInt(int64(decInt16(p)), 10)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecStringR(p []byte, v **string) error {
+	if p != nil {
+		*v = new(string)
+		return DecString(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecBigInt(p []byte, v *big.Int) error {
+	switch len(p) {
+	case 0:
+		v.SetInt64(0)
+	case 2:
+		v.SetInt64(int64(decInt16(p)))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecBigIntR(p []byte, v **big.Int) error {
+	if p != nil {
+		*v = big.NewInt(0)
+		return DecBigInt(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return fmt.Errorf("failed to unmarshal smallint: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.Int8:
+		return decReflectInt8(p, v)
+	case reflect.Uint8:
+		return decReflectUint8(p, v)
+	case reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return decReflectInts(p, v)
+	case reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		return decReflectUints(p, v)
+	case reflect.String:
+		return decReflectString(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%#[1]v)", v.Interface())
+	}
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if p != nil {
+		zeroValue := reflect.New(v.Type().Elem().Elem())
+		v.Elem().Set(zeroValue)
+		return DecReflect(p, v.Elem())
+	}
+	nilValue := reflect.Zero(v.Elem().Type())
+	v.Elem().Set(nilValue)
+	return nil
+}
+
+func decReflectInt8(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetInt(0)
+	case 2:
+		val := decInt16(p)
+		if val > math.MaxInt8 || val < math.MinInt8 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into int8, the data should be in the int8 range")
+		}
+		v.SetInt(int64(val))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectInts(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetInt(0)
+	case 2:
+		v.SetInt(int64(decInt16(p)))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUint8(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetUint(0)
+	case 2:
+		if p[0] != 0 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint8, the data should be in the uint8 range")
+		}
+		v.SetUint(uint64(p[1]))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUints(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetUint(0)
+	case 2:
+		v.SetUint(decUint64(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectString(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p != nil {
+			v.SetString("0")
+		} else {
+			v.SetString("")
+		}
+	case 2:
+		v.SetString(strconv.FormatInt(int64(decInt16(p)), 10))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decInt16(p []byte) int16 {
+	return int16(p[0])<<8 | int16(p[1])
+}
+
+func decUint64(p []byte) uint64 {
+	return uint64(p[0])<<8 | uint64(p[1])
+}

--- a/marshal_3_smallint_corrupt_test.go
+++ b/marshal_3_smallint_corrupt_test.go
@@ -7,86 +7,101 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/marshal/smallint"
 )
 
 func TestMarshalSmallintCorrupt(t *testing.T) {
-	tType := gocql.NewNativeType(4, gocql.TypeSmallInt, "")
-
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	// unmarshal function does not return an error in cases where the length of the data is different from 0 or 2
-	brokenUnmarshalTypes := serialization.GetTypes(
-		mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			*big.NewInt(0),
-		}.AddVariants(mod.All...)...)
-	brokenUnmarshalTypes = append(brokenUnmarshalTypes, serialization.GetTypes("", (*string)(nil))...)
+	tType := gocql.NewNativeType(4, gocql.TypeSmallInt, "")
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			int32(32768), int64(32768), int(32768),
-			"32768", *big.NewInt(32768),
-			int32(-32769), int64(-32769), int(-32769),
-			"-32769", *big.NewInt(-32769),
-			uint32(65536), uint64(65536), uint(65536),
-		}.AddVariants(mod.All...),
-	}.Run("big_vals", t, marshal)
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.smallint",
+			marshal:   smallint.Marshal,
+			unmarshal: smallint.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{"1s2", "1s", "-1s", ".1", ",1", "0.1", "0,1"}.AddVariants(mod.All...),
-	}.Run("corrupt_vals", t, marshal)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x80\x00\x00"),
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"", *big.NewInt(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenUnmarshalTypes,
-	}.Run("big_data", t, unmarshal)
+		t.Run(tSuite.name, func(t *testing.T) {
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					int32(32768), int64(32768), int(32768),
+					"32768", *big.NewInt(32768),
+					int32(-32769), int64(-32769), int(-32769),
+					"-32769", *big.NewInt(-32769),
+					uint32(65536), uint64(65536), uint(65536),
+				}.AddVariants(mod.All...),
+			}.Run("big_vals", t, marshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x80"),
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"", *big.NewInt(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenUnmarshalTypes,
-	}.Run("small_data", t, unmarshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{"1s2", "1s", "-1s", ".1", ",1", "0.1", "0,1"}.AddVariants(mod.All...),
+			}.Run("corrupt_vals", t, marshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data:   []byte("\x00\x80"),
-		Values: mod.Values{int8(0)}.AddVariants(mod.All...),
-	}.Run("small_type_int8_128", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80\x00\x00"),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("big_data", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data:   []byte("\x7f\xff"),
-		Values: mod.Values{int8(0)}.AddVariants(mod.All...),
-	}.Run("small_type_int8_32767", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80"),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("small_data", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data:   []byte("\xff\x7f"),
-		Values: mod.Values{int8(0)}.AddVariants(mod.All...),
-	}.Run("small_type_int8_-129", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x00\x80"),
+				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_int8_128", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data:   []byte("\x7f\xff"),
-		Values: mod.Values{int8(0)}.AddVariants(mod.All...),
-	}.Run("small_type_int8_-32768", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x7f\xff"),
+				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_int8_32767", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data:   []byte("\x01\x00"),
-		Values: mod.Values{int8(0)}.AddVariants(mod.All...),
-	}.Run("small_type_uint_256", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\xff\x7f"),
+				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_int8_-129", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data:   []byte("\xff\xff"),
-		Values: mod.Values{uint8(0)}.AddVariants(mod.All...),
-	}.Run("small_type_uint_65535", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x7f\xff"),
+				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_int8_-32768", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x01\x00"),
+				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_uint_256", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\xff\xff"),
+				Values: mod.Values{uint8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_uint_65535", t, unmarshal)
+		})
+	}
 }

--- a/marshal_3_smallint_test.go
+++ b/marshal_3_smallint_test.go
@@ -7,104 +7,105 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/marshal/smallint"
 )
 
 func TestMarshalSmallint(t *testing.T) {
-	tType := gocql.NewNativeType(4, gocql.TypeSmallInt, "")
-
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	// unmarshal `custom string` unsupported
-	brokenCustomStrings := serialization.GetTypes(mod.String(""), (*mod.String)(nil))
+	tType := gocql.NewNativeType(4, gocql.TypeSmallInt, "")
 
-	// marshal "" (empty string) unsupported
-	// unmarshal nil value into (string)("0")
-	brokenEmptyStrings := serialization.GetTypes(string(""), mod.String(""))
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.smallint",
+			marshal:   smallint.Marshal,
+			unmarshal: smallint.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	// marshal `custom string` unsupported
-	// marshal `big.Int` unsupported
-	brokenMarshalTypes := append(brokenCustomStrings, serialization.GetTypes(big.Int{}, &big.Int{})...)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			(*int8)(nil), (*int16)(nil), (*int32)(nil), (*int64)(nil), (*int)(nil),
-			(*uint8)(nil), (*uint16)(nil), (*uint32)(nil), (*uint64)(nil), (*uint)(nil),
-			(*string)(nil), (*big.Int)(nil), "",
-		}.AddVariants(mod.CustomType),
-		BrokenMarshalTypes:   brokenEmptyStrings,
-		BrokenUnmarshalTypes: brokenEmptyStrings,
-	}.Run("[nil]nullable", t, marshal, unmarshal)
+		t.Run(tSuite.name, func(t *testing.T) {
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					(*int8)(nil), (*int16)(nil), (*int32)(nil), (*int64)(nil), (*int)(nil),
+					(*uint8)(nil), (*uint16)(nil), (*uint32)(nil), (*uint64)(nil), (*uint)(nil),
+					(*string)(nil), (*big.Int)(nil), "",
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]nullable", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"0", big.Int{},
-		}.AddVariants(mod.CustomType),
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("[nil]unmarshal", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"", big.Int{},
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data: make([]byte, 0),
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"0", *big.NewInt(0),
-		}.AddVariants(mod.All...),
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("[]unmarshal", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data: make([]byte, 0),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"0", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("[]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00"),
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"0", *big.NewInt(0),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("zeros", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00"),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"0", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("zeros", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:                 []byte("\x00\x7f"),
-		Values:               mod.Values{int8(127), int16(127), int32(127), int64(127), int(127), "127", *big.NewInt(127)}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("127", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\x00\x7f"),
+				Values: mod.Values{int8(127), int16(127), int32(127), int64(127), int(127), "127", *big.NewInt(127)}.AddVariants(mod.All...),
+			}.Run("127", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:                 []byte("\xff\x80"),
-		Values:               mod.Values{int8(-128), int16(-128), int32(-128), int64(-128), int(-128), "-128", *big.NewInt(-128)}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("-128", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\xff\x80"),
+				Values: mod.Values{int8(-128), int16(-128), int32(-128), int64(-128), int(-128), "-128", *big.NewInt(-128)}.AddVariants(mod.All...),
+			}.Run("-128", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:                 []byte("\x7f\xff"),
-		Values:               mod.Values{int16(32767), int32(32767), int64(32767), int(32767), "32767", *big.NewInt(32767)}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("32767", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\x7f\xff"),
+				Values: mod.Values{int16(32767), int32(32767), int64(32767), int(32767), "32767", *big.NewInt(32767)}.AddVariants(mod.All...),
+			}.Run("32767", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:                 []byte("\x80\x00"),
-		Values:               mod.Values{int16(-32768), int32(-32768), int64(-32768), int(-32768), "-32768", *big.NewInt(-32768)}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("-32768", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\x80\x00"),
+				Values: mod.Values{int16(-32768), int32(-32768), int64(-32768), int(-32768), "-32768", *big.NewInt(-32768)}.AddVariants(mod.All...),
+			}.Run("-32768", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\x00\xff"),
-		Values: mod.Values{uint8(255), uint16(255), uint32(255), uint64(255), uint(255)}.AddVariants(mod.All...),
-	}.Run("255", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\x00\xff"),
+				Values: mod.Values{uint8(255), uint16(255), uint32(255), uint64(255), uint(255)}.AddVariants(mod.All...),
+			}.Run("255", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\xff\xff"),
-		Values: mod.Values{uint16(65535), uint32(65535), uint64(65535), uint(65535)}.AddVariants(mod.All...),
-	}.Run("65535", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\xff\xff"),
+				Values: mod.Values{uint16(65535), uint32(65535), uint64(65535), uint(65535)}.AddVariants(mod.All...),
+			}.Run("65535", t, marshal, unmarshal)
+		})
+	}
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -815,97 +815,6 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\x7f\xff"),
-		32767, // math.MaxInt16
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\x7f\xff"),
-		"32767", // math.MaxInt16
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\x00\x01"),
-		int16(1),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		int16(-1),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\x00\xff"),
-		uint8(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		uint16(65535),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		uint32(65535),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		uint64(65535),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\x00\xff"),
-		AliasUint8(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		AliasUint16(65535),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		AliasUint32(65535),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		AliasUint64(65535),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		AliasUint(65535),
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeTinyInt},
 		[]byte("\x7f"),
 		127, // math.MaxInt8
@@ -1078,18 +987,6 @@ var unmarshalTests = []struct {
 	UnmarshalError error
 }{
 	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		uint8(0),
-		unmarshalErrorf("unmarshal int: value -1 out of range for uint8"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\x01\x00"),
-		uint8(0),
-		unmarshalErrorf("unmarshal int: value 256 out of range for uint8"),
-	},
-	{
 		NativeType{proto: 2, typ: TypeInt},
 		[]byte("\xff\xff\xff\xff"),
 		uint8(0),
@@ -1160,18 +1057,6 @@ var unmarshalTests = []struct {
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x00"),
 		uint32(0),
 		unmarshalErrorf("unmarshal int: value 4294967296 out of range for uint32"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\xff\xff"),
-		AliasUint8(0),
-		unmarshalErrorf("unmarshal int: value -1 out of range for gocql.AliasUint8"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeSmallInt},
-		[]byte("\x01\x00"),
-		AliasUint8(0),
-		unmarshalErrorf("unmarshal int: value 256 out of range for gocql.AliasUint8"),
 	},
 	{
 		NativeType{proto: 2, typ: TypeInt},


### PR DESCRIPTION
Fixed for `smallint` type:
1. `string` marshal and unmarshal as `nullable`. 
1.1. Was: marshals `""` - caused an error; unmarshals `nil data` into `"0"`.
1.2. Now: marshals and unmarshals `nil data` - `""`.
2. `custom string` marshals and unmarshals was `not supported`, now `supported`.
3. `big.Int` marshals was `not supported`, now `supported`.
4. Also was fixed cases when marshal and unmarshal should an error, but currently we does not have a `corrupt test suite`.

Close issues for `smallint`:
1) #246 
2) #243
3) #244
4) #250