### PR TITLE
Use commit SHA instead of branch name in extended-ci

### DIFF
--- a/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
+++ b/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push Scylla-bench Docker Image with gocql from PR
         run: |
           cd scylla-bench
-          GOCQL_REPO="github.com/${{ github.event.pull_request.head.repo.full_name }}" GOCQL_VERSION="${{ github.event.pull_request.head.ref }}" make build-with-custom-gocql-version
+          GOCQL_REPO="github.com/${{ github.event.pull_request.head.repo.full_name }}" GOCQL_VERSION="${{ github.event.pull_request.head.sha }}" make build-with-custom-gocql-version
           DOCKER_IMAGE_TAG="scylladb/gocql-extended-ci:scylla-bench-${{ github.event.pull_request.head.sha }}" DOCKER_IMAGE_LABELS="com.scylladb.gocql-version=${{ github.event.pull_request.head.sha }}" make build-sct-docker-image
           docker push "scylladb/gocql-extended-ci:scylla-bench-${{ github.event.pull_request.head.sha }}"
 


### PR DESCRIPTION
Previously branch name was used, but it didn't work if the branch name had '/' character.

Fixes: #358 