### PR TITLE
Fix `int` marshal, unmarshall

### DIFF
--- a/marshal/cqlint/marshal.go
+++ b/marshal/cqlint/marshal.go
@@ -1,0 +1,74 @@
+package cqlint
+
+import (
+	"math/big"
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case int8:
+		return EncInt8(v)
+	case int32:
+		return EncInt32(v)
+	case int16:
+		return EncInt16(v)
+	case int64:
+		return EncInt64(v)
+	case int:
+		return EncInt(v)
+
+	case uint8:
+		return EncUint8(v)
+	case uint16:
+		return EncUint16(v)
+	case uint32:
+		return EncUint32(v)
+	case uint64:
+		return EncUint64(v)
+	case uint:
+		return EncUint(v)
+
+	case big.Int:
+		return EncBigInt(v)
+	case string:
+		return EncString(v)
+
+	case *int8:
+		return EncInt8R(v)
+	case *int16:
+		return EncInt16R(v)
+	case *int32:
+		return EncInt32R(v)
+	case *int64:
+		return EncInt64R(v)
+	case *int:
+		return EncIntR(v)
+
+	case *uint8:
+		return EncUint8R(v)
+	case *uint16:
+		return EncUint16R(v)
+	case *uint32:
+		return EncUint32R(v)
+	case *uint64:
+		return EncUint64R(v)
+	case *uint:
+		return EncUintR(v)
+
+	case *big.Int:
+		return EncBigIntR(v)
+	case *string:
+		return EncStringR(v)
+	default:
+		// Custom types (type MyInt int) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/marshal/cqlint/marshal_utils.go
+++ b/marshal/cqlint/marshal_utils.go
@@ -1,0 +1,194 @@
+package cqlint
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+)
+
+var (
+	maxBigInt = big.NewInt(math.MaxInt32)
+	minBigInt = big.NewInt(math.MinInt32)
+)
+
+func EncInt8(v int8) ([]byte, error) {
+	return encInt32(int32(v)), nil
+}
+
+func EncInt8R(v *int8) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt8(*v)
+}
+
+func EncInt16(v int16) ([]byte, error) {
+	return encInt32(int32(v)), nil
+}
+
+func EncInt16R(v *int16) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt16(*v)
+}
+
+func EncInt32(v int32) ([]byte, error) {
+	return encInt32(v), nil
+}
+
+func EncInt32R(v *int32) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt32(*v)
+}
+
+func EncInt64(v int64) ([]byte, error) {
+	if v > math.MaxInt32 || v < math.MinInt32 {
+		return nil, fmt.Errorf("failed to marshal int: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
+}
+
+func EncInt64R(v *int64) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt64(*v)
+}
+
+func EncInt(v int) ([]byte, error) {
+	if v > math.MaxInt32 || v < math.MinInt32 {
+		return nil, fmt.Errorf("failed to marshal int: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
+}
+
+func EncIntR(v *int) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt(*v)
+}
+
+func EncUint8(v uint8) ([]byte, error) {
+	return []byte{0, 0, 0, v}, nil
+}
+
+func EncUint8R(v *uint8) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint8(*v)
+}
+
+func EncUint16(v uint16) ([]byte, error) {
+	return []byte{0, 0, byte(v >> 8), byte(v)}, nil
+}
+
+func EncUint16R(v *uint16) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint16(*v)
+}
+
+func EncUint32(v uint32) ([]byte, error) {
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
+}
+
+func EncUint32R(v *uint32) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint32(*v)
+}
+
+func EncUint64(v uint64) ([]byte, error) {
+	if v > math.MaxUint32 {
+		return nil, fmt.Errorf("failed to marshal int: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
+}
+
+func EncUint64R(v *uint64) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint64(*v)
+}
+
+func EncUint(v uint) ([]byte, error) {
+	if v > math.MaxUint32 {
+		return nil, fmt.Errorf("failed to marshal int: value %#v out of range", v)
+	}
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
+}
+
+func EncUintR(v *uint) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncUint(*v)
+}
+
+func EncBigInt(v big.Int) ([]byte, error) {
+	if v.Cmp(maxBigInt) == 1 || v.Cmp(minBigInt) == -1 {
+		return nil, fmt.Errorf("failed to marshal int: value (%T)(%s) out of range", v, v.String())
+	}
+	n := v.Int64()
+	return []byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}, nil
+}
+
+func EncBigIntR(v *big.Int) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncBigInt(*v)
+}
+
+func EncString(v string) ([]byte, error) {
+	if v == "" {
+		return nil, nil
+	}
+
+	n, err := strconv.ParseInt(v, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal int: can not marshal %#v %s", v, err)
+	}
+	return []byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}, nil
+}
+
+func EncStringR(v *string) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncString(*v)
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Type().Kind() {
+	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
+		return EncInt64(v.Int())
+	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+		return EncUint64(v.Uint())
+	case reflect.String:
+		return EncString(v.String())
+	default:
+		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%#[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encInt32(v int32) []byte {
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}

