### PR TITLE
Make it possible for NewSession not to block

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -340,6 +340,10 @@ func (cfg *ClusterConfig) CreateSession() (*Session, error) {
 	return NewSession(*cfg)
 }
 
+func (cfg *ClusterConfig) CreateSessionNonBlocking() (*Session, error) {
+	return NewSessionNonBlocking(*cfg)
+}
+
 // translateAddressPort is a helper method that will use the given AddressTranslator
 // if defined, to translate the given address and port into a possibly new address
 // and port, If no AddressTranslator or if an error occurs, the given address and

--- a/session.go
+++ b/session.go
@@ -79,6 +79,8 @@ type Session struct {
 	// isInitialized is true once Session.init succeeds.
 	// you can use initialized() to read the value.
 	isInitialized bool
+	initErr       error
+	readyCh       chan struct{}
 
 	logger StdLogger
 
@@ -114,8 +116,7 @@ func addrsToHosts(addrs []string, defaultPort int, logger StdLogger) ([]*HostInf
 	return hosts, nil
 }
 
-// NewSession wraps an existing Node.
-func NewSession(cfg ClusterConfig) (*Session, error) {
+func newSessionCommon(cfg ClusterConfig) (*Session, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("gocql: unable to create session: cluster config validation failed: %v", err)
 	}
@@ -132,6 +133,7 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		ctx:             ctx,
 		cancel:          cancel,
 		logger:          cfg.logger(),
+		readyCh:         make(chan struct{}, 1),
 	}
 
 	// Close created resources on error otherwise they'll leak
@@ -181,6 +183,16 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 	}
 	s.connCfg = connCfg
 
+	return s, nil
+}
+
+// NewSession wraps an existing Node.
+func NewSession(cfg ClusterConfig) (*Session, error) {
+	s, err := newSessionCommon(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	if err = s.init(); err != nil {
 		if err == ErrNoConnectionsStarted {
 			//This error used to be generated inside NewSession & returned directly
@@ -191,6 +203,29 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 			return nil, fmt.Errorf("gocql: unable to create session: %v", err)
 		}
 	}
+
+	s.readyCh <- struct{}{}
+	close(s.readyCh)
+
+	return s, nil
+}
+
+func NewSessionNonBlocking(cfg ClusterConfig) (*Session, error) {
+	s, err := newSessionCommon(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		if initErr := s.init(); initErr != nil {
+			s.sessionStateMu.Lock()
+			s.initErr = fmt.Errorf("gocql: unable to create session: %v", initErr)
+			s.sessionStateMu.Unlock()
+		}
+
+		s.readyCh <- struct{}{}
+		close(s.readyCh)
+	}()
 
 	return s, nil
 }
@@ -404,6 +439,9 @@ func (s *Session) AwaitSchemaAgreement(ctx context.Context) error {
 	if s.cfg.disableControlConn {
 		return errNoControl
 	}
+	if err := s.Ready(); err != nil {
+		return err
+	}
 	ch := s.control.getConn()
 	return (&Iter{err: ch.conn.awaitSchemaAgreement(ctx)}).err
 }
@@ -570,10 +608,28 @@ func (s *Session) initialized() bool {
 	return initialized
 }
 
+func (s *Session) Ready() error {
+	s.sessionStateMu.RLock()
+	err := ErrSessionNotReady
+	if s.isInitialized || s.initErr != nil {
+		err = s.initErr
+	}
+	s.sessionStateMu.RUnlock()
+	return err
+}
+
+func (s *Session) WaitUntilReady() error {
+	<-s.readyCh
+	return s.initErr
+}
+
 func (s *Session) executeQuery(qry *Query) (it *Iter) {
 	// fail fast
 	if s.Closed() {
 		return &Iter{err: ErrSessionClosed}
+	}
+	if err := s.Ready(); err != nil {
+		return &Iter{err: err}
 	}
 
 	iter, err := s.executor.executeQuery(qry)
@@ -599,6 +655,8 @@ func (s *Session) KeyspaceMetadata(keyspace string) (*KeyspaceMetadata, error) {
 	// fail fast
 	if s.Closed() {
 		return nil, ErrSessionClosed
+	} else if err := s.Ready(); err != nil {
+		return nil, err
 	} else if keyspace == "" {
 		return nil, ErrNoKeyspace
 	}
@@ -611,6 +669,8 @@ func (s *Session) TabletsMetadata() (TabletInfoList, error) {
 	// fail fast
 	if s.Closed() {
 		return nil, ErrSessionClosed
+	} else if err := s.Ready(); err != nil {
+		return nil, err
 	} else if !s.tabletsRoutingV1 {
 		return nil, ErrTabletsNotUsed
 	}
@@ -797,6 +857,9 @@ func (s *Session) executeBatch(batch *Batch) *Iter {
 	// fail fast
 	if s.Closed() {
 		return &Iter{err: ErrSessionClosed}
+	}
+	if err := s.Ready(); err != nil {
+		return &Iter{err: err}
 	}
 
 	// Prevent the execution of the batch if greater than the limit
@@ -2364,6 +2427,7 @@ var (
 	ErrKeyspaceDoesNotExist = errors.New("keyspace does not exist")
 	ErrNoMetadata           = errors.New("no metadata available")
 	ErrTabletsNotUsed       = errors.New("tablets not used")
+	ErrSessionNotReady      = errors.New("session is not ready yet")
 )
 
 type ErrProtocol struct{ error }

--- a/session.go
+++ b/session.go
@@ -192,10 +192,6 @@ func NewSession(cfg ClusterConfig) (*Session, error) {
 		}
 	}
 
-	if err = s.policy.IsOperational(s); err != nil {
-		return nil, fmt.Errorf("gocql: unable to create session: %v", err)
-	}
-
 	return s, nil
 }
 
@@ -385,6 +381,10 @@ func (s *Session) init() error {
 	// parameters. This is used by tokenAwareHostPolicy to discover replicas.
 	if !s.cfg.disableControlConn && s.cfg.Keyspace != "" {
 		s.policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: s.cfg.Keyspace})
+	}
+
+	if err = s.policy.IsOperational(s); err != nil {
+		return fmt.Errorf("gocql: unable to create session: %v", err)
 	}
 
 	s.sessionStateMu.Lock()

--- a/session_test.go
+++ b/session_test.go
@@ -68,16 +68,16 @@ func TestSessionAPI(t *testing.T) {
 	}
 
 	itr := s.executeQuery(qry)
-	if itr.err != ErrNoConnections {
-		t.Fatalf("expected itr.err to be '%v', got '%v'", ErrNoConnections, itr.err)
+	if itr.err != ErrSessionNotReady {
+		t.Fatalf("expected itr.err to be '%v', got '%v'", ErrSessionNotReady, itr.err)
 	}
 
 	testBatch := s.NewBatch(LoggedBatch)
 	testBatch.Query("test")
 	err := s.ExecuteBatch(testBatch)
 
-	if err != ErrNoConnections {
-		t.Fatalf("expected session.ExecuteBatch to return '%v', got '%v'", ErrNoConnections, err)
+	if err != ErrSessionNotReady {
+		t.Fatalf("expected session.ExecuteBatch to return '%v', got '%v'", ErrSessionNotReady, err)
 	}
 
 	s.Close()


### PR DESCRIPTION
Idea is the following:
* You create cluster configuration
* You create session of it that does not actually connects to the cluster, but rather just starting this proccess.
* If you are trying to execute query on such session, if it is not ready yeat it will throw you an NotReady error
* Have an API that allows you to know if session is ready to execute queries


Fixes: #234 