### PR TITLE
Add `map` marshal tests

### DIFF
--- a/internal/tests/serialization/mod/custom.go
+++ b/internal/tests/serialization/mod/custom.go
@@ -32,18 +32,35 @@ type (
 	SliceInt16R  []*int16
 	SliceInt16C  []Int16
 	SliceInt16CR []*Int16
-	SliceAny     []interface{}
+
+	SliceInt32   []int32
+	SliceInt32R  []*int32
+	SliceInt32C  []Int32
+	SliceInt32CR []*Int32
+
+	SliceAny []interface{}
 
 	Arr1Int16   [1]int16
 	Arr1Int16R  [1]*int16
 	Arr1Int16C  [1]Int16
 	Arr1Int16CR [1]*Int16
-	ArrAny      [1]interface{}
+
+	Arr1Int32   [1]int32
+	Arr1Int32R  [1]*int32
+	Arr1Int32C  [1]Int32
+	Arr1Int32CR [1]*Int32
+
+	ArrAny [1]interface{}
 
 	MapInt16   map[int16]int16
 	MapInt16R  map[int16]*int16
 	MapInt16C  map[Int16]Int16
 	MapInt16CR map[Int16]*Int16
+
+	MapInt32   map[int32]int32
+	MapInt32R  map[int32]*int32
+	MapInt32C  map[Int32]Int32
+	MapInt32CR map[Int32]*Int32
 
 	MapUDT map[string]interface{}
 )
