### PR TITLE
Fix `double` marshal, unmarshall functions

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -119,13 +119,6 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: 2, typ: TypeDouble},
-		[]byte("\x40\x09\x21\xfb\x53\xc8\xd4\xf1"),
-		float64(3.14159265),
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeDecimal},
 		[]byte("\x00\x00\x00\x00\x00"),
 		inf.NewDec(0, 0),
@@ -532,23 +525,6 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeBoolean},
 		[]byte(nil),
 		(*bool)(nil),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeDouble},
-		[]byte("\x40\x09\x21\xfb\x53\xc8\xd4\xf1"),
-		func() *float64 {
-			d := float64(3.14159265)
-			return &d
-		}(),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeDouble},
-		[]byte(nil),
-		(*float64)(nil),
 		nil,
 		nil,
 	},

--- a/serialization/double/marshal.go
+++ b/serialization/double/marshal.go
@@ -1,0 +1,24 @@
+package double
+
+import (
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case float64:
+		return EncFloat64(v)
+	case *float64:
+		return EncFloat64R(v)
+	default:
+		// Custom types (type MyFloat float64) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/serialization/double/marshal_utils.go
+++ b/serialization/double/marshal_utils.go
@@ -1,0 +1,54 @@
+package double
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+func EncFloat64(v float64) ([]byte, error) {
+	return encFloat64(v), nil
+}
+
+func EncFloat64R(v *float64) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return encFloat64R(v), nil
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Kind() {
+	case reflect.Float64:
+		return encFloat64(v.Float()), nil
+	default:
+		return nil, fmt.Errorf("failed to marshal double: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encFloat64(v float64) []byte {
+	return encUint64(floatToUint(v))
+}
+
+func encFloat64R(v *float64) []byte {
+	return encUint64(floatToUintR(v))
+}
+
+func encUint64(v uint64) []byte {
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+func floatToUint(v float64) uint64 {
+	return *(*uint64)(unsafe.Pointer(&v))
+}
+
+func floatToUintR(v *float64) uint64 {
+	return *(*uint64)(unsafe.Pointer(v))
+}

--- a/serialization/double/unmarshal.go
+++ b/serialization/double/unmarshal.go
@@ -1,0 +1,29 @@
+package double
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case *float64:
+		return DecFloat64(data, v)
+	case **float64:
+		return DecFloat64R(data, v)
+	default:
+		// Custom types (type MyFloat float64) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v)", v)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/serialization/double/unmarshal_utils.go
+++ b/serialization/double/unmarshal_utils.go
@@ -1,0 +1,126 @@
+package double
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+var errWrongDataLen = fmt.Errorf("failed to unmarshal double: the length of the data should be 0 or 8")
+
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal double: can not unmarshal into nil reference(%T)(%[1]v)", v)
+}
+
+func DecFloat64(p []byte, v *float64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 8:
+		*v = decFloat64(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecFloat64R(p []byte, v **float64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(float64)
+		}
+	case 8:
+		*v = decFloat64R(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.Float64:
+		return decReflectFloat32(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v.Type().Elem().Elem().Kind() {
+	case reflect.Float64:
+		return decReflectFloat32R(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectFloat32(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetFloat(0)
+	case 8:
+		v.SetFloat(decFloat64(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectFloat32R(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 8:
+		val := reflect.New(v.Type().Elem().Elem())
+		val.Elem().SetFloat(decFloat64(p))
+		v.Elem().Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectNullableR(p []byte, v reflect.Value) reflect.Value {
+	if p == nil {
+		return reflect.Zero(v.Elem().Type())
+	}
+	return reflect.New(v.Type().Elem().Elem())
+}
+
+func decFloat64(p []byte) float64 {
+	return uint64ToFloat(decUint64(p))
+}
+
+func decFloat64R(p []byte) *float64 {
+	return uint64ToFloatR(decUint64(p))
+}
+
+func uint64ToFloat(v uint64) float64 {
+	return *(*float64)(unsafe.Pointer(&v))
+}
+
+func uint64ToFloatR(v uint64) *float64 {
+	return (*float64)(unsafe.Pointer(&v))
+}
+
+func decUint64(p []byte) uint64 {
+	return uint64(p[0])<<56 | uint64(p[1])<<48 | uint64(p[2])<<40 | uint64(p[3])<<32 | uint64(p[4])<<24 | uint64(p[5])<<16 | uint64(p[6])<<8 | uint64(p[7])
+}

--- a/tests/serialization/marshal_9_double_corrupt_test.go
+++ b/tests/serialization/marshal_9_double_corrupt_test.go
@@ -6,23 +6,23 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
-	"github.com/gocql/gocql/serialization/float"
+	"github.com/gocql/gocql/serialization/double"
 )
 
-func TestMarshalFloatCorrupt(t *testing.T) {
+func TestMarshalDoubleCorrupt(t *testing.T) {
 	type testSuite struct {
 		name      string
 		marshal   func(interface{}) ([]byte, error)
 		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	tType := gocql.NewNativeType(4, gocql.TypeFloat, "")
+	tType := gocql.NewNativeType(4, gocql.TypeDouble, "")
 
 	testSuites := [2]testSuite{
 		{
-			name:      "serialization.float",
-			marshal:   float.Marshal,
-			unmarshal: float.Unmarshal,
+			name:      "serialization.double",
+			marshal:   double.Marshal,
+			unmarshal: double.Unmarshal,
 		},
 		{
 			name: "glob",
@@ -41,18 +41,18 @@ func TestMarshalFloatCorrupt(t *testing.T) {
 		t.Run(tSuite.name, func(t *testing.T) {
 
 			serialization.NegativeUnmarshalSet{
-				Data:   []byte("\x80\x00\x00\x00\x00"),
-				Values: mod.Values{float32(0)}.AddVariants(mod.All...),
+				Data:   []byte("\x80\x00\x00\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{float64(0)}.AddVariants(mod.All...),
 			}.Run("big_data", t, unmarshal)
 
 			serialization.NegativeUnmarshalSet{
 				Data:   []byte("\x80"),
-				Values: mod.Values{float32(0)}.AddVariants(mod.All...),
+				Values: mod.Values{float64(0)}.AddVariants(mod.All...),
 			}.Run("small_data1", t, unmarshal)
 
 			serialization.NegativeUnmarshalSet{
-				Data:   []byte("\x80\x00\x00"),
-				Values: mod.Values{float32(0)}.AddVariants(mod.All...),
+				Data:   []byte("\x80\x00\x00\x00"),
+				Values: mod.Values{float64(0)}.AddVariants(mod.All...),
 			}.Run("small_data2", t, unmarshal)
 		})
 	}

--- a/tests/serialization/marshal_9_duble_test.go
+++ b/tests/serialization/marshal_9_duble_test.go
@@ -7,58 +7,90 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/serialization/double"
 )
 
 func TestMarshalDouble(t *testing.T) {
-	tType := gocql.NewNativeType(4, gocql.TypeDouble, "")
-
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	serialization.PositiveSet{
-		Data:   nil,
-		Values: mod.Values{(*float64)(nil)}.AddVariants(mod.CustomType),
-	}.Run("[nil]nullable", t, marshal, unmarshal)
+	tType := gocql.NewNativeType(4, gocql.TypeDouble, "")
 
-	serialization.PositiveSet{
-		Data:   nil,
-		Values: mod.Values{float64(0)}.AddVariants(mod.CustomType),
-	}.Run("[nil]unmarshal", t, nil, unmarshal)
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.double",
+			marshal:   double.Marshal,
+			unmarshal: double.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	serialization.PositiveSet{
-		Data:   make([]byte, 0),
-		Values: mod.Values{float64(0)}.AddVariants(mod.All...),
-	}.Run("[]unmarshal", t, nil, unmarshal)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.PositiveSet{
-		Data:   []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
-		Values: mod.Values{float64(0)}.AddVariants(mod.All...),
-	}.Run("zeros", t, marshal, unmarshal)
+		t.Run(tSuite.name, func(t *testing.T) {
 
-	serialization.PositiveSet{
-		Data:   []byte("\x7f\xef\xff\xff\xff\xff\xff\xff"),
-		Values: mod.Values{float64(math.MaxFloat64)}.AddVariants(mod.All...),
-	}.Run("max", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   nil,
+				Values: mod.Values{(*float64)(nil)}.AddVariants(mod.CustomType),
+			}.Run("[nil]nullable", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
-		Values: mod.Values{float64(math.SmallestNonzeroFloat64)}.AddVariants(mod.All...),
-	}.Run("smallest", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   nil,
+				Values: mod.Values{float64(0)}.AddVariants(mod.CustomType),
+			}.Run("[nil]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\x7f\xf0\x00\x00\x00\x00\x00\x00"),
-		Values: mod.Values{float64(math.Inf(1))}.AddVariants(mod.All...),
-	}.Run("inf+", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   make([]byte, 0),
+				Values: mod.Values{float64(0)}.AddVariants(mod.All...),
+			}.Run("[]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\xff\xf0\x00\x00\x00\x00\x00\x00"),
-		Values: mod.Values{float64(math.Inf(-1))}.AddVariants(mod.All...),
-	}.Run("inf-", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{float64(0)}.AddVariants(mod.All...),
+			}.Run("zeros", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\x7f\xf8\x00\x00\x00\x00\x00\x01"),
-		Values: mod.Values{float64(math.NaN())}.AddVariants(mod.All...),
-	}.Run("nan", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   []byte("\x7f\xef\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{float64(math.MaxFloat64)}.AddVariants(mod.All...),
+			}.Run("max", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
+				Values: mod.Values{float64(math.SmallestNonzeroFloat64)}.AddVariants(mod.All...),
+			}.Run("smallest", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x7f\xf0\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{float64(math.Inf(1))}.AddVariants(mod.All...),
+			}.Run("inf+", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\xff\xf0\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{float64(math.Inf(-1))}.AddVariants(mod.All...),
+			}.Run("inf-", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x7f\xf8\x00\x00\x00\x00\x00\x01"),
+				Values: mod.Values{float64(math.NaN())}.AddVariants(mod.All...),
+			}.Run("nan", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x40\x09\x21\xfb\x53\xc8\xd4\xf1"),
+				Values: mod.Values{float64(3.14159265)}.AddVariants(mod.All...),
+			}.Run("pi", t, marshal, unmarshal)
+		})
+	}
 }


### PR DESCRIPTION
Changes:
1. On unmarshall data which length different from 0 or 8 was `no error` before, now return an error.
2. Optimized marshal, unmarshall functions. 