### PR TITLE
Fix `debounce` add skipping the `TestSimpleDebouncer` test

### DIFF
--- a/debounce/simple_debouncer_test.go
+++ b/debounce/simple_debouncer_test.go
@@ -8,6 +8,7 @@ import (
 
 // TestDebouncer tests that the debouncer allows only one function to execute at a time
 func TestSimpleDebouncer(t *testing.T) {
+	t.Skip("This test sometimes ends vai panic. Issue https://github.com/scylladb/gocql/pull/344")
 	d := NewSimpleDebouncer()
 	var executions int32
 	startedCh := make(chan struct{}, 1)


### PR DESCRIPTION
Reason - sometimes this test panics, this leads to problems with the pipelines.
So, i suggest skipping the `TestSimpleDebouncer` test before solving the problem with `debounce`, to not create problems for other PRs.