### PR TITLE
Fix `time` marshal, unmarshall functions

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -123,20 +123,6 @@ var marshalTests = []struct {
 		nil,
 	},
 	{
-		NativeType{proto: 4, typ: TypeTime},
-		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
-		time.Duration(int64(1376387523000)),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 4, typ: TypeTime},
-		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
-		int64(1376387523000),
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeTimestamp},
 		[]byte("\x00\x00\x01\x40\x77\x16\xe1\xb8"),
 		time.Date(2013, time.August, 13, 9, 52, 3, 0, time.UTC),
@@ -551,13 +537,6 @@ var marshalTests = []struct {
 		nil,
 		nil,
 	},
-	{
-		NativeType{proto: 2, typ: TypeTime},
-		encBigInt(1000),
-		time.Duration(1000),
-		nil,
-		nil,
-	},
 }
 
 var unmarshalTests = []struct {
@@ -881,46 +860,6 @@ func TestMarshalPointer(t *testing.T) {
 	}
 	if len(data) != 1 || data[0] != 42 {
 		t.Errorf("Pointer marshaling failed. Expected %+v, got %+v", []byte{42}, data)
-	}
-}
-
-func TestMarshalTime(t *testing.T) {
-	durationS := "1h10m10s"
-	duration, _ := time.ParseDuration(durationS)
-	expectedData := encBigInt(duration.Nanoseconds())
-	var marshalTimeTests = []struct {
-		Info  TypeInfo
-		Data  []byte
-		Value interface{}
-	}{
-		{
-			NativeType{proto: 4, typ: TypeTime},
-			expectedData,
-			duration.Nanoseconds(),
-		},
-		{
-			NativeType{proto: 4, typ: TypeTime},
-			expectedData,
-			duration,
-		},
-		{
-			NativeType{proto: 4, typ: TypeTime},
-			expectedData,
-			&duration,
-		},
-	}
-
-	for i, test := range marshalTimeTests {
-		t.Log(i, test)
-		data, err := Marshal(test.Info, test.Value)
-		if err != nil {
-			t.Errorf("marshalTest[%d]: %v", i, err)
-			continue
-		}
-		if !bytes.Equal(data, test.Data) {
-			t.Errorf("marshalTest[%d]: expected %x (%v), got %x (%v) for time %s", i,
-				test.Data, decInt(test.Data), data, decInt(data), test.Value)
-		}
 	}
 }
 

