### PR TITLE
Add tags to all test files

### DIFF
--- a/address_translators_test.go
+++ b/address_translators_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/compressor_test.go
+++ b/compressor_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql_test
 
 import (

--- a/control_test.go
+++ b/control_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/debounce/simple_debouncer_test.go
+++ b/debounce/simple_debouncer_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package debounce
 
 import (

--- a/events_test.go
+++ b/events_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/filters_test.go
+++ b/filters_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/frame_test.go
+++ b/frame_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/framer_bench_test.go
+++ b/framer_bench_test.go
@@ -1,3 +1,6 @@
+//go:build all
+// +build all
+
 package gocql
 
 import (

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/internal/ccm/ccm_test.go
+++ b/internal/ccm/ccm_test.go
@@ -1,4 +1,5 @@
-// +build ccm
+//go:build all || ccm
+// +build all ccm
 
 package ccm
 

--- a/internal/lru/lru_test.go
+++ b/internal/lru/lru_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 /*
 Copyright 2015 To gocql authors
 Copyright 2013 Google Inc.

--- a/internal/murmur/murmur_test.go
+++ b/internal/murmur/murmur_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package murmur
 
 import (

--- a/internal/streams/streams_test.go
+++ b/internal/streams/streams_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package streams
 
 import (

--- a/internal/tests/serialization/pointers_test.go
+++ b/internal/tests/serialization/pointers_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization
 
 import "testing"

--- a/lz4/lz4_test.go
+++ b/lz4/lz4_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package lz4
 
 import (

--- a/metadata_scylla_test.go
+++ b/metadata_scylla_test.go
@@ -1,5 +1,5 @@
-//go:build !cassandra
-// +build !cassandra
+//go:build !cassandra && unit
+// +build !cassandra,unit
 
 // Copyright (c) 2015 The gocql Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/policies_test.go
+++ b/policies_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/ring_test.go
+++ b/ring_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/scyllacloud/config_test.go
+++ b/scyllacloud/config_test.go
@@ -1,5 +1,8 @@
 // Copyright (C) 2021 ScyllaDB
 
+//go:build all || unit
+// +build all unit
+
 package scyllacloud
 
 import (

--- a/scyllacloud/hostdialer_test.go
+++ b/scyllacloud/hostdialer_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package scyllacloud
 
 import (

--- a/tests/serialization/marshal_10_decimal_test.go
+++ b/tests/serialization/marshal_10_decimal_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_11_texts_test.go
+++ b/tests/serialization/marshal_11_texts_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_12_ascii_corrupt_test.go
+++ b/tests/serialization/marshal_12_ascii_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_12_ascii_test.go
+++ b/tests/serialization/marshal_12_ascii_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_13_uuids_corrupt_test.go
+++ b/tests/serialization/marshal_13_uuids_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_13_uuids_test.go
+++ b/tests/serialization/marshal_13_uuids_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_14_inet_corrupt_test.go
+++ b/tests/serialization/marshal_14_inet_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_14_inet_test.go
+++ b/tests/serialization/marshal_14_inet_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_15_time_corrupt_test.go
+++ b/tests/serialization/marshal_15_time_corrupt_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"math"

--- a/tests/serialization/marshal_15_time_test.go
+++ b/tests/serialization/marshal_15_time_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"testing"

--- a/tests/serialization/marshal_16_timestamp_corrupt_test.go
+++ b/tests/serialization/marshal_16_timestamp_corrupt_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"testing"

--- a/tests/serialization/marshal_16_timestamp_test.go
+++ b/tests/serialization/marshal_16_timestamp_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"math"

--- a/tests/serialization/marshal_17_date_corrupt_test.go
+++ b/tests/serialization/marshal_17_date_corrupt_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"testing"

--- a/tests/serialization/marshal_17_date_test.go
+++ b/tests/serialization/marshal_17_date_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"testing"

--- a/tests/serialization/marshal_18_duration_corrupt_test.go
+++ b/tests/serialization/marshal_18_duration_corrupt_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"testing"

--- a/tests/serialization/marshal_18_duration_test.go
+++ b/tests/serialization/marshal_18_duration_test.go
@@ -1,4 +1,7 @@
-package serialization
+//go:build all || unit
+// +build all unit
+
+package serialization_test
 
 import (
 	"math"

--- a/tests/serialization/marshal_19_list_set_v2_corrupt_test.go
+++ b/tests/serialization/marshal_19_list_set_v2_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_19_list_set_v2_test.go
+++ b/tests/serialization/marshal_19_list_set_v2_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_19_list_set_v3_corrupt_test.go
+++ b/tests/serialization/marshal_19_list_set_v3_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_19_list_set_v3_test.go
+++ b/tests/serialization/marshal_19_list_set_v3_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_1_boolean_test.go
+++ b/tests/serialization/marshal_1_boolean_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_20_map_v2_corrupt_test.go
+++ b/tests/serialization/marshal_20_map_v2_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_20_map_v2_test.go
+++ b/tests/serialization/marshal_20_map_v2_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_20_map_v3_corrupt_test.go
+++ b/tests/serialization/marshal_20_map_v3_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_20_map_v3_test.go
+++ b/tests/serialization/marshal_20_map_v3_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_2_tinyint_corrupt_test.go
+++ b/tests/serialization/marshal_2_tinyint_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_2_tinyint_test.go
+++ b/tests/serialization/marshal_2_tinyint_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_3_smallint_corrupt_test.go
+++ b/tests/serialization/marshal_3_smallint_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_3_smallint_test.go
+++ b/tests/serialization/marshal_3_smallint_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_4_int_corrupt_test.go
+++ b/tests/serialization/marshal_4_int_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_4_int_test.go
+++ b/tests/serialization/marshal_4_int_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_5_bigint_corrupt_test.go
+++ b/tests/serialization/marshal_5_bigint_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_5_bigint_test.go
+++ b/tests/serialization/marshal_5_bigint_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_6_counter_corrupt_test.go
+++ b/tests/serialization/marshal_6_counter_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_6_counter_test.go
+++ b/tests/serialization/marshal_6_counter_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_7_varint_test.go
+++ b/tests/serialization/marshal_7_varint_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_8_float_corrupt_test.go
+++ b/tests/serialization/marshal_8_float_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_8_float_test.go
+++ b/tests/serialization/marshal_8_float_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_9_double_corrupt_test.go
+++ b/tests/serialization/marshal_9_double_corrupt_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/tests/serialization/marshal_9_duble_test.go
+++ b/tests/serialization/marshal_9_duble_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package serialization_test
 
 import (

--- a/token_test.go
+++ b/token_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (

--- a/topology_test.go
+++ b/topology_test.go
@@ -1,3 +1,6 @@
+//go:build all || unit
+// +build all unit
+
 package gocql
 
 import (


### PR DESCRIPTION
If there is not tag specified for a test file it is executed regardless or tags configuration. Previously this created the situation when some unittests when executed always even though e.g. 'integration' tag was specified.

This commit fixes that by adding tags to all files.

Fixes: https://github.com/scylladb/gocql-driver-matrix/issues/17 