### PR TITLE
Fix `varchar`, `text`, `blob` marshal, unmarshall

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -21,11 +21,14 @@ import (
 	"gopkg.in/inf.v0"
 
 	"github.com/gocql/gocql/serialization/bigint"
+	"github.com/gocql/gocql/serialization/blob"
 	"github.com/gocql/gocql/serialization/counter"
 	"github.com/gocql/gocql/serialization/cqlint"
 	"github.com/gocql/gocql/serialization/float"
 	"github.com/gocql/gocql/serialization/smallint"
+	"github.com/gocql/gocql/serialization/text"
 	"github.com/gocql/gocql/serialization/tinyint"
+	"github.com/gocql/gocql/serialization/varchar"
 )
 
 var (
@@ -136,8 +139,14 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 	}
 
 	switch info.Type() {
-	case TypeVarchar, TypeAscii, TypeBlob, TypeText:
-		return marshalVarchar(info, value)
+	case TypeVarchar:
+		return marshalVarchar(value)
+	case TypeText:
+		return marshalText(value)
+	case TypeBlob:
+		return marshalVarchar(value)
+	case TypeAscii:
+		return marshalVarcharOld(info, value)
 	case TypeBoolean:
 		return marshalBool(info, value)
 	case TypeTinyInt:
@@ -240,8 +249,14 @@ func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
 	}
 
 	switch info.Type() {
-	case TypeVarchar, TypeAscii, TypeBlob, TypeText:
-		return unmarshalVarchar(info, data, value)
+	case TypeVarchar:
+		return unmarshalVarchar(data, value)
+	case TypeText:
+		return unmarshalVarchar(data, value)
+	case TypeBlob:
+		return unmarshalVarchar(data, value)
+	case TypeAscii:
+		return unmarshalVarcharOld(info, data, value)
 	case TypeBoolean:
 		return unmarshalBool(info, data, value)
 	case TypeInt:
@@ -318,7 +333,54 @@ func unmarshalNullable(info TypeInfo, data []byte, value interface{}) error {
 	return Unmarshal(info, data, newValue.Interface())
 }
 
-func marshalVarchar(info TypeInfo, value interface{}) ([]byte, error) {
+func marshalVarchar(value interface{}) ([]byte, error) {
+	data, err := varchar.Marshal(value)
+	if err != nil {
+		return nil, wrapMarshalError(err, "marshal error")
+	}
+	return data, nil
+}
+func marshalText(value interface{}) ([]byte, error) {
+	data, err := text.Marshal(value)
+	if err != nil {
+		return nil, wrapMarshalError(err, "marshal error")
+	}
+	return data, nil
+}
+
+func marshalBlob(value interface{}) ([]byte, error) {
+	data, err := blob.Marshal(value)
+	if err != nil {
+		return nil, wrapMarshalError(err, "marshal error")
+	}
+	return data, nil
+}
+
+func unmarshalVarchar(data []byte, value interface{}) error {
+	err := varchar.Unmarshal(data, value)
+	if err != nil {
+		return wrapUnmarshalError(err, "unmarshal error")
+	}
+	return nil
+}
+
+func unmarshalText(data []byte, value interface{}) error {
+	err := text.Unmarshal(data, value)
+	if err != nil {
+		return wrapUnmarshalError(err, "unmarshal error")
+	}
+	return nil
+}
+
+func unmarshalBlob(data []byte, value interface{}) error {
+	err := blob.Unmarshal(data, value)
+	if err != nil {
+		return wrapUnmarshalError(err, "unmarshal error")
+	}
+	return nil
+}
+
+func marshalVarcharOld(info TypeInfo, value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case Marshaler:
 		return v.MarshalCQL(info)
@@ -346,7 +408,7 @@ func marshalVarchar(info TypeInfo, value interface{}) ([]byte, error) {
 	return nil, marshalErrorf("can not marshal %T into %s", value, info)
 }
 
-func unmarshalVarchar(info TypeInfo, data []byte, value interface{}) error {
+func unmarshalVarcharOld(info TypeInfo, data []byte, value interface{}) error {
 	switch v := value.(type) {
 	case Unmarshaler:
 		return v.UnmarshalCQL(info, data)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -32,55 +32,6 @@ var marshalTests = []struct {
 	UnmarshalError error
 }{
 	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte("hello world"),
-		[]byte("hello world"),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte("hello world"),
-		"hello world",
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte(nil),
-		[]byte(nil),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte("hello world"),
-		MyString("hello world"),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte("HELLO WORLD"),
-		CustomString("hello world"),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeBlob},
-		[]byte("hello\x00"),
-		[]byte("hello\x00"),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeBlob},
-		[]byte(nil),
-		[]byte(nil),
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeTimeUUID},
 		[]byte{0x3d, 0xcd, 0x98, 0x0, 0xf3, 0xd9, 0x11, 0xbf, 0x86, 0xd4, 0xb8, 0xe8, 0x56, 0x2c, 0xc, 0xd0},
 		func() UUID {
@@ -321,7 +272,7 @@ var marshalTests = []struct {
 		},
 		[]byte("\x00\x01\x00\x03foo\x00\x05\x01\x02\x03\x04\x05"),
 		map[string]interface{}{
-			"foo": []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			"foo": string([]byte{0x01, 0x02, 0x03, 0x04, 0x05}),
 		},
 		nil,
 		nil,
@@ -457,23 +408,6 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeInet},
 		[]byte("\xfe\x80\x00\x00\x00\x00\x00\x00\x02\x02\xb3\xff\xfe\x1e\x83\x29"),
 		net.ParseIP("fe80::202:b3ff:fe1e:8329"),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte("nullable string"),
-		func() *string {
-			value := "nullable string"
-			return &value
-		}(),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte(nil),
-		(*string)(nil),
 		nil,
 		nil,
 	},
@@ -631,23 +565,6 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte("HELLO WORLD"),
-		func() *CustomString {
-			customString := CustomString("hello world")
-			return &customString
-		}(),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte(nil),
-		(*CustomString)(nil),
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeTinyInt},
 		[]byte("\x7f"),
 		127, // math.MaxInt8
@@ -742,23 +659,6 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeTinyInt},
 		[]byte("\xff"),
 		AliasUint(255),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeBlob},
