### PR TITLE
Fix marshal `cqlint` - optimization

### DIFF
--- a/serialization/cqlint/unmarshal_utils.go
+++ b/serialization/cqlint/unmarshal_utils.go
@@ -37,11 +37,23 @@ func DecInt8R(p []byte, v **int8) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(int8)
-		return DecInt8(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int8)
+		}
+	case 4:
+		val := decInt32(p)
+		if val > math.MaxInt8 || val < math.MinInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int8, the data should be in the int8 range")
+		}
+		tmp := int8(val)
+		*v = &tmp
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -68,11 +80,23 @@ func DecInt16R(p []byte, v **int16) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(int16)
-		return DecInt16(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int16)
+		}
+	case 4:
+		val := decInt32(p)
+		if val > math.MaxInt16 || val < math.MinInt16 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into int16, the data should be in the int16 range")
+		}
+		tmp := int16(val)
+		*v = &tmp
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -95,11 +119,19 @@ func DecInt32R(p []byte, v **int32) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(int32)
-		return DecInt32(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int32)
+		}
+	case 4:
+		tmp := decInt32(p)
+		*v = &tmp
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -111,7 +143,7 @@ func DecInt64(p []byte, v *int64) error {
 	case 0:
 		*v = 0
 	case 4:
-		*v = int64(decInt32(p))
+		*v = decInt64(p)
 	default:
 		return errWrongDataLen
 	}
@@ -122,11 +154,19 @@ func DecInt64R(p []byte, v **int64) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(int64)
-		return DecInt64(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int64)
+		}
+	case 4:
+		val := decInt64(p)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -138,7 +178,7 @@ func DecInt(p []byte, v *int) error {
 	case 0:
 		*v = 0
 	case 4:
-		*v = int(decInt32(p))
+		*v = decInt(p)
 	default:
 		return errWrongDataLen
 	}
@@ -149,11 +189,19 @@ func DecIntR(p []byte, v **int) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(int)
-		return DecInt(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int)
+		}
+	case 4:
+		val := decInt(p)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -179,11 +227,22 @@ func DecUint8R(p []byte, v **uint8) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(uint8)
-		return DecUint8(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint8)
+		}
+	case 4:
+		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint8, the data should be in the uint8 range")
+		}
+		val := p[3]
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -209,11 +268,22 @@ func DecUint16R(p []byte, v **uint16) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(uint16)
-		return DecUint16(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint16)
+		}
+	case 4:
+		if p[0] != 0 || p[1] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into uint16, the data should be in the uint16 range")
+		}
+		val := uint16(p[2])<<8 | uint16(p[3])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -236,11 +306,19 @@ func DecUint32R(p []byte, v **uint32) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(uint32)
-		return DecUint32(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint32)
+		}
+	case 4:
+		val := uint32(p[0])<<24 | uint32(p[1])<<16 | uint32(p[2])<<8 | uint32(p[3])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -263,11 +341,19 @@ func DecUint64R(p []byte, v **uint64) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(uint64)
-		return DecUint64(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint64)
+		}
+	case 4:
+		val := decUint64(p)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -290,11 +376,19 @@ func DecUintR(p []byte, v **uint) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(uint)
-		return DecUint(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(uint)
+		}
+	case 4:
+		val := uint(p[0])<<24 | uint(p[1])<<16 | uint(p[2])<<8 | uint(p[3])
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -304,13 +398,13 @@ func DecString(p []byte, v *string) error {
 	}
 	switch len(p) {
 	case 0:
-		if p != nil {
-			*v = "0"
-		} else {
+		if p == nil {
 			*v = ""
+		} else {
+			*v = "0"
 		}
 	case 4:
-		*v = strconv.FormatInt(int64(decInt32(p)), 10)
+		*v = strconv.FormatInt(decInt64(p), 10)
 	default:
 		return errWrongDataLen
 	}
@@ -321,11 +415,20 @@ func DecStringR(p []byte, v **string) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = new(string)
-		return DecString(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			val := "0"
+			*v = &val
+		}
+	case 4:
+		val := strconv.FormatInt(decInt64(p), 10)
+		*v = &val
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -337,7 +440,7 @@ func DecBigInt(p []byte, v *big.Int) error {
 	case 0:
 		v.SetInt64(0)
 	case 4:
-		v.SetInt64(int64(decInt32(p)))
+		v.SetInt64(decInt64(p))
 	default:
 		return errWrongDataLen
 	}
@@ -348,11 +451,18 @@ func DecBigIntR(p []byte, v **big.Int) error {
 	if v == nil {
 		return errNilReference(v)
 	}
-	if p != nil {
-		*v = big.NewInt(0)
-		return DecBigInt(p, *v)
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = big.NewInt(0)
+		}
+	case 4:
+		*v = big.NewInt(decInt64(p))
+	default:
+		return errWrongDataLen
 	}
-	*v = nil
 	return nil
 }
 
