### PR TITLE
Make driver print warnings returned by server

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -109,6 +109,8 @@ type ClusterConfig struct {
 	// Default: nil
 	Authenticator Authenticator
 
+	WarningsHandlerBuilder WarningHandlerBuilder
+
 	// An Authenticator factory. Can be used to create alternative authenticators.
 	// Default: nil
 	AuthProvider func(h *HostInfo) (Authenticator, error)
@@ -322,6 +324,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		WriteCoalesceWaitTime:        200 * time.Microsecond,
 		MetadataSchemaRequestTimeout: 60 * time.Second,
 		DisableSkipMetadata:          true,
+		WarningsHandlerBuilder:       DefaultWarningHandlerBuilder,
 	}
 
 	return cfg

--- a/session.go
+++ b/session.go
@@ -87,6 +87,7 @@ type Session struct {
 	tabletsRoutingV1 bool
 
 	usingTimeoutClause string
+	warningHandler     WarningHandler
 }
 
 var queryPool = &sync.Pool{
@@ -182,7 +183,9 @@ func newSessionCommon(cfg ClusterConfig) (*Session, error) {
 		return nil, fmt.Errorf("gocql: unable to create session: %v", err)
 	}
 	s.connCfg = connCfg
-
+	if cfg.WarningsHandlerBuilder != nil {
+		s.warningHandler = cfg.WarningsHandlerBuilder(s)
+	}
 	return s, nil
 }
 

--- a/warning_handler.go
+++ b/warning_handler.go
@@ -1,0 +1,28 @@
+package gocql
+
+type DefaultWarningHandler struct {
+	logger StdLogger
+}
+
+func DefaultWarningHandlerBuilder(session *Session) WarningHandler {
+	return DefaultWarningHandler{
+		logger: session.logger,
+	}
+}
+
+func (d DefaultWarningHandler) HandleWarnings(qry ExecutableQuery, host *HostInfo, warnings []string) {
+	if d.logger == nil {
+		return
+	}
+	if host != nil && len(host.hostId) > 0 {
+		d.logger.Printf("[%s] warnings: %v", host.hostId, warnings)
+	} else {
+		d.logger.Printf("Cluster warnings: %v", warnings)
+	}
+}
+
+var _ WarningHandler = DefaultWarningHandler{}
+
+func NoopWarningHandlerBuilder(session *Session) WarningHandler {
+	return nil
+}


### PR DESCRIPTION
Time to time server provides usefull information in warnings.
Almost all drivers print it out, we need to make gocql do the same.