--- a/serialization/cqltime/marshal.go
+++ b/serialization/cqltime/marshal.go
@@ -1,0 +1,30 @@
+package cqltime
+
+import (
+	"reflect"
+	"time"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case int64:
+		return EncInt64(v)
+	case *int64:
+		return EncInt64R(v)
+	case time.Duration:
+		return EncDuration(v)
+	case *time.Duration:
+		return EncDurationR(v)
+
+	default:
+		// Custom types (type MyTime int64) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/serialization/cqltime/marshal_utils.go
+++ b/serialization/cqltime/marshal_utils.go
@@ -1,0 +1,76 @@
+package cqltime
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+const (
+	maxValInt64 int64         = 86399999999999
+	minValInt64 int64         = 0
+	maxValDur   time.Duration = 86399999999999
+	minValDur   time.Duration = 0
+)
+
+var (
+	errOutRangeInt64 = fmt.Errorf("failed to marshal time: the (int64) should be in the range 0 to 86399999999999")
+	errOutRangeDur   = fmt.Errorf("failed to marshal time: the (time.Duration) should be in the range 0 to 86399999999999")
+)
+
+func EncInt64(v int64) ([]byte, error) {
+	if v > maxValInt64 || v < minValInt64 {
+		return nil, errOutRangeInt64
+	}
+	return encInt64(v), nil
+}
+
+func EncInt64R(v *int64) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncInt64(*v)
+}
+
+func EncDuration(v time.Duration) ([]byte, error) {
+	if v > maxValDur || v < minValDur {
+		return nil, errOutRangeDur
+	}
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, nil
+}
+
+func EncDurationR(v *time.Duration) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return EncDuration(*v)
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Kind() {
+	case reflect.Int64:
+		val := v.Int()
+		if val > maxValInt64 || val < minValInt64 {
+			return nil, fmt.Errorf("failed to marshal time: the (%T) should be in the range 0 to 86399999999999", v.Interface())
+		}
+		return encInt64(val), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+	default:
+		return nil, fmt.Errorf("failed to marshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encInt64(v int64) []byte {
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}

--- a/serialization/cqltime/unmarshal.go
+++ b/serialization/cqltime/unmarshal.go
@@ -1,0 +1,36 @@
+package cqltime
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+
+	case *int64:
+		return DecInt64(data, v)
+	case **int64:
+		return DecInt64R(data, v)
+	case *time.Duration:
+		return DecDuration(data, v)
+	case **time.Duration:
+		return DecDurationR(data, v)
+	default:
+
+		// Custom types (type MyTime int64) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v)", value)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/serialization/cqltime/unmarshal_utils.go
+++ b/serialization/cqltime/unmarshal_utils.go
@@ -1,0 +1,171 @@
+package cqltime
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
+
+var (
+	errWrongDataLen      = fmt.Errorf("failed to unmarshal time: the length of the data should be 0 or 8")
+	errDataOutRangeInt64 = fmt.Errorf("failed to unmarshal time: (int64) the data should be in the range 0 to 86399999999999")
+	errDataOutRangeDur   = fmt.Errorf("failed to unmarshal time: (time.Duration) the data should be in the range 0 to 86399999999999")
+)
+
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal time: can not unmarshal into nil reference (%T)(%[1]v))", v)
+}
+
+func DecInt64(p []byte, v *int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 8:
+		*v = decInt64(p)
+		if *v > maxValInt64 || *v < minValInt64 {
+			return errDataOutRangeInt64
+		}
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecInt64R(p []byte, v **int64) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(int64)
+		}
+	case 8:
+		val := decInt64(p)
+		if val > maxValInt64 || val < minValInt64 {
+			return errDataOutRangeInt64
+		}
+		*v = &val
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecDuration(p []byte, v *time.Duration) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		*v = 0
+	case 8:
+		*v = decDur(p)
+		if *v > maxValDur || *v < minValDur {
+			return errDataOutRangeDur
+		}
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecDurationR(p []byte, v **time.Duration) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(time.Duration)
+		}
+	case 8:
+		val := decDur(p)
+		if val > maxValDur || val < minValDur {
+			return errDataOutRangeDur
+		}
+		*v = &val
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return fmt.Errorf("failed to unmarshal time: can not unmarshal into nil reference (%T)(%[1]v))", v.Interface())
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.Int64, reflect.Int:
+		return decReflectInt64(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectInt64(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetInt(0)
+	case 8:
+		val := decInt64(p)
+		if val > maxValInt64 || val < minValInt64 {
+			return fmt.Errorf("failed to unmarshal time: (%T) the data should be in the range 0 to 86399999999999", v.Interface())
+		}
+		v.SetInt(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return fmt.Errorf("failed to unmarshal time: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
+	}
+
+	switch v.Type().Elem().Elem().Kind() {
+	case reflect.Int64, reflect.Int:
+		return decReflectIntsR(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectIntsR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.Elem().Set(reflect.Zero(v.Elem().Type()))
+		} else {
+			v.Elem().Set(reflect.New(v.Type().Elem().Elem()))
+		}
+	case 8:
+		vv := decInt64(p)
+		if vv > maxValInt64 || vv < minValInt64 {
+			return fmt.Errorf("failed to unmarshal time: (%T) the data should be in the range 0 to 86399999999999", v.Interface())
+		}
+		val := reflect.New(v.Type().Elem().Elem())
+		val.Elem().SetInt(vv)
+		v.Elem().Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decInt64(p []byte) int64 {
+	return int64(p[0])<<56 | int64(p[1])<<48 | int64(p[2])<<40 | int64(p[3])<<32 | int64(p[4])<<24 | int64(p[5])<<16 | int64(p[6])<<8 | int64(p[7])
+}
+
+func decDur(p []byte) time.Duration {
+	return time.Duration(p[0])<<56 | time.Duration(p[1])<<48 | time.Duration(p[2])<<40 | time.Duration(p[3])<<32 | time.Duration(p[4])<<24 | time.Duration(p[5])<<16 | time.Duration(p[6])<<8 | time.Duration(p[7])
+}

--- a/tests/serialization/marshal_15_time_corrupt_test.go
+++ b/tests/serialization/marshal_15_time_corrupt_test.go
@@ -11,89 +11,110 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/serialization/cqltime"
 )
 
 func TestMarshalTimeCorrupt(t *testing.T) {
 	tType := gocql.NewNativeType(4, gocql.TypeTime, "")
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	// marshal, unmarshal of all supported `go types` does not return an error on all type of corruption.
-	brokenTypes := serialization.GetTypes(int64(0), (*int64)(nil), mod.Int64(0), (*mod.Int64)(nil), time.Duration(0), (*time.Duration)(nil))
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.cqltime",
+			marshal:   cqltime.Marshal,
+			unmarshal: cqltime.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			int64(86300000000000), time.Duration(86300000000000),
-			int64(math.MaxInt64), time.Duration(math.MaxInt64),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("big_vals", t, marshal)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.NegativeMarshalSet{
-		Values: mod.Values{
-			int64(-1), time.Duration(-1),
-			int64(math.MinInt8), time.Duration(math.MinInt8),
-			int64(math.MinInt64), time.Duration(math.MinInt64),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("small_vals", t, marshal)
+		t.Run(tSuite.name, func(t *testing.T) {
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x00\x00\x4e\x94\x91\x4e\xff\xff\xff"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("big_data_len", t, unmarshal)
+			// marshal, unmarshal of all supported `go types` does not return an error on all type of corruption.
+			//brokenTypes := serialization.GetTypes(int64(0), (*int64)(nil), mod.Int64(0), (*mod.Int64)(nil), time.Duration(0), (*time.Duration)(nil))
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x00\x00\x4e\x94\x91\x4e\xff"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("small_data_len1", t, unmarshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					int64(86400000000000), time.Duration(86400000000000),
+					int64(86500000000000), time.Duration(86500000000000),
+					int64(math.MaxInt64), time.Duration(math.MaxInt64),
+				}.AddVariants(mod.All...),
+			}.Run("big_vals", t, marshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x00"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("small_data_len2", t, unmarshal)
+			serialization.NegativeMarshalSet{
+				Values: mod.Values{
+					int64(-1), time.Duration(-1),
+					int64(math.MinInt8), time.Duration(math.MinInt8),
+					int64(math.MinInt16), time.Duration(math.MinInt16),
+					int64(math.MinInt32), time.Duration(math.MinInt32),
+					int64(math.MinInt64), time.Duration(math.MinInt64),
+				}.AddVariants(mod.All...),
+			}.Run("small_vals", t, marshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x00\x00\x4e\x94\x91\x4f\x00\x00"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("big_data1", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x00\x00\x4e\x94\x91\x4e\xff\xff\xff"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("big_data_len", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("big_data2", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x00\x00\x4e\x94\x91\x4e\xff"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("small_data_len1", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("small_data1", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x00"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("small_data_len2", t, unmarshal)
 
-	serialization.NegativeUnmarshalSet{
-		Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-		BrokenTypes: brokenTypes,
-	}.Run("small_data2", t, unmarshal)
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x00\x00\x4e\x94\x91\x4f\x00\x00"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("big_data1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("big_data2", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("small_data1", t, unmarshal)
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("small_data2", t, unmarshal)
+		})
+	}
 }

--- a/tests/serialization/marshal_15_time_test.go
+++ b/tests/serialization/marshal_15_time_test.go
@@ -10,49 +10,75 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/serialization/cqltime"
 )
 
 func TestMarshalsTime(t *testing.T) {
 	tType := gocql.NewNativeType(4, gocql.TypeTime, "")
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			(*int64)(nil), (*time.Duration)(nil),
-		}.AddVariants(mod.CustomType),
-	}.Run("[nil]nullable", t, marshal, unmarshal)
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.cqltime",
+			marshal:   cqltime.Marshal,
+			unmarshal: cqltime.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	serialization.PositiveSet{
-		Data: nil,
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.CustomType),
-	}.Run("[nil]unmarshal", t, nil, unmarshal)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.PositiveSet{
-		Data: make([]byte, 0),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-	}.Run("[]unmarshal", t, nil, unmarshal)
+		t.Run(tSuite.name, func(t *testing.T) {
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
-		Values: mod.Values{
-			int64(0), time.Duration(0),
-		}.AddVariants(mod.All...),
-	}.Run("zeros", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					(*int64)(nil), (*time.Duration)(nil),
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]nullable", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\x4e\x94\x91\x4e\xff\xff"),
-		Values: mod.Values{
-			int64(86399999999999), time.Duration(86399999999999),
-		}.AddVariants(mod.All...),
-	}.Run("max", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data: nil,
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.CustomType),
+			}.Run("[nil]unmarshal", t, nil, unmarshal)
 
+			serialization.PositiveSet{
+				Data: make([]byte, 0),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("[]unmarshal", t, nil, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
+				Values: mod.Values{
+					int64(0), time.Duration(0),
+				}.AddVariants(mod.All...),
+			}.Run("zeros", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x4e\x94\x91\x4e\xff\xff"),
+				Values: mod.Values{
+					int64(86399999999999), time.Duration(86399999999999),
+				}.AddVariants(mod.All...),
+			}.Run("max", t, marshal, unmarshal)
+		})
+	}
 }


### PR DESCRIPTION
Changes:
1. Marshallig `out of range values` does not return an error before, now returns an error.
2. Unmarshalling `corrupted data` and `out of range data` does not return an error before, now returns an error.