### PR TITLE
Fix `inet` marshal, unmarshall functions

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1374,7 +1374,7 @@ func TestMarshalNil(t *testing.T) {
 func TestUnmarshalInetCopyBytes(t *testing.T) {
 	data := []byte{127, 0, 0, 1}
 	var ip net.IP
-	if err := unmarshalInet(NativeType{proto: 2, typ: TypeInet}, data, &ip); err != nil {
+	if err := unmarshalInet(data, &ip); err != nil {
 		t.Fatal(err)
 	}
 

--- a/serialization/inet/marshal.go
+++ b/serialization/inet/marshal.go
@@ -1,0 +1,41 @@
+package inet
+
+import (
+	"net"
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case []byte:
+		return EncBytes(v)
+	case *[]byte:
+		return EncBytesR(v)
+	case net.IP:
+		return EncNetIP(v)
+	case *net.IP:
+		return EncNetIPr(v)
+	case [4]byte:
+		return EncArray4(v)
+	case *[4]byte:
+		return EncArray4R(v)
+	case [16]byte:
+		return EncArray16(v)
+	case *[16]byte:
+		return EncArray16R(v)
+	case string:
+		return EncString(v)
+	case *string:
+		return EncStringR(v)
+	default:
+		// Custom types (type MyIP []byte) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/serialization/inet/marshal_utils.go
+++ b/serialization/inet/marshal_utils.go
@@ -1,0 +1,192 @@
+package inet
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+)
+
+func EncBytes(v []byte) ([]byte, error) {
+	switch len(v) {
+	case 0:
+		if v == nil {
+			return nil, nil
+		}
+		return make([]byte, 0), nil
+	case 4:
+		tmp := make([]byte, 4)
+		copy(tmp, v)
+		return tmp, nil
+	case 16:
+		tmp := make([]byte, 16)
+		copy(tmp, v)
+		return tmp, nil
+	default:
+		return nil, fmt.Errorf("failed to marshal inet: the ([]byte) length can be 0,4,16")
+	}
+}
+
+func EncBytesR(v *[]byte) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncBytes(*v)
+}
+
+func EncNetIP(v net.IP) ([]byte, error) {
+	switch len(v) {
+	case 0:
+		if v == nil {
+			return nil, nil
+		}
+		return make([]byte, 0), nil
+	case 4, 16:
+		t := v.To4()
+		if t == nil {
+			return v.To16(), nil
+		}
+		return t, nil
+	default:
+		return nil, fmt.Errorf("failed to marshal inet: the (net.IP) length can be 0,4,16")
+	}
+}
+
+func EncNetIPr(v *net.IP) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncNetIP(*v)
+}
+
+func EncArray16(v [16]byte) ([]byte, error) {
+	tmp := make([]byte, 16)
+	copy(tmp, v[:])
+	return tmp, nil
+}
+
+func EncArray16R(v *[16]byte) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncArray16(*v)
+}
+
+func EncArray4(v [4]byte) ([]byte, error) {
+	tmp := make([]byte, 4)
+	copy(tmp, v[:])
+	return tmp, nil
+}
+
+func EncArray4R(v *[4]byte) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncArray4(*v)
+}
+
+func EncString(v string) ([]byte, error) {
+	if len(v) == 0 {
+		return nil, nil
+	}
+	b := net.ParseIP(v)
+	if b != nil {
+		t := b.To4()
+		if t == nil {
+			return b.To16(), nil
+		}
+		return t, nil
+	}
+	return nil, fmt.Errorf("failed to marshal inet: invalid IP string %s", v)
+}
+
+func EncStringR(v *string) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncString(*v)
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Kind() {
+	case reflect.Array:
+		if l := v.Len(); v.Type().Elem().Kind() != reflect.Uint8 || (l != 16 && l != 4) {
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		nv := reflect.New(v.Type())
+		nv.Elem().Set(v)
+		return nv.Elem().Bytes(), nil
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return encReflectBytes(v)
+	case reflect.String:
+		return encReflectString(v)
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+	default:
+		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	switch ev := v.Elem(); ev.Kind() {
+	case reflect.Array:
+		if l := v.Len(); ev.Type().Elem().Kind() != reflect.Uint8 || (l != 16 && l != 4) {
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return v.Elem().Bytes(), nil
+	case reflect.Slice:
+		if ev.Type().Elem().Kind() != reflect.Uint8 {
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return encReflectBytes(ev)
+	case reflect.String:
+		return encReflectString(ev)
+	default:
+		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func encReflectString(v reflect.Value) ([]byte, error) {
+	val := v.String()
+	if len(val) == 0 {
+		return nil, nil
+	}
+	b := net.ParseIP(val)
+	if b != nil {
+		t := b.To4()
+		if t == nil {
+			return b.To16(), nil
+		}
+		return t, nil
+	}
+	return nil, fmt.Errorf("failed to marshal inet: invalid IP string (%T)(%[1]v)", v.Interface())
+}
+
+func encReflectBytes(v reflect.Value) ([]byte, error) {
+	val := v.Bytes()
+	switch len(val) {
+	case 0:
+		if val == nil {
+			return nil, nil
+		}
+		return make([]byte, 0), nil
+	case 4:
+		tmp := make([]byte, 4)
+		copy(tmp, val)
+		return tmp, nil
+	case 16:
+		tmp := make([]byte, 16)
+		copy(tmp, val)
+		return tmp, nil
+	default:
+		return nil, fmt.Errorf("failed to marshal inet: the (%T) length can be 0,4,16", v.Interface())
+	}
+}

--- a/serialization/inet/unmarshal.go
+++ b/serialization/inet/unmarshal.go
@@ -1,0 +1,46 @@
+package inet
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case *[]byte:
+		return DecBytes(data, v)
+	case **[]byte:
+		return DecBytesR(data, v)
+	case *net.IP:
+		return DecNetIP(data, v)
+	case **net.IP:
+		return DecNetIPr(data, v)
+	case *[4]byte:
+		return DecArray4(data, v)
+	case **[4]byte:
+		return DecArray4R(data, v)
+	case *[16]byte:
+		return DecArray16(data, v)
+	case **[16]byte:
+		return DecArray16R(data, v)
+	case *string:
+		return DecString(data, v)
+	case **string:
+		return DecStringR(data, v)
+	default:
+		// Custom types (type MyIP []byte) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/serialization/inet/unmarshal_utils.go
+++ b/serialization/inet/unmarshal_utils.go
@@ -1,0 +1,514 @@
+package inet
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"reflect"
+	"unsafe"
+)
+
+var (
+	errWrongDataLen = fmt.Errorf("failed to unmarshal inet: the length of the data can be 0,4,16")
+
+	digits = getDigits()
+)
+
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal inet: can not unmarshal into nil reference(%T)(%[1]v)", v)
+}
+
+func DecBytes(p []byte, v *[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = make([]byte, 0)
+		}
+	case 4:
+		*v = make([]byte, 4)
+		copy(*v, p)
+	case 16:
+		*v = make([]byte, 16)
+		copy(*v, p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecBytesR(p []byte, v **[]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			tmp := make([]byte, 0)
+			*v = &tmp
+		}
+	case 4:
+		*v = &[]byte{0, 0, 0, 0}
+		copy(**v, p)
+	case 16:
+		*v = &[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+		copy(**v, p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecNetIP(p []byte, v *net.IP) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = make(net.IP, 0)
+		}
+	case 4:
+		*v = make(net.IP, 4)
+		copy(*v, p)
+	case 16:
+		*v = make(net.IP, 16)
+		copy(*v, p)
+		if v4 := v.To4(); v4 != nil {
+			*v = v4
+		}
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecNetIPr(p []byte, v **net.IP) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			tmp := make(net.IP, 0)
+			*v = &tmp
+		}
+	case 4:
+		*v = &net.IP{0, 0, 0, 0}
+		copy(**v, p)
+	case 16:
+		*v = &net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+		copy(**v, p)
+		if v4 := (*v).To4(); v4 != nil {
+			**v = v4
+		}
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecArray4(p []byte, v *[4]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		*v = [4]byte{}
+	case 4:
+		*v = [4]byte{}
+		copy(v[:], p)
+	case 16:
+		if !isFist10Zeros(p) {
+			return fmt.Errorf("failed to unmarshal inet: can not unmarshal ipV6 into [4]byte")
+		}
+		*v = [4]byte{}
+		copy(v[:], p[12:16])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecArray4R(p []byte, v **[4]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = &[4]byte{}
+		}
+	case 4:
+		*v = &[4]byte{}
+		copy((*v)[:], p)
+	case 16:
+		if !isFist10Zeros(p) {
+			return fmt.Errorf("failed to unmarshal inet: can not unmarshal ipV6 into [4]byte")
+		}
+		*v = &[4]byte{}
+		copy((*v)[:], p[12:16])
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecArray16(p []byte, v *[16]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		*v = [16]byte{}
+	case 4, 16:
+		*v = [16]byte{}
+		copy(v[:], p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecArray16R(p []byte, v **[16]byte) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = &[16]byte{}
+		}
+	case 4, 16:
+		*v = &[16]byte{}
+		copy((*v)[:], p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecString(p []byte, v *string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = ""
+		} else {
+			*v = "0.0.0.0"
+		}
+	case 4:
+		*v = decString4(p)
+	case 16:
+		*v = decString16(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecStringR(p []byte, v **string) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			tmp := "0.0.0.0"
+			*v = &tmp
+		}
+	case 4:
+		tmp := decString4(p)
+		*v = &tmp
+	case 16:
+		tmp := decString16(p)
+		*v = &tmp
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.Array:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		switch v.Len() {
+		case 4:
+			return decReflectArray4(p, v)
+		case 16:
+			return decReflectArray16(p, v)
+		default:
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+	case reflect.Slice:
+		if v.Type().Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return decReflectBytes(p, v)
+	case reflect.String:
+		return decReflectString(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	ev := v.Elem()
+	switch evt := ev.Type().Elem(); evt.Kind() {
+	case reflect.Array:
+		if evt.Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		switch ev.Len() {
+		case 4:
+			return decReflectArray4R(p, ev)
+		case 16:
+			return decReflectArray16R(p, ev)
+		default:
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+	case reflect.Slice:
+		if evt.Elem().Kind() != reflect.Uint8 {
+			return fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		}
+		return decReflectBytesR(p, ev)
+	case reflect.String:
+		return decReflectStringR(p, ev)
+	default:
+		return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectArray4(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetZero()
+	case 4:
+		val := reflect.New(v.Type())
+		copy((*[4]byte)(val.UnsafePointer())[:], p)
+		v.Set(val.Elem())
+	case 16:
+		if !isFist10Zeros(p) {
+			return fmt.Errorf("failed to unmarshal inet: can not unmarshal ipV6 into (%T)", v.Interface())
+		}
+		val := reflect.New(v.Type())
+		copy((*[4]byte)(val.UnsafePointer())[:], p[12:16])
+		v.Set(val.Elem())
+	default:
+		return fmt.Errorf("failed to unmarshal inet: to unmarshal into (%T) the length of the data can be 0,4,16", v.Interface())
+	}
+	return nil
+}
+
+func decReflectArray16(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetZero()
+	case 4, 16:
+		val := reflect.New(v.Type())
+		copy((*[16]byte)(val.UnsafePointer())[:], p)
+		v.Set(val.Elem())
+	default:
+		return fmt.Errorf("failed to unmarshal inet: to unmarshal into (%T) the length of the data can be 0,4,16", v.Interface())
+	}
+	return nil
+}
+
+func decReflectBytes(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.SetBytes(nil)
+		} else {
+			v.SetBytes(make([]byte, 0))
+		}
+	case 4:
+		tmp := make([]byte, 4)
+		copy(tmp, p)
+		v.SetBytes(tmp)
+	case 16:
+		tmp := make([]byte, 16)
+		copy(tmp, p)
+		v.SetBytes(tmp)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectString(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.SetString("")
+		} else {
+			v.SetString("0.0.0.0")
+		}
+	case 4:
+		v.SetString(decString4(p))
+	case 16:
+		v.SetString(decString16(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectArray4R(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.Set(reflect.Zero(v.Type()))
+		} else {
+			val := reflect.New(v.Type().Elem())
+			v.Set(val)
+		}
+	case 4:
+		val := reflect.New(v.Type().Elem())
+		copy((*[4]byte)(val.UnsafePointer())[:], p)
+		v.Set(val)
+	case 16:
+		if !isFist10Zeros(p) {
+			return fmt.Errorf("failed to unmarshal inet: can not unmarshal ipV6 into (%T)", v.Interface())
+		}
+		val := reflect.New(v.Type().Elem())
+		copy((*[4]byte)(val.UnsafePointer())[:], p[12:16])
+		v.Set(val)
+	default:
+		return fmt.Errorf("failed to unmarshal inet: to unmarshal into (%T) the length of the data can be 0,4,16", v.Interface())
+	}
+	return nil
+}
+
+func decReflectArray16R(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.Set(reflect.Zero(v.Type()))
+		} else {
+			val := reflect.New(v.Type().Elem())
+			v.Set(val)
+		}
+	case 4, 16:
+		val := reflect.New(v.Type().Elem())
+		copy((*[16]byte)(val.UnsafePointer())[:], p)
+		v.Set(val)
+	default:
+		return fmt.Errorf("failed to unmarshal inet: to unmarshal into (%T) the length of the data can be 0,4,16", v.Interface())
+	}
+	return nil
+}
+
+func decReflectBytesR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.Set(reflect.Zero(v.Type()))
+		} else {
+			val := reflect.New(v.Type().Elem())
+			val.Elem().SetBytes(make([]byte, 0))
+			v.Set(val)
+		}
+	case 4:
+		tmp := make([]byte, 4)
+		copy(tmp, p)
+		val := reflect.New(v.Type().Elem())
+		val.Elem().SetBytes(tmp)
+		v.Set(val)
+	case 16:
+		tmp := make([]byte, 16)
+		copy(tmp, p)
+		val := reflect.New(v.Type().Elem())
+		val.Elem().SetBytes(tmp)
+		v.Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectStringR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.Set(reflect.Zero(v.Type()))
+		} else {
+			val := reflect.New(v.Type().Elem())
+			val.Elem().SetString("0.0.0.0")
+			v.Set(val)
+		}
+	case 4:
+		val := reflect.New(v.Type().Elem())
+		val.Elem().SetString(decString4(p))
+		v.Set(val)
+	case 16:
+		val := reflect.New(v.Type().Elem())
+		val.Elem().SetString(decString16(p))
+		v.Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decString4(p []byte) string {
+	out := make([]byte, 0, 15)
+	for _, x := range p {
+		out = append(out, digits[x]...)
+	}
+	return string(out[:len(out)-1])
+}
+
+func decString16(p []byte) string {
+	if isV4MappedToV6(p) {
+		return decString4(p[12:16])
+	}
+	return netip.AddrFrom16(*(*[16]byte)(unsafe.Pointer(&p[0]))).String()
+}
+
+func getDigits() []string {
+	out := make([]string, 256)
+	for i := range out {
+		out[i] = fmt.Sprintf("%d.", i)
+	}
+	return out
+}
+
+func isV4MappedToV6(p []byte) bool {
+	return p[0] == 0 && p[1] == 0 && p[2] == 0 && p[3] == 0 && p[4] == 0 &&
+		p[5] == 0 && p[6] == 0 && p[7] == 0 && p[8] == 0 && p[9] == 0 && p[10] == 255 && p[11] == 255
+}
+
+func isFist10Zeros(p []byte) bool {
+	return p[0] == 0 && p[1] == 0 && p[2] == 0 && p[3] == 0 && p[4] == 0 &&
+		p[5] == 0 && p[6] == 0 && p[7] == 0 && p[8] == 0 && p[9] == 0
+}

--- a/tests/serialization/marshal_14_inet_corrupt_test.go
+++ b/tests/serialization/marshal_14_inet_corrupt_test.go
@@ -10,111 +10,131 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/serialization/inet"
 )
 
 func TestMarshalsInetMustFail(t *testing.T) {
 	tType := gocql.NewNativeType(4, gocql.TypeInet, "")
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	// marshal big and small `net.IP` values does not return error
-	brokenNetIP := serialization.GetTypes(net.IP{}, &net.IP{})
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.inet",
+			marshal:   inet.Marshal,
+			unmarshal: inet.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	// unmarshal big and small data into `string` and `*string` does not return error
-	brokenString := serialization.GetTypes("", (*string)(nil))
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			"192.168.0.1.1",
-			net.IP{192, 168, 0, 1, 1},
-			[]byte{192, 168, 0, 1, 1},
-			[5]byte{192, 168, 0, 1, 1},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenNetIP,
-	}.Run("big_valsV4", t, marshal)
+		t.Run(tSuite.name, func(t *testing.T) {
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			"fe80:cd00:0:cde:1257:0:211e:729cc",
-			net.IP("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf\xaf"),
-			[]byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf\xaf"),
-			[17]byte{254, 128, 205, 0, 0, 0, 12, 222, 18, 87, 0, 0, 33, 30, 114, 156, 156},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenNetIP,
-	}.Run("big_valsV6", t, marshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					"192.168.0.1.1",
+					net.IP{192, 168, 0, 1, 1},
+					[]byte{192, 168, 0, 1, 1},
+					[5]byte{192, 168, 0, 1, 1},
+				}.AddVariants(mod.All...),
+			}.Run("big_valsV4", t, marshal)
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			"192.168.0",
-			net.IP{192, 168, 0},
-			[]byte{192, 168, 0},
-			[3]byte{192, 168, 0},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenNetIP,
-	}.Run("small_valsV4", t, marshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					"fe80:cd00:0:cde:1257:0:211e:729cc",
+					net.IP("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf\xaf"),
+					[]byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf\xaf"),
+					[17]byte{254, 128, 205, 0, 0, 0, 12, 222, 18, 87, 0, 0, 33, 30, 114, 156, 156},
+				}.AddVariants(mod.All...),
+			}.Run("big_valsV6", t, marshal)
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			"fe80:cd00:0:cde:1257:0:211e",
-			net.IP("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2"),
-			[]byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2"),
-			[15]byte{254, 128, 205, 0, 0, 0, 12, 222, 18, 87, 0, 0, 33, 30, 114},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenNetIP,
-	}.Run("small_valsV6", t, marshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					"192.168.0",
+					net.IP{192, 168, 0},
+					[]byte{192, 168, 0},
+					[3]byte{192, 168, 0},
+				}.AddVariants(mod.All...),
+			}.Run("small_valsV4", t, marshal)
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			"b6b77c@3-c776-40ff-828d-a385f3e8a2a",
-			"00000000-0000-0000-0000-0#0000000000",
-			"192.168.a.1",
-		}.AddVariants(mod.All...),
-	}.Run("corrupt_vals", t, marshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					"fe80:cd00:0:cde:1257:0:211e",
+					net.IP("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2"),
+					[]byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2"),
+					[15]byte{254, 128, 205, 0, 0, 0, 12, 222, 18, 87, 0, 0, 33, 30, 114},
+				}.AddVariants(mod.All...),
+			}.Run("small_valsV6", t, marshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte{192, 168, 0, 1, 1},
-		Values: mod.Values{
-			"",
-			net.IP{},
-			[]byte{},
-			[4]byte{},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenString,
-	}.Run("big_dataV4", t, unmarshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					"b6b77c@3-c776-40ff-828d-a385f3e8a2a",
+					"00000000-0000-0000-0000-0#0000000000",
+					"192.168.a.1",
+				}.AddVariants(mod.All...),
+			}.Run("corrupt_vals", t, marshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf\xaf"),
-		Values: mod.Values{
-			"",
-			net.IP{},
-			[]byte{},
-			[16]byte{},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenString,
-	}.Run("big_dataV6", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte{192, 168, 0, 1, 1},
+				Values: mod.Values{
+					"",
+					net.IP{},
+					[]byte{},
+					[4]byte{},
+				}.AddVariants(mod.All...),
+			}.Run("big_dataV4", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte{192, 168, 0},
-		Values: mod.Values{
-			"",
-			net.IP{},
-			[]byte{},
-			[4]byte{},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenString,
-	}.Run("small_dataV4", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf\xaf"),
+				Values: mod.Values{
+					"",
+					net.IP{},
+					[]byte{},
+					[16]byte{},
+				}.AddVariants(mod.All...),
+			}.Run("big_dataV6", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2"),
-		Values: mod.Values{
-			"",
-			net.IP{},
-			[]byte{},
-			[16]byte{},
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenString,
-	}.Run("small_dataV6", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf"),
+				Values: mod.Values{
+					[4]byte{},
+				}.AddVariants(mod.All...),
+			}.Run("big_dataV6Array4", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte{192, 168, 0},
+				Values: mod.Values{
+					"",
+					net.IP{},
+					[]byte{},
+					[4]byte{},
+				}.AddVariants(mod.All...),
+			}.Run("small_dataV4", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2"),
+				Values: mod.Values{
+					"",
+					net.IP{},
+					[]byte{},
+					[16]byte{},
+				}.AddVariants(mod.All...),
+			}.Run("small_dataV6", t, unmarshal)
+		})
+	}
 }