@@ -382,14 +492,28 @@ func DecReflect(p []byte, v reflect.Value) error {
 }
 
 func DecReflectR(p []byte, v reflect.Value) error {
-	if p != nil {
-		zeroValue := reflect.New(v.Type().Elem().Elem())
-		v.Elem().Set(zeroValue)
-		return DecReflect(p, v.Elem())
+	if v.IsNil() {
+		return fmt.Errorf("failed to unmarshal int: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
 	}
-	nilValue := reflect.Zero(v.Elem().Type())
-	v.Elem().Set(nilValue)
-	return nil
+
+	switch v.Type().Elem().Elem().Kind() {
+	case reflect.Int8:
+		return decReflectInt8R(p, v)
+	case reflect.Int16:
+		return decReflectInt16R(p, v)
+	case reflect.Int32, reflect.Int64, reflect.Int:
+		return decReflectIntsR(p, v)
+	case reflect.Uint8:
+		return decReflectUint8R(p, v)
+	case reflect.Uint16:
+		return decReflectUint16R(p, v)
+	case reflect.Uint32, reflect.Uint64, reflect.Uint:
+		return decReflectUintsR(p, v)
+	case reflect.String:
+		return decReflectStringR(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
 }
 
 func decReflectInt8(p []byte, v reflect.Value) error {
@@ -397,11 +521,11 @@ func decReflectInt8(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetInt(0)
 	case 4:
-		val := decInt32(p)
+		val := decInt64(p)
 		if val > math.MaxInt8 || val < math.MinInt8 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the int8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the int8 range", v.Interface())
 		}
-		v.SetInt(int64(val))
+		v.SetInt(val)
 	default:
 		return errWrongDataLen
 	}
@@ -413,11 +537,11 @@ func decReflectInt16(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetInt(0)
 	case 4:
-		val := decInt32(p)
+		val := decInt64(p)
 		if val > math.MaxInt16 || val < math.MinInt16 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the int16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the int16 range", v.Interface())
 		}
-		v.SetInt(int64(val))
+		v.SetInt(val)
 	default:
 		return errWrongDataLen
 	}
@@ -429,7 +553,7 @@ func decReflectInts(p []byte, v reflect.Value) error {
 	case 0:
 		v.SetInt(0)
 	case 4:
-		v.SetInt(int64(decInt32(p)))
+		v.SetInt(decInt64(p))
 	default:
 		return errWrongDataLen
 	}
@@ -442,7 +566,7 @@ func decReflectUint8(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 4:
 		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the uint8 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the uint8 range", v.Interface())
 		}
 		v.SetUint(uint64(p[3]))
 	default:
@@ -457,7 +581,7 @@ func decReflectUint16(p []byte, v reflect.Value) error {
 		v.SetUint(0)
 	case 4:
 		if p[0] != 0 || p[1] != 0 {
-			return fmt.Errorf("failed to unmarshal int: to unmarshal into %T, the data should be in the uint16 range", v.Interface())
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the uint16 range", v.Interface())
 		}
 		v.SetUint(uint64(p[2])<<8 | uint64(p[3]))
 	default:
@@ -481,13 +605,139 @@ func decReflectUints(p []byte, v reflect.Value) error {
 func decReflectString(p []byte, v reflect.Value) error {
 	switch len(p) {
 	case 0:
-		if p != nil {
-			v.SetString("0")
-		} else {
+		if p == nil {
 			v.SetString("")
+		} else {
+			v.SetString("0")
 		}
 	case 4:
-		v.SetString(strconv.FormatInt(int64(decInt32(p)), 10))
+		v.SetString(strconv.FormatInt(decInt64(p), 10))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectNullableR(p []byte, v reflect.Value) reflect.Value {
+	if p == nil {
+		return reflect.Zero(v.Elem().Type())
+	}
+	return reflect.New(v.Type().Elem().Elem())
+}
+
+func decReflectInt8R(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 4:
+		val := decInt64(p)
+		if val > math.MaxInt8 || val < math.MinInt8 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the int8 range", v.Interface())
+		}
+		newVal := reflect.New(v.Type().Elem().Elem())
+		newVal.Elem().SetInt(val)
+		v.Elem().Set(newVal)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectInt16R(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 4:
+		val := decInt64(p)
+		if val > math.MaxInt16 || val < math.MinInt16 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the int16 range", v.Interface())
+		}
+		newVal := reflect.New(v.Type().Elem().Elem())
+		newVal.Elem().SetInt(val)
+		v.Elem().Set(newVal)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectIntsR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 4:
+		newVal := reflect.New(v.Type().Elem().Elem())
+		newVal.Elem().SetInt(decInt64(p))
+		v.Elem().Set(newVal)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUint8R(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 4:
+		if p[0] != 0 || p[1] != 0 || p[2] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the uint8 range", v.Interface())
+		}
+		newVal := reflect.New(v.Type().Elem().Elem())
+		newVal.Elem().SetUint(uint64(p[3]))
+		v.Elem().Set(newVal)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUint16R(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 4:
+		if p[0] != 0 || p[1] != 0 {
+			return fmt.Errorf("failed to unmarshal int: to unmarshal into (%T), the data should be in the uint16 range", v.Interface())
+		}
+		newVal := reflect.New(v.Type().Elem().Elem())
+		newVal.Elem().SetUint(uint64(p[2])<<8 | uint64(p[3]))
+		v.Elem().Set(newVal)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectUintsR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.Elem().Set(decReflectNullableR(p, v))
+	case 4:
+		newVal := reflect.New(v.Type().Elem().Elem())
+		newVal.Elem().SetUint(decUint64(p))
+		v.Elem().Set(newVal)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectStringR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		var val reflect.Value
+		if p == nil {
+			val = reflect.Zero(v.Type().Elem())
+		} else {
+			val = reflect.New(v.Type().Elem().Elem())
+			val.Elem().SetString("0")
+		}
+		v.Elem().Set(val)
+	case 4:
+		newVal := reflect.New(v.Type().Elem().Elem())
+		newVal.Elem().SetString(strconv.FormatInt(decInt64(p), 10))
+		v.Elem().Set(newVal)
 	default:
 		return errWrongDataLen
 	}
@@ -496,6 +746,20 @@ func decReflectString(p []byte, v reflect.Value) error {
 
 func decInt32(p []byte) int32 {
 	return int32(p[0])<<24 | int32(p[1])<<16 | int32(p[2])<<8 | int32(p[3])
+}
+
+func decInt64(p []byte) int64 {
+	if p[0] > math.MaxInt8 {
+		return int64(-1)<<32 | int64(p[0])<<24 | int64(p[1])<<16 | int64(p[2])<<8 | int64(p[3])
+	}
+	return int64(p[0])<<24 | int64(p[1])<<16 | int64(p[2])<<8 | int64(p[3])
+}
+
+func decInt(p []byte) int {
+	if p[0] > math.MaxInt8 {
+		return int(-1)<<32 | int(p[0])<<24 | int(p[1])<<16 | int(p[2])<<8 | int(p[3])
+	}
+	return int(p[0])<<24 | int(p[1])<<16 | int(p[2])<<8 | int(p[3])
 }
 
 func decUint64(p []byte) uint64 {


### PR DESCRIPTION
Changes:

Marshal functions:
* unnecessary value type conversion has been removed.
* unnecessary dereference has been removed.
* removed unnecessary value checks for `reflect.Int8`, `reflect.Int16`, `reflect.Int32`, `reflect.Uint8`, `reflect.Uint16`, `reflect.Uint32` kinds
* makes the right value type in the error of the `EncReflect` function

Unmarshal functions:
* unnecessary value type conversion has been removed.
* redo the functions for the double references values.
* the condition `data == nil` moved after the condition `len(data)==0` in the functions of the double references values.