-		[]byte(nil),
-		([]byte)(nil),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeVarchar},
-		[]byte{},
-		func() interface{} {
-			var s string
-			return &s
-		}(),
 		nil,
 		nil,
 	},
@@ -1866,7 +1766,7 @@ func BenchmarkUnmarshalVarchar(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := unmarshalVarchar(NativeType{}, src, &dst); err != nil {
+		if err := unmarshalVarchar(src, &dst); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/serialization/blob/marshal.go
+++ b/serialization/blob/marshal.go
@@ -1,0 +1,28 @@
+package blob
+
+import (
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		return EncString(v)
+	case *string:
+		return EncStringR(v)
+	case []byte:
+		return EncBytes(v)
+	case *[]byte:
+		return EncBytesR(v)
+	default:
+		// Custom types (type MyString string) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/serialization/blob/marshal_utils.go
+++ b/serialization/blob/marshal_utils.go
@@ -1,0 +1,56 @@
+package blob
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func EncString(v string) ([]byte, error) {
+	return encString(v), nil
+}
+
+func EncStringR(v *string) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return encString(*v), nil
+}
+
+func EncBytes(v []byte) ([]byte, error) {
+	return v, nil
+}
+
+func EncBytesR(v *[]byte) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return *v, nil
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Kind() {
+	case reflect.String:
+		return encString(v.String()), nil
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return EncBytes(v.Bytes())
+	default:
+		return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encString(v string) []byte {
+	if v == "" {
+		return make([]byte, 0)
+	}
+	return []byte(v)
+}

--- a/serialization/blob/unmarshal.go
+++ b/serialization/blob/unmarshal.go
@@ -1,0 +1,35 @@
+package blob
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case *string:
+		return DecString(data, v)
+	case **string:
+		return DecStringR(data, v)
+	case *[]byte:
+		return DecBytes(data, v)
+	case **[]byte:
+		return DecBytesR(data, v)
+	case *interface{}:
+		return DecInterface(data, v)
+	default:
+		// Custom types (type MyString string) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v)", v)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/serialization/blob/unmarshal_utils.go
+++ b/serialization/blob/unmarshal_utils.go
@@ -1,0 +1,170 @@
+package blob
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal blob: can not unmarshal into nil reference(%T)(%[1]v)", v)
+}
+
+func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decString(p)
+	return nil
+}
+
+func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decStringR(p)
+	return nil
+}
+
+func DecBytes(p []byte, v *[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decBytes(p)
+	return nil
+}
+
+func DecBytesR(p []byte, v **[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decBytesR(p)
+	return nil
+}
+
+func DecInterface(p []byte, v *interface{}) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decString(p)
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.String:
+		v.SetString(decString(p))
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		v.SetBytes(decBytes(p))
+	case reflect.Interface:
+		v.Set(reflect.ValueOf(decString(p)))
+	default:
+		return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+	return nil
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch ev := v.Type().Elem().Elem(); ev.Kind() {
+	case reflect.String:
+		return decReflectStringR(p, v)
+	case reflect.Slice:
+		if ev.Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return decReflectBytesR(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectNullableR(p []byte, v reflect.Value) reflect.Value {
+	if p == nil {
+		return reflect.Zero(v.Elem().Type())
+	}
+	return reflect.New(v.Type().Elem().Elem())
+}
+
+func decReflectStringR(p []byte, v reflect.Value) error {
+	if len(p) == 0 {
+		v.Elem().Set(decReflectNullableR(p, v))
+		return nil
+	}
+	val := reflect.New(v.Type().Elem().Elem())
+	val.Elem().SetString(string(p))
+	v.Elem().Set(val)
+	return nil
+}
+
+func decReflectBytesR(p []byte, v reflect.Value) error {
+	if len(p) == 0 {
+		if p == nil {
+			v.Elem().Set(reflect.Zero(v.Elem().Type()))
+		} else {
+			val := reflect.New(v.Type().Elem().Elem())
+			val.Elem().SetBytes(make([]byte, 0))
+			v.Elem().Set(val)
+		}
+		return nil
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+
+	val := reflect.New(v.Type().Elem().Elem())
+	val.Elem().SetBytes(tmp)
+	v.Elem().Set(val)
+	return nil
+}
+
+func decString(p []byte) string {
+	if len(p) == 0 {
+		return ""
+	}
+	return string(p)
+}
+
+func decStringR(p []byte) *string {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		return new(string)
+	}
+	tmp := string(p)
+	return &tmp
+}
+
+func decBytes(p []byte) []byte {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		return make([]byte, 0)
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+	return tmp
+}
+
+func decBytesR(p []byte) *[]byte {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		tmp := make([]byte, 0)
+		return &tmp
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+	return &tmp
+}

--- a/serialization/text/marshal.go
+++ b/serialization/text/marshal.go
@@ -1,0 +1,28 @@
+package text
+
+import (
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		return EncString(v)
+	case *string:
+		return EncStringR(v)
+	case []byte:
+		return EncBytes(v)
+	case *[]byte:
+		return EncBytesR(v)
+	default:
+		// Custom types (type MyString string) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/serialization/text/marshal_utils.go
+++ b/serialization/text/marshal_utils.go
@@ -1,0 +1,56 @@
+package text
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func EncString(v string) ([]byte, error) {
+	return encString(v), nil
+}
+
+func EncStringR(v *string) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return encString(*v), nil
+}
+
+func EncBytes(v []byte) ([]byte, error) {
+	return v, nil
+}
+
+func EncBytesR(v *[]byte) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return *v, nil
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Kind() {
+	case reflect.String:
+		return encString(v.String()), nil
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return EncBytes(v.Bytes())
+	default:
+		return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encString(v string) []byte {
+	if v == "" {
+		return make([]byte, 0)
+	}
+	return []byte(v)
+}

--- a/serialization/text/unmarshal.go
+++ b/serialization/text/unmarshal.go
@@ -1,0 +1,35 @@
+package text
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case *string:
+		return DecString(data, v)
+	case **string:
+		return DecStringR(data, v)
+	case *[]byte:
+		return DecBytes(data, v)
+	case **[]byte:
+		return DecBytesR(data, v)
+	case *interface{}:
+		return DecInterface(data, v)
+	default:
+		// Custom types (type MyString string) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v)", v)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/serialization/text/unmarshal_utils.go
+++ b/serialization/text/unmarshal_utils.go
@@ -1,0 +1,170 @@
+package text
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal text: can not unmarshal into nil reference(%T)(%[1]v)", v)
+}
+
+func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decString(p)
+	return nil
+}
+
+func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decStringR(p)
+	return nil
+}
+
+func DecBytes(p []byte, v *[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decBytes(p)
+	return nil
+}
+
+func DecBytesR(p []byte, v **[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decBytesR(p)
+	return nil
+}
+
+func DecInterface(p []byte, v *interface{}) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decString(p)
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.String:
+		v.SetString(decString(p))
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		v.SetBytes(decBytes(p))
+	case reflect.Interface:
+		v.Set(reflect.ValueOf(decString(p)))
+	default:
+		return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+	return nil
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch ev := v.Type().Elem().Elem(); ev.Kind() {
+	case reflect.String:
+		return decReflectStringR(p, v)
+	case reflect.Slice:
+		if ev.Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return decReflectBytesR(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectNullableR(p []byte, v reflect.Value) reflect.Value {
+	if p == nil {
+		return reflect.Zero(v.Elem().Type())
+	}
+	return reflect.New(v.Type().Elem().Elem())
+}
+
+func decReflectStringR(p []byte, v reflect.Value) error {
+	if len(p) == 0 {
+		v.Elem().Set(decReflectNullableR(p, v))
+		return nil
+	}
+	val := reflect.New(v.Type().Elem().Elem())
+	val.Elem().SetString(string(p))
+	v.Elem().Set(val)
+	return nil
+}
+
+func decReflectBytesR(p []byte, v reflect.Value) error {
+	if len(p) == 0 {
+		if p == nil {
+			v.Elem().Set(reflect.Zero(v.Elem().Type()))
+		} else {
+			val := reflect.New(v.Type().Elem().Elem())
+			val.Elem().SetBytes(make([]byte, 0))
+			v.Elem().Set(val)
+		}
+		return nil
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+
+	val := reflect.New(v.Type().Elem().Elem())
+	val.Elem().SetBytes(tmp)
+	v.Elem().Set(val)
+	return nil
+}
+
+func decString(p []byte) string {
+	if len(p) == 0 {
+		return ""
+	}
+	return string(p)
+}
+
+func decStringR(p []byte) *string {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		return new(string)
+	}
+	tmp := string(p)
+	return &tmp
+}
+
+func decBytes(p []byte) []byte {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		return make([]byte, 0)
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+	return tmp
+}
+
+func decBytesR(p []byte) *[]byte {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		tmp := make([]byte, 0)
+		return &tmp
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+	return &tmp
+}

--- a/serialization/varchar/marshal.go
+++ b/serialization/varchar/marshal.go
@@ -1,0 +1,28 @@
+package varchar
+
+import (
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		return EncString(v)
+	case *string:
+		return EncStringR(v)
+	case []byte:
+		return EncBytes(v)
+	case *[]byte:
+		return EncBytesR(v)
+	default:
+		// Custom types (type MyString string) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/serialization/varchar/marshal_utils.go
+++ b/serialization/varchar/marshal_utils.go
@@ -1,0 +1,56 @@
+package varchar
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func EncString(v string) ([]byte, error) {
+	return encString(v), nil
+}
+
+func EncStringR(v *string) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return encString(*v), nil
+}
+
+func EncBytes(v []byte) ([]byte, error) {
+	return v, nil
+}
+
+func EncBytesR(v *[]byte) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return *v, nil
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Kind() {
+	case reflect.String:
+		return encString(v.String()), nil
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return EncBytes(v.Bytes())
+	default:
+		return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encString(v string) []byte {
+	if v == "" {
+		return make([]byte, 0)
+	}
+	return []byte(v)
+}

--- a/serialization/varchar/unmarshal.go
+++ b/serialization/varchar/unmarshal.go
@@ -1,0 +1,35 @@
+package varchar
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case *string:
+		return DecString(data, v)
+	case **string:
+		return DecStringR(data, v)
+	case *[]byte:
+		return DecBytes(data, v)
+	case **[]byte:
+		return DecBytesR(data, v)
+	case *interface{}:
+		return DecInterface(data, v)
+	default:
+		// Custom types (type MyString string) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v)", v)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/serialization/varchar/unmarshal_utils.go
+++ b/serialization/varchar/unmarshal_utils.go
@@ -1,0 +1,170 @@
+package varchar
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal varchar: can not unmarshal into nil reference(%T)(%[1]v)", v)
+}
+
+func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decString(p)
+	return nil
+}
+
+func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decStringR(p)
+	return nil
+}
+
+func DecBytes(p []byte, v *[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decBytes(p)
+	return nil
+}
+
+func DecBytesR(p []byte, v **[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decBytesR(p)
+	return nil
+}
+
+func DecInterface(p []byte, v *interface{}) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	*v = decString(p)
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.String:
+		v.SetString(decString(p))
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		v.SetBytes(decBytes(p))
+	case reflect.Interface:
+		v.Set(reflect.ValueOf(decString(p)))
+	default:
+		return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+	return nil
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch ev := v.Type().Elem().Elem(); ev.Kind() {
+	case reflect.String:
+		return decReflectStringR(p, v)
+	case reflect.Slice:
+		if ev.Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return decReflectBytesR(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectNullableR(p []byte, v reflect.Value) reflect.Value {
+	if p == nil {
+		return reflect.Zero(v.Elem().Type())
+	}
+	return reflect.New(v.Type().Elem().Elem())
+}
+
+func decReflectStringR(p []byte, v reflect.Value) error {
+	if len(p) == 0 {
+		v.Elem().Set(decReflectNullableR(p, v))
+		return nil
+	}
+	val := reflect.New(v.Type().Elem().Elem())
+	val.Elem().SetString(string(p))
+	v.Elem().Set(val)
+	return nil
+}
+
+func decReflectBytesR(p []byte, v reflect.Value) error {
+	if len(p) == 0 {
+		if p == nil {
+			v.Elem().Set(reflect.Zero(v.Elem().Type()))
+		} else {
+			val := reflect.New(v.Type().Elem().Elem())
+			val.Elem().SetBytes(make([]byte, 0))
+			v.Elem().Set(val)
+		}
+		return nil
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+
+	val := reflect.New(v.Type().Elem().Elem())
+	val.Elem().SetBytes(tmp)
+	v.Elem().Set(val)
+	return nil
+}
+
+func decString(p []byte) string {
+	if len(p) == 0 {
+		return ""
+	}
+	return string(p)
+}
+
+func decStringR(p []byte) *string {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		return new(string)
+	}
+	tmp := string(p)
+	return &tmp
+}
+
+func decBytes(p []byte) []byte {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		return make([]byte, 0)
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+	return tmp
+}
+
+func decBytesR(p []byte) *[]byte {
+	if len(p) == 0 {
+		if p == nil {
+			return nil
+		}
+		tmp := make([]byte, 0)
+		return &tmp
+	}
+	tmp := make([]byte, len(p))
+	copy(tmp, p)
+	return &tmp
+}


### PR DESCRIPTION
Changes:
1. Unmarshalling `zero data` into `[]byte`, `*[]byte`, returned `([]byte)(nil)` and `(*[]byte)(*[nil])` before, now  returns `([]byte)([])` and `(*[]byte)(*[])`
2. Unmarshalling into `*interface{}`, unmarshals as a `[]byte` before, now as a `string`