### PR TITLE
Do not throw a warning for zero token nodes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1860,6 +1860,8 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 			if !isValidPeer(host) || host.schemaVersion == "" {
 				c.logger.Printf("invalid peer or peer with empty schema_version: peer=%q", host)
 				continue
+			} else if isZeroToken(host) {
+				continue
 			}
 
 			versions[host.schemaVersion] = struct{}{}

--- a/host_source.go
+++ b/host_source.go
@@ -848,6 +848,8 @@ func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo) ([]*HostInfo, er
 			r.session.logger.Printf("Found invalid peer '%s' "+
 				"Likely due to a gossip or snitch issue, this host will be ignored", host)
 			continue
+		} else if isZeroToken(host) {
+			continue
 		}
 
 		peers = append(peers, host)
@@ -861,8 +863,11 @@ func isValidPeer(host *HostInfo) bool {
 	return !(len(host.RPCAddress()) == 0 ||
 		host.hostId == "" ||
 		host.dataCenter == "" ||
-		host.rack == "" ||
-		len(host.tokens) == 0)
+		host.rack == "")
+}
+
+func isZeroToken(host *HostInfo) bool {
+	return len(host.tokens) == 0
 }
 
 // GetHosts returns a list of hosts found via queries to system.local and system.peers


### PR DESCRIPTION
https://github.com/scylladb/scylladb/pull/19684 brings possibility of having nodes coordinator-only nodes (or zero-token nodes). So now there is a possibility of having hosts with no tokens. We do not want to throw a warning when such scenario occurs. But also we do not want to send requests to such a node.

Refs: https://github.com/scylladb/gocql/issues/226