### PR TITLE
Fix `int like` `cql types` with negative range, add error when processing `uint like` `go types`

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -17,13 +17,6 @@ import (
 	"gopkg.in/inf.v0"
 )
 
-type AliasInt int
-type AliasUint uint
-type AliasUint8 uint8
-type AliasUint16 uint16
-type AliasUint32 uint32
-type AliasUint64 uint64
-
 var marshalTests = []struct {
 	Info           TypeInfo
 	Data           []byte
@@ -696,76 +689,6 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeTinyInt},
 		[]byte("\xff"),
 		int16(-1),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		uint8(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		uint64(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		uint32(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		uint16(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		uint(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		AliasUint8(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		AliasUint64(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		AliasUint32(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		AliasUint16(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeTinyInt},
-		[]byte("\xff"),
-		AliasUint(255),
 		nil,
 		nil,
 	},

--- a/serialization/bigint/unmarshal_utils.go
+++ b/serialization/bigint/unmarshal_utils.go
@@ -24,7 +24,7 @@ func DecInt8(p []byte, v *int8) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int8, the data value should be in the int8 range")
 		}
 		*v = int8(val)
 	default:
@@ -47,7 +47,7 @@ func DecInt8R(p []byte, v **int8) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int8, the data value should be in the int8 range")
 		}
 		tmp := int8(val)
 		*v = &tmp
@@ -67,7 +67,7 @@ func DecInt16(p []byte, v *int16) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int16, the data value should be in the int16 range")
 		}
 		*v = int16(val)
 	default:
@@ -90,7 +90,7 @@ func DecInt16R(p []byte, v **int16) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int16, the data value should be in the int16 range")
 		}
 		tmp := int16(val)
 		*v = &tmp
@@ -110,7 +110,7 @@ func DecInt32(p []byte, v *int32) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int32, the data value should be in the int32 range")
 		}
 		*v = int32(val)
 	default:
@@ -133,7 +133,7 @@ func DecInt32R(p []byte, v **int32) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into int32, the data value should be in the int32 range")
 		}
 		tmp := int32(val)
 		*v = &tmp
@@ -222,7 +222,7 @@ func DecUint8(p []byte, v *uint8) error {
 		*v = 0
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint8, the data value should be in the uint8 range")
 		}
 		*v = p[7]
 	default:
@@ -244,7 +244,7 @@ func DecUint8R(p []byte, v **uint8) error {
 		}
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint8, the data value should be in the uint8 range")
 		}
 		val := p[7]
 		*v = &val
@@ -263,7 +263,7 @@ func DecUint16(p []byte, v *uint16) error {
 		*v = 0
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint16, the data value should be in the uint16 range")
 		}
 		*v = uint16(p[6])<<8 | uint16(p[7])
 	default:
@@ -285,7 +285,7 @@ func DecUint16R(p []byte, v **uint16) error {
 		}
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint16, the data value should be in the uint16 range")
 		}
 		val := uint16(p[6])<<8 | uint16(p[7])
 		*v = &val
@@ -304,7 +304,7 @@ func DecUint32(p []byte, v *uint32) error {
 		*v = 0
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint32, the data value should be in the uint32 range")
 		}
 		*v = uint32(p[4])<<24 | uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7])
 	default:
@@ -326,7 +326,7 @@ func DecUint32R(p []byte, v **uint32) error {
 		}
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint32, the data value should be in the uint32 range")
 		}
 		val := uint32(p[4])<<24 | uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7])
 		*v = &val
@@ -344,6 +344,9 @@ func DecUint64(p []byte, v *uint64) error {
 	case 0:
 		*v = 0
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint64, the data value should be positive")
+		}
 		*v = decUint64(p)
 	default:
 		return errWrongDataLen
@@ -363,6 +366,9 @@ func DecUint64R(p []byte, v **uint64) error {
 			*v = new(uint64)
 		}
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint64, the data value should be positive")
+		}
 		val := decUint64(p)
 		*v = &val
 	default:
@@ -379,7 +385,10 @@ func DecUint(p []byte, v *uint) error {
 	case 0:
 		*v = 0
 	case 8:
-		*v = uint(p[0])<<56 | uint(p[1])<<48 | uint(p[2])<<40 | uint(p[3])<<32 | uint(p[4])<<24 | uint(p[5])<<16 | uint(p[6])<<8 | uint(p[7])
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint, the data value should be positive")
+		}
+		*v = decUint(p)
 	default:
 		return errWrongDataLen
 	}
@@ -398,7 +407,10 @@ func DecUintR(p []byte, v **uint) error {
 			*v = new(uint)
 		}
 	case 8:
-		val := uint(p[0])<<56 | uint(p[1])<<48 | uint(p[2])<<40 | uint(p[3])<<32 | uint(p[4])<<24 | uint(p[5])<<16 | uint(p[6])<<8 | uint(p[7])
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into uint64, the data value should be positive")
+		}
+		val := decUint(p)
 		*v = &val
 	default:
 		return errWrongDataLen
@@ -516,7 +528,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the int8 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -532,7 +544,7 @@ func decReflectInt16(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the int16 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -548,7 +560,7 @@ func decReflectInt32(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the int32 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -575,7 +587,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[7]))
 	default:
