### PR TITLE
Wait for zero-token nodes in schema agreement

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1827,8 +1827,6 @@ func getSchemaAgreement(queryLocalSchemasRows []string, querySystemPeersRows []m
 		if !isValidPeer(host) || host.schemaVersion == "" {
 			logger.Printf("invalid peer or peer with empty schema_version: peer=%q", host)
 			continue
-		} else if isZeroToken(host) {
-			continue
 		}
 
 		versions[host.schemaVersion] = struct{}{}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1470,7 +1470,7 @@ func TestGetSchemaAgreement(t *testing.T) {
 			logger,
 		)
 
-		assert.NoError(t, err, "expected no error when zero-token node has different schema because it is ommitted")
+		assert.Error(t, err, "expected error when zero-token node has different schema")
 	})
 
 	t.Run("SchemaConsistent", func(t *testing.T) {


### PR DESCRIPTION
Previously when node was zero-token type we did not consider it in schema agreement process. 

This PR fixes that. 