### PR TITLE
Fix `gocql.Marshal` add the `unsetColumn` processing

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -2370,6 +2370,13 @@ func (c CollectionType) String() string {
 	}
 }
 
+func NewTupleType(n NativeType, elems ...TypeInfo) TupleTypeInfo {
+	return TupleTypeInfo{
+		NativeType: n,
+		Elems:      elems,
+	}
+}
+
 type TupleTypeInfo struct {
 	NativeType
 	Elems []TypeInfo
@@ -2405,6 +2412,15 @@ func (t TupleTypeInfo) New() interface{} {
 type UDTField struct {
 	Name string
 	Type TypeInfo
+}
+
+func NewUDTType(proto byte, name, keySpace string, elems ...UDTField) UDTTypeInfo {
+	return UDTTypeInfo{
+		NativeType: NativeType{proto, TypeUDT, ""},
+		Name:       name,
+		KeySpace:   keySpace,
+		Elements:   elems,
+	}
 }
 
 type UDTTypeInfo struct {

--- a/serialization/bigint/marshal_utils.go
+++ b/serialization/bigint/marshal_utils.go
@@ -184,6 +184,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal bigint: can not marshal (%T)(%[1]v) %s", v.Interface(), err)
 		}
 		return encInt64(n), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/blob/marshal_utils.go
+++ b/serialization/blob/marshal_utils.go
@@ -36,6 +36,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
 		}
 		return EncBytes(v.Bytes())
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/counter/marshal_utils.go
+++ b/serialization/counter/marshal_utils.go
@@ -184,6 +184,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal counter: can not marshal (%T)(%[1]v) %s", v.Interface(), err)
 		}
 		return encInt64(n), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/cqlint/marshal_utils.go
+++ b/serialization/cqlint/marshal_utils.go
@@ -223,6 +223,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal int: can not marshal (%T)(%[1]v) %s", v.Interface(), err)
 		}
 		return encInt64(n), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/double/marshal_utils.go
+++ b/serialization/double/marshal_utils.go
@@ -21,6 +21,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Float64:
 		return encFloat64(v.Float()), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal double: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal double: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/float/marshal_utils.go
+++ b/serialization/float/marshal_utils.go
@@ -21,6 +21,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Float32:
 		return encFloat32(float32(v.Float())), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal float: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal float: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/smallint/marshal_utils.go
+++ b/serialization/smallint/marshal_utils.go
@@ -217,6 +217,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal smallint: can not marshal (%T)(%[1]v), %s", v.Interface(), err)
 		}
 		return encInt64(n), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/text/marshal_utils.go
+++ b/serialization/text/marshal_utils.go
@@ -36,6 +36,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
 		}
 		return EncBytes(v.Bytes())
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/timeuuid/marshal_utils.go
+++ b/serialization/timeuuid/marshal_utils.go
@@ -65,6 +65,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		return encReflectBytes(v)
 	case reflect.String:
 		return encReflectString(v)
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal timeuuid: timeuuid value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/tinyint/marshal_utils.go
+++ b/serialization/tinyint/marshal_utils.go
@@ -209,6 +209,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal tinyint: can not marshal (%T)(%[1]v) %s", v.Interface(), err)
 		}
 		return []byte{byte(n)}, nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/uuid/marshal_utils.go
+++ b/serialization/uuid/marshal_utils.go
@@ -65,6 +65,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		return encReflectBytes(v)
 	case reflect.String:
 		return encReflectString(v)
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal uuid: timeuuid value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/serialization/varchar/marshal_utils.go
+++ b/serialization/varchar/marshal_utils.go
@@ -36,6 +36,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 			return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
 		}
 		return EncBytes(v.Bytes())
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
 	default:
 		return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
 	}

--- a/tests/serialization/marshal_0_unset_test.go
+++ b/tests/serialization/marshal_0_unset_test.go
@@ -1,0 +1,70 @@
+//go:build all || unit
+// +build all unit
+
+package serialization_test
+
+import (
+	"testing"
+
+	"github.com/gocql/gocql"
+)
+
+func TestMarshalUnsetColumn(t *testing.T) {
+	type tCase struct {
+		tp      gocql.TypeInfo
+		nilData bool
+		err     bool
+	}
+
+	elem := gocql.NewNativeType(2, gocql.TypeSmallInt, "")
+	cases := []tCase{
+		{gocql.NewNativeType(4, gocql.TypeBoolean, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeTinyInt, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeSmallInt, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeInt, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeBigInt, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeCounter, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeVarint, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeFloat, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeDouble, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeDecimal, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeVarchar, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeText, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeBlob, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeAscii, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeUUID, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeTimeUUID, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeInet, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeTime, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeTimestamp, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeDate, ""), true, false},
+		{gocql.NewNativeType(4, gocql.TypeDuration, ""), true, false},
+
+		{gocql.NewCollectionType(gocql.NewNativeType(2, gocql.TypeList, ""), nil, elem), true, false},
+		{gocql.NewCollectionType(gocql.NewNativeType(2, gocql.TypeSet, ""), nil, elem), true, false},
+		{gocql.NewCollectionType(gocql.NewNativeType(3, gocql.TypeList, ""), nil, elem), true, false},
+		{gocql.NewCollectionType(gocql.NewNativeType(3, gocql.TypeSet, ""), nil, elem), true, false},
+
+		{gocql.NewCollectionType(gocql.NewNativeType(2, gocql.TypeMap, ""), nil, elem), true, false},
+		{gocql.NewCollectionType(gocql.NewNativeType(3, gocql.TypeMap, ""), elem, elem), true, false},
+
+		{gocql.NewUDTType(3, "udt1", "", gocql.UDTField{Name: "1", Type: elem}), true, true},
+		{gocql.NewTupleType(gocql.NewNativeType(3, gocql.TypeTuple, ""), elem), true, true},
+	}
+
+	for _, expected := range cases {
+		data, err := gocql.Marshal(expected.tp, gocql.UnsetValue)
+		if expected.nilData && data != nil {
+			t.Errorf("marshallig unsetColumn for the cqltype %s should return nil data", expected.tp.Type())
+		}
+		if !expected.nilData && data == nil {
+			t.Errorf("marshallig unsetColumn for the cqltype %s should return not nil data", expected.tp.Type())
+		}
+		if expected.err && err == nil {
+			t.Errorf("marshallig unsetColumn for the cqltype %s should return an error", expected.tp.Type())
+		}
+		if !expected.err && err != nil {
+			t.Errorf("marshallig unsetColumn for the cqltype %s should not return an error", expected.tp.Type())
+		}
+	}
+}


### PR DESCRIPTION
Changes:
* fix `gocql.Marshal` add the `unsetColumn` processing before the `cql types` processing