### PR TITLE
Fix `boolean`, marshal, unmarshall functions

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -32,20 +32,6 @@ var marshalTests = []struct {
 	UnmarshalError error
 }{
 	{
-		NativeType{proto: 2, typ: TypeBoolean},
-		[]byte("\x00"),
-		false,
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeBoolean},
-		[]byte("\x01"),
-		true,
-		nil,
-		nil,
-	},
-	{
 		NativeType{proto: 2, typ: TypeDecimal},
 		[]byte("\x00\x00\x00\x00\x00"),
 		inf.NewDec(0, 0),
@@ -300,33 +286,6 @@ var marshalTests = []struct {
 		NativeType{proto: 2, typ: TypeInet},
 		[]byte("\xfe\x80\x00\x00\x00\x00\x00\x00\x02\x02\xb3\xff\xfe\x1e\x83\x29"),
 		net.ParseIP("fe80::202:b3ff:fe1e:8329"),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeBoolean},
-		[]byte("\x00"),
-		func() *bool {
-			b := false
-			return &b
-		}(),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeBoolean},
-		[]byte("\x01"),
-		func() *bool {
-			b := true
-			return &b
-		}(),
-		nil,
-		nil,
-	},
-	{
-		NativeType{proto: 2, typ: TypeBoolean},
-		[]byte(nil),
-		(*bool)(nil),
 		nil,
 		nil,
 	},

--- a/serialization/boolean/marshal.go
+++ b/serialization/boolean/marshal.go
@@ -1,0 +1,24 @@
+package boolean
+
+import (
+	"reflect"
+)
+
+func Marshal(value interface{}) ([]byte, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case bool:
+		return EncBool(v)
+	case *bool:
+		return EncBoolR(v)
+	default:
+		// Custom types (type MyBool bool) can be serialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.TypeOf(value)
+		if rv.Kind() != reflect.Ptr {
+			return EncReflect(reflect.ValueOf(v))
+		}
+		return EncReflectR(reflect.ValueOf(v))
+	}
+}

