### PR TITLE
docs: add data types and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Your project now uses the Scylla driver fork, make sure you are using the `Token
 Spawn a ScyllaDB Instance using Docker Run command:
 
 ```sh
-docker run --name node1 --network ws-scylla -p "9042:9042" -d scylladb/scylla:6.1.2 \
+docker run --name node1 --network your-network -p "9042:9042" -d scylladb/scylla:6.1.2 \
 	--overprovisioned 1 \
 	--smp 1
 ```


### PR DESCRIPTION
I was looking after the Data Types cheatsheet and after a while I found at [GoCQLX Example file](https://github.com/scylladb/gocqlx/blob/ab73391f35174a29624a55cb9cfdbc059ae302e2/example_test.go#L176). IMHO this information should be more straightforward as possible.

Also added an "Quick Start" section to give some orientation for a driver newcomer to see it run ASAP.

### New Content:

* Added a "Quick Start" section with instructions on how to spawn a ScyllaDB instance using Docker and create a new connection using ScyllaDB GoCQL. (`README.md`)
* Introduced a "Data Types" section listing all ScyllaDB types reflected in the GoCQL environment along with their corresponding Go types. (`README.md`)