### PR TITLE
Fix marshal  `tinyint` - optimization

### DIFF
--- a/marshal/tinyint/unmarshal.go
+++ b/marshal/tinyint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%#[1]v)", value)
+			return fmt.Errorf("failed to unmarshal tinyint: unsupported value type %#v", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/marshal/tinyint/unmarshal_utils.go
+++ b/marshal/tinyint/unmarshal_utils.go
@@ -10,7 +10,14 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal tinyint: the length of the data should less or equal then 1")
 
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference %#v)", v)
+}
+
 func DecInt8(p []byte, v *int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -23,6 +30,9 @@ func DecInt8(p []byte, v *int8) error {
 }
 
 func DecInt8R(p []byte, v **int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -40,6 +50,9 @@ func DecInt8R(p []byte, v **int8) error {
 }
 
 func DecInt16(p []byte, v *int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -52,6 +65,9 @@ func DecInt16(p []byte, v *int16) error {
 }
 
 func DecInt16R(p []byte, v **int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -69,6 +85,9 @@ func DecInt16R(p []byte, v **int16) error {
 }
 
 func DecInt32(p []byte, v *int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -81,6 +100,9 @@ func DecInt32(p []byte, v *int32) error {
 }
 
 func DecInt32R(p []byte, v **int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -98,6 +120,9 @@ func DecInt32R(p []byte, v **int32) error {
 }
 
 func DecInt64(p []byte, v *int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -110,6 +135,9 @@ func DecInt64(p []byte, v *int64) error {
 }
 
 func DecInt64R(p []byte, v **int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -127,6 +155,9 @@ func DecInt64R(p []byte, v **int64) error {
 }
 
 func DecInt(p []byte, v *int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -139,6 +170,9 @@ func DecInt(p []byte, v *int) error {
 }
 
 func DecIntR(p []byte, v **int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -156,6 +190,9 @@ func DecIntR(p []byte, v **int) error {
 }
 
 func DecUint8(p []byte, v *uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -168,6 +205,9 @@ func DecUint8(p []byte, v *uint8) error {
 }
 
 func DecUint8R(p []byte, v **uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -185,6 +225,9 @@ func DecUint8R(p []byte, v **uint8) error {
 }
 
 func DecUint16(p []byte, v *uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -197,6 +240,9 @@ func DecUint16(p []byte, v *uint16) error {
 }
 
 func DecUint16R(p []byte, v **uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -214,6 +260,9 @@ func DecUint16R(p []byte, v **uint16) error {
 }
 
 func DecUint32(p []byte, v *uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -226,6 +275,9 @@ func DecUint32(p []byte, v *uint32) error {
 }
 
 func DecUint32R(p []byte, v **uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -243,6 +295,9 @@ func DecUint32R(p []byte, v **uint32) error {
 }
 
 func DecUint64(p []byte, v *uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -255,6 +310,9 @@ func DecUint64(p []byte, v *uint64) error {
 }
 
 func DecUint64R(p []byte, v **uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -272,6 +330,9 @@ func DecUint64R(p []byte, v **uint64) error {
 }
 
 func DecUint(p []byte, v *uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -284,6 +345,9 @@ func DecUint(p []byte, v *uint) error {
 }
 
 func DecUintR(p []byte, v **uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -301,6 +365,9 @@ func DecUintR(p []byte, v **uint) error {
 }
 
 func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -317,6 +384,9 @@ func DecString(p []byte, v *string) error {
 }
 
 func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -335,6 +405,9 @@ func DecStringR(p []byte, v **string) error {
 }
 
 func DecBigInt(p []byte, v *big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		v.SetInt64(0)
@@ -347,6 +420,9 @@ func DecBigInt(p []byte, v *big.Int) error {
 }
 
 func DecBigIntR(p []byte, v **big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -364,7 +440,7 @@ func DecBigIntR(p []byte, v **big.Int) error {
 
 func DecReflect(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return errNilReference(v)
 	}
 
 	switch v = v.Elem(); v.Kind() {
@@ -375,13 +451,13 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type %#v)", v.Interface())
 	}
 }
 
 func DecReflectR(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return errNilReference(v)
 	}
 
 	switch v.Type().Elem().Elem().Kind() {

--- a/marshal/tinyint/unmarshal_utils.go
+++ b/marshal/tinyint/unmarshal_utils.go
@@ -2,6 +2,7 @@ package tinyint
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -22,11 +23,19 @@ func DecInt8(p []byte, v *int8) error {
 }
 
 func DecInt8R(p []byte, v **int8) error {
-	if p != nil {
-		*v = new(int8)
-		return DecInt8(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int8)
+		}
+	case 1:
+		val := int8(p[0])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -35,7 +44,7 @@ func DecInt16(p []byte, v *int16) error {
 	case 0:
 		*v = 0
 	case 1:
-		*v = int16(int8(p[0]))
+		*v = decInt16(p)
 	default:
 		return errWrongDataLen
 	}
@@ -43,11 +52,19 @@ func DecInt16(p []byte, v *int16) error {
 }
 
 func DecInt16R(p []byte, v **int16) error {
-	if p != nil {
-		*v = new(int16)
-		return DecInt16(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int16)
+		}
+	case 1:
+		val := decInt16(p)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -56,7 +73,7 @@ func DecInt32(p []byte, v *int32) error {
 	case 0:
 		*v = 0
 	case 1:
-		*v = int32(int8(p[0]))
+		*v = decInt32(p)
 	default:
 		return errWrongDataLen
 	}
@@ -64,11 +81,19 @@ func DecInt32(p []byte, v *int32) error {
 }
 
 func DecInt32R(p []byte, v **int32) error {
-	if p != nil {
-		*v = new(int32)
-		return DecInt32(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int32)
+		}
+	case 1:
+		val := decInt32(p)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -77,7 +102,7 @@ func DecInt64(p []byte, v *int64) error {
 	case 0:
 		*v = 0
 	case 1:
-		*v = int64(int8(p[0]))
+		*v = decInt64(p)
 	default:
 		return errWrongDataLen
 	}
@@ -85,11 +110,19 @@ func DecInt64(p []byte, v *int64) error {
 }
 
 func DecInt64R(p []byte, v **int64) error {
-	if p != nil {
-		*v = new(int64)
-		return DecInt64(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int64)
+		}
+	case 1:
+		val := decInt64(p)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -98,7 +131,7 @@ func DecInt(p []byte, v *int) error {
 	case 0:
 		*v = 0
 	case 1:
-		*v = int(int8(p[0]))
+		*v = decInt(p)
 	default:
 		return errWrongDataLen
 	}
@@ -106,11 +139,19 @@ func DecInt(p []byte, v *int) error {
 }
 
 func DecIntR(p []byte, v **int) error {
-	if p != nil {
-		*v = new(int)
-		return DecInt(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int)
+		}
+	case 1:
+		val := decInt(p)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -127,11 +168,19 @@ func DecUint8(p []byte, v *uint8) error {
 }
 
 func DecUint8R(p []byte, v **uint8) error {
-	if p != nil {
-		*v = new(uint8)
-		return DecUint8(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint8)
+		}
+	case 1:
+		val := p[0]
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -148,11 +197,19 @@ func DecUint16(p []byte, v *uint16) error {
 }
 
 func DecUint16R(p []byte, v **uint16) error {
-	if p != nil {
-		*v = new(uint16)
-		return DecUint16(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint16)
+		}
+	case 1:
+		val := uint16(p[0])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -169,11 +226,19 @@ func DecUint32(p []byte, v *uint32) error {
 }
 
 func DecUint32R(p []byte, v **uint32) error {
-	if p != nil {
-		*v = new(uint32)
-		return DecUint32(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint32)
+		}
+	case 1:
+		val := uint32(p[0])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -190,11 +255,19 @@ func DecUint64(p []byte, v *uint64) error {
 }
 
 func DecUint64R(p []byte, v **uint64) error {
-	if p != nil {
-		*v = new(uint64)
-		return DecUint64(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint64)
+		}
+	case 1:
+		val := uint64(p[0])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -211,24 +284,32 @@ func DecUint(p []byte, v *uint) error {
 }
 
 func DecUintR(p []byte, v **uint) error {
-	if p != nil {
-		*v = new(uint)
-		return DecUint(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint)
+		}
+	case 1:
+		val := uint(p[0])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
 func DecString(p []byte, v *string) error {
 	switch len(p) {
 	case 0:
-		if p != nil {
-			*v = "0"
-		} else {
+		if p == nil {
 			*v = ""
+		} else {
+			*v = "0"
 		}
 	case 1:
-		*v = strconv.FormatInt(int64(int8(p[0])), 10)
+		*v = strconv.FormatInt(decInt64(p), 10)
 	default:
 		return errWrongDataLen
 	}
@@ -236,11 +317,20 @@ func DecString(p []byte, v *string) error {
 }
 
 func DecStringR(p []byte, v **string) error {
-	if p != nil {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			val := "0"
+			*v = &val
+		}
+	case 1:
 		*v = new(string)
-		return DecString(p, *v)
+		**v = strconv.FormatInt(decInt64(p), 10)
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -249,7 +339,7 @@ func DecBigInt(p []byte, v *big.Int) error {
 	case 0:
 		v.SetInt64(0)
 	case 1:
-		v.SetInt64(int64(int8(p[0])))
+		v.SetInt64(decInt64(p))
 	default:
 		return errWrongDataLen
 	}
@@ -257,11 +347,18 @@ func DecBigInt(p []byte, v *big.Int) error {
 }
 
 func DecBigIntR(p []byte, v **big.Int) error {
-	if p != nil {
-		*v = big.NewInt(0)
-		return DecBigInt(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = big.NewInt(0)
+		}
+	case 1:
+		*v = big.NewInt(decInt64(p))
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -283,14 +380,20 @@ func DecReflect(p []byte, v reflect.Value) error {
 }
 
 func DecReflectR(p []byte, v reflect.Value) error {
-	if p != nil {
-		zeroValue := reflect.New(v.Type().Elem().Elem())
-		v.Elem().Set(zeroValue)
-		return DecReflect(p, v.Elem())
+	if v.IsNil() {
+		return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
 	}
-	nilValue := reflect.Zero(v.Elem().Type())
-	v.Elem().Set(nilValue)
-	return nil
+
+	switch v.Type().Elem().Elem().Kind() {
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return decReflectIntsR(p, v)
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		return decReflectUintsR(p, v)
+	case reflect.String:
+		return decReflectStringR(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%#[1]v)", v.Interface())
+	}
 }
 
 func decReflectInts(p []byte, v reflect.Value) error {
@@ -298,7 +401,7 @@ func decReflectInts(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetInt(0)
 	case 1:
-		v.SetInt(int64(int8(p[0])))
+		v.SetInt(decInt64(p))
 	default:
 		return errWrongDataLen
 	}
@@ -320,15 +423,99 @@ func decReflectUints(p []byte, v reflect.Value) error {
 func decReflectString(p []byte, v reflect.Value) error {
 	switch len(p) {
 	case 0:
-		if p != nil {
-			v.SetString("0")
-		} else {
+		if p == nil {
 			v.SetString("")
+		} else {
+			v.SetString("0")
 		}
 	case 1:
-		v.SetString(strconv.FormatInt(int64(int8(p[0])), 10))
+		v.SetString(strconv.FormatInt(decInt64(p), 10))
 	default:
 		return errWrongDataLen
 	}
 	return nil
+}
+
+func decReflectIntsR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 1:
+		val := reflect.New(v.Type().Elem().Elem())
+		val.Elem().SetInt(decInt64(p))
+		v.Elem().Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUintsR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 1:
+		val := reflect.New(v.Type().Elem().Elem())
+		val.Elem().SetUint(uint64(p[0]))
+		v.Elem().Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectStringR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		var val reflect.Value
+		if p == nil {
+			val = reflect.Zero(v.Type().Elem())
+		} else {
+			val = reflect.New(v.Type().Elem().Elem())
+			val.Elem().SetString("0")
+		}
+		v.Elem().Set(val)
+	case 1:
+		val := reflect.New(v.Type().Elem().Elem())
+		val.Elem().SetString(strconv.FormatInt(decInt64(p), 10))
+		v.Elem().Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectNullableR(p []byte, v reflect.Value) reflect.Value {
+	if p == nil {
+		return reflect.Zero(v.Elem().Type())
+	}
+	return reflect.New(v.Type().Elem().Elem())
+}
+
+func decInt16(p []byte) int16 {
+	if p[0] > math.MaxInt8 {
+		return int16(p[0]) - 256
+	}
+	return int16(p[0])
+}
+
+func decInt32(p []byte) int32 {
+	if p[0] > math.MaxInt8 {
+		return int32(p[0]) - 256
+	}
+	return int32(p[0])
+}
+
+func decInt64(p []byte) int64 {
+	if p[0] > math.MaxInt8 {
+		return int64(p[0]) - 256
+	}
+	return int64(p[0])
+}
+
+func decInt(p []byte) int {
+	if p[0] > math.MaxInt8 {
+		return int(p[0]) - 256
+	}
+	return int(p[0])
 }

--- a/marshal_2_tinyint_test.go
+++ b/marshal_2_tinyint_test.go
@@ -78,8 +78,24 @@ func TestMarshalTinyint(t *testing.T) {
 			}.Run("zeros", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
-				Data:   []byte("\x7f"),
-				Values: mod.Values{int8(127), int16(127), int32(127), int64(127), int(127), "127", *big.NewInt(127)}.AddVariants(mod.All...),
+				Data: []byte("\x01"),
+				Values: mod.Values{
+					int8(1), int16(1), int32(1), int64(1), int(1),
+					uint8(1), uint16(1), uint32(1), uint64(1), uint(1),
+					"1", *big.NewInt(1)}.AddVariants(mod.All...),
+			}.Run("1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\xff"),
+				Values: mod.Values{int8(-1), int16(-1), int32(-1), int64(-1), int(-1), "-1", *big.NewInt(-1)}.AddVariants(mod.All...),
+			}.Run("-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x7f"),
+				Values: mod.Values{
+					int8(127), int16(127), int32(127), int64(127), int(127),
+					uint8(127), uint16(127), uint32(127), uint64(127), uint(127),
+					"127", *big.NewInt(127)}.AddVariants(mod.All...),
 			}.Run("127", t, marshal, unmarshal)
 
 			serialization.PositiveSet{


### PR DESCRIPTION
Chenges:
1. Unmarshal functions:
1.1. The double conversion of values has been removed in the functions of single reference values.
1.2. The condition `data == nil` moved after the condition `len(data)==0` in the functions of the double references values.
2. `EncReflect` function:
2.1. Removed unnecessary checks for `reflect.Int8` and `reflect.Uint8` kinds.
2.2. Makes the right value type in the error for `reflect.String` kind.