--- a/serialization/boolean/marshal_utils.go
+++ b/serialization/boolean/marshal_utils.go
@@ -1,0 +1,45 @@
+package boolean
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func EncBool(v bool) ([]byte, error) {
+	return encBool(v), nil
+}
+
+func EncBoolR(v *bool) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return encBool(*v), nil
+}
+
+func EncReflect(v reflect.Value) ([]byte, error) {
+	switch v.Kind() {
+	case reflect.Bool:
+		return encBool(v.Bool()), nil
+	case reflect.Struct:
+		if v.Type().String() == "gocql.unsetColumn" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to marshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+	default:
+		return nil, fmt.Errorf("failed to marshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func EncReflectR(v reflect.Value) ([]byte, error) {
+	if v.IsNil() {
+		return nil, nil
+	}
+	return EncReflect(v.Elem())
+}
+
+func encBool(v bool) []byte {
+	if v {
+		return []byte{1}
+	}
+	return []byte{0}
+}

--- a/serialization/boolean/unmarshal.go
+++ b/serialization/boolean/unmarshal.go
@@ -1,0 +1,29 @@
+package boolean
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func Unmarshal(data []byte, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case *bool:
+		return DecBool(data, v)
+	case **bool:
+		return DecBoolR(data, v)
+	default:
+		// Custom types (type MyBool bool) can be deserialized only via `reflect` package.
+		// Later, when generic-based serialization is introduced we can do that via generics.
+		rv := reflect.ValueOf(value)
+		rt := rv.Type()
+		if rt.Kind() != reflect.Ptr {
+			return fmt.Errorf("failed to unmarshal boolean: unsupported value type (%T)(%[1]v)", v)
+		}
+		if rt.Elem().Kind() != reflect.Ptr {
+			return DecReflect(data, rv)
+		}
+		return DecReflectR(data, rv)
+	}
+}

--- a/serialization/boolean/unmarshal_utils.go
+++ b/serialization/boolean/unmarshal_utils.go
@@ -1,0 +1,108 @@
+package boolean
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var errWrongDataLen = fmt.Errorf("failed to unmarshal boolean: the length of the data should be 0 or 1")
+
+func errNilReference(v interface{}) error {
+	return fmt.Errorf("failed to unmarshal boolean: can not unmarshal into nil reference(%T)(%[1]v)", v)
+}
+
+func DecBool(p []byte, v *bool) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		*v = false
+	case 1:
+		*v = decBool(p)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecBoolR(p []byte, v **bool) error {
+	if v == nil {
+		return errNilReference(v)
+	}
+	switch len(p) {
+	case 0:
+		if p == nil {
+			*v = nil
+		} else {
+			*v = new(bool)
+		}
+	case 1:
+		val := decBool(p)
+		*v = &val
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func DecReflect(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v = v.Elem(); v.Kind() {
+	case reflect.Bool:
+		return decReflectBool(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func DecReflectR(p []byte, v reflect.Value) error {
+	if v.IsNil() {
+		return errNilReference(v)
+	}
+
+	switch v.Type().Elem().Elem().Kind() {
+	case reflect.Bool:
+		return decReflectBoolR(p, v)
+	default:
+		return fmt.Errorf("failed to unmarshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+	}
+}
+
+func decReflectBool(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		v.SetBool(false)
+	case 1:
+		v.SetBool(decBool(p))
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decReflectBoolR(p []byte, v reflect.Value) error {
+	switch len(p) {
+	case 0:
+		if p == nil {
+			v.Elem().Set(reflect.Zero(v.Type().Elem()))
+		} else {
+			val := reflect.New(v.Type().Elem().Elem())
+			v.Elem().Set(val)
+		}
+	case 1:
+		val := reflect.New(v.Type().Elem().Elem())
+		val.Elem().SetBool(decBool(p))
+		v.Elem().Set(val)
+	default:
+		return errWrongDataLen
+	}
+	return nil
+}
+
+func decBool(p []byte) bool {
+	return p[0] != 0
+}

--- a/tests/serialization/marshal_1_boolean_corrupt_test.go
+++ b/tests/serialization/marshal_1_boolean_corrupt_test.go
@@ -1,0 +1,54 @@
+//go:build all || unit
+// +build all unit
+
+package serialization_test
+
+import (
+	"github.com/gocql/gocql/serialization/boolean"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/gocql/gocql/internal/tests/serialization"
+	"github.com/gocql/gocql/internal/tests/serialization/mod"
+)
+
+func TestMarshalBooleanCorrupt(t *testing.T) {
+	tType := gocql.NewNativeType(4, gocql.TypeBoolean, "")
+
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
+	}
+
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.boolean",
+			marshal:   boolean.Marshal,
+			unmarshal: boolean.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
+
+	for _, tSuite := range testSuites {
+		unmarshal := tSuite.unmarshal
+
+		t.Run(tSuite.name, func(t *testing.T) {
+
+			serialization.NegativeUnmarshalSet{
+				Data: []byte("\x00\x00"),
+				Values: mod.Values{
+					false,
+				}.AddVariants(mod.All...),
+			}.Run("big_data", t, unmarshal)
+		})
+	}
+}

--- a/tests/serialization/marshal_1_boolean_test.go
+++ b/tests/serialization/marshal_1_boolean_test.go
@@ -9,43 +9,70 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/internal/tests/serialization"
 	"github.com/gocql/gocql/internal/tests/serialization/mod"
+	"github.com/gocql/gocql/serialization/boolean"
 )
 
 func TestMarshalBoolean(t *testing.T) {
 	tType := gocql.NewNativeType(4, gocql.TypeBoolean, "")
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
-		return gocql.Unmarshal(tType, bytes, i)
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
 	}
 
-	serialization.PositiveSet{
-		Data:   nil,
-		Values: mod.Values{(*bool)(nil)}.AddVariants(mod.CustomType),
-	}.Run("[nil]nullable", t, marshal, unmarshal)
+	testSuites := [2]testSuite{
+		{
+			name:      "serialization.boolean",
+			marshal:   boolean.Marshal,
+			unmarshal: boolean.Unmarshal,
+		},
+		{
+			name: "glob",
+			marshal: func(i interface{}) ([]byte, error) {
+				return gocql.Marshal(tType, i)
+			},
+			unmarshal: func(bytes []byte, i interface{}) error {
+				return gocql.Unmarshal(tType, bytes, i)
+			},
+		},
+	}
 
-	serialization.PositiveSet{
-		Data:   nil,
-		Values: mod.Values{false}.AddVariants(mod.CustomType),
-	}.Run("[nil]unmarshal", t, nil, unmarshal)
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
 
-	serialization.PositiveSet{
-		Data:   make([]byte, 0),
-		Values: mod.Values{false}.AddVariants(mod.All...),
-	}.Run("[]unmarshal", t, nil, unmarshal)
+		t.Run(tSuite.name, func(t *testing.T) {
 
-	serialization.PositiveSet{
-		Data:   []byte("\x00"),
-		Values: mod.Values{false}.AddVariants(mod.All...),
-	}.Run("zeros", t, marshal, unmarshal)
+			serialization.PositiveSet{
+				Data:   nil,
+				Values: mod.Values{(*bool)(nil)}.AddVariants(mod.CustomType),
+			}.Run("[nil]nullable", t, marshal, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\x01"),
-		Values: mod.Values{true}.AddVariants(mod.All...),
-	}.Run("[ff]unmarshal", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data:   nil,
+				Values: mod.Values{false}.AddVariants(mod.CustomType),
+			}.Run("[nil]unmarshal", t, nil, unmarshal)
 
-	serialization.PositiveSet{
-		Data:   []byte("\xff"),
-		Values: mod.Values{true}.AddVariants(mod.All...),
-	}.Run("[01]", t, nil, unmarshal)
+			serialization.PositiveSet{
+				Data:   make([]byte, 0),
+				Values: mod.Values{false}.AddVariants(mod.All...),
+			}.Run("[]unmarshal", t, nil, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x00"),
+				Values: mod.Values{false}.AddVariants(mod.All...),
+			}.Run("zeros", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x01"),
+				Values: mod.Values{true}.AddVariants(mod.All...),
+			}.Run("[1]unmarshal", t, nil, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\xff"),
+				Values: mod.Values{true}.AddVariants(mod.All...),
+			}.Run("[255]", t, nil, unmarshal)
+		})
+	}
 }


### PR DESCRIPTION
Changes:
1. Unmarshalling `big data` does not return an error before, now returns an error.