--- a/marshal/cqlint/unmarshal.go
+++ b/marshal/cqlint/unmarshal.go
@@ -1,0 +1,81 @@
+package cqlint
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+
+	case *int8:
+		return DecInt8(data, v)
+	case *int16:
+		return DecInt16(data, v)
+	case *int32:
+		return DecInt32(data, v)
+	case *int64:
+		return DecInt64(data, v)
+	case *int:
+		return DecInt(data, v)
+
+	case *uint8:
+		return DecUint8(data, v)
+	case *uint16:
+		return DecUint16(data, v)
+	case *uint32:
+		return DecUint32(data, v)
+	case *uint64:
+		return DecUint64(data, v)
+	case *uint:
+		return DecUint(data, v)
+
+	case *big.Int:
+		return DecBigInt(data, v)
+	case *string:
+		return DecString(data, v)
+
+	case **int8:
+		return DecInt8R(data, v)
+	case **int16:
+		return DecInt16R(data, v)
+	case **int32:
+		return DecInt32R(data, v)
+	case **int64:
+		return DecInt64R(data, v)
+	case **int:
+		return DecIntR(data, v)
+
+	case **uint8:
+		return DecUint8R(data, v)
+	case **uint16:
+		return DecUint16R(data, v)
+	case **uint32:
+		return DecUint32R(data, v)
+	case **uint64:
+		return DecUint64R(data, v)
+	case **uint:
+		return DecUintR(data, v)
+
+	case **big.Int:
+		return DecBigIntR(data, v)
+	case **string:
+		return DecStringR(data, v)
+	default:
+
+		// Custom types (type MyInt int) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%#[1]v)", value)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/marshal/cqlint/unmarshal_utils.go
+++ b/marshal/cqlint/unmarshal_utils.go
@@ -1,0 +1,427 @@
+package cqlint
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+)
+
+var errWrongDataLen = fmt.Errorf("failed to unmarshal int: the length of the data should be 0 or 4")
+
+func DecInt8(p []byte, v *int8) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		val := decInt32(p)
+		if val > math.MaxInt8 || val < math.MinInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int8, the data should be in the int8 range")
+		}
+		*v = int8(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt8R(p []byte, v **int8) error {
+	if p != nil {
+		*v = new(int8)
+		return DecInt8(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt16(p []byte, v *int16) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		val := decInt32(p)
+		if val > math.MaxInt16 || val < math.MinInt16 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int16, the data should be in the int16 range")
+		}
+		*v = int16(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt16R(p []byte, v **int16) error {
+	if p != nil {
+		*v = new(int16)
+		return DecInt16(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt32(p []byte, v *int32) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		*v = decInt32(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt32R(p []byte, v **int32) error {
+	if p != nil {
+		*v = new(int32)
+		return DecInt32(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt64(p []byte, v *int64) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		*v = int64(decInt32(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt64R(p []byte, v **int64) error {
+	if p != nil {
+		*v = new(int64)
+		return DecInt64(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecInt(p []byte, v *int) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		*v = int(decInt32(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecIntR(p []byte, v **int) error {
+	if p != nil {
+		*v = new(int)
+		return DecInt(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint8(p []byte, v *uint8) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint8, the data should be in the uint8 range")
+		}
+		*v = p[3]
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint8R(p []byte, v **uint8) error {
+	if p != nil {
+		*v = new(uint8)
+		return DecUint8(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint16(p []byte, v *uint16) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		if p[0] != 0 || p[1] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint16, the data should be in the uint16 range")
+		}
+		*v = uint16(p[2])<<8 | uint16(p[3])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint16R(p []byte, v **uint16) error {
+	if p != nil {
+		*v = new(uint16)
+		return DecUint16(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint32(p []byte, v *uint32) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		*v = uint32(p[0])<<24 | uint32(p[1])<<16 | uint32(p[2])<<8 | uint32(p[3])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint32R(p []byte, v **uint32) error {
+	if p != nil {
+		*v = new(uint32)
+		return DecUint32(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint64(p []byte, v *uint64) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		*v = decUint64(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUint64R(p []byte, v **uint64) error {
+	if p != nil {
+		*v = new(uint64)
+		return DecUint64(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecUint(p []byte, v *uint) error {
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 4:
+		*v = uint(p[0])<<24 | uint(p[1])<<16 | uint(p[2])<<8 | uint(p[3])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecUintR(p []byte, v **uint) error {
+	if p != nil {
+		*v = new(uint)
+		return DecUint(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecString(p []byte, v *string) error {
+	switch len(p) {
+	case 0:
+		if p != nil {
+			*v = "0"
+		} else {
+			*v = ""
+		}
+	case 4:
+		*v = strconv.FormatInt(int64(decInt32(p)), 10)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecStringR(p []byte, v **string) error {
+	if p != nil {
+		*v = new(string)
+		return DecString(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecBigInt(p []byte, v *big.Int) error {
+	switch len(p) {
+	case 0:
+		v.SetInt64(0)
+	case 4:
+		v.SetInt64(int64(decInt32(p)))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecBigIntR(p []byte, v **big.Int) error {
+	if p != nil {
+		*v = big.NewInt(0)
+		return DecBigInt(p, *v)
+	}
+	*v = nil
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return fmt.Errorf("failed to unmarshal int: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.Int8:
+		return decReflectInt8(p, v)
+	case reflect.Int16:
+		return decReflectInt16(p, v)
+	case reflect.Int32, reflect.Int64, reflect.Int:
+		return decReflectInts(p, v)
+	case reflect.Uint8:
+		return decReflectUint8(p, v)
+	case reflect.Uint16:
+		return decReflectUint16(p, v)
+	case reflect.Uint32, reflect.Uint64, reflect.Uint:
+		return decReflectUints(p, v)
+	case reflect.String:
+		return decReflectString(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%#[1]v)", v.Interface())
+	}
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if p != nil {
+		zeroValue := reflect.New(v.Type().Elem().Elem())
+		v.Elem().Set(zeroValue)
+		return DecReflect(p, v.Elem())
+	}
+	nilValue := reflect.Zero(v.Elem().Type())
+	v.Elem().Set(nilValue)
+	return nil
+}
+
+func decReflectInt8(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetInt(0)
+	case 4:
+		val := decInt32(p)
+		if val > math.MaxInt8 || val < math.MinInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int8, the data should be in the int8 range")
+		}
+		v.SetInt(int64(val))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectInt16(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetInt(0)
+	case 4:
+		val := decInt32(p)
+		if val > math.MaxInt16 || val < math.MinInt16 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int16, the data should be in the int16 range")
+		}
+		v.SetInt(int64(val))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectInts(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetInt(0)
+	case 4:
+		v.SetInt(int64(decInt32(p)))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUint8(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetUint(0)
+	case 4:
+		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint8, the data should be in the uint8 range")
+		}
+		v.SetUint(uint64(p[3]))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUint16(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetUint(0)
+	case 4:
+		if p[0] != 0 || p[1] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint16, the data should be in the uint16 range")
+		}
+		v.SetUint(uint64(p[2])<<8 | uint64(p[3]))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUints(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetUint(0)
+	case 4:
+		v.SetUint(decUint64(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectString(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p != nil {
+			v.SetString("0")
+		} else {
+			v.SetString("")
+		}
+	case 4:
+		v.SetString(strconv.FormatInt(int64(decInt32(p)), 10))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decInt32(p []byte) int32 {
+	return int32(p[0])<<24 | int32(p[1])<<16 | int32(p[2])<<8 | int32(p[3])
+}
+
+func decUint64(p []byte) uint64 {
+	return uint64(p[0])<<24 | uint64(p[1])<<16 | uint64(p[2])<<8 | uint64(p[3])
+}

--- a/marshal_3_smallint_corrupt_test.go
+++ b/marshal_3_smallint_corrupt_test.go
@@ -95,7 +95,7 @@ func TestMarshalSmallintCorrupt(t *testing.T) {
 
 			serialization.NegativeUnmarshalSet{
 				Data:   []byte("\x01\x00"),
-				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+				Values: mod.Values{uint8(0)}.AddVariants(mod.All...),
 			}.Run("small_type_uint_256", t, unmarshal)
 
 			serialization.NegativeUnmarshalSet{

--- a/marshal_4_int_corrupt_test.go
+++ b/marshal_4_int_corrupt_test.go
@@ -1,0 +1,131 @@
+package gocql_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/gocql/gocql/internal/tests/serialization"
+	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/marshal/cqlint"
+)
+
+func TestMarshalIntCorrupt(t *testing.T) {
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
+	}
+
+	tType := gocql.NewNativeType(4, gocql.TypeInt, "")
+
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.int",
+			marshal:   cqlint.Marshal,
+			unmarshal: cqlint.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
+
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
+
+		t.Run(tSuite.name, func(t *testing.T) {
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					int64(2147483648), int(2147483648),
+					"2147483648", *big.NewInt(2147483648),
+					int64(-2147483649), int(-2147483649),
+					"-2147483649", *big.NewInt(-2147483649),
+					uint64(4294967296), uint(4294967296),
+				}.AddVariants(mod.All...),
+			}.Run("big_vals", t, marshal)
+
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{"1s2", "1s", "-1s", ".1", ",1", "0.1", "0,1"}.AddVariants(mod.All...),
+			}.Run("corrupt_vals", t, marshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("big_data", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80"),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("small_data1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80\x00\x00"),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("small_data2", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x80\x00\x00\x00"),
+				Values: mod.Values{int8(0), int16(0)}.AddVariants(mod.All...),
+			}.Run("small_types_int_2147483648", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x7f\xff\xff\xff"),
+				Values: mod.Values{int8(0), int16(0)}.AddVariants(mod.All...),
+			}.Run("small_types_int_-2147483647", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x00\x00\x80\x00"),
+				Values: mod.Values{int8(0), int16(0)}.AddVariants(mod.All...),
+			}.Run("small_types_int_32768", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\xff\xff\x7f\xff"),
+				Values: mod.Values{int8(0), int16(0)}.AddVariants(mod.All...),
+			}.Run("small_types_int_-32769", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x00\x00\x00\x80"),
+				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_int8_128", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\xff\xff\xff\x7f"),
+				Values: mod.Values{int8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_int8_-129", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\xff\xff\xff\xff"),
+				Values: mod.Values{uint8(0), uint16(0)}.AddVariants(mod.All...),
+			}.Run("small_types_uint_4294967295", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x00\x01\x00\x00"),
+				Values: mod.Values{uint8(0), uint16(0)}.AddVariants(mod.All...),
+			}.Run("small_types_uint_65536", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data:   []byte("\x00\x00\x01\x00"),
+				Values: mod.Values{uint8(0)}.AddVariants(mod.All...),
+			}.Run("small_type_uint_256", t, unmarshal)
+		})
+	}
+}

--- a/marshal_4_int_test.go
+++ b/marshal_4_int_test.go
@@ -7,151 +7,145 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/marshal/cqlint"
 )
 
 func TestMarshalInt(t *testing.T) {
-	tType := gocql.NewNativeType(4, gocql.TypeInt, "")
-
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	// unmarshal `custom string` unsupported
-	brokenCustomStrings := serialization.GetTypes(mod.String(""), (*mod.String)(nil))
+	tType := gocql.NewNativeType(4, gocql.TypeInt, "")
 
-	// marshal "" (empty string) unsupported
-	// unmarshal nil value into (string)("0")
-	brokenEmptyStrings := serialization.GetTypes(string(""), mod.String(""))
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.int",
+			marshal:   cqlint.Marshal,
+			unmarshal: cqlint.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	// marshal `custom string` unsupported
-	// marshal `big.Int` unsupported
-	brokenMarshalTypes := append(brokenCustomStrings, serialization.GetTypes(big.Int{}, &big.Int{})...)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	// marshal data, which equal math.MaxUint32, into uint32, uit64, uint leads to an error
-	brokenUints := serialization.GetTypes(mod.Uint32(0), mod.Uint64(0), mod.Uint(0), (*mod.Uint32)(nil), (*mod.Uint64)(nil), (*mod.Uint)(nil))
+		t.Run(tSuite.name, func(t *testing.T) {
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			(*int8)(nil), (*int16)(nil), (*int32)(nil), (*int64)(nil), (*int)(nil),
-			(*uint8)(nil), (*uint16)(nil), (*uint32)(nil), (*uint64)(nil), (*uint)(nil),
-			(*string)(nil), (*big.Int)(nil), "",
-		}.AddVariants(mod.CustomType),
-		BrokenMarshalTypes:   brokenEmptyStrings,
-		BrokenUnmarshalTypes: brokenEmptyStrings,
-	}.Run("[nil]nullable", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					(*int8)(nil), (*int16)(nil), (*int32)(nil), (*int64)(nil), (*int)(nil),
+					(*uint8)(nil), (*uint16)(nil), (*uint32)(nil), (*uint64)(nil), (*uint)(nil),
+					(*string)(nil), (*big.Int)(nil), "",
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]nullable", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"0", big.Int{},
-		}.AddVariants(mod.CustomType),
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("[nil]unmarshal", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"", big.Int{},
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data: make([]byte, 0),
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"0", *big.NewInt(0),
-		}.AddVariants(mod.All...),
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("[]unmarshal", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data: make([]byte, 0),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"0", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("[]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\x00\x00"),
-		Values: mod.Values{
-			int8(0), int16(0), int32(0), int64(0), int(0),
-			uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
-			"0", *big.NewInt(0),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("zeros", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int8(0), int16(0), int32(0), int64(0), int(0),
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+					"0", *big.NewInt(0),
+				}.AddVariants(mod.All...),
+			}.Run("zeros", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x7f\xff\xff\xff"),
-		Values: mod.Values{
-			int32(2147483647), int64(2147483647), int(2147483647),
-			"2147483647", *big.NewInt(2147483647),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("2147483647", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x7f\xff\xff\xff"),
+				Values: mod.Values{
+					int32(2147483647), int64(2147483647), int(2147483647),
+					"2147483647", *big.NewInt(2147483647),
+				}.AddVariants(mod.All...),
+			}.Run("2147483647", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x80\x00\x00\x00"),
-		Values: mod.Values{
-			int32(-2147483648), int64(-2147483648), int(-2147483648),
-			"-2147483648", *big.NewInt(-2147483648),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("-2147483648", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x80\x00\x00\x00"),
+				Values: mod.Values{
+					int32(-2147483648), int64(-2147483648), int(-2147483648),
+					"-2147483648", *big.NewInt(-2147483648),
+				}.AddVariants(mod.All...),
+			}.Run("-2147483648", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\x7f\xff"),
-		Values: mod.Values{
-			int16(32767), int32(32767), int64(32767), int(32767),
-			"32767", *big.NewInt(32767),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("32767", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x7f\xff"),
+				Values: mod.Values{
+					int16(32767), int32(32767), int64(32767), int(32767),
+					"32767", *big.NewInt(32767),
+				}.AddVariants(mod.All...),
+			}.Run("32767", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\xff\xff\x80\x00"),
-		Values: mod.Values{
-			int16(-32768), int32(-32768), int64(-32768), int(-32768),
-			"-32768", *big.NewInt(-32768),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("-32768", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\x80\x00"),
+				Values: mod.Values{
+					int16(-32768), int32(-32768), int64(-32768), int(-32768),
+					"-32768", *big.NewInt(-32768),
+				}.AddVariants(mod.All...),
+			}.Run("-32768", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\x00\x7f"),
-		Values: mod.Values{
-			int8(127), int16(127), int32(127), int64(127), int(127),
-			"127", *big.NewInt(127),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("127", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x7f"),
+				Values: mod.Values{
+					int8(127), int16(127), int32(127), int64(127), int(127),
+					"127", *big.NewInt(127),
+				}.AddVariants(mod.All...),
+			}.Run("127", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\xff\xff\xff\x80"),
-		Values: mod.Values{
-			int8(-128), int16(-128), int32(-128), int64(-128), int(-128),
-			"-128", *big.NewInt(-128),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenMarshalTypes,
-		BrokenUnmarshalTypes: brokenCustomStrings,
-	}.Run("-128", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\x80"),
+				Values: mod.Values{
+					int8(-128), int16(-128), int32(-128), int64(-128), int(-128),
+					"-128", *big.NewInt(-128),
+				}.AddVariants(mod.All...),
+			}.Run("-128", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\x00\xff"),
-		Values: mod.Values{
-			uint8(255), uint16(255), uint32(255), uint64(255), uint(255),
-		}.AddVariants(mod.All...),
-	}.Run("255", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\xff"),
+				Values: mod.Values{
+					uint8(255), uint16(255), uint32(255), uint64(255), uint(255),
+				}.AddVariants(mod.All...),
+			}.Run("255", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\xff\xff"),
-		Values: mod.Values{
-			uint16(65535), uint32(65535), uint64(65535), uint(65535),
-		}.AddVariants(mod.All...),
-	}.Run("65535", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\xff\xff"),
+				Values: mod.Values{
+					uint16(65535), uint32(65535), uint64(65535), uint(65535),
+				}.AddVariants(mod.All...),
+			}.Run("65535", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\xff\xff\xff\xff"),
-		Values: mod.Values{
-			uint32(4294967295), uint64(4294967295), uint(4294967295),
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes: brokenUints,
-	}.Run("4294967295", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff"),
+				Values: mod.Values{
+					uint32(4294967295), uint64(4294967295), uint(4294967295),
+				}.AddVariants(mod.All...),
+			}.Run("4294967295", t, marshal, unmarshal)
+		})
+	}
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -105,69 +105,6 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x00\x00\x00\x00"),
-		0,
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x01\x02\x03\x04"),
-		int(16909060),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x01\x02\x03\x04"),
-		AliasInt(16909060),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x80\x00\x00\x00"),
-		int32(math.MinInt32),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x7f\xff\xff\xff"),
-		int32(math.MaxInt32),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x00\x00\x00\x00"),
-		"0",
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x01\x02\x03\x04"),
-		"16909060",
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x80\x00\x00\x00"),
-		"-2147483648", // math.MinInt32
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x7f\xff\xff\xff"),
-		"2147483647", // math.MaxInt32
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeBigInt},
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
 		0,
@@ -587,13 +524,6 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte(nil),
-		nil,
-		nil,
-		unmarshalErrorf("can not unmarshal into non-pointer <nil>"),
-	},
-	{
 		NativeType{proto: 2, typ: TypeVarchar},
 		[]byte("nullable string"),
 		func() *string {
@@ -607,23 +537,6 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeVarchar},
 		[]byte(nil),
 		(*string)(nil),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x7f\xff\xff\xff"),
-		func() *int {
-			var value int = math.MaxInt32
-			return &value
-		}(),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte(nil),
-		(*int)(nil),
 		nil,
 		nil,
 	},
@@ -941,20 +854,6 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\xff\xff\xff\xff"),
-		uint32(math.MaxUint32),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\xff\xff\xff\xff"),
-		uint64(math.MaxUint32),
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeBlob},
 		[]byte(nil),
 		([]byte)(nil),
@@ -986,30 +885,6 @@ var unmarshalTests = []struct {
 	Value          interface{}
 	UnmarshalError error
 }{
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\xff\xff\xff\xff"),
-		uint8(0),
-		unmarshalErrorf("unmarshal int: value -1 out of range for uint8"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x00\x00\x01\x00"),
-		uint8(0),
-		unmarshalErrorf("unmarshal int: value 256 out of range for uint8"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\xff\xff\xff\xff"),
-		uint16(0),
-		unmarshalErrorf("unmarshal int: value -1 out of range for uint16"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x00\x01\x00\x00"),
-		uint16(0),
-		unmarshalErrorf("unmarshal int: value 65536 out of range for uint16"),
-	},
 	{
 		NativeType{proto: 2, typ: TypeBigInt},
 		[]byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
@@ -1057,30 +932,6 @@ var unmarshalTests = []struct {
 		[]byte("\x00\x00\x00\x01\x00\x00\x00\x00"),
 		uint32(0),
 		unmarshalErrorf("unmarshal int: value 4294967296 out of range for uint32"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\xff\xff\xff\xff"),
-		AliasUint8(0),
-		unmarshalErrorf("unmarshal int: value -1 out of range for gocql.AliasUint8"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x00\x00\x01\x00"),
-		AliasUint8(0),
-		unmarshalErrorf("unmarshal int: value 256 out of range for gocql.AliasUint8"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\xff\xff\xff\xff"),
-		AliasUint16(0),
-		unmarshalErrorf("unmarshal int: value -1 out of range for gocql.AliasUint16"),
-	},
-	{
-		NativeType{proto: 2, typ: TypeInt},
-		[]byte("\x00\x01\x00\x00"),
-		AliasUint16(0),
-		unmarshalErrorf("unmarshal int: value 65536 out of range for gocql.AliasUint16"),
 	},
 	{
 		NativeType{proto: 2, typ: TypeBigInt},

--- a/token_test.go
+++ b/token_test.go
@@ -24,7 +24,7 @@ func TestMurmur3Partitioner(t *testing.T) {
 
 	// at least verify that the partitioner
 	// doesn't return nil
-	pk, _ := marshalInt(nil, 1)
+	pk, _ := marshalInt(1)
 	token = murmur3Partitioner{}.Hash(pk)
 	if token == nil {
 		t.Fatal("token was nil")
@@ -49,7 +49,7 @@ func TestOrderedPartitioner(t *testing.T) {
 	// at least verify that the partitioner
 	// doesn't return nil
 	p := orderedPartitioner{}
-	pk, _ := marshalInt(nil, 1)
+	pk, _ := marshalInt(1)
 	token := p.Hash(pk)
 	if token == nil {
 		t.Fatal("token was nil")
@@ -85,7 +85,7 @@ func TestRandomPartitioner(t *testing.T) {
 	// at least verify that the partitioner
 	// doesn't return nil
 	p := randomPartitioner{}
-	pk, _ := marshalInt(nil, 1)
+	pk, _ := marshalInt(1)
 	token := p.Hash(pk)
 	if token == nil {
 		t.Fatal("token was nil")


### PR DESCRIPTION
Fixed for `int` type:
1. `string` marshal and unmarshal as `nullable`. 
1.1. Before: marshals `""` - caused an error; unmarshals `nil data` into `"0"`.
1.2. Now: marshals and unmarshals `nil data` - `""`.
2. `custom string` marshals and unmarshals, before `not supported`, now `supported`.
3. `big.Int` marshals, before `not supported`, now `supported`.
4. Marshal data, which equal `math.MaxUint32`, into `uint32`, `uint64`, `uint`, return `error' before, now `no error`.
5. Unmarshal `data` with the length is different from `0` and `4`, did not return `error` before, now it returns `error'.

Close issues for `int`:
1) #246 
2) #243
3) #244
4) #250
5) #252