### PR TITLE
Let retry policy to decide about non idempotent queries

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -311,7 +311,7 @@ func TestCancel(t *testing.T) {
 	wg.Add(1)
 
 	go func() {
-		if err := qry.Exec(); err != context.Canceled {
+		if err := qry.Exec(); !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected to get context cancel error: '%v', got '%v'", context.Canceled, err)
 		}
 		wg.Done()
@@ -573,7 +573,7 @@ func TestQueryTimeout(t *testing.T) {
 
 	select {
 	case err := <-ch:
-		if err != ErrTimeoutNoResponse {
+		if !errors.Is(err, ErrTimeoutNoResponse) {
 			t.Fatalf("expected to get %v for timeout got %v", ErrTimeoutNoResponse, err)
 		}
 	case <-time.After(40*time.Millisecond + db.cfg.Timeout):
@@ -667,8 +667,8 @@ func TestQueryTimeoutClose(t *testing.T) {
 		t.Fatal("timedout waiting to get a response once cluster is closed")
 	}
 
-	if err != ErrConnectionClosed {
-		t.Fatalf("expected to get %v got %v", ErrConnectionClosed, err)
+	if !errors.Is(err, ErrConnectionClosed) {
+		t.Fatalf("expected to get %v or an error wrapping it, got %v", ErrConnectionClosed, err)
 	}
 }
 
@@ -721,7 +721,7 @@ func TestContext_Timeout(t *testing.T) {
 	cancel()
 
 	err = db.Query("timeout").WithContext(ctx).Exec()
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected to get context cancel error: %v got %v", context.Canceled, err)
 	}
 }
@@ -838,7 +838,7 @@ func TestContext_CanceledBeforeExec(t *testing.T) {
 	cancel()
 
 	err = db.Query("timeout").WithContext(ctx).Exec()
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected to get context cancel error: %v got %v", context.Canceled, err)
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -456,6 +456,10 @@ func (t *testRetryPolicy) Attempt(qry RetryableQuery) bool {
 	return qry.Attempts() <= t.NumRetries
 }
 func (t *testRetryPolicy) GetRetryType(err error) RetryType {
+	var executedErr *QueryError
+	if errors.As(err, &executedErr) && executedErr.PotentiallyExecuted() && !executedErr.IsIdempotent() {
+		return Rethrow
+	}
 	return Retry
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -4,6 +4,7 @@
 package gocql
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -18,12 +19,12 @@ func TestErrorsParse(t *testing.T) {
 	if err := createTable(session, `CREATE TABLE gocql_test.errors_parse (id int primary key)`); err == nil {
 		t.Fatal("Should have gotten already exists error from cassandra server.")
 	} else {
-		switch e := err.(type) {
-		case *RequestErrAlreadyExists:
+		e := &RequestErrAlreadyExists{}
+		if errors.As(err, &e) {
 			if e.Table != "errors_parse" {
 				t.Fatalf("expected error table to be 'errors_parse' but was %q", e.Table)
 			}
-		default:
+		} else {
 			t.Fatalf("expected to get RequestErrAlreadyExists instead got %T", e)
 		}
 	}

--- a/query_executor.go
+++ b/query_executor.go
@@ -2,6 +2,7 @@ package gocql
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 )
@@ -107,74 +108,107 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 }
 
 func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter NextHost) *Iter {
-	selectedHost := hostIter()
 	rt := qry.retryPolicy()
-	lwt_rt, use_lwt_rt := rt.(LWTRetryPolicy)
-	// We only want to apply LWT policy to LWT queries
-	use_lwt_rt = use_lwt_rt && qry.IsLWT()
+	if rt == nil {
+		rt = &SimpleRetryPolicy{3}
+	}
 
-	var lastErr error
-	var iter *Iter
-	for selectedHost != nil {
+	lwtRT, isRTSupportsLWT := rt.(LWTRetryPolicy)
+
+	var getShouldRetry func(qry RetryableQuery) bool
+	var getRetryType func(error) RetryType
+
+	if isRTSupportsLWT && qry.IsLWT() {
+		getShouldRetry = lwtRT.AttemptLWT
+		getRetryType = lwtRT.GetRetryTypeLWT
+	} else {
+		getShouldRetry = rt.Attempt
+		getRetryType = rt.GetRetryType
+	}
+
+	var potentiallyExecuted bool
+
+	execute := func(qry ExecutableQuery, selectedHost SelectedHost) (iter *Iter, retry RetryType) {
 		host := selectedHost.Info()
 		if host == nil || !host.IsUp() {
-			selectedHost = hostIter()
-			continue
+			return &Iter{
+				err: &QueryError{
+					err:                 ErrHostDown,
+					potentiallyExecuted: potentiallyExecuted,
+				},
+			}, RetryNextHost
 		}
-
 		pool, ok := q.pool.getPool(host)
 		if !ok {
-			selectedHost = hostIter()
-			continue
+			return &Iter{
+				err: &QueryError{
+					err:                 ErrNoPool,
+					potentiallyExecuted: potentiallyExecuted,
+				},
+			}, RetryNextHost
 		}
-
 		conn := pool.Pick(selectedHost.Token(), qry)
 		if conn == nil {
-			selectedHost = hostIter()
-			continue
+			return &Iter{
+				err: &QueryError{
+					err:                 ErrNoConnectionsInPool,
+					potentiallyExecuted: potentiallyExecuted,
+				},
+			}, RetryNextHost
 		}
-
 		iter = q.attemptQuery(ctx, qry, conn)
 		iter.host = selectedHost.Info()
 		// Update host
-		switch iter.err {
-		case context.Canceled, context.DeadlineExceeded, ErrNotFound:
-			// those errors represents logical errors, they should not count
-			// toward removing a node from the pool
+		if iter.err == nil {
+			return iter, RetryType(255)
+		}
+
+		switch {
+		case errors.Is(iter.err, context.Canceled),
+			errors.Is(iter.err, context.DeadlineExceeded):
 			selectedHost.Mark(nil)
-			return iter
+			potentiallyExecuted = true
+			retry = Rethrow
 		default:
 			selectedHost.Mark(iter.err)
+			retry = RetryType(255) // Don't enforce retry and get it from retry policy
 		}
 
-		// Exit if the query was successful
-		// or no retry policy defined
-		if iter.err == nil || rt == nil {
+		var qErr *QueryError
+		if errors.As(iter.err, &qErr) {
+			potentiallyExecuted = potentiallyExecuted && qErr.PotentiallyExecuted()
+			qErr.potentiallyExecuted = potentiallyExecuted
+			qErr.isIdempotent = qry.IsIdempotent()
+			iter.err = qErr
+		} else {
+			iter.err = &QueryError{
+				err:                 iter.err,
+				potentiallyExecuted: potentiallyExecuted,
+				isIdempotent:        qry.IsIdempotent(),
+			}
+		}
+		return iter, retry
+	}
+
+	var lastErr error
+	selectedHost := hostIter()
+	for selectedHost != nil {
+		iter, retryType := execute(qry, selectedHost)
+		if iter.err == nil {
 			return iter
 		}
-
-		// or retry policy decides to not retry anymore
-		if use_lwt_rt {
-			if !lwt_rt.AttemptLWT(qry) {
-				return iter
-			}
-		} else {
-			if !rt.Attempt(qry) {
-				return iter
-			}
-		}
-
 		lastErr = iter.err
 
-		var retry_type RetryType
-		if use_lwt_rt {
-			retry_type = lwt_rt.GetRetryTypeLWT(iter.err)
-		} else {
-			retry_type = rt.GetRetryType(iter.err)
+		// Exit if retry policy decides to not retry anymore
+		if retryType == RetryType(255) {
+			if !getShouldRetry(qry) {
+				return iter
+			}
+			retryType = getRetryType(iter.err)
 		}
 
 		// If query is unsuccessful, check the error with RetryPolicy to retry
-		switch retry_type {
+		switch retryType {
 		case Retry:
 			// retry on the same host
 			continue
@@ -189,11 +223,9 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 			return &Iter{err: ErrUnknownRetryType}
 		}
 	}
-
 	if lastErr != nil {
 		return &Iter{err: lastErr}
 	}
-
 	return &Iter{err: ErrNoConnections}
 }
 


### PR DESCRIPTION
This PR:
* Makes Conn.exec to include a flag into error that signals that query could have been actually executed, despite error been recieved.
* Picks up this error in queryExecutor.do and if query is not idempotent wrap it with user-facing error that would signal to retry policy and to user that this non idempotent query was failed but could be actually executed.

Fixes: #326, #331