### PR TITLE
Fix unmarshall errors, add condition for `nil reference`

### DIFF
--- a/serialization/bigint/marshal_utils.go
+++ b/serialization/bigint/marshal_utils.go
@@ -156,7 +156,7 @@ func EncString(v string) ([]byte, error) {
 
 	n, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal bigint: can not marshal %#v %s", v, err)
+		return nil, fmt.Errorf("failed to marshal bigint: can not marshal (%T)(%[1]v) %s", v, err)
 	}
 	return encInt64(n), nil
 }
@@ -181,11 +181,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		}
 		n, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal bigint: can not marshal %#v %s", v.Interface(), err)
+			return nil, fmt.Errorf("failed to marshal bigint: can not marshal (%T)(%[1]v) %s", v.Interface(), err)
 		}
 		return encInt64(n), nil
 	default:
-		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 

--- a/serialization/bigint/unmarshal.go
+++ b/serialization/bigint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%#[1]v)", value)
+			return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v)", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/bigint/unmarshal_utils.go
+++ b/serialization/bigint/unmarshal_utils.go
@@ -10,7 +10,14 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal bigint: the length of the data should be 0 or 8")
 
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal bigint: can not unmarshal into nil reference (%T)(%[1]v))", v)
+}
+
 func DecInt8(p []byte, v *int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -27,6 +34,9 @@ func DecInt8(p []byte, v *int8) error {
 }
 
 func DecInt8R(p []byte, v **int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -48,6 +58,9 @@ func DecInt8R(p []byte, v **int8) error {
 }
 
 func DecInt16(p []byte, v *int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -64,6 +77,9 @@ func DecInt16(p []byte, v *int16) error {
 }
 
 func DecInt16R(p []byte, v **int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -85,6 +101,9 @@ func DecInt16R(p []byte, v **int16) error {
 }
 
 func DecInt32(p []byte, v *int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -101,6 +120,9 @@ func DecInt32(p []byte, v *int32) error {
 }
 
 func DecInt32R(p []byte, v **int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -122,6 +144,9 @@ func DecInt32R(p []byte, v **int32) error {
 }
 
 func DecInt64(p []byte, v *int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -134,6 +159,9 @@ func DecInt64(p []byte, v *int64) error {
 }
 
 func DecInt64R(p []byte, v **int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -151,6 +179,9 @@ func DecInt64R(p []byte, v **int64) error {
 }
 
 func DecInt(p []byte, v *int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -163,6 +194,9 @@ func DecInt(p []byte, v *int) error {
 }
 
 func DecIntR(p []byte, v **int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -180,6 +214,9 @@ func DecIntR(p []byte, v **int) error {
 }
 
 func DecUint8(p []byte, v *uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -195,6 +232,9 @@ func DecUint8(p []byte, v *uint8) error {
 }
 
 func DecUint8R(p []byte, v **uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -215,6 +255,9 @@ func DecUint8R(p []byte, v **uint8) error {
 }
 
 func DecUint16(p []byte, v *uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -230,6 +273,9 @@ func DecUint16(p []byte, v *uint16) error {
 }
 
 func DecUint16R(p []byte, v **uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -250,6 +296,9 @@ func DecUint16R(p []byte, v **uint16) error {
 }
 
 func DecUint32(p []byte, v *uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -265,6 +314,9 @@ func DecUint32(p []byte, v *uint32) error {
 }
 
 func DecUint32R(p []byte, v **uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -285,6 +337,9 @@ func DecUint32R(p []byte, v **uint32) error {
 }
 
 func DecUint64(p []byte, v *uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -297,6 +352,9 @@ func DecUint64(p []byte, v *uint64) error {
 }
 
 func DecUint64R(p []byte, v **uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -314,6 +372,9 @@ func DecUint64R(p []byte, v **uint64) error {
 }
 
 func DecUint(p []byte, v *uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -326,6 +387,9 @@ func DecUint(p []byte, v *uint) error {
 }
 
 func DecUintR(p []byte, v **uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -343,6 +407,9 @@ func DecUintR(p []byte, v **uint) error {
 }
 
 func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -359,6 +426,9 @@ func DecString(p []byte, v *string) error {
 }
 
 func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -377,6 +447,9 @@ func DecStringR(p []byte, v **string) error {
 }
 
 func DecBigInt(p []byte, v *big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		v.SetInt64(0)
@@ -389,6 +462,9 @@ func DecBigInt(p []byte, v *big.Int) error {
 }
 
 func DecBigIntR(p []byte, v **big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -406,7 +482,7 @@ func DecBigIntR(p []byte, v **big.Int) error {
 
 func DecReflect(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal bigint: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal bigint: can not unmarshal into nil reference (%T)(%[1]v))", v.Interface())
 	}
 
 	switch v = v.Elem(); v.Kind() {
@@ -429,7 +505,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 
@@ -440,7 +516,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int8 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -456,7 +532,7 @@ func decReflectInt16(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int16 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -472,7 +548,7 @@ func decReflectInt32(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int32 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -499,7 +575,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[7]))
 	default:
@@ -514,7 +590,7 @@ func decReflectUint16(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
 		}
 		v.SetUint(uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -529,7 +605,7 @@ func decReflectUint32(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
 		}
 		v.SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -568,7 +644,7 @@ func decReflectString(p []byte, v reflect.Value) error {
 
 func DecReflectR(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal bigint: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal bigint: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
 	}
 
 	switch v.Type().Elem().Elem().Kind() {
@@ -591,7 +667,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 
@@ -602,7 +678,7 @@ func decReflectInt8R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int8 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -620,7 +696,7 @@ func decReflectInt16R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int16 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -638,7 +714,7 @@ func decReflectInt32R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int32 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -670,7 +746,7 @@ func decReflectUint8R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -687,7 +763,7 @@ func decReflectUint16R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -704,7 +780,7 @@ func decReflectUint32R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into custom uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)

--- a/serialization/counter/marshal_utils.go
+++ b/serialization/counter/marshal_utils.go
@@ -181,11 +181,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		}
 		n, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal counter: can not marshal %#v %s", v.Interface(), err)
+			return nil, fmt.Errorf("failed to marshal counter: can not marshal (%T)(%[1]v) %s", v.Interface(), err)
 		}
 		return encInt64(n), nil
 	default:
-		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 

--- a/serialization/counter/unmarshal.go
+++ b/serialization/counter/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%#[1]v)", value)
+			return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v)", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/counter/unmarshal_utils.go
+++ b/serialization/counter/unmarshal_utils.go
@@ -10,7 +10,14 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal counter: the length of the data should be 0 or 8")
 
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal counter: can not unmarshal into nil reference (%T)(%[1]v))", v)
+}
+
 func DecInt8(p []byte, v *int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -27,6 +34,9 @@ func DecInt8(p []byte, v *int8) error {
 }
 
 func DecInt8R(p []byte, v **int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -48,6 +58,9 @@ func DecInt8R(p []byte, v **int8) error {
 }
 
 func DecInt16(p []byte, v *int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -64,6 +77,9 @@ func DecInt16(p []byte, v *int16) error {
 }
 
 func DecInt16R(p []byte, v **int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -85,6 +101,9 @@ func DecInt16R(p []byte, v **int16) error {
 }
 
 func DecInt32(p []byte, v *int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -101,6 +120,9 @@ func DecInt32(p []byte, v *int32) error {
 }
 
 func DecInt32R(p []byte, v **int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -122,6 +144,9 @@ func DecInt32R(p []byte, v **int32) error {
 }
 
 func DecInt64(p []byte, v *int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -134,6 +159,9 @@ func DecInt64(p []byte, v *int64) error {
 }
 
 func DecInt64R(p []byte, v **int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -151,6 +179,9 @@ func DecInt64R(p []byte, v **int64) error {
 }
 
 func DecInt(p []byte, v *int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -163,6 +194,9 @@ func DecInt(p []byte, v *int) error {
 }
 
 func DecIntR(p []byte, v **int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -180,6 +214,9 @@ func DecIntR(p []byte, v **int) error {
 }
 
 func DecUint8(p []byte, v *uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -195,6 +232,9 @@ func DecUint8(p []byte, v *uint8) error {
 }
 
 func DecUint8R(p []byte, v **uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -215,6 +255,9 @@ func DecUint8R(p []byte, v **uint8) error {
 }
 
 func DecUint16(p []byte, v *uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -230,6 +273,9 @@ func DecUint16(p []byte, v *uint16) error {
 }
 
 func DecUint16R(p []byte, v **uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -250,6 +296,9 @@ func DecUint16R(p []byte, v **uint16) error {
 }
 
 func DecUint32(p []byte, v *uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -265,6 +314,9 @@ func DecUint32(p []byte, v *uint32) error {
 }
 
 func DecUint32R(p []byte, v **uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -285,6 +337,9 @@ func DecUint32R(p []byte, v **uint32) error {
 }
 
 func DecUint64(p []byte, v *uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -297,6 +352,9 @@ func DecUint64(p []byte, v *uint64) error {
 }
 
 func DecUint64R(p []byte, v **uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -314,6 +372,9 @@ func DecUint64R(p []byte, v **uint64) error {
 }
 
 func DecUint(p []byte, v *uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -326,6 +387,9 @@ func DecUint(p []byte, v *uint) error {
 }
 
 func DecUintR(p []byte, v **uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -343,6 +407,9 @@ func DecUintR(p []byte, v **uint) error {
 }
 
 func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -359,6 +426,9 @@ func DecString(p []byte, v *string) error {
 }
 
 func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -377,6 +447,9 @@ func DecStringR(p []byte, v **string) error {
 }
 
 func DecBigInt(p []byte, v *big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		v.SetInt64(0)
@@ -389,6 +462,9 @@ func DecBigInt(p []byte, v *big.Int) error {
 }
 
 func DecBigIntR(p []byte, v **big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p == nil {
@@ -406,7 +482,7 @@ func DecBigIntR(p []byte, v **big.Int) error {
 
 func DecReflect(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal counter: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal counter: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
 	}
 
 	switch v = v.Elem(); v.Kind() {
@@ -429,7 +505,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 
@@ -440,7 +516,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int8 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -456,7 +532,7 @@ func decReflectInt16(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int16 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -472,7 +548,7 @@ func decReflectInt32(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int32 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -499,7 +575,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[7]))
 	default:
@@ -514,7 +590,7 @@ func decReflectUint16(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
 		}
 		v.SetUint(uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -529,7 +605,7 @@ func decReflectUint32(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
 		}
 		v.SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -568,7 +644,7 @@ func decReflectString(p []byte, v reflect.Value) error {
 
 func DecReflectR(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal counter: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal counter: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
 	}
 
 	switch v.Type().Elem().Elem().Kind() {
@@ -591,7 +667,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 
@@ -602,7 +678,7 @@ func decReflectInt8R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int8 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -620,7 +696,7 @@ func decReflectInt16R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int16 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -638,7 +714,7 @@ func decReflectInt32R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int32 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -670,7 +746,7 @@ func decReflectUint8R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -687,7 +763,7 @@ func decReflectUint16R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -704,7 +780,7 @@ func decReflectUint32R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into custom uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)

--- a/serialization/cqlint/marshal_utils.go
+++ b/serialization/cqlint/marshal_utils.go
@@ -157,7 +157,7 @@ func EncString(v string) ([]byte, error) {
 
 	n, err := strconv.ParseInt(v, 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal int: can not marshal %#v %s", v, err)
+		return nil, fmt.Errorf("failed to marshal int: can not marshal (%T)(%[1]v) %s", v, err)
 	}
 	return []byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}, nil
 }
@@ -178,7 +178,7 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	case reflect.String:
 		return EncString(v.String())
 	default:
-		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 

--- a/serialization/cqlint/unmarshal.go
+++ b/serialization/cqlint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%#[1]v)", value)
+			return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v)", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/cqlint/unmarshal_utils.go
+++ b/serialization/cqlint/unmarshal_utils.go
@@ -10,7 +10,14 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal int: the length of the data should be 0 or 4")
 
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal int: can not unmarshal into nil reference (%T)(%[1]v))", v)
+}
+
 func DecInt8(p []byte, v *int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -27,6 +34,9 @@ func DecInt8(p []byte, v *int8) error {
 }
 
 func DecInt8R(p []byte, v **int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int8)
 		return DecInt8(p, *v)
@@ -36,6 +46,9 @@ func DecInt8R(p []byte, v **int8) error {
 }
 
 func DecInt16(p []byte, v *int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -52,6 +65,9 @@ func DecInt16(p []byte, v *int16) error {
 }
 
 func DecInt16R(p []byte, v **int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int16)
 		return DecInt16(p, *v)
@@ -61,6 +77,9 @@ func DecInt16R(p []byte, v **int16) error {
 }
 
 func DecInt32(p []byte, v *int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -73,6 +92,9 @@ func DecInt32(p []byte, v *int32) error {
 }
 
 func DecInt32R(p []byte, v **int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int32)
 		return DecInt32(p, *v)
@@ -82,6 +104,9 @@ func DecInt32R(p []byte, v **int32) error {
 }
 
 func DecInt64(p []byte, v *int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -94,6 +119,9 @@ func DecInt64(p []byte, v *int64) error {
 }
 
 func DecInt64R(p []byte, v **int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int64)
 		return DecInt64(p, *v)
@@ -103,6 +131,9 @@ func DecInt64R(p []byte, v **int64) error {
 }
 
 func DecInt(p []byte, v *int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -115,6 +146,9 @@ func DecInt(p []byte, v *int) error {
 }
 
 func DecIntR(p []byte, v **int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int)
 		return DecInt(p, *v)
@@ -124,6 +158,9 @@ func DecIntR(p []byte, v **int) error {
 }
 
 func DecUint8(p []byte, v *uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -139,6 +176,9 @@ func DecUint8(p []byte, v *uint8) error {
 }
 
 func DecUint8R(p []byte, v **uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint8)
 		return DecUint8(p, *v)
@@ -148,6 +188,9 @@ func DecUint8R(p []byte, v **uint8) error {
 }
 
 func DecUint16(p []byte, v *uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -163,6 +206,9 @@ func DecUint16(p []byte, v *uint16) error {
 }
 
 func DecUint16R(p []byte, v **uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint16)
 		return DecUint16(p, *v)
@@ -172,6 +218,9 @@ func DecUint16R(p []byte, v **uint16) error {
 }
 
 func DecUint32(p []byte, v *uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -184,6 +233,9 @@ func DecUint32(p []byte, v *uint32) error {
 }
 
 func DecUint32R(p []byte, v **uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint32)
 		return DecUint32(p, *v)
@@ -193,6 +245,9 @@ func DecUint32R(p []byte, v **uint32) error {
 }
 
 func DecUint64(p []byte, v *uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -205,6 +260,9 @@ func DecUint64(p []byte, v *uint64) error {
 }
 
 func DecUint64R(p []byte, v **uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint64)
 		return DecUint64(p, *v)
@@ -214,6 +272,9 @@ func DecUint64R(p []byte, v **uint64) error {
 }
 
 func DecUint(p []byte, v *uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -226,6 +287,9 @@ func DecUint(p []byte, v *uint) error {
 }
 
 func DecUintR(p []byte, v **uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint)
 		return DecUint(p, *v)
@@ -235,6 +299,9 @@ func DecUintR(p []byte, v **uint) error {
 }
 
 func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p != nil {
@@ -251,6 +318,9 @@ func DecString(p []byte, v *string) error {
 }
 
 func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(string)
 		return DecString(p, *v)
@@ -260,6 +330,9 @@ func DecStringR(p []byte, v **string) error {
 }
 
 func DecBigInt(p []byte, v *big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		v.SetInt64(0)
@@ -272,6 +345,9 @@ func DecBigInt(p []byte, v *big.Int) error {
 }
 
 func DecBigIntR(p []byte, v **big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = big.NewInt(0)
 		return DecBigInt(p, *v)
@@ -282,7 +358,7 @@ func DecBigIntR(p []byte, v **big.Int) error {
 
 func DecReflect(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal int: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal int: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
 	}
 
 	switch v = v.Elem(); v.Kind() {
@@ -301,7 +377,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 
@@ -323,7 +399,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 4:
 		val := decInt32(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the int8 range", v.Interface())
 		}
 		v.SetInt(int64(val))
 	default:
@@ -339,7 +415,7 @@ func decReflectInt16(p []byte, v reflect.Value) error {
 	case 4:
 		val := decInt32(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the int16 range", v.Interface())
 		}
 		v.SetInt(int64(val))
 	default:
@@ -366,7 +442,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 4:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[3]))
 	default:
@@ -381,7 +457,7 @@ func decReflectUint16(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 4:
 		if p[0] != 0 || p[1] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
 		}
 		v.SetUint(uint64(p[2])<<8 | uint64(p[3]))
 	default:

--- a/serialization/smallint/marshal_utils.go
+++ b/serialization/smallint/marshal_utils.go
@@ -163,7 +163,7 @@ func EncString(v string) ([]byte, error) {
 
 	n, err := strconv.ParseInt(v, 10, 16)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal smallint: can not marshal %#v %s", v, err)
+		return nil, fmt.Errorf("failed to marshal smallint: can not marshal (%T)(%[1]v) %s", v, err)
 	}
 	return []byte{byte(n >> 8), byte(n)}, nil
 }
@@ -184,7 +184,7 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	case reflect.String:
 		return EncString(v.String())
 	default:
-		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 

--- a/serialization/smallint/unmarshal.go
+++ b/serialization/smallint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%#[1]v)", value)
+			return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%[1]v)", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/smallint/unmarshal_utils.go
+++ b/serialization/smallint/unmarshal_utils.go
@@ -10,7 +10,14 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal smallint: the length of the data should be 0 or 2")
 
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal smallint: can not unmarshal into nil reference (%T)(%[1]v))", v)
+}
+
 func DecInt8(p []byte, v *int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -27,6 +34,9 @@ func DecInt8(p []byte, v *int8) error {
 }
 
 func DecInt8R(p []byte, v **int8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int8)
 		return DecInt8(p, *v)
@@ -36,6 +46,9 @@ func DecInt8R(p []byte, v **int8) error {
 }
 
 func DecInt16(p []byte, v *int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -48,6 +61,9 @@ func DecInt16(p []byte, v *int16) error {
 }
 
 func DecInt16R(p []byte, v **int16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int16)
 		return DecInt16(p, *v)
@@ -57,6 +73,9 @@ func DecInt16R(p []byte, v **int16) error {
 }
 
 func DecInt32(p []byte, v *int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -69,6 +88,9 @@ func DecInt32(p []byte, v *int32) error {
 }
 
 func DecInt32R(p []byte, v **int32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int32)
 		return DecInt32(p, *v)
@@ -78,6 +100,9 @@ func DecInt32R(p []byte, v **int32) error {
 }
 
 func DecInt64(p []byte, v *int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -90,6 +115,9 @@ func DecInt64(p []byte, v *int64) error {
 }
 
 func DecInt64R(p []byte, v **int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int64)
 		return DecInt64(p, *v)
@@ -99,6 +127,9 @@ func DecInt64R(p []byte, v **int64) error {
 }
 
 func DecInt(p []byte, v *int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -111,6 +142,9 @@ func DecInt(p []byte, v *int) error {
 }
 
 func DecIntR(p []byte, v **int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(int)
 		return DecInt(p, *v)
@@ -120,6 +154,9 @@ func DecIntR(p []byte, v **int) error {
 }
 
 func DecUint8(p []byte, v *uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -135,6 +172,9 @@ func DecUint8(p []byte, v *uint8) error {
 }
 
 func DecUint8R(p []byte, v **uint8) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint8)
 		return DecUint8(p, *v)
@@ -144,6 +184,9 @@ func DecUint8R(p []byte, v **uint8) error {
 }
 
 func DecUint16(p []byte, v *uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -156,6 +199,9 @@ func DecUint16(p []byte, v *uint16) error {
 }
 
 func DecUint16R(p []byte, v **uint16) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint16)
 		return DecUint16(p, *v)
@@ -165,6 +211,9 @@ func DecUint16R(p []byte, v **uint16) error {
 }
 
 func DecUint32(p []byte, v *uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -177,6 +226,9 @@ func DecUint32(p []byte, v *uint32) error {
 }
 
 func DecUint32R(p []byte, v **uint32) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint32)
 		return DecUint32(p, *v)
@@ -186,6 +238,9 @@ func DecUint32R(p []byte, v **uint32) error {
 }
 
 func DecUint64(p []byte, v *uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -198,6 +253,9 @@ func DecUint64(p []byte, v *uint64) error {
 }
 
 func DecUint64R(p []byte, v **uint64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint64)
 		return DecUint64(p, *v)
@@ -207,6 +265,9 @@ func DecUint64R(p []byte, v **uint64) error {
 }
 
 func DecUint(p []byte, v *uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		*v = 0
@@ -219,6 +280,9 @@ func DecUint(p []byte, v *uint) error {
 }
 
 func DecUintR(p []byte, v **uint) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(uint)
 		return DecUint(p, *v)
@@ -228,6 +292,9 @@ func DecUintR(p []byte, v **uint) error {
 }
 
 func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		if p != nil {
@@ -244,6 +311,9 @@ func DecString(p []byte, v *string) error {
 }
 
 func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = new(string)
 		return DecString(p, *v)
@@ -253,6 +323,9 @@ func DecStringR(p []byte, v **string) error {
 }
 
 func DecBigInt(p []byte, v *big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	switch len(p) {
 	case 0:
 		v.SetInt64(0)
@@ -265,6 +338,9 @@ func DecBigInt(p []byte, v *big.Int) error {
 }
 
 func DecBigIntR(p []byte, v **big.Int) error {
+	if v == nil {
+		return errNilReference(v)
+	}
 	if p != nil {
 		*v = big.NewInt(0)
 		return DecBigInt(p, *v)
@@ -275,7 +351,7 @@ func DecBigIntR(p []byte, v **big.Int) error {
 
 func DecReflect(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal smallint: can not unmarshal into nil reference (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal smallint: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
 	}
 
 	switch v = v.Elem(); v.Kind() {
@@ -290,7 +366,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 
@@ -312,7 +388,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 2:
 		val := decInt16(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into %T, the data should be in the int8 range", v.Interface())
 		}
 		v.SetInt(int64(val))
 	default:
@@ -339,7 +415,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 2:
 		if p[0] != 0 {
-			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[1]))
 	default:

--- a/serialization/tinyint/marshal_utils.go
+++ b/serialization/tinyint/marshal_utils.go
@@ -168,7 +168,7 @@ func EncString(v string) ([]byte, error) {
 
 	n, err := strconv.ParseInt(v, 10, 8)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal tinyint: can not marshal %#v %s", v, err)
+		return nil, fmt.Errorf("failed to marshal tinyint: can not marshal (%T)(%[1]v) %s", v, err)
 	}
 	return []byte{byte(n)}, nil
 }
@@ -187,7 +187,7 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16:
 		val := v.Int()
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return nil, fmt.Errorf("failed to marshal tinyint: value %#v out of range", v.Interface())
+			return nil, fmt.Errorf("failed to marshal tinyint: value (%T)(%[1]v) out of range", v.Interface())
 		}
 		return []byte{byte(val)}, nil
 	case reflect.Uint8:
@@ -195,7 +195,7 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16:
 		val := v.Uint()
 		if val > math.MaxUint8 {
-			return nil, fmt.Errorf("failed to marshal tinyint: value %#v out of range", v.Interface())
+			return nil, fmt.Errorf("failed to marshal tinyint: value (%T)(%[1]v) out of range", v.Interface())
 		}
 		return []byte{byte(val)}, nil
 	case reflect.String:
@@ -206,11 +206,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 
 		n, err := strconv.ParseInt(val, 10, 8)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal tinyint: can not marshal %#v %s", v.Interface(), err)
+			return nil, fmt.Errorf("failed to marshal tinyint: can not marshal (%T)(%[1]v) %s", v.Interface(), err)
 		}
 		return []byte{byte(n)}, nil
 	default:
-		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 

--- a/serialization/tinyint/unmarshal.go
+++ b/serialization/tinyint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal tinyint: unsupported value type %#v", value)
+			return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v)", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/tinyint/unmarshal_utils.go
+++ b/serialization/tinyint/unmarshal_utils.go
@@ -11,7 +11,7 @@ import (
 var errWrongDataLen = fmt.Errorf("failed to unmarshal tinyint: the length of the data should less or equal then 1")
 
 func errNilReference(v interface{}) error {
-	return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference %#v)", v)
+	return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 
 func DecInt8(p []byte, v *int8) error {
@@ -451,7 +451,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type %#v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 
@@ -468,7 +468,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}
 }
 


### PR DESCRIPTION

Added for `smallint`, `int`, `bigint`, `counter` `cql types`.
Additional fixed `errors text` for `tinyint` `cql type`