@@ -590,7 +602,7 @@ func decReflectUint16(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the uint16 range", v.Interface())
 		}
 		v.SetUint(uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -605,7 +617,7 @@ func decReflectUint32(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the uint32 range", v.Interface())
 		}
 		v.SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -619,6 +631,9 @@ func decReflectUints(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetUint(0)
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
 		v.SetUint(decUint64(p))
 	default:
 		return errWrongDataLen
@@ -678,7 +693,7 @@ func decReflectInt8R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the int8 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -696,7 +711,7 @@ func decReflectInt16R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the int16 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -714,7 +729,7 @@ func decReflectInt32R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the int32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the int32 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -746,7 +761,7 @@ func decReflectUint8R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the uint8 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -763,7 +778,7 @@ func decReflectUint16R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the uint16 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -780,7 +795,7 @@ func decReflectUint32R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be in the uint32 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -795,6 +810,9 @@ func decReflectUintsR(p []byte, v reflect.Value) error {
 	case 0:
 		v.Elem().Set(decReflectNullableR(p, v))
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal bigint: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
 		val := reflect.New(v.Type().Elem().Elem())
 		val.Elem().SetUint(decUint64(p))
 		v.Elem().Set(val)
@@ -838,4 +856,8 @@ func decInt64(p []byte) int64 {
 
 func decUint64(p []byte) uint64 {
 	return uint64(p[0])<<56 | uint64(p[1])<<48 | uint64(p[2])<<40 | uint64(p[3])<<32 | uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7])
+}
+
+func decUint(p []byte) uint {
+	return uint(p[0])<<56 | uint(p[1])<<48 | uint(p[2])<<40 | uint(p[3])<<32 | uint(p[4])<<24 | uint(p[5])<<16 | uint(p[6])<<8 | uint(p[7])
 }

--- a/serialization/counter/marshal_utils.go
+++ b/serialization/counter/marshal_utils.go
@@ -111,7 +111,10 @@ func EncUint32R(v *uint32) ([]byte, error) {
 }
 
 func EncUint64(v uint64) ([]byte, error) {
-	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
+	if v > math.MaxInt64 {
+		return nil, fmt.Errorf("failed to marshal counter: value %#v out of range", v)
+	}
+	return encUint64(v), nil
 }
 
 func EncUint64R(v *uint64) ([]byte, error) {
@@ -122,6 +125,9 @@ func EncUint64R(v *uint64) ([]byte, error) {
 }
 
 func EncUint(v uint) ([]byte, error) {
+	if v > math.MaxInt64 {
+		return nil, fmt.Errorf("failed to marshal bigint: value %#v out of range", v)
+	}
 	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
 }
 
@@ -172,8 +178,14 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
 		return EncInt64(v.Int())
-	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
-		return EncUint64(v.Uint())
+	case reflect.Uint32, reflect.Uint16, reflect.Uint8:
+		return encUint64(v.Uint()), nil
+	case reflect.Uint, reflect.Uint64:
+		val := v.Uint()
+		if val > math.MaxInt64 {
+			return nil, fmt.Errorf("failed to marshal counter: value (%T)(%[1]v) out of range", v.Interface())
+		}
+		return encUint64(val), nil
 	case reflect.String:
 		val := v.String()
 		if val == "" {
@@ -197,5 +209,9 @@ func EncReflectR(v reflect.Value) ([]byte, error) {
 }
 
 func encInt64(v int64) []byte {
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+func encUint64(v uint64) []byte {
 	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
 }

--- a/serialization/counter/unmarshal_utils.go
+++ b/serialization/counter/unmarshal_utils.go
@@ -24,7 +24,7 @@ func DecInt8(p []byte, v *int8) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int8, the data value should be in the int8 range")
 		}
 		*v = int8(val)
 	default:
@@ -47,7 +47,7 @@ func DecInt8R(p []byte, v **int8) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int8, the data value should be in the int8 range")
 		}
 		tmp := int8(val)
 		*v = &tmp
@@ -67,7 +67,7 @@ func DecInt16(p []byte, v *int16) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int16, the data value should be in the int16 range")
 		}
 		*v = int16(val)
 	default:
@@ -90,7 +90,7 @@ func DecInt16R(p []byte, v **int16) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int16, the data value should be in the int16 range")
 		}
 		tmp := int16(val)
 		*v = &tmp
@@ -110,7 +110,7 @@ func DecInt32(p []byte, v *int32) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int32, the data value should be in the int32 range")
 		}
 		*v = int32(val)
 	default:
@@ -133,7 +133,7 @@ func DecInt32R(p []byte, v **int32) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int32, the data should be in the int32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into int32, the data value should be in the int32 range")
 		}
 		tmp := int32(val)
 		*v = &tmp
@@ -222,7 +222,7 @@ func DecUint8(p []byte, v *uint8) error {
 		*v = 0
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint8, the data value should be in the uint8 range")
 		}
 		*v = p[7]
 	default:
@@ -244,7 +244,7 @@ func DecUint8R(p []byte, v **uint8) error {
 		}
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint8, the data value should be in the uint8 range")
 		}
 		val := p[7]
 		*v = &val
@@ -263,7 +263,7 @@ func DecUint16(p []byte, v *uint16) error {
 		*v = 0
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint16, the data value should be in the uint16 range")
 		}
 		*v = uint16(p[6])<<8 | uint16(p[7])
 	default:
@@ -285,7 +285,7 @@ func DecUint16R(p []byte, v **uint16) error {
 		}
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint16, the data value should be in the uint16 range")
 		}
 		val := uint16(p[6])<<8 | uint16(p[7])
 		*v = &val
@@ -304,7 +304,7 @@ func DecUint32(p []byte, v *uint32) error {
 		*v = 0
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint32, the data value should be in the uint32 range")
 		}
 		*v = uint32(p[4])<<24 | uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7])
 	default:
@@ -326,7 +326,7 @@ func DecUint32R(p []byte, v **uint32) error {
 		}
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint32, the data should be in the uint32 range")
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint32, the data value should be in the uint32 range")
 		}
 		val := uint32(p[4])<<24 | uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7])
 		*v = &val
@@ -344,6 +344,9 @@ func DecUint64(p []byte, v *uint64) error {
 	case 0:
 		*v = 0
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint64, the data value should be positive")
+		}
 		*v = decUint64(p)
 	default:
 		return errWrongDataLen
@@ -363,6 +366,9 @@ func DecUint64R(p []byte, v **uint64) error {
 			*v = new(uint64)
 		}
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint64, the data value should be positive")
+		}
 		val := decUint64(p)
 		*v = &val
 	default:
@@ -379,6 +385,9 @@ func DecUint(p []byte, v *uint) error {
 	case 0:
 		*v = 0
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint, the data value should be positive")
+		}
 		*v = uint(p[0])<<56 | uint(p[1])<<48 | uint(p[2])<<40 | uint(p[3])<<32 | uint(p[4])<<24 | uint(p[5])<<16 | uint(p[6])<<8 | uint(p[7])
 	default:
 		return errWrongDataLen
@@ -398,6 +407,9 @@ func DecUintR(p []byte, v **uint) error {
 			*v = new(uint)
 		}
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into uint, the data value should be positive")
+		}
 		val := uint(p[0])<<56 | uint(p[1])<<48 | uint(p[2])<<40 | uint(p[3])<<32 | uint(p[4])<<24 | uint(p[5])<<16 | uint(p[6])<<8 | uint(p[7])
 		*v = &val
 	default:
@@ -516,7 +528,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the int8 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -532,7 +544,7 @@ func decReflectInt16(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the int16 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -548,7 +560,7 @@ func decReflectInt32(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the int32 range", v.Interface())
 		}
 		v.SetInt(val)
 	default:
@@ -575,7 +587,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[7]))
 	default:
