### PR TITLE
Check if localHost is not zero token node

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -885,7 +885,12 @@ func (r *ringDescriber) GetHosts() ([]*HostInfo, string, error) {
 		return r.prevHosts, r.prevPartitioner, err
 	}
 
-	hosts := append([]*HostInfo{localHost}, peerHosts...)
+	var hosts []*HostInfo
+	if !isZeroToken(localHost) {
+		hosts = []*HostInfo{localHost}
+	}
+	hosts = append(hosts, peerHosts...)
+
 	var partitioner string
 	if len(hosts) > 0 {
 		partitioner = hosts[0].Partitioner()

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -73,6 +73,25 @@ func TestIsValidPeer(t *testing.T) {
 	}
 }
 
+func TestIsZeroToken(t *testing.T) {
+	host := &HostInfo{
+		rpcAddress: net.ParseIP("0.0.0.0"),
+		rack:       "myRack",
+		hostId:     "0",
+		dataCenter: "datacenter",
+		tokens:     []string{"0", "1"},
+	}
+
+	if isZeroToken(host) {
+		t.Errorf("expected %+v to NOT be a zero-token host", host)
+	}
+
+	host.tokens = []string{}
+	if !isZeroToken(host) {
+		t.Errorf("expected %+v to be a zero-token host", host)
+	}
+}
+
 func TestHostInfo_ConnectAddress(t *testing.T) {
 	var localhost = net.IPv4(127, 0, 0, 1)
 	tests := []struct {


### PR DESCRIPTION
To ensure that driver handles zero-token nodes properly we need to make sure that following scenarios work as intended:
`datacenter2` is a zero-token datacenter
target host - host you feed to `NewCluster`
target dc - dc name you feed to `DCAwareRoundRobinPolicy`
1. `target host` = `any host from datacenter1`, `target dc` = `datacenter1`. It should succeed, you should be able to execute queries
2. `target host` = `any host from datacenter2`, `target dc` = `datacenter1`. It should succeed, you should be able to execute queries
3. `target host` = `any host from datacenter1`, `target dc` = `datacenter2`. It should fail with error
4. `target host` = `any host from datacenter2`, `target dc` = `datacenter2`. It should fail with error

This PR is needed for scenario 4 to work properly. 