@@ -114,6 +131,14 @@ func customType(i interface{}) interface{} {
 		return SliceInt16C(v)
 	case []*Int16:
 		return SliceInt16CR(v)
+	case []int32:
+		return SliceInt32(v)
+	case []*int32:
+		return SliceInt32R(v)
+	case []Int32:
+		return SliceInt32C(v)
+	case []*Int32:
+		return SliceInt32CR(v)
 	case [1]int16:
 		return Arr1Int16(v)
 	case [1]*int16:
@@ -122,6 +147,14 @@ func customType(i interface{}) interface{} {
 		return Arr1Int16C(v)
 	case [1]*Int16:
 		return Arr1Int16CR(v)
+	case [1]int32:
+		return Arr1Int32(v)
+	case [1]*int32:
+		return Arr1Int32R(v)
+	case [1]Int32:
+		return Arr1Int32C(v)
+	case [1]*Int32:
+		return Arr1Int32CR(v)
 	case map[int16]int16:
 		return MapInt16(v)
 	case map[int16]*int16:
@@ -130,6 +163,14 @@ func customType(i interface{}) interface{} {
 		return MapInt16C(v)
 	case map[Int16]*Int16:
 		return MapInt16CR(v)
+	case map[int32]int32:
+		return MapInt32(v)
+	case map[int32]*int32:
+		return MapInt32R(v)
+	case map[Int32]Int32:
+		return MapInt32C(v)
+	case map[Int32]*Int32:
+		return MapInt32CR(v)
 	case map[string]interface{}:
 		return MapUDT(v)
 	case []interface{}:
@@ -185,6 +226,14 @@ func intoCustomR(i interface{}) interface{} {
 		return (*SliceInt16C)(v)
 	case *[]*Int16:
 		return (*SliceInt16CR)(v)
+	case *[]int32:
+		return (*SliceInt32)(v)
+	case *[]*int32:
+		return (*SliceInt32R)(v)
+	case *[]Int32:
+		return (*SliceInt32C)(v)
+	case *[]*Int32:
+		return (*SliceInt32CR)(v)
 	case *[1]int16:
 		return (*Arr1Int16)(v)
 	case *[1]*int16:
@@ -193,6 +242,14 @@ func intoCustomR(i interface{}) interface{} {
 		return (*Arr1Int16C)(v)
 	case *[1]*Int16:
 		return (*Arr1Int16CR)(v)
+	case *[1]int32:
+		return (*Arr1Int32)(v)
+	case *[1]*int32:
+		return (*Arr1Int32R)(v)
+	case *[1]Int32:
+		return (*Arr1Int32C)(v)
+	case *[1]*Int32:
+		return (*Arr1Int32CR)(v)
 	case *map[int16]int16:
 		return (*MapInt16)(v)
 	case *map[int16]*int16:
@@ -201,6 +258,14 @@ func intoCustomR(i interface{}) interface{} {
 		return (*MapInt16C)(v)
 	case *map[Int16]*Int16:
 		return (*MapInt16CR)(v)
+	case *map[int32]int32:
+		return (*MapInt32)(v)
+	case *map[int32]*int32:
+		return (*MapInt32R)(v)
+	case *map[Int32]Int32:
+		return (*MapInt32C)(v)
+	case *map[Int32]*Int32:
+		return (*MapInt32CR)(v)
 	case *map[string]interface{}:
 		return (*MapUDT)(v)
 	case *[]interface{}:

--- a/internal/tests/serialization/utils_str.go
+++ b/internal/tests/serialization/utils_str.go
@@ -15,7 +15,7 @@ const printLimit = 100
 func stringValue(in interface{}) string {
 	valStr := stringVal(in)
 	if len(valStr) > printLimit {
-		valStr = valStr[:printLimit]
+		return fmt.Sprintf("(%T)", in)
 	}
 	return fmt.Sprintf("(%T)(%s)", in, valStr)
 }

--- a/marshal.go
+++ b/marshal.go
@@ -2314,6 +2314,14 @@ func (s NativeType) String() string {
 	}
 }
 
+func NewCollectionType(m NativeType, key, elem TypeInfo) CollectionType {
+	return CollectionType{
+		NativeType: m,
+		Key:        key,
+		Elem:       elem,
+	}
+}
+
 type CollectionType struct {
 	NativeType
 	Key  TypeInfo // only used for TypeMap

--- a/tests/serialization/marshal_20_map_v2_corrupt_test.go
+++ b/tests/serialization/marshal_20_map_v2_corrupt_test.go
@@ -1,0 +1,191 @@
+package serialization_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/gocql/gocql/internal/tests/serialization"
+	"github.com/gocql/gocql/internal/tests/serialization/mod"
+)
+
+func TestMarshalMapV2Corrupt(t *testing.T) {
+	elem := gocql.NewNativeType(2, gocql.TypeSmallInt, "")
+	tType := gocql.NewCollectionType(gocql.NewNativeType(2, gocql.TypeMap, ""), elem, elem)
+
+	//unmarshal data than bigger the normal data, does not return error.
+	brokenBigData := serialization.GetTypes(mod.Values{
+		make(map[int16]int16), make(map[int16]*int16),
+		make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+	}.AddVariants(mod.All...)...)
+
+	refInt32 := func(v int32) *int32 { return &v }
+	refModInt32 := func(v mod.Int32) *mod.Int32 { return &v }
+
+	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i interface{}) error {
+		return gocql.Unmarshal(tType, bytes, i)
+	}
+
+	val := int32(math.MaxInt16 + 1)
+	valc := mod.Int32(val)
+	serialization.NegativeMarshalSet{
+		Values: mod.Values{
+			map[int32]int32{val: val}, map[int32]int32{val: 0}, map[int32]int32{0: val},
+			map[int32]*int32{val: refInt32(val)}, map[int32]*int32{val: refInt32(0)}, map[int32]*int32{0: refInt32(val)},
+			map[mod.Int32]mod.Int32{valc: valc}, map[mod.Int32]mod.Int32{valc: 0}, map[mod.Int32]mod.Int32{0: valc},
+			map[mod.Int32]*mod.Int32{valc: refModInt32(valc)}, map[mod.Int32]*mod.Int32{valc: refModInt32(0)}, map[mod.Int32]*mod.Int32{0: refModInt32(valc)},
+		}.AddVariants(mod.All...),
+	}.Run("big_vals", t, marshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x02\xff\xff\x00\x02\xff\xff\x01"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+		BrokenTypes: brokenBigData,
+	}.Run("big_data_elem1+", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x00\x00\x00\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+		BrokenTypes: brokenBigData,
+	}.Run("big_data_zeroElem1+", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x01"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+		BrokenTypes: brokenBigData,
+	}.Run("big_data_elems0+", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x02\xff\xff\x00\x02\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val_value-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x02\xff\xff\x00\x02"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val_len", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x02\xff\xff\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val_len-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x02\xff\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x02\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_key_value-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00\x02"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_key_len", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_key_len-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x01"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_pair-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_elems-", t, unmarshal)
+}
+
+func TestMarshalMapV2CorruptMax(t *testing.T) {
+	t.Parallel()
+	elem := gocql.NewNativeType(2, gocql.TypeSmallInt, "")
+	tType := gocql.NewCollectionType(gocql.NewNativeType(2, gocql.TypeMap, ""), elem, elem)
+
+	elems := math.MaxUint16 + 1
+	values := []func() interface{}{
+		func() interface{} {
+			out := make(map[int32]int32, elems)
+			for i := 0; i < elems; i++ {
+				out[int32(i)] = int32(1)
+			}
+			return out
+		},
+		func() interface{} {
+			out := make(map[int32]*int32, elems)
+			for i := 0; i < elems; i++ {
+				tmp := int32(1)
+				out[int32(i)] = &tmp
+			}
+			return out
+		},
+		func() interface{} {
+			out := make(map[mod.Int32]mod.Int32, elems)
+			for i := 0; i < elems; i++ {
+				out[mod.Int32(i)] = mod.Int32(1)
+			}
+			return out
+		},
+		func() interface{} {
+			out := make(map[mod.Int32]*mod.Int32, elems)
+			for i := 0; i < elems; i++ {
+				tmp := mod.Int32(1)
+				out[mod.Int32(i)] = &tmp
+			}
+			return out
+		},
+	}
+
+	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
+
+	for _, v := range values {
+		value := v()
+		name := fmt.Sprintf("%T", value)
+
+		serialization.NegativeMarshalSet{
+			Values: mod.Values{value}.AddVariants(mod.All...),
+		}.Run(name, t, marshal)
+	}
+}

--- a/tests/serialization/marshal_20_map_v2_test.go
+++ b/tests/serialization/marshal_20_map_v2_test.go
@@ -1,0 +1,130 @@
+package serialization_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/gocql/gocql/internal/tests/serialization"
+	"github.com/gocql/gocql/internal/tests/serialization/mod"
+)
+
+func TestMarshalMapV2(t *testing.T) {
+	elem := gocql.NewNativeType(2, gocql.TypeSmallInt, "")
+	tType := gocql.NewCollectionType(gocql.NewNativeType(2, gocql.TypeMap, ""), elem, elem)
+
+	refInt16 := func(v int16) *int16 { return &v }
+	refModInt16 := func(v mod.Int16) *mod.Int16 { return &v }
+
+	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i interface{}) error {
+		return gocql.Unmarshal(tType, bytes, i)
+	}
+
+	serialization.PositiveSet{
+		Data: nil,
+		Values: mod.Values{
+			(map[int16]int16)(nil), (map[int16]*int16)(nil),
+			(map[mod.Int16]mod.Int16)(nil), (map[mod.Int16]*mod.Int16)(nil),
+			(*map[int16]int16)(nil), (*map[int16]*int16)(nil),
+			(*map[mod.Int16]mod.Int16)(nil), (*map[mod.Int16]*mod.Int16)(nil),
+		}.AddVariants(mod.CustomType),
+	}.Run("[nil]nullable", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("zero elems", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x01\x00\x00\x00\x00"),
+		Values: mod.Values{
+			map[int16]int16{0: 0}, map[int16]*int16{0: refInt16(0)},
+			map[mod.Int16]mod.Int16{0: 0}, map[mod.Int16]*mod.Int16{0: refModInt16(0)},
+		}.AddVariants(mod.All...),
+	}.Run("[]{zero elem}unmarshal", t, nil, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x01\x00\x02\x00\x00\x00\x02\x00\x00"),
+		Values: mod.Values{
+			map[int16]int16{0: 0}, map[int16]*int16{0: refInt16(0)},
+			map[mod.Int16]mod.Int16{0: 0}, map[mod.Int16]*mod.Int16{0: refModInt16(0)},
+		}.AddVariants(mod.All...),
+	}.Run("[]{0:0}", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x01\x00\x02\x7f\xff\x00\x02\x7f\xff"),
+		Values: mod.Values{
+			map[int16]int16{32767: 32767}, map[int16]*int16{32767: refInt16(32767)},
+			map[mod.Int16]mod.Int16{32767: 32767}, map[mod.Int16]*mod.Int16{32767: refModInt16(32767)},
+		}.AddVariants(mod.All...),
+	}.Run("[]{max:max}", t, marshal, unmarshal)
+}
+
+func TestMarshalMapV2Max(t *testing.T) {
+	t.Parallel()
+	elem := gocql.NewNativeType(2, gocql.TypeSmallInt, "")
+	tType := gocql.NewCollectionType(gocql.NewNativeType(2, gocql.TypeMap, ""), elem, elem)
+
+	elems := math.MaxUint16
+
+	data := make([]byte, 0, elems*4+2)
+	data = append(data, 255, 255)
+	uintData := func(v uint) (byte, byte) {
+		return byte(v >> 8), byte(v)
+	}
+	for v := 0; v < elems; v++ {
+		b1, b2 := uintData(uint(v))
+		data = append(data, 0, 2, b1, b2, 0, 2, 0, 1)
+	}
+
+	values := []func() interface{}{
+		func() interface{} {
+			out := make(map[int16]int16, elems)
+			for i := 0; i < elems; i++ {
+				out[int16(i)] = int16(1)
+			}
+			return out
+		},
+		func() interface{} {
+			out := make(map[int16]*int16, elems)
+			for i := 0; i < elems; i++ {
+				tmp := int16(1)
+				out[int16(i)] = &tmp
+			}
+			return out
+		},
+		func() interface{} {
+			out := make(map[mod.Int16]mod.Int16, elems)
+			for i := 0; i < elems; i++ {
+				out[mod.Int16(i)] = mod.Int16(1)
+			}
+			return out
+		},
+		func() interface{} {
+			out := make(map[mod.Int16]*mod.Int16, elems)
+			for i := 0; i < elems; i++ {
+				tmp := mod.Int16(1)
+				out[mod.Int16(i)] = &tmp
+			}
+			return out
+		},
+	}
+	unmarshal := func(bytes []byte, i interface{}) error {
+		return gocql.Unmarshal(tType, bytes, i)
+	}
+
+	for _, v := range values {
+		value := v()
+		name := fmt.Sprintf("%T", value)
+
+		serialization.PositiveSet{
+			Data:   data,
+			Values: mod.Values{value}.AddVariants(mod.All...),
+		}.Run(name, t, nil, unmarshal)
+	}
+}

--- a/tests/serialization/marshal_20_map_v3_corrupt_test.go
+++ b/tests/serialization/marshal_20_map_v3_corrupt_test.go
@@ -1,0 +1,139 @@
+package serialization_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/gocql/gocql/internal/tests/serialization"
+	"github.com/gocql/gocql/internal/tests/serialization/mod"
+)
+
+func TestMarshalMapV3Corrupt(t *testing.T) {
+	elem := gocql.NewNativeType(3, gocql.TypeSmallInt, "")
+	tType := gocql.NewCollectionType(gocql.NewNativeType(3, gocql.TypeMap, ""), elem, elem)
+
+	//unmarshal data than bigger the normal data, does not return error.
+	brokenBigData := serialization.GetTypes(mod.Values{
+		make(map[int16]int16), make(map[int16]*int16),
+		make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+	}.AddVariants(mod.All...)...)
+
+	refInt32 := func(v int32) *int32 { return &v }
+	refModInt32 := func(v mod.Int32) *mod.Int32 { return &v }
+
+	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i interface{}) error {
+		return gocql.Unmarshal(tType, bytes, i)
+	}
+
+	val := int32(math.MaxInt16 + 1)
+	valc := mod.Int32(val)
+	serialization.NegativeMarshalSet{
+		Values: mod.Values{
+			map[int32]int32{val: val}, map[int32]int32{val: 0}, map[int32]int32{0: val},
+			map[int32]*int32{val: refInt32(val)}, map[int32]*int32{val: refInt32(0)}, map[int32]*int32{0: refInt32(val)},
+			map[mod.Int32]mod.Int32{valc: valc}, map[mod.Int32]mod.Int32{valc: 0}, map[mod.Int32]mod.Int32{0: valc},
+			map[mod.Int32]*mod.Int32{valc: refModInt32(valc)}, map[mod.Int32]*mod.Int32{valc: refModInt32(0)}, map[mod.Int32]*mod.Int32{0: refModInt32(valc)},
+		}.AddVariants(mod.All...),
+	}.Run("big_vals", t, marshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\xff\xff\x00\x00\x00\x02\xff\xff\x01"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+		BrokenTypes: brokenBigData,
+	}.Run("big_data_elem1+", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+		BrokenTypes: brokenBigData,
+	}.Run("big_data_zeroElem1+", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x00\x01"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+		BrokenTypes: brokenBigData,
+	}.Run("big_data_elems0+", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\xff\xff\x00\x00\x00\x02\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val_value-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\xff\xff\x00\x00\x00\x02"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val_len", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\xff\xff\x00\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val_len-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\xff\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_val-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\xff"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_key_value-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_key_len", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_key_len-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00\x00\x01"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_pair-", t, unmarshal)
+
+	serialization.NegativeUnmarshalSet{
+		Data: []byte("\x00\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("small_data_elems-", t, unmarshal)
+}

--- a/tests/serialization/marshal_20_map_v3_test.go
+++ b/tests/serialization/marshal_20_map_v3_test.go
@@ -1,0 +1,64 @@
+package serialization_test
+
+import (
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/gocql/gocql/internal/tests/serialization"
+	"github.com/gocql/gocql/internal/tests/serialization/mod"
+)
+
+func TestMarshalMapV3(t *testing.T) {
+	elem := gocql.NewNativeType(3, gocql.TypeSmallInt, "")
+	tType := gocql.NewCollectionType(gocql.NewNativeType(3, gocql.TypeMap, ""), elem, elem)
+
+	refInt16 := func(v int16) *int16 { return &v }
+	refModInt16 := func(v mod.Int16) *mod.Int16 { return &v }
+
+	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i interface{}) error {
+		return gocql.Unmarshal(tType, bytes, i)
+	}
+
+	serialization.PositiveSet{
+		Data: nil,
+		Values: mod.Values{
+			(map[int16]int16)(nil), (map[int16]*int16)(nil),
+			(map[mod.Int16]mod.Int16)(nil), (map[mod.Int16]*mod.Int16)(nil),
+			(*map[int16]int16)(nil), (*map[int16]*int16)(nil),
+			(*map[mod.Int16]mod.Int16)(nil), (*map[mod.Int16]*mod.Int16)(nil),
+		}.AddVariants(mod.CustomType),
+	}.Run("[nil]nullable", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x00\x00\x00"),
+		Values: mod.Values{
+			make(map[int16]int16), make(map[int16]*int16),
+			make(map[mod.Int16]mod.Int16), make(map[mod.Int16]*mod.Int16),
+		}.AddVariants(mod.All...),
+	}.Run("zero elems", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00"),
+		Values: mod.Values{
+			map[int16]int16{0: 0}, map[int16]*int16{0: refInt16(0)},
+			map[mod.Int16]mod.Int16{0: 0}, map[mod.Int16]*mod.Int16{0: refModInt16(0)},
+		}.AddVariants(mod.All...),
+	}.Run("[]{zero elem}unmarshal", t, nil, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x00\x00\x02\x00\x00"),
+		Values: mod.Values{
+			map[int16]int16{0: 0}, map[int16]*int16{0: refInt16(0)},
+			map[mod.Int16]mod.Int16{0: 0}, map[mod.Int16]*mod.Int16{0: refModInt16(0)},
+		}.AddVariants(mod.All...),
+	}.Run("[]{0:0}", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\x00\x00\x01\x00\x00\x00\x02\x7f\xff\x00\x00\x00\x02\x7f\xff"),
+		Values: mod.Values{
+			map[int16]int16{32767: 32767}, map[int16]*int16{32767: refInt16(32767)},
+			map[mod.Int16]mod.Int16{32767: 32767}, map[mod.Int16]*mod.Int16{32767: refModInt16(32767)},
+		}.AddVariants(mod.All...),
+	}.Run("[]{max:max}", t, marshal, unmarshal)
+}


### PR DESCRIPTION
Changes:
1. Added marshal tests for `list`, `set` `cql types`
2. Added `gocql.NewCollectionType` function to create `CollectionType`
3. Added `custom types` for `map[int32]int32`,`map[int32]*int32` into `mod` package
4. Makes it so, if the `value string` out of print limit, then `value string` include only `value type`