### PR TITLE
Fix `varint`, makes `encInt64` function exportable

### DIFF
--- a/serialization/varint/marshal_bigint_test.go
+++ b/serialization/varint/marshal_bigint_test.go
@@ -47,7 +47,7 @@ func TestEnc2BigInt(t *testing.T) {
 				t.Fatalf("%d\nexpected:%x\nreceived:%x", i, expected, received)
 			}
 
-			received = encInt64(i)
+			received = EncInt64Ext(i)
 			if !bytes.Equal(expected, received) {
 				t.Fatalf("%d\nexpected:%x\nreceived:%x", i, expected, received)
 			}
@@ -64,7 +64,7 @@ func TestEnc2BigInt(t *testing.T) {
 				t.Fatalf("%d\nexpected:%x\nreceived:%x", i, expected, received)
 			}
 
-			received = encInt64(i)
+			received = EncInt64Ext(i)
 			if !bytes.Equal(expected, received) {
 				t.Fatalf("%d\nexpected:%x\nreceived:%x", i, expected, received)
 			}

--- a/serialization/varint/marshal_custom.go
+++ b/serialization/varint/marshal_custom.go
@@ -55,11 +55,11 @@ func encReflectString(v reflect.Value) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal varint: can not marshal (%T)(%[1]v), %s", v.Interface(), err)
 		}
-		return encInt64(n), nil
+		return EncInt64Ext(n), nil
 	case len(val) <= 20:
 		n, err := strconv.ParseInt(val, 10, 64)
 		if err == nil {
-			return encInt64(n), nil
+			return EncInt64Ext(n), nil
 		}
 
 		t, ok := new(big.Int).SetString(val, 10)

--- a/serialization/varint/marshal_ints.go
+++ b/serialization/varint/marshal_ints.go
@@ -34,14 +34,14 @@ func EncInt32R(v *int32) ([]byte, error) {
 }
 
 func EncInt64(v int64) ([]byte, error) {
-	return encInt64(v), nil
+	return EncInt64Ext(v), nil
 }
 
 func EncInt64R(v *int64) ([]byte, error) {
 	if v == nil {
 		return nil, nil
 	}
-	return encInt64(*v), nil
+	return EncInt64Ext(*v), nil
 }
 
 func EncInt(v int) ([]byte, error) {
@@ -79,7 +79,7 @@ func encInt32(v int32) []byte {
 	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
 }
 
-func encInt64(v int64) []byte {
+func EncInt64Ext(v int64) []byte {
 	if v <= maxInt8 && v >= minInt8 {
 		return []byte{byte(v)}
 	}

--- a/serialization/varint/marshal_utils.go
+++ b/serialization/varint/marshal_utils.go
@@ -46,11 +46,11 @@ func EncString(v string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal varint: can not marshal %#v, %s", v, err)
 		}
-		return encInt64(n), nil
+		return EncInt64Ext(n), nil
 	case len(v) <= 20:
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err == nil {
-			return encInt64(n), nil
+			return EncInt64Ext(n), nil
 		}
 
 		t, ok := new(big.Int).SetString(v, 10)


### PR DESCRIPTION
This change is necessary to use the `encInt64` function in the `decimal` package to marshaling.