--- a/tests/serialization/marshal_14_inet_test.go
+++ b/tests/serialization/marshal_14_inet_test.go
@@ -10,110 +10,150 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/serialization/inet"
 )
 
 func TestMarshalsInet(t *testing.T) {
 	tType := gocql.NewNativeType(4, gocql.TypeInet, "")
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	// marshal and unmarshal []byte{}, [4]byte{}, [16]byte{} and `custom types` of these types unsupported
-	// marshal and unmarshal `custom string` unsupported
-	brokenTypes := serialization.GetTypes(mod.Values{
-		[]byte{},
-		[4]byte{},
-		[16]byte{},
-		mod.String(""),
-	}.AddVariants(mod.All...)...)
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.inet",
+			marshal:   inet.Marshal,
+			unmarshal: inet.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	// unmarshal zero and nil data into `net.IP` and `string` unsupported
-	brokenZeroUnmarshal := serialization.GetTypes(mod.Values{net.IP{}, ""}.AddVariants(mod.Reference)...)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			([]byte)(nil),
-			(*[]byte)(nil),
-			(*[4]byte)(nil),
-			(*[16]byte)(nil),
-			(net.IP)(nil),
-			(*net.IP)(nil),
-			"",
-			(*string)(nil),
-		}.AddVariants(mod.CustomType),
-		BrokenMarshalTypes:   serialization.GetTypes([]byte{}, mod.Bytes{}, "", mod.String("")),
-		BrokenUnmarshalTypes: serialization.GetTypes([]byte{}, mod.Bytes{}, net.IP{}, mod.String("")),
-	}.Run("[nil]nullable", t, marshal, unmarshal)
+		t.Run(tSuite.name, func(t *testing.T) {
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					([]byte)(nil),
+					(*[]byte)(nil),
+					(*[4]byte)(nil),
+					(*[16]byte)(nil),
+					(net.IP)(nil),
+					(*net.IP)(nil),
+					"",
+					(*string)(nil),
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]nullable", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			[4]byte{},
-			[16]byte{},
-		}.AddVariants(mod.CustomType),
-		BrokenUnmarshalTypes: brokenTypes,
-	}.Run("[nil]unmarshal", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					[4]byte{},
+					[16]byte{},
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data: make([]byte, 0),
-		Values: mod.Values{
-			make([]byte, 0),
-			[4]byte{},
-			[16]byte{},
-			make(net.IP, 0),
-			"0.0.0.0",
-		}.AddVariants(mod.All...),
-		BrokenUnmarshalTypes: append(brokenTypes, brokenZeroUnmarshal...),
-	}.Run("[]unmarshal", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data: make([]byte, 0),
+				Values: mod.Values{
+					make([]byte, 0),
+					[4]byte{},
+					[16]byte{},
+					make(net.IP, 0),
+					"0.0.0.0",
+				}.AddVariants(mod.All...),
+			}.Run("[]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte{0, 0, 0, 0},
-		Values: mod.Values{
-			"0.0.0.0",
-			[]byte{0, 0, 0, 0},
-			net.IP{0, 0, 0, 0},
-			[4]byte{0, 0, 0, 0},
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenTypes,
-		BrokenUnmarshalTypes: brokenTypes,
-	}.Run("zerosV4", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte{0, 0, 0, 0},
+				Values: mod.Values{
+					"0.0.0.0",
+					[]byte{0, 0, 0, 0},
+					net.IP{0, 0, 0, 0},
+					[4]byte{},
+				}.AddVariants(mod.All...),
+			}.Run("zerosV4", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		Values: mod.Values{
-			"::",
-			[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			[16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenTypes,
-		BrokenUnmarshalTypes: brokenTypes,
-	}.Run("zerosV6", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte{0, 0, 0, 0},
+				Values: mod.Values{
+					[16]byte{},
+				}.AddVariants(mod.All...),
+			}.Run("zerosV4unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte{192, 168, 0, 1},
-		Values: mod.Values{
-			"192.168.0.1",
-			[]byte{192, 168, 0, 1},
-			net.IP{192, 168, 0, 1},
-			[4]byte{192, 168, 0, 1},
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenTypes,
-		BrokenUnmarshalTypes: brokenTypes,
-	}.Run("ipV4", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Values: mod.Values{
+					"::",
+					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					[16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				}.AddVariants(mod.All...),
+			}.Run("zerosV6", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
-		Values: mod.Values{
-			"fe80:cd00:0:cde:1257:0:211e:729c",
-			[]byte("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
-			net.IP("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
-			[16]byte{254, 128, 205, 0, 0, 0, 12, 222, 18, 87, 0, 0, 33, 30, 114, 156},
-		}.AddVariants(mod.All...),
-		BrokenMarshalTypes:   brokenTypes,
-		BrokenUnmarshalTypes: brokenTypes,
-	}.Run("ipV6", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Values: mod.Values{
+					[4]byte{0, 0, 0, 0},
+				}.AddVariants(mod.All...),
+			}.Run("zerosV6unmarshal", t, nil, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte{192, 168, 0, 1},
+				Values: mod.Values{
+					"192.168.0.1",
+					[]byte{192, 168, 0, 1},
+					net.IP{192, 168, 0, 1},
+					[4]byte{192, 168, 0, 1},
+				}.AddVariants(mod.All...),
+			}.Run("ipV4", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte{192, 168, 0, 1},
+				Values: mod.Values{
+					[16]byte{192, 168, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				}.AddVariants(mod.All...),
+			}.Run("ipV4unmarshal", t, nil, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte{255, 255, 255, 255},
+				Values: mod.Values{
+					"255.255.255.255",
+					[]byte{255, 255, 255, 255},
+					net.IP{255, 255, 255, 255},
+					[4]byte{255, 255, 255, 255},
+				}.AddVariants(mod.All...),
+			}.Run("ipV4max", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte{255, 255, 255, 255},
+				Values: mod.Values{
+					[16]byte{255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				}.AddVariants(mod.All...),
+			}.Run("ipV4maxUnmarshal", t, nil, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
+				Values: mod.Values{
+					"fe80:cd00:0:cde:1257:0:211e:729c",
+					[]byte("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
+					net.IP("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
+					[16]byte{254, 128, 205, 0, 0, 0, 12, 222, 18, 87, 0, 0, 33, 30, 114, 156},
+				}.AddVariants(mod.All...),
+			}.Run("ipV6", t, marshal, unmarshal)
+		})
+	}
 }


### PR DESCRIPTION
Changes:
1. Marshaling `out of the bounds` `net.IP` values does not return an error before, now returns an error.
2. Unmarshalling `out of the bounds` data into `string` and `*string` does not return an error before, now returns an error.
3. Marshaling and unmarshalling `[]byte{}`, `[4]byte{}`, `[16]byte{}` and `custom types` of these types and `custom string` was unsupported before, now is supported.
4. Unmarshalling `zero` and `nil` data into `net.IP` and `string` was unsupported before, now is supported.