@@ -590,7 +602,7 @@ func decReflectUint16(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the uint16 range", v.Interface())
 		}
 		v.SetUint(uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -605,7 +617,7 @@ func decReflectUint32(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 8:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the uint32 range", v.Interface())
 		}
 		v.SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 	default:
@@ -619,6 +631,9 @@ func decReflectUints(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetUint(0)
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
 		v.SetUint(decUint64(p))
 	default:
 		return errWrongDataLen
@@ -678,7 +693,7 @@ func decReflectInt8R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the int8 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -696,7 +711,7 @@ func decReflectInt16R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the int16 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -714,7 +729,7 @@ func decReflectInt32R(p []byte, v reflect.Value) error {
 	case 8:
 		val := decInt64(p)
 		if val > math.MaxInt32 || val < math.MinInt32 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the int32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the int32 range", v.Interface())
 		}
 		newVal := reflect.New(v.Type().Elem().Elem())
 		newVal.Elem().SetInt(val)
@@ -746,7 +761,7 @@ func decReflectUint8R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 || p[6] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the uint8 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -763,7 +778,7 @@ func decReflectUint16R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 || p[4] != 0 || p[5] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the uint16 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -780,7 +795,7 @@ func decReflectUint32R(p []byte, v reflect.Value) error {
 	case 8:
 		newVal := reflect.New(v.Type().Elem().Elem())
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0 {
-			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data should be in the uint32 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be in the uint32 range", v.Interface())
 		}
 		newVal.Elem().SetUint(uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7]))
 		v.Elem().Set(newVal)
@@ -795,6 +810,9 @@ func decReflectUintsR(p []byte, v reflect.Value) error {
 	case 0:
 		v.Elem().Set(decReflectNullableR(p, v))
 	case 8:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal counter: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
 		val := reflect.New(v.Type().Elem().Elem())
 		val.Elem().SetUint(decUint64(p))
 		v.Elem().Set(val)

--- a/serialization/cqlint/unmarshal_utils.go
+++ b/serialization/cqlint/unmarshal_utils.go
@@ -24,7 +24,7 @@ func DecInt8(p []byte, v *int8) error {
 	case 4:
 		val := decInt32(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int8, the data value should be in the int8 range")
 		}
 		*v = int8(val)
 	default:
@@ -55,7 +55,7 @@ func DecInt16(p []byte, v *int16) error {
 	case 4:
 		val := decInt32(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into int16, the data should be in the int16 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int16, the data value should be in the int16 range")
 		}
 		*v = int16(val)
 	default:
@@ -166,7 +166,7 @@ func DecUint8(p []byte, v *uint8) error {
 		*v = 0
 	case 4:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint8, the data value should be in the uint8 range")
 		}
 		*v = p[3]
 	default:
@@ -196,7 +196,7 @@ func DecUint16(p []byte, v *uint16) error {
 		*v = 0
 	case 4:
 		if p[0] != 0 || p[1] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint16, the data should be in the uint16 range")
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint16, the data value should be in the uint16 range")
 		}
 		*v = uint16(p[2])<<8 | uint16(p[3])
 	default:
@@ -225,6 +225,9 @@ func DecUint32(p []byte, v *uint32) error {
 	case 0:
 		*v = 0
 	case 4:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint32, the data value should be positive")
+		}
 		*v = uint32(p[0])<<24 | uint32(p[1])<<16 | uint32(p[2])<<8 | uint32(p[3])
 	default:
 		return errWrongDataLen
@@ -252,6 +255,9 @@ func DecUint64(p []byte, v *uint64) error {
 	case 0:
 		*v = 0
 	case 4:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint64, the data value should be positive")
+		}
 		*v = decUint64(p)
 	default:
 		return errWrongDataLen
@@ -279,6 +285,9 @@ func DecUint(p []byte, v *uint) error {
 	case 0:
 		*v = 0
 	case 4:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint, the data value should be positive")
+		}
 		*v = uint(p[0])<<24 | uint(p[1])<<16 | uint(p[2])<<8 | uint(p[3])
 	default:
 		return errWrongDataLen
@@ -399,7 +408,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 4:
 		val := decInt32(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the int8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data value should be in the int8 range", v.Interface())
 		}
 		v.SetInt(int64(val))
 	default:
@@ -415,7 +424,7 @@ func decReflectInt16(p []byte, v reflect.Value) error {
 	case 4:
 		val := decInt32(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the int16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data value should be in the int16 range", v.Interface())
 		}
 		v.SetInt(int64(val))
 	default:
@@ -442,7 +451,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 4:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data value should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[3]))
 	default:
@@ -457,7 +466,7 @@ func decReflectUint16(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 4:
 		if p[0] != 0 || p[1] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data value should be in the uint16 range", v.Interface())
 		}
 		v.SetUint(uint64(p[2])<<8 | uint64(p[3]))
 	default:
@@ -471,6 +480,9 @@ func decReflectUints(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetUint(0)
 	case 4:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
 		v.SetUint(decUint64(p))
 	default:
 		return errWrongDataLen

--- a/serialization/smallint/unmarshal_utils.go
+++ b/serialization/smallint/unmarshal_utils.go
@@ -24,7 +24,7 @@ func DecInt8(p []byte, v *int8) error {
 	case 2:
 		val := decInt16(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into int8, the data should be in the int8 range")
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into int8, the data value should be in the int8 range")
 		}
 		*v = int8(val)
 	default:
@@ -162,7 +162,7 @@ func DecUint8(p []byte, v *uint8) error {
 		*v = 0
 	case 2:
 		if p[0] != 0 {
-			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint8, the data should be in the uint8 range")
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint8, the data value should be in the uint8 range")
 		}
 		*v = p[1]
 	default:
@@ -191,6 +191,9 @@ func DecUint16(p []byte, v *uint16) error {
 	case 0:
 		*v = 0
 	case 2:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint16, the data value should be positive")
+		}
 		*v = uint16(p[0])<<8 | uint16(p[1])
 	default:
 		return errWrongDataLen
@@ -218,6 +221,9 @@ func DecUint32(p []byte, v *uint32) error {
 	case 0:
 		*v = 0
 	case 2:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint32, the data value should be positive")
+		}
 		*v = uint32(p[0])<<8 | uint32(p[1])
 	default:
 		return errWrongDataLen
@@ -245,6 +251,9 @@ func DecUint64(p []byte, v *uint64) error {
 	case 0:
 		*v = 0
 	case 2:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint64, the data value should be positive")
+		}
 		*v = decUint64(p)
 	default:
 		return errWrongDataLen
@@ -272,6 +281,9 @@ func DecUint(p []byte, v *uint) error {
 	case 0:
 		*v = 0
 	case 2:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into uint, the data value should be positive")
+		}
 		*v = uint(p[0])<<8 | uint(p[1])
 	default:
 		return errWrongDataLen
@@ -388,7 +400,7 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 2:
 		val := decInt16(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into %T, the data should be in the int8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into %T, the data value should be in the int8 range", v.Interface())
 		}
 		v.SetInt(int64(val))
 	default:
@@ -415,7 +427,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 2:
 		if p[0] != 0 {
-			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into %T, the data value should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[1]))
 	default:
@@ -429,7 +441,11 @@ func decReflectUints(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetUint(0)
 	case 2:
-		v.SetUint(decUint64(p))
+		val := decUint64(p)
+		if val > math.MaxInt16 {
+			return fmt.Errorf("failed to unmarshal smallint: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
+		v.SetUint(val)
 	default:
 		return errWrongDataLen
 	}

--- a/serialization/tinyint/marshal_utils.go
+++ b/serialization/tinyint/marshal_utils.go
@@ -81,6 +81,9 @@ func EncIntR(v *int) ([]byte, error) {
 }
 
 func EncUint8(v uint8) ([]byte, error) {
+	if v > math.MaxInt8 {
+		return nil, fmt.Errorf("failed to marshal tinyint: value %#v out of range", v)
+	}
 	return []byte{v}, nil
 }
 
@@ -92,7 +95,7 @@ func EncUint8R(v *uint8) ([]byte, error) {
 }
 
 func EncUint16(v uint16) ([]byte, error) {
-	if v > math.MaxUint8 {
+	if v > math.MaxInt8 {
 		return nil, fmt.Errorf("failed to marshal tinyint: value %#v out of range", v)
 	}
 	return []byte{byte(v)}, nil
@@ -106,7 +109,7 @@ func EncUint16R(v *uint16) ([]byte, error) {
 }
 
 func EncUint32(v uint32) ([]byte, error) {
-	if v > math.MaxUint8 {
+	if v > math.MaxInt8 {
 		return nil, fmt.Errorf("failed to marshal tinyint: value %#v out of range", v)
 	}
 	return []byte{byte(v)}, nil
@@ -120,7 +123,7 @@ func EncUint32R(v *uint32) ([]byte, error) {
 }
 
 func EncUint64(v uint64) ([]byte, error) {
-	if v > math.MaxUint8 {
+	if v > math.MaxInt8 {
 		return nil, fmt.Errorf("failed to marshal tinyint: value %#v out of range", v)
 	}
 	return []byte{byte(v)}, nil
@@ -134,7 +137,7 @@ func EncUint64R(v *uint64) ([]byte, error) {
 }
 
 func EncUint(v uint) ([]byte, error) {
-	if v > math.MaxUint8 {
+	if v > math.MaxInt8 {
 		return nil, fmt.Errorf("failed to marshal tinyint: value %#v out of range", v)
 	}
 	return []byte{byte(v)}, nil
@@ -190,11 +193,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal tinyint: value (%T)(%[1]v) out of range", v.Interface())
 		}
 		return []byte{byte(val)}, nil
-	case reflect.Uint8:
-		return []byte{byte(v.Uint())}, nil
-	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16:
+	case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
 		val := v.Uint()
-		if val > math.MaxUint8 {
+		if val > math.MaxInt8 {
 			return nil, fmt.Errorf("failed to marshal tinyint: value (%T)(%[1]v) out of range", v.Interface())
 		}
 		return []byte{byte(val)}, nil

--- a/serialization/tinyint/unmarshal_utils.go
+++ b/serialization/tinyint/unmarshal_utils.go
@@ -197,6 +197,9 @@ func DecUint8(p []byte, v *uint8) error {
 	case 0:
 		*v = 0
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint8, the data value should be positive")
+		}
 		*v = p[0]
 	default:
 		return errWrongDataLen
@@ -216,6 +219,9 @@ func DecUint8R(p []byte, v **uint8) error {
 			*v = new(uint8)
 		}
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint8, the data value should be positive")
+		}
 		val := p[0]
 		*v = &val
 	default:
@@ -232,6 +238,9 @@ func DecUint16(p []byte, v *uint16) error {
 	case 0:
 		*v = 0
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint16, the data value should be positive")
+		}
 		*v = uint16(p[0])
 	default:
 		return errWrongDataLen
@@ -251,6 +260,9 @@ func DecUint16R(p []byte, v **uint16) error {
 			*v = new(uint16)
 		}
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint16, the data value should be positive")
+		}
 		val := uint16(p[0])
 		*v = &val
 	default:
@@ -267,6 +279,9 @@ func DecUint32(p []byte, v *uint32) error {
 	case 0:
 		*v = 0
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint32, the data value should be positive")
+		}
 		*v = uint32(p[0])
 	default:
 		return errWrongDataLen
@@ -286,6 +301,9 @@ func DecUint32R(p []byte, v **uint32) error {
 			*v = new(uint32)
 		}
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint32, the data value should be positive")
+		}
 		val := uint32(p[0])
 		*v = &val
 	default:
@@ -302,6 +320,9 @@ func DecUint64(p []byte, v *uint64) error {
 	case 0:
 		*v = 0
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint64, the data value should be positive")
+		}
 		*v = uint64(p[0])
 	default:
 		return errWrongDataLen
@@ -321,6 +342,9 @@ func DecUint64R(p []byte, v **uint64) error {
 			*v = new(uint64)
 		}
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint64, the data value should be positive")
+		}
 		val := uint64(p[0])
 		*v = &val
 	default:
@@ -337,6 +361,9 @@ func DecUint(p []byte, v *uint) error {
 	case 0:
 		*v = 0
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint, the data value should be positive")
+		}
 		*v = uint(p[0])
 	default:
 		return errWrongDataLen
@@ -356,6 +383,9 @@ func DecUintR(p []byte, v **uint) error {
 			*v = new(uint)
 		}
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into uint, the data value should be positive")
+		}
 		val := uint(p[0])
 		*v = &val
 	default:
@@ -489,6 +519,9 @@ func decReflectUints(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetUint(0)
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
 		v.SetUint(uint64(p[0]))
 	default:
 		return errWrongDataLen
@@ -531,6 +564,9 @@ func decReflectUintsR(p []byte, v reflect.Value) error {
 	case 0:
 		v.Elem().Set(decReflectNullableR(p, v))
 	case 1:
+		if p[0] > math.MaxInt8 {
+			return fmt.Errorf("failed to unmarshal tinyint: to unmarshal into %T, the data value should be positive", v.Interface())
+		}
 		val := reflect.New(v.Type().Elem().Elem())
 		val.Elem().SetUint(uint64(p[0]))
 		v.Elem().Set(val)

--- a/tests/serialization/marshal_2_tinyint_corrupt_test.go
+++ b/tests/serialization/marshal_2_tinyint_corrupt_test.go
@@ -1,6 +1,7 @@
 package serialization_test
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -44,11 +45,11 @@ func TestMarshalTinyintCorrupt(t *testing.T) {
 
 			serialization.NegativeMarshalSet{
 				Values: mod.Values{
-					int16(128), int32(128), int64(128), int(128),
-					"128", *big.NewInt(128),
-					int16(-129), int32(-129), int64(-129), int(-129),
-					"-129", *big.NewInt(-129),
-					uint16(256), uint32(256), uint64(256), uint(256),
+					int16(math.MaxInt8 + 1), int32(math.MaxInt8 + 1), int64(math.MaxInt8 + 1), int(math.MaxInt8 + 1),
+					uint8(math.MaxInt8 + 1), uint16(math.MaxInt8 + 1), uint32(math.MaxInt8 + 1), uint64(math.MaxInt8 + 1), uint(math.MaxInt8 + 1),
+					"128", *big.NewInt(math.MaxInt8 + 1),
+					int16(math.MinInt8 - 1), int32(math.MinInt8 - 1), int64(math.MinInt8 - 1), int(math.MinInt8 - 1),
+					"-129", *big.NewInt(math.MinInt8 - 1),
 				}.AddVariants(mod.All...),
 			}.Run("big_vals", t, marshal)
 
@@ -64,6 +65,20 @@ func TestMarshalTinyintCorrupt(t *testing.T) {
 					"", *big.NewInt(0),
 				}.AddVariants(mod.All...),
 			}.Run("big_data", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints-1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints-128", t, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_2_tinyint_test.go
+++ b/tests/serialization/marshal_2_tinyint_test.go
@@ -102,11 +102,6 @@ func TestMarshalTinyint(t *testing.T) {
 				Data:   []byte("\x80"),
 				Values: mod.Values{int8(-128), int16(-128), int32(-128), int64(-128), int(-128), "-128", *big.NewInt(-128)}.AddVariants(mod.All...),
 			}.Run("-128", t, marshal, unmarshal)
-
-			serialization.PositiveSet{
-				Data:   []byte("\xff"),
-				Values: mod.Values{uint8(255), uint16(255), uint32(255), uint64(255), uint(255)}.AddVariants(mod.All...),
-			}.Run("255", t, marshal, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_3_smallint_corrupt_test.go
+++ b/tests/serialization/marshal_3_smallint_corrupt_test.go
@@ -1,6 +1,7 @@
 package serialization_test
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -43,11 +44,11 @@ func TestMarshalSmallintCorrupt(t *testing.T) {
 		t.Run(tSuite.name, func(t *testing.T) {
 			serialization.NegativeMarshalSet{
 				Values: mod.Values{
-					int32(32768), int64(32768), int(32768),
-					"32768", *big.NewInt(32768),
-					int32(-32769), int64(-32769), int(-32769),
-					"-32769", *big.NewInt(-32769),
-					uint32(65536), uint64(65536), uint(65536),
+					int32(math.MaxInt16 + 1), int64(math.MaxInt16 + 1), int(math.MaxInt16 + 1),
+					uint16(math.MaxInt16 + 1), uint32(math.MaxInt16 + 1), uint64(math.MaxInt16 + 1), uint(math.MaxInt16 + 1),
+					"32768", *big.NewInt(math.MaxInt16 + 1),
+					int32(math.MinInt16 - 1), int64(math.MinInt16 - 1), int(math.MinInt16 - 1),
+					"-32769", *big.NewInt(math.MinInt16 - 1),
 				}.AddVariants(mod.All...),
 			}.Run("big_vals", t, marshal)
 
@@ -102,6 +103,34 @@ func TestMarshalSmallintCorrupt(t *testing.T) {
 				Data:   []byte("\xff\xff"),
 				Values: mod.Values{uint8(0)}.AddVariants(mod.All...),
 			}.Run("small_type_uint_65535", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\xff"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints-1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\x80"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt8", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\x7f"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt8-1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80\x00"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt16", t, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_3_smallint_test.go
+++ b/tests/serialization/marshal_3_smallint_test.go
@@ -160,13 +160,6 @@ func TestMarshalSmallint(t *testing.T) {
 					"256", *big.NewInt(256),
 				}.AddVariants(mod.All...),
 			}.Run("maxUint8+1", t, marshal, unmarshal)
-
-			serialization.PositiveSet{
-				Data: []byte("\xff\xff"),
-				Values: mod.Values{
-					uint16(65535), uint32(65535), uint64(65535), uint(65535),
-				}.AddVariants(mod.All...),
-			}.Run("maxUint16", t, marshal, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_4_int_corrupt_test.go
+++ b/tests/serialization/marshal_4_int_corrupt_test.go
@@ -1,6 +1,7 @@
 package serialization_test
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -43,11 +44,11 @@ func TestMarshalIntCorrupt(t *testing.T) {
 		t.Run(tSuite.name, func(t *testing.T) {
 			serialization.NegativeMarshalSet{
 				Values: mod.Values{
-					int64(2147483648), int(2147483648),
-					"2147483648", *big.NewInt(2147483648),
+					int64(math.MaxInt32 + 1), int(math.MaxInt32 + 1),
+					"2147483648", *big.NewInt(math.MaxInt32 + 1),
+					uint32(math.MaxInt32 + 1), uint64(math.MaxInt32 + 1), uint(math.MaxInt32 + 1),
 					int64(-2147483649), int(-2147483649),
 					"-2147483649", *big.NewInt(-2147483649),
-					uint64(4294967296), uint(4294967296),
 				}.AddVariants(mod.All...),
 			}.Run("big_vals", t, marshal)
 
@@ -126,6 +127,62 @@ func TestMarshalIntCorrupt(t *testing.T) {
 				Data:   []byte("\x00\x00\x01\x00"),
 				Values: mod.Values{uint8(0)}.AddVariants(mod.All...),
 			}.Run("small_type_uint_256", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\xff\xff\xff"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints-1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\xff\xff\x80"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt8", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\xff\xff\x7f"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt8-1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\xff\x80\x00"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt16", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\xff\x7f\xff"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt16-1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\x80\x00\x00"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt24", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\x7f\xff\xff"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt24-1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80\x00\x00\x00"),
+				Values: mod.Values{
+					uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+				}.AddVariants(mod.All...),
+			}.Run("neg_uints_minInt36", t, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_4_int_test.go
+++ b/tests/serialization/marshal_4_int_test.go
@@ -164,6 +164,40 @@ func TestMarshalInt(t *testing.T) {
 			}.Run("minInt16-1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
+				Data: []byte("\x00\x7f\xff\xff"),
+				Values: mod.Values{
+					int32(8388607), int64(8388607), int(8388607),
+					uint32(8388607), uint64(8388607), uint(8388607),
+					"8388607", *big.NewInt(8388607),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\x80\x00\x00"),
+				Values: mod.Values{
+					int32(-8388608), int64(-8388608), int(-8388608),
+					"-8388608", *big.NewInt(-8388608),
+				}.AddVariants(mod.All...),
+			}.Run("minInt24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x80\x00\x00"),
+				Values: mod.Values{
+					int32(8388608), int64(8388608), int(8388608),
+					uint32(8388608), uint64(8388608), uint(8388608),
+					"8388608", *big.NewInt(8388608),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt24+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\x7f\xff\xff"),
+				Values: mod.Values{
+					int32(-8388609), int64(-8388609), int(-8388609),
+					"-8388609", *big.NewInt(-8388609),
+				}.AddVariants(mod.All...),
+			}.Run("minInt24-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
 				Data: []byte("\x7f\xff\xff\xff"),
 				Values: mod.Values{
 					int32(2147483647), int64(2147483647), int(2147483647),
@@ -217,11 +251,22 @@ func TestMarshalInt(t *testing.T) {
 			}.Run("maxUint16+1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
-				Data: []byte("\xff\xff\xff\xff"),
+				Data: []byte("\x00\xff\xff\xff"),
 				Values: mod.Values{
-					uint32(4294967295), uint64(4294967295), uint(4294967295),
+					uint32(16777215), uint64(16777215), uint(16777215),
+					int32(16777215), int64(16777215), int(16777215),
+					"16777215", *big.NewInt(16777215),
 				}.AddVariants(mod.All...),
-			}.Run("maxUint32", t, marshal, unmarshal)
+			}.Run("maxUint24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x01\x00\x00\x00"),
+				Values: mod.Values{
+					uint32(16777216), uint64(16777216), uint(16777216),
+					int32(16777216), int64(16777216), int(16777216),
+					"16777216", *big.NewInt(16777216),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint24+1", t, marshal, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_5_bigint_corrupt_test.go
+++ b/tests/serialization/marshal_5_bigint_corrupt_test.go
@@ -1,6 +1,7 @@
 package serialization_test
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -44,8 +45,9 @@ func TestMarshalBigIntCorrupt(t *testing.T) {
 			Values: mod.Values{
 				"9223372036854775808",
 				"-9223372036854775809",
-				*big.NewInt(0).Add(big.NewInt(9223372036854775807), big.NewInt(1)),
-				*big.NewInt(0).Add(big.NewInt(-9223372036854775808), big.NewInt(-1)),
+				uint64(math.MaxInt64 + 1), uint(math.MaxInt64 + 1),
+				*big.NewInt(0).Add(big.NewInt(math.MaxInt64), big.NewInt(1)),
+				*big.NewInt(0).Add(big.NewInt(math.MinInt64), big.NewInt(-1)),
 			}.AddVariants(mod.All...),
 		}.Run("big_vals", t, marshal)
 
@@ -129,5 +131,117 @@ func TestMarshalBigIntCorrupt(t *testing.T) {
 			Data:   []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 			Values: mod.Values{uint8(0), uint16(0), uint32(0)}.AddVariants(mod.All...),
 		}.Run("small_type_uint_max", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\xff\x80"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt8", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\xff\x7f"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt8-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\x80\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt16", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\x7f\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt16-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\x80\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt24", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\x7f\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt24-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\x80\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt36", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\x7f\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt36-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\x80\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt40", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\x7f\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt40-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\x80\x00\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt48", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\x7f\xff\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt48-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\x80\x00\x00\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt56", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\x7f\xff\xff\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt56-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt64", t, unmarshal)
 	}
 }

--- a/tests/serialization/marshal_5_bigint_test.go
+++ b/tests/serialization/marshal_5_bigint_test.go
@@ -163,6 +163,40 @@ func TestMarshalBigInt(t *testing.T) {
 			}.Run("minInt16-1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x00\x7f\xff\xff"),
+				Values: mod.Values{
+					int32(8388607), int64(8388607), int(8388607),
+					uint32(8388607), uint64(8388607), uint(8388607),
+					"8388607", *big.NewInt(8388607),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff\xff\x80\x00\x00"),
+				Values: mod.Values{
+					int32(-8388608), int64(-8388608), int(-8388608),
+					"-8388608", *big.NewInt(-8388608),
+				}.AddVariants(mod.All...),
+			}.Run("minInt24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x00\x80\x00\x00"),
+				Values: mod.Values{
+					int32(8388608), int64(8388608), int(8388608),
+					uint32(8388608), uint64(8388608), uint(8388608),
+					"8388608", *big.NewInt(8388608),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt24+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff\xff\x7f\xff\xff"),
+				Values: mod.Values{
+					int32(-8388609), int64(-8388609), int(-8388609),
+					"-8388609", *big.NewInt(-8388609),
+				}.AddVariants(mod.All...),
+			}.Run("minInt24-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
 				Data: []byte("\x00\x00\x00\x00\x7f\xff\xff\xff"),
 				Values: mod.Values{
 					int32(2147483647), int64(2147483647), int(2147483647),
@@ -195,6 +229,108 @@ func TestMarshalBigInt(t *testing.T) {
 					"-2147483649", *big.NewInt(-2147483649),
 				}.AddVariants(mod.All...),
 			}.Run("minInt32-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x7f\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(549755813887), int(549755813887),
+					uint64(549755813887), uint(549755813887),
+					"549755813887", *big.NewInt(549755813887),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt40", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\x80\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(-549755813888), int(-549755813888),
+					"-549755813888", *big.NewInt(-549755813888),
+				}.AddVariants(mod.All...),
+			}.Run("minInt40", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x80\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(549755813888), int(549755813888),
+					uint64(549755813888), uint(549755813888),
+					"549755813888", *big.NewInt(549755813888),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt40+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\x7f\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(-549755813889), int(-549755813889),
+					"-549755813889", *big.NewInt(-549755813889),
+				}.AddVariants(mod.All...),
+			}.Run("minInt40-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x7f\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(140737488355327), int(140737488355327),
+					uint64(140737488355327), uint(140737488355327),
+					"140737488355327", *big.NewInt(140737488355327),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt48", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\x80\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(-140737488355328), int(-140737488355328),
+					"-140737488355328", *big.NewInt(-140737488355328),
+				}.AddVariants(mod.All...),
+			}.Run("minInt48", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x80\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(140737488355328), int(140737488355328),
+					uint64(140737488355328), uint(140737488355328),
+					"140737488355328", *big.NewInt(140737488355328),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt48+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\x7f\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(-140737488355329), int(-140737488355329),
+					"-140737488355329", *big.NewInt(-140737488355329),
+				}.AddVariants(mod.All...),
+			}.Run("minInt48-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x7f\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(36028797018963967), int(36028797018963967),
+					uint64(36028797018963967), uint(36028797018963967),
+					"36028797018963967", *big.NewInt(36028797018963967),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt56", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\x80\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(-36028797018963968), int(-36028797018963968),
+					"-36028797018963968", *big.NewInt(-36028797018963968),
+				}.AddVariants(mod.All...),
+			}.Run("minInt56", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x80\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(36028797018963968), int(36028797018963968),
+					uint64(36028797018963968), uint(36028797018963968),
+					"36028797018963968", *big.NewInt(36028797018963968),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt56+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\x7f\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(-36028797018963969), int(-36028797018963969),
+					"-36028797018963969", *big.NewInt(-36028797018963969),
+				}.AddVariants(mod.All...),
+			}.Run("minInt56-1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
@@ -250,6 +386,24 @@ func TestMarshalBigInt(t *testing.T) {
 			}.Run("maxUint16+1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x00\xff\xff\xff"),
+				Values: mod.Values{
+					uint32(16777215), uint64(16777215), uint(16777215),
+					int32(16777215), int64(16777215), int(16777215),
+					"16777215", *big.NewInt(16777215),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x01\x00\x00\x00"),
+				Values: mod.Values{
+					uint32(16777216), uint64(16777216), uint(16777216),
+					int32(16777216), int64(16777216), int(16777216),
+					"16777216", *big.NewInt(16777216),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint24+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
 				Data: []byte("\x00\x00\x00\x00\xff\xff\xff\xff"),
 				Values: mod.Values{
 					uint32(4294967295), uint64(4294967295), uint(4294967295),
@@ -268,11 +422,58 @@ func TestMarshalBigInt(t *testing.T) {
 			}.Run("maxUint32+1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
-				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
+				Data: []byte("\x00\x00\x00\xff\xff\xff\xff\xff"),
 				Values: mod.Values{
-					uint64(18446744073709551615), uint(18446744073709551615),
+					uint64(1099511627775), uint(1099511627775),
+					int64(1099511627775), int(1099511627775),
+					"1099511627775", *big.NewInt(1099511627775),
 				}.AddVariants(mod.All...),
-			}.Run("maxUint64", t, marshal, unmarshal)
+			}.Run("maxUint40", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x01\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					uint64(1099511627776), uint(1099511627776),
+					int64(1099511627776), int(1099511627776),
+					"1099511627776", *big.NewInt(1099511627776),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint40+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					uint64(281474976710655), uint(281474976710655),
+					int64(281474976710655), int(281474976710655),
+					"281474976710655", *big.NewInt(281474976710655),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint48", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x01\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					uint64(281474976710656), uint(281474976710656),
+					int64(281474976710656), int(281474976710656),
+					"281474976710656", *big.NewInt(281474976710656),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint48+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\xff\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					uint64(72057594037927935), uint(72057594037927935),
+					int64(72057594037927935), int(72057594037927935),
+					"72057594037927935", *big.NewInt(72057594037927935),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint56", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x01\x00\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					uint64(72057594037927936), uint(72057594037927936),
+					int64(72057594037927936), int(72057594037927936),
+					"72057594037927936", *big.NewInt(72057594037927936),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint56+1", t, marshal, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_6_counter_corrupt_test.go
+++ b/tests/serialization/marshal_6_counter_corrupt_test.go
@@ -1,6 +1,7 @@
 package serialization_test
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -44,8 +45,9 @@ func TestMarshalCounterCorrupt(t *testing.T) {
 			Values: mod.Values{
 				"9223372036854775808",
 				"-9223372036854775809",
-				*big.NewInt(0).Add(big.NewInt(9223372036854775807), big.NewInt(1)),
-				*big.NewInt(0).Add(big.NewInt(-9223372036854775808), big.NewInt(-1)),
+				uint64(math.MaxInt64 + 1), uint(math.MaxInt64 + 1),
+				*big.NewInt(0).Add(big.NewInt(math.MaxInt64), big.NewInt(1)),
+				*big.NewInt(0).Add(big.NewInt(math.MinInt64), big.NewInt(-1)),
 			}.AddVariants(mod.All...),
 		}.Run("big_vals", t, marshal)
 
@@ -129,5 +131,116 @@ func TestMarshalCounterCorrupt(t *testing.T) {
 			Data:   []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
 			Values: mod.Values{uint8(0), uint16(0), uint32(0)}.AddVariants(mod.All...),
 		}.Run("small_type_uint_max", t, unmarshal)
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\xff\x80"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt8", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\xff\x7f"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt8-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\x80\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt16", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\xff\x7f\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt16-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\x80\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt24", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\xff\x7f\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt24-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\x80\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt36", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\xff\x7f\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt36-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\x80\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt40", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\xff\x7f\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt40-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\x80\x00\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt48", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\xff\x7f\xff\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt48-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\x80\x00\x00\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt56", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\xff\x7f\xff\xff\xff\xff\xff\xff"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt56-1", t, unmarshal)
+
+		serialization.NegativeUnmarshalSet{
+			Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
+			Values: mod.Values{
+				uint8(0), uint16(0), uint32(0), uint64(0), uint(0),
+			}.AddVariants(mod.All...),
+		}.Run("neg_uints_minInt64", t, unmarshal)
 	}
 }

--- a/tests/serialization/marshal_6_counter_test.go
+++ b/tests/serialization/marshal_6_counter_test.go
@@ -163,6 +163,40 @@ func TestMarshalCounter(t *testing.T) {
 			}.Run("minInt16-1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x00\x7f\xff\xff"),
+				Values: mod.Values{
+					int32(8388607), int64(8388607), int(8388607),
+					uint32(8388607), uint64(8388607), uint(8388607),
+					"8388607", *big.NewInt(8388607),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff\xff\x80\x00\x00"),
+				Values: mod.Values{
+					int32(-8388608), int64(-8388608), int(-8388608),
+					"-8388608", *big.NewInt(-8388608),
+				}.AddVariants(mod.All...),
+			}.Run("minInt24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x00\x80\x00\x00"),
+				Values: mod.Values{
+					int32(8388608), int64(8388608), int(8388608),
+					uint32(8388608), uint64(8388608), uint(8388608),
+					"8388608", *big.NewInt(8388608),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt24+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff\xff\x7f\xff\xff"),
+				Values: mod.Values{
+					int32(-8388609), int64(-8388609), int(-8388609),
+					"-8388609", *big.NewInt(-8388609),
+				}.AddVariants(mod.All...),
+			}.Run("minInt24-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
 				Data: []byte("\x00\x00\x00\x00\x7f\xff\xff\xff"),
 				Values: mod.Values{
 					int32(2147483647), int64(2147483647), int(2147483647),
@@ -195,6 +229,108 @@ func TestMarshalCounter(t *testing.T) {
 					"-2147483649", *big.NewInt(-2147483649),
 				}.AddVariants(mod.All...),
 			}.Run("minInt32-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x7f\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(549755813887), int(549755813887),
+					uint64(549755813887), uint(549755813887),
+					"549755813887", *big.NewInt(549755813887),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt40", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\x80\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(-549755813888), int(-549755813888),
+					"-549755813888", *big.NewInt(-549755813888),
+				}.AddVariants(mod.All...),
+			}.Run("minInt40", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x80\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(549755813888), int(549755813888),
+					uint64(549755813888), uint(549755813888),
+					"549755813888", *big.NewInt(549755813888),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt40+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\x7f\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(-549755813889), int(-549755813889),
+					"-549755813889", *big.NewInt(-549755813889),
+				}.AddVariants(mod.All...),
+			}.Run("minInt40-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x7f\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(140737488355327), int(140737488355327),
+					uint64(140737488355327), uint(140737488355327),
+					"140737488355327", *big.NewInt(140737488355327),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt48", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\x80\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(-140737488355328), int(-140737488355328),
+					"-140737488355328", *big.NewInt(-140737488355328),
+				}.AddVariants(mod.All...),
+			}.Run("minInt48", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x80\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(140737488355328), int(140737488355328),
+					uint64(140737488355328), uint(140737488355328),
+					"140737488355328", *big.NewInt(140737488355328),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt48+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\x7f\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(-140737488355329), int(-140737488355329),
+					"-140737488355329", *big.NewInt(-140737488355329),
+				}.AddVariants(mod.All...),
+			}.Run("minInt48-1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x7f\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(36028797018963967), int(36028797018963967),
+					uint64(36028797018963967), uint(36028797018963967),
+					"36028797018963967", *big.NewInt(36028797018963967),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt56", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\x80\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(-36028797018963968), int(-36028797018963968),
+					"-36028797018963968", *big.NewInt(-36028797018963968),
+				}.AddVariants(mod.All...),
+			}.Run("minInt56", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x80\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(36028797018963968), int(36028797018963968),
+					uint64(36028797018963968), uint(36028797018963968),
+					"36028797018963968", *big.NewInt(36028797018963968),
+				}.AddVariants(mod.All...),
+			}.Run("maxInt56+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\x7f\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(-36028797018963969), int(-36028797018963969),
+					"-36028797018963969", *big.NewInt(-36028797018963969),
+				}.AddVariants(mod.All...),
+			}.Run("minInt56-1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
@@ -250,6 +386,24 @@ func TestMarshalCounter(t *testing.T) {
 			}.Run("maxUint16+1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x00\xff\xff\xff"),
+				Values: mod.Values{
+					uint32(16777215), uint64(16777215), uint(16777215),
+					int32(16777215), int64(16777215), int(16777215),
+					"16777215", *big.NewInt(16777215),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint24", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x01\x00\x00\x00"),
+				Values: mod.Values{
+					uint32(16777216), uint64(16777216), uint(16777216),
+					int32(16777216), int64(16777216), int(16777216),
+					"16777216", *big.NewInt(16777216),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint24+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
 				Data: []byte("\x00\x00\x00\x00\xff\xff\xff\xff"),
 				Values: mod.Values{
 					uint32(4294967295), uint64(4294967295), uint(4294967295),
@@ -268,11 +422,58 @@ func TestMarshalCounter(t *testing.T) {
 			}.Run("maxUint32+1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
-				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
+				Data: []byte("\x00\x00\x00\xff\xff\xff\xff\xff"),
 				Values: mod.Values{
-					uint64(18446744073709551615), uint(18446744073709551615),
+					uint64(1099511627775), uint(1099511627775),
+					int64(1099511627775), int(1099511627775),
+					"1099511627775", *big.NewInt(1099511627775),
 				}.AddVariants(mod.All...),
-			}.Run("maxUint64", t, marshal, unmarshal)
+			}.Run("maxUint40", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x01\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					uint64(1099511627776), uint(1099511627776),
+					int64(1099511627776), int(1099511627776),
+					"1099511627776", *big.NewInt(1099511627776),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint40+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					uint64(281474976710655), uint(281474976710655),
+					int64(281474976710655), int(281474976710655),
+					"281474976710655", *big.NewInt(281474976710655),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint48", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x01\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					uint64(281474976710656), uint(281474976710656),
+					int64(281474976710656), int(281474976710656),
+					"281474976710656", *big.NewInt(281474976710656),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint48+1", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\xff\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					uint64(72057594037927935), uint(72057594037927935),
+					int64(72057594037927935), int(72057594037927935),
+					"72057594037927935", *big.NewInt(72057594037927935),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint56", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x01\x00\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					uint64(72057594037927936), uint(72057594037927936),
+					int64(72057594037927936), int(72057594037927936),
+					"72057594037927936", *big.NewInt(72057594037927936),
+				}.AddVariants(mod.All...),
+			}.Run("maxUint56+1", t, marshal, unmarshal)
 		})
 	}
 }


### PR DESCRIPTION
All `int` like `cql types` have `negative` range and `positive` range, but `uint` like `go types` have only `positive` range.
For example, if cast `-1` `tinyint` `[]byte("\xff")` into `uint like` `go types` we got `255`.

In the old marhsal/unmarshal functions (before the starts redesign), this problem was solved in different ways.
Now marhsal/unmarshal functions (before the starts redesign), allow the processing with a negative range of the `int` like `cql types` for all `uint like` `go types`.
But this can lead to problems due to the different  `DB` and `GO` representations of the same values .

So, my suggest to leave only one way - stop the processing with a negative range of the `int` like `cql types` for all `uint like` `go types`.