### PR TITLE
Add `scylla` serialization tests

### DIFF
--- a/integration_serialization_scylla_test.go
+++ b/integration_serialization_scylla_test.go
@@ -1,0 +1,218 @@
+//go:build integration && scylla
+// +build integration,scylla
+
+package gocql
+
+import (
+	"bytes"
+	"fmt"
+	"gopkg.in/inf.v0"
+	"math/big"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/gocql/gocql/internal/tests/serialization/valcases"
+)
+
+func TestSerializationSimpleTypesCassandra(t *testing.T) {
+	const (
+		pkColumn   = "test_id"
+		testColumn = "test_col"
+	)
+
+	typeCases := valcases.GetSimple()
+
+	session := createSession(t)
+	defer session.Close()
+
+	//Checks data and values conversion
+	t.Run("Marshal", func(t *testing.T) {
+		for _, tc := range typeCases {
+			checkTypeMarshal(t, tc)
+		}
+	})
+
+	t.Run("Unmarshal", func(t *testing.T) {
+		for _, tc := range typeCases {
+			checkTypeUnmarshal(t, tc)
+		}
+	})
+
+	//Create are tables
+	tables := make([]string, len(typeCases))
+	for i, tc := range typeCases {
+		table := "test_" + tc.CQLName
+
+		stmt := fmt.Sprintf(`CREATE TABLE %s (%s text, %s %s, PRIMARY KEY (test_id))`, table, pkColumn, testColumn, tc.CQLName)
+		if err := createTable(session, stmt); err != nil {
+			t.Fatalf("failed to create table for cqltype (%s) with error '%v'", tc.CQLName, err)
+		}
+		tables[i] = table
+	}
+
+	//Check Insert and Select are values
+	t.Run("InsertSelect", func(t *testing.T) {
+		for i, tc := range typeCases {
+			insertStmt := fmt.Sprintf("INSERT INTO %s (%s, %s) VALUES(?, ?)", tables[i], pkColumn, testColumn)
+			selectStmt := fmt.Sprintf("SELECT %s FROM %s WHERE %s = ?", testColumn, tables[i], pkColumn)
+
+			checkTypeInsertSelect(t, session, insertStmt, selectStmt, tc)
+		}
+	})
+}
+
+func checkTypeMarshal(t *testing.T, tc valcases.SimpleTypeCases) {
+	cqlName := tc.CQLName
+	t.Run(cqlName, func(t *testing.T) {
+		tp := Type(tc.CQLType)
+		cqlType := NewNativeType(4, tp, "")
+
+		for _, valCase := range tc.Cases {
+			for _, langCase := range valCase.LangCases {
+				receivedData, err := Marshal(cqlType, langCase.Value)
+
+				if !langCase.ErrInsert && err != nil {
+					t.Errorf("failed to marshal case (%s)(%s) value (%T) with error '%v'", valCase.Name, langCase.LangType, langCase.Value, err)
+				} else if langCase.ErrInsert && err == nil {
+					t.Errorf("expected an error on marshal case (%s)(%s) value (%T)(%[2]v), but have no error", valCase.Name, langCase.LangType, langCase.Value)
+				} else if !bytes.Equal(valCase.Data, receivedData) {
+					t.Errorf("failed to equal case (%s)(%s) data: expected %d, got %d", valCase.Name, langCase.LangType, valCase.Data, receivedData)
+				}
+			}
+		}
+	})
+}
+
+func checkTypeUnmarshal(t *testing.T, tc valcases.SimpleTypeCases) {
+	cqlName := tc.CQLName
+	t.Run(cqlName, func(t *testing.T) {
+		tp := Type(tc.CQLType)
+		cqlType := NewNativeType(4, tp, "")
+
+		for _, valCase := range tc.Cases {
+			for _, langCase := range valCase.LangCases {
+				received := newRef(langCase.Value)
+
+				err := Unmarshal(cqlType, valCase.Data, received)
+				if !langCase.ErrSelect && err != nil {
+					t.Errorf("failed to unmarshal case (%s)(%s) value (%T) with error '%v'", valCase.Name, langCase.LangType, langCase.Value, err)
+				}
+				if langCase.ErrSelect && err == nil {
+					t.Errorf("expected an error on unmarshal case (%s)(%s) value (%T)(%[2]v), but have no error", valCase.Name, langCase.LangType, langCase.Value)
+				}
+				received = deReference(received)
+				if !equalVals(langCase.Value, received) {
+					t.Errorf("failed to equal case (%s)(%s) value: expected %d, got %d", valCase.Name, langCase.LangType, langCase.Value, received)
+				}
+			}
+		}
+	})
+}
+
+func checkTypeInsertSelect(t *testing.T, session *Session, insertStmt, selectStmt string, tc valcases.SimpleTypeCases) {
+	cqlName := tc.CQLName
+	t.Run(cqlName, func(t *testing.T) {
+		tp := Type(tc.CQLType)
+		cqlType := NewNativeType(4, tp, "")
+
+		for _, valCase := range tc.Cases {
+			valCaseName := valCase.Name
+
+			for _, langCase := range valCase.LangCases {
+				var insertedValue interface{}
+				//Check Insert value as values
+				insertedValue = langCase.Value
+				err := session.Query(insertStmt, valCaseName, insertedValue).Exec()
+				if !langCase.ErrInsert && err != nil {
+					t.Errorf("failed to insert case (%s) value (%T)(%[2]v) with error '%v'", valCaseName, insertedValue, err)
+				} else if langCase.ErrInsert && err == nil {
+					t.Errorf("expected an error on insert case (%s) value (%T)(%[2]v), but have no error", valCaseName, insertedValue, err)
+				}
+
+				//Check Select value as value
+				selectedValue := newRef(langCase.Value)
+				err = session.Query(selectStmt, valCase.Name).Scan(selectedValue)
+				if !langCase.ErrSelect && err != nil {
+					t.Errorf("failed to select case (%s) value (%T) with error '%v'", valCaseName, selectedValue, err)
+				} else if langCase.ErrSelect && err == nil {
+					t.Errorf("expected an error on select case (%s) value (%T)(%[2]v), but have no error", valCaseName, selectedValue)
+				}
+				selectedValue = deReference(selectedValue)
+				if !equalVals(langCase.Value, selectedValue) {
+					t.Errorf("failed to equal case (%s) value: expected: %d, got: %d", valCaseName, langCase.Value, selectedValue)
+				}
+
+				//Check Select value as bytes
+				selectedValue = &DirectUnmarshal{}
+				err = session.Query(selectStmt, valCase.Name).Scan(selectedValue)
+				if err != nil {
+					t.Errorf("failed to select case (%s) value (%T) for cqltype (%s) with error '%v'", valCaseName, selectedValue, cqlType, err)
+				}
+				selectedValue = *(*[]byte)(selectedValue.(*DirectUnmarshal))
+				if !equalVals(valCase.Data, selectedValue) {
+					t.Errorf("failed to equal case (%s) value for cqltype (%s): expected: %d, got: %d", valCaseName, cqlType, valCase.Data, selectedValue)
+				}
+			}
+		}
+	})
+}
+
+// newRef returns the nil reference to the input type value (*type)(nil)
+func newRef(in interface{}) interface{} {
+	out := reflect.New(reflect.TypeOf(in)).Interface()
+	return out
+}
+
+func deReference(in interface{}) interface{} {
+	return reflect.Indirect(reflect.ValueOf(in)).Interface()
+}
+
+func equalVals(in1, in2 interface{}) bool {
+	rin1 := reflect.ValueOf(in1)
+	rin2 := reflect.ValueOf(in2)
+	if rin1.Kind() != rin2.Kind() {
+		return false
+	}
+	if rin1.Kind() == reflect.Ptr && (rin1.IsNil() || rin2.IsNil()) {
+		return rin1.IsNil() && rin2.IsNil()
+	}
+
+	switch vin1 := in1.(type) {
+	case float32:
+		vin2 := in2.(float32)
+		return *(*[4]byte)(unsafe.Pointer(&vin1)) == *(*[4]byte)(unsafe.Pointer(&vin2))
+	case *float32:
+		vin2 := in2.(*float32)
+		return *(*[4]byte)(unsafe.Pointer(vin1)) == *(*[4]byte)(unsafe.Pointer(vin2))
+	case float64:
+		vin2 := in2.(float64)
+		return *(*[8]byte)(unsafe.Pointer(&vin1)) == *(*[8]byte)(unsafe.Pointer(&vin2))
+	case *float64:
+		vin2 := in2.(*float64)
+		return *(*[8]byte)(unsafe.Pointer(vin1)) == *(*[8]byte)(unsafe.Pointer(vin2))
+	case big.Int:
+		vin2 := in2.(big.Int)
+		return vin1.Cmp(&vin2) == 0
+	case *big.Int:
+		vin2 := in2.(*big.Int)
+		return vin1.Cmp(vin2) == 0
+	case inf.Dec:
+		vin2 := in2.(inf.Dec)
+		if vin1.Scale() != vin2.Scale() {
+			return false
+		}
+		return vin1.UnscaledBig().Cmp(vin2.UnscaledBig()) == 0
+	case *inf.Dec:
+		vin2 := in2.(*inf.Dec)
+		if vin1.Scale() != vin2.Scale() {
+			return false
+		}
+		return vin1.UnscaledBig().Cmp(vin2.UnscaledBig()) == 0
+	case fmt.Stringer:
+		vin2 := in2.(fmt.Stringer)
+		return vin1.String() == vin2.String()
+	default:
+		return reflect.DeepEqual(in1, in2)
+	}
+}

--- a/internal/tests/serialization/valcases/get.go
+++ b/internal/tests/serialization/valcases/get.go
@@ -1,0 +1,37 @@
+package valcases
+
+import (
+	"reflect"
+)
+
+type SimpleTypes []SimpleTypeCases
+
+type SimpleTypeCases struct {
+	CQLName string
+	CQLType int
+	Cases   []SimpleTypeCase
+}
+
+type SimpleTypeCase struct {
+	Name      string
+	Data      []byte
+	LangCases []LangCase
+}
+
+type LangCase struct {
+	LangType  string
+	Value     interface{}
+	ErrInsert bool
+	ErrSelect bool
+}
+
+var nilBytes = ([]byte)(nil)
+
+func GetSimple() SimpleTypes {
+	return simpleTypesCases
+}
+
+func nilRef(in interface{}) interface{} {
+	out := reflect.NewAt(reflect.TypeOf(in), nil).Interface()
+	return out
+}

--- a/internal/tests/serialization/valcases/simple.go
+++ b/internal/tests/serialization/valcases/simple.go
@@ -1,0 +1,902 @@
+package valcases
+
+import (
+	"gopkg.in/inf.v0"
+	"math"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/gocql/gocql/serialization/duration"
+)
+
+var simpleTypesCases = SimpleTypes{
+	{
+		CQLName: "boolean",
+		CQLType: 0x0004,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte{1},
+				LangCases: []LangCase{
+					{LangType: "bool", Value: true},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte{0},
+				LangCases: []LangCase{
+					{LangType: "bool", Value: false},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "bool", Value: nilRef(false)},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "tinyint",
+		CQLType: 0x0014,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f"),
+				LangCases: []LangCase{
+					{LangType: "int8", Value: int8(math.MaxInt8)},
+					{LangType: "big.Int", Value: big.NewInt(math.MaxInt8)},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\x80"),
+				LangCases: []LangCase{
+					{LangType: "int8", Value: int8(math.MinInt8)},
+					{LangType: "big.Int", Value: big.NewInt(math.MinInt8)},
+				},
+			},
+			{
+				Name: "+1",
+				Data: []byte("\x01"),
+				LangCases: []LangCase{
+					{LangType: "int8", Value: int8(1)},
+					{LangType: "big.Int", Value: big.NewInt(1)},
+				},
+			},
+			{
+				Name: "-1",
+				Data: []byte("\xff"),
+				LangCases: []LangCase{
+					{LangType: "int8", Value: int8(-1)},
+					{LangType: "big.Int", Value: big.NewInt(-1)},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00"),
+				LangCases: []LangCase{
+					{LangType: "int8", Value: int8(0)},
+					{LangType: "big.Int", Value: big.NewInt(0)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int8", Value: nilRef(int8(0))},
+					{LangType: "big.Int", Value: nilRef(big.Int{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "smallint",
+		CQLType: 0x0013,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f\xff"),
+				LangCases: []LangCase{
+					{LangType: "int16", Value: int16(math.MaxInt16)},
+					{LangType: "big.Int", Value: big.NewInt(math.MaxInt16)},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\x80\x00"),
+				LangCases: []LangCase{
+					{LangType: "int16", Value: int16(math.MinInt16)},
+					{LangType: "big.Int", Value: big.NewInt(math.MinInt16)},
+				},
+			},
+			{
+				Name: "+1",
+				Data: []byte("\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "int16", Value: int16(1)},
+					{LangType: "big.Int", Value: big.NewInt(1)},
+				},
+			},
+			{
+				Name: "-1",
+				Data: []byte("\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int16", Value: int16(-1)},
+					{LangType: "big.Int", Value: big.NewInt(-1)},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int16", Value: int16(0)},
+					{LangType: "big.Int", Value: big.NewInt(0)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int16", Value: nilRef(int16(0))},
+					{LangType: "big.Int", Value: nilRef(big.Int{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "int",
+		CQLType: 0x0009,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int32", Value: int32(math.MaxInt32)},
+					{LangType: "big.Int", Value: big.NewInt(math.MaxInt32)},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\x80\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int32", Value: int32(math.MinInt32)},
+					{LangType: "big.Int", Value: big.NewInt(math.MinInt32)},
+				},
+			},
+			{
+				Name: "+1",
+				Data: []byte("\x00\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "int32", Value: int32(1)},
+					{LangType: "big.Int", Value: big.NewInt(1)},
+				},
+			},
+			{
+				Name: "-1",
+				Data: []byte("\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int32", Value: int32(-1)},
+					{LangType: "big.Int", Value: big.NewInt(-1)},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int32", Value: int32(0)},
+					{LangType: "big.Int", Value: big.NewInt(0)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int32", Value: nilRef(int32(0))},
+					{LangType: "big.Int", Value: nilRef(big.Int{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "bigint",
+		CQLType: 0x0002,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(math.MaxInt64)},
+					{LangType: "big.Int", Value: big.NewInt(math.MaxInt64)},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(math.MinInt64)},
+					{LangType: "big.Int", Value: big.NewInt(math.MinInt64)},
+				},
+			},
+			{
+				Name: "+1",
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(1)},
+					{LangType: "big.Int", Value: big.NewInt(1)},
+				},
+			},
+			{
+				Name: "-1",
+				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(-1)},
+					{LangType: "big.Int", Value: big.NewInt(-1)},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(0)},
+					{LangType: "big.Int", Value: big.NewInt(0)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int64", Value: nilRef(int64(0))},
+					{LangType: "big.Int", Value: nilRef(big.Int{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "varint",
+		CQLType: 0x000E,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(math.MaxInt64)},
+					{LangType: "big.Int", Value: big.NewInt(math.MaxInt64)},
+					{LangType: "string", Value: "9223372036854775807"},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(math.MinInt64)},
+					{LangType: "big.Int", Value: big.NewInt(math.MinInt64)},
+					{LangType: "string", Value: "-9223372036854775808"},
+				},
+			},
+			{
+				Name: "+1",
+				Data: []byte("\x01"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(1)},
+					{LangType: "big.Int", Value: big.NewInt(1)},
+					{LangType: "string", Value: "1"},
+				},
+			},
+			{
+				Name: "-1",
+				Data: []byte("\xff"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(-1)},
+					{LangType: "big.Int", Value: big.NewInt(-1)},
+					{LangType: "string", Value: "-1"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(0)},
+					{LangType: "big.Int", Value: big.NewInt(0)},
+					{LangType: "string", Value: "0"},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int64", Value: nilRef(int64(0))},
+					{LangType: "big.Int", Value: nilRef(big.Int{})},
+					{LangType: "string", Value: ""},
+					{LangType: "string_ref", Value: nilRef("")},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "float",
+		CQLType: 0x0008,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f\x7f\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "float32", Value: float32(math.MaxFloat32)},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\xff\x7f\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "float32", Value: float32(-math.MaxFloat32)},
+				},
+			},
+			{
+				Name: "smallest_pos",
+				Data: []byte("\x00\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "float32", Value: float32(math.SmallestNonzeroFloat32)},
+				},
+			},
+			{
+				Name: "smallest_neg",
+				Data: []byte("\x80\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "float32", Value: float32(-math.SmallestNonzeroFloat32)},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "float32", Value: float32(0)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "float32", Value: nilRef(float32(0))},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "double",
+		CQLType: 0x0007,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f\xef\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "float64", Value: math.MaxFloat64},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\xff\xef\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "float64", Value: -math.MaxFloat64},
+				},
+			},
+			{
+				Name: "smallest_pos",
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "float64", Value: math.SmallestNonzeroFloat64},
+				},
+			},
+			{
+				Name: "smallest_neg",
+				Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "float64", Value: -math.SmallestNonzeroFloat64},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "float64", Value: float64(0)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "float64", Value: nilRef(float64(0))},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "decimal",
+		CQLType: 0x0006,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x00\x00\x7f\xff\x7f\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "inf.Dec", Value: *inf.NewDec(math.MaxInt64, math.MaxInt16)},
+					{LangType: "string", Value: "32767;9223372036854775807"},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\xff\xff\x80\x00\x80\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "inf.Dec", Value: *inf.NewDec(math.MinInt64, math.MinInt16)},
+					{LangType: "string", Value: "-32768;-9223372036854775808"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "inf.Dec", Value: *inf.NewDec(0, 0)},
+					{LangType: "string", Value: "0;0"},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "inf.Dec", Value: nilRef(inf.Dec{})},
+					{LangType: "string", Value: ""},
+					{LangType: "string_ref", Value: nilRef("")},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "varchar",
+		CQLType: 0x000D,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "val",
+				Data: []byte("test string"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "test string"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: make([]byte, 0),
+				LangCases: []LangCase{
+					{LangType: "string", Value: ""},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "string", Value: nilRef("")},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "text",
+		CQLType: 0x000A,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "val",
+				Data: []byte("test string"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "test string"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: make([]byte, 0),
+				LangCases: []LangCase{
+					{LangType: "string", Value: ""},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "string", Value: nilRef("")},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "blob",
+		CQLType: 0x0003,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "val",
+				Data: []byte("test string"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "test string"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: make([]byte, 0),
+				LangCases: []LangCase{
+					{LangType: "string", Value: ""},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "string", Value: nilRef("")},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "ascii",
+		CQLType: 0x0001,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "val",
+				Data: []byte("test string"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "test string"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: make([]byte, 0),
+				LangCases: []LangCase{
+					{LangType: "string", Value: ""},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "string", Value: nilRef("")},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "uuid",
+		CQLType: 0x000C,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "ffffffff-ffff-ffff-ffff-ffffffffffff"},
+					{LangType: "[16]byte", Value: [16]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}},
+				},
+			},
+			{
+				Name: "val",
+				Data: []byte("\xe9\x39\xf5\x2a\xd6\x90\x11\xef\x9c\xd2\x02\x42\xac\x12\x00\x02"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "e939f52a-d690-11ef-9cd2-0242ac120002"},
+					{LangType: "[16]byte", Value: [16]byte{233, 57, 245, 42, 214, 144, 17, 239, 156, 210, 2, 66, 172, 18, 0, 2}},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: make([]byte, 16),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "00000000-0000-0000-0000-000000000000"},
+					{LangType: "[16]byte", Value: [16]byte{}},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "string", Value: ""},
+					{LangType: "string_ref", Value: nilRef("")},
+					{LangType: "[16]byte", Value: nilRef([16]byte{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "timeuuid",
+		CQLType: 0x000F,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\xff\xff\xff\xff\xff\xff\x1f\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "ffffffff-ffff-1fff-ffff-ffffffffffff"},
+					{LangType: "[16]byte", Value: [16]byte{255, 255, 255, 255, 255, 255, 31, 255, 255, 255, 255, 255, 255, 255, 255, 255}},
+				},
+			},
+			{
+				Name: "val",
+				Data: []byte("\xe9\x39\xf5\x2a\xd6\x90\x11\xef\x9c\xd2\x02\x42\xac\x12\x00\x02"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "e939f52a-d690-11ef-9cd2-0242ac120002"},
+					{LangType: "[16]byte", Value: [16]byte{233, 57, 245, 42, 214, 144, 17, 239, 156, 210, 2, 66, 172, 18, 0, 2}},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte{0, 0, 0, 0, 0, 0, 1 << 4, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				LangCases: []LangCase{
+					{LangType: "string", Value: "00000000-0000-1000-0000-000000000000"},
+					{LangType: "[16]byte", Value: [16]byte{0, 0, 0, 0, 0, 0, 1 << 4, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "string", Value: ""},
+					{LangType: "string_ref", Value: nilRef("")},
+					{LangType: "[16]byte", Value: nilRef([16]byte{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "inet",
+		CQLType: 0x0010,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "v6max",
+				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+					{LangType: "net.IP", Value: net.IP("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff")},
+				},
+			},
+			{
+				Name: "v4max",
+				Data: []byte("\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "255.255.255.255"},
+					{LangType: "net.IP", Value: net.IP("\xff\xff\xff\xff")},
+				},
+			},
+			{
+				Name: "v6zeros",
+				Data: make([]byte, 16),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "::"},
+					{LangType: "net.IP", Value: make(net.IP, 16)},
+				},
+			},
+			{
+				Name: "v4zeros",
+				Data: make([]byte, 4),
+				LangCases: []LangCase{
+					{LangType: "string", Value: "0.0.0.0"},
+					{LangType: "net.IP", Value: make(net.IP, 4)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "string", Value: ""},
+					{LangType: "string_ref", Value: nilRef("")},
+					{LangType: "net.IP", Value: (net.IP)(nil)},
+					{LangType: "net.IP_ref", Value: nilRef(net.IP{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "time",
+		CQLType: 0x0012,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x00\x00\x4e\x94\x91\x4e\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(86399999999999)},
+					{LangType: "time.Duration", Value: time.Duration(86399999999999)},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(0)},
+					{LangType: "time.Duration", Value: time.Duration(0)},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int64", Value: nilRef(int64(0))},
+					{LangType: "time.Duration", Value: nilRef(time.Duration(0))},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "timestamp",
+		CQLType: 0x000B,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\x7f\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(math.MaxInt64)},
+					{LangType: "time.Time", Value: time.UnixMilli(math.MaxInt64).UTC()},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\x80\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(math.MinInt64)},
+					{LangType: "time.Time", Value: time.UnixMilli(math.MinInt64).UTC()},
+				},
+			},
+			{
+				Name: "+1",
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(1)},
+					{LangType: "time.Time", Value: time.UnixMilli(1).UTC()},
+				},
+			},
+			{
+				Name: "-1",
+				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(-1)},
+					{LangType: "time.Time", Value: time.UnixMilli(-1).UTC()},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "int64", Value: int64(0)},
+					{LangType: "time.Time", Value: time.UnixMilli(0).UTC()},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int64", Value: nilRef(int64(0))},
+					{LangType: "time.Time", Value: nilRef(time.Time{})},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "date",
+		CQLType: 0x0011,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "uint32", Value: uint32(math.MaxUint32)},
+					{LangType: "int32", Value: int32(-1)},
+					{LangType: "time.Time", Value: time.Date(5881580, 07, 11, 0, 0, 0, 0, time.UTC)},
+					{LangType: "string", Value: "5881580-07-11"},
+				},
+			},
+			{
+				Name: "mid",
+				Data: []byte("\x80\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "uint32", Value: uint32(1 << 31)},
+					{LangType: "int32", Value: int32(math.MinInt32)},
+					{LangType: "time.Time", Value: time.Date(1970, 01, 01, 0, 0, 0, 0, time.UTC)},
+					{LangType: "string", Value: "1970-01-01"},
+				},
+			},
+			{
+				Name: "1",
+				Data: []byte("\x00\x00\x00\x01"),
+				LangCases: []LangCase{
+					{LangType: "uint32", Value: uint32(1)},
+					{LangType: "int32", Value: int32(1)},
+					{LangType: "time.Time", Value: time.Date(-5877641, 06, 24, 0, 0, 0, 0, time.UTC)},
+					{LangType: "string", Value: "-5877641-06-24"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "uint32", Value: uint32(0)},
+					{LangType: "int32", Value: int32(0)},
+					{LangType: "time.Time", Value: time.Date(-5877641, 06, 23, 0, 0, 0, 0, time.UTC)},
+					{LangType: "string", Value: "-5877641-06-23"},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "int32", Value: nilRef(int32(0))},
+					{LangType: "time.Time", Value: nilRef(time.Time{})},
+					{LangType: "string", Value: ""},
+					{LangType: "string_ref", Value: nilRef("")},
+				},
+			},
+		},
+	},
+	{
+		CQLName: "duration",
+		CQLType: 0x0015,
+		Cases: []SimpleTypeCase{
+			{
+				Name: "max",
+				Data: []byte("\xf0\xff\xff\xff\xfe\xf0\xff\xff\xff\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xfe"),
+				LangCases: []LangCase{
+					{LangType: "duration", Value: duration.Duration{Days: math.MaxInt32, Months: math.MaxInt32, Nanoseconds: math.MaxInt64}},
+				},
+			},
+			{
+				Name: "min",
+				Data: []byte("\xf0\xff\xff\xff\xff\xf0\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "duration", Value: duration.Duration{Days: math.MinInt32, Months: math.MinInt32, Nanoseconds: math.MinInt64}},
+				},
+			},
+			{
+				Name: "+1",
+				Data: []byte("\x02\x02\x02"),
+				LangCases: []LangCase{
+					{LangType: "duration", Value: duration.Duration{Days: 1, Months: 1, Nanoseconds: 1}},
+				},
+			},
+			{
+				Name: "-1",
+				Data: []byte("\x01\x01\x01"),
+				LangCases: []LangCase{
+					{LangType: "duration", Value: duration.Duration{Days: -1, Months: -1, Nanoseconds: -1}},
+				},
+			},
+			{
+				Name: "maxNanos",
+				Data: []byte("\x00\xc3\x41\xfe\xfc\x9b\xc5\xc4\x9d\xff\xfe"),
+				LangCases: []LangCase{
+					{LangType: "duration", Value: duration.Duration{Days: 106751, Months: 0, Nanoseconds: 85636854775807}},
+					{LangType: "int64", Value: int64(math.MaxInt64)},
+					{LangType: "time.Duration", Value: time.Duration(math.MaxInt64)},
+					{LangType: "string", Value: "2562047h47m16.854775807s"},
+				},
+			},
+			{
+				Name: "minNanos",
+				Data: []byte("\x00\xc3\x41\xfd\xfc\x9b\xc5\xc4\x9d\xff\xff"),
+				LangCases: []LangCase{
+					{LangType: "duration", Value: duration.Duration{Days: -106751, Months: 0, Nanoseconds: -85636854775808}},
+					{LangType: "int64", Value: int64(math.MinInt64)},
+					{LangType: "time.Duration", Value: time.Duration(math.MinInt64)},
+					{LangType: "string", Value: "-2562047h47m16.854775808s"},
+				},
+			},
+			{
+				Name: "zeros",
+				Data: []byte("\x00\x00\x00"),
+				LangCases: []LangCase{
+					{LangType: "duration", Value: duration.Duration{}},
+					{LangType: "int64", Value: int64(0)},
+					{LangType: "time.Duration", Value: time.Duration(0)},
+					{LangType: "string", Value: "0s"},
+				},
+			},
+			{
+				Name: "nil",
+				Data: nilBytes,
+				LangCases: []LangCase{
+					{LangType: "duration", Value: nilRef(duration.Duration{})},
+					{LangType: "int64", Value: nilRef(int64(0))},
+					{LangType: "time.Duration", Value: nilRef(time.Duration(0))},
+					{LangType: "string", Value: ""},
+					{LangType: "string_ref", Value: nilRef("")},
+				},
+			},
+		},
+	},
+}

--- a/marshal.go
+++ b/marshal.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/gocql/gocql/serialization/boolean"
 	"math"
 	"reflect"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"github.com/gocql/gocql/serialization/ascii"
 	"github.com/gocql/gocql/serialization/bigint"
 	"github.com/gocql/gocql/serialization/blob"
+	"github.com/gocql/gocql/serialization/boolean"
 	"github.com/gocql/gocql/serialization/counter"
 	"github.com/gocql/gocql/serialization/cqlint"
 	"github.com/gocql/gocql/serialization/cqltime"
@@ -60,6 +60,12 @@ type Marshaler interface {
 	MarshalCQL(info TypeInfo) ([]byte, error)
 }
 
+type DirectMarshal []byte
+
+func (m DirectMarshal) MarshalCQL(_ TypeInfo) ([]byte, error) {
+	return m, nil
+}
+
 // Unmarshaler is an interface for custom unmarshaler.
 // Each value of the 'CQL binary protocol' consist of <value_len> and <value_data>.
 // <value_len> can be 'unset'(-2), 'nil'(-1), 'zero'(0) or any value up to 2147483647.
@@ -73,6 +79,13 @@ type Marshaler interface {
 // CQL binary protocol info:https://github.com/apache/cassandra/tree/trunk/doc
 type Unmarshaler interface {
 	UnmarshalCQL(info TypeInfo, data []byte) error
+}
+
+type DirectUnmarshal []byte
+
+func (d *DirectUnmarshal) UnmarshalCQL(_ TypeInfo, data []byte) error {
+	*d = bytes.Clone(data)
+	return nil
 }
 
 // Marshal returns the CQL encoding of the value for the Cassandra

--- a/serialization/duration/marshal_utils.go
+++ b/serialization/duration/marshal_utils.go
@@ -80,7 +80,7 @@ func EncDurationR(v *Duration) ([]byte, error) {
 func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Int64:
-		return encNanos(encIntZigZag64(v.Int())), nil
+		return encInt64(v.Int()), nil
 	case reflect.String:
 		val := v.String()
 		if val == "" {

--- a/serialization/timeuuid/marshal_utils.go
+++ b/serialization/timeuuid/marshal_utils.go
@@ -115,6 +115,9 @@ func encReflectBytes(rv reflect.Value) ([]byte, error) {
 // The following code was taken from the `Parse` function of the "github.com/google/uuid" package.
 func encReflectString(v reflect.Value) ([]byte, error) {
 	s := v.String()
+	if s == zeroUUID {
+		return make([]byte, 0), nil
+	}
 	switch len(s) {
 	case 45: // urn:timeuuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 		if !strings.EqualFold(s[:9], "urn:timeuuid:") {
@@ -165,6 +168,9 @@ func encReflectString(v reflect.Value) ([]byte, error) {
 // encString encodes uuid strings.
 // The following code was taken from the `Parse` function of the "github.com/google/uuid" package.
 func encString(s string) ([]byte, error) {
+	if s == zeroUUID {
+		return make([]byte, 0), nil
+	}
 	switch len(s) {
 	case 45: // urn:timeuuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 		if !strings.EqualFold(s[:9], "urn:timeuuid:") {

--- a/serialization/timeuuid/unmarshal_utils.go
+++ b/serialization/timeuuid/unmarshal_utils.go
@@ -6,7 +6,10 @@ import (
 	"time"
 )
 
-const hexString = "0123456789abcdef"
+const (
+	hexString = "0123456789abcdef"
+	zeroUUID  = "00000000-0000-0000-0000-000000000000"
+)
 
 var (
 	offsets  = [...]int{0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34}
@@ -104,7 +107,7 @@ func DecString(p []byte, v *string) error {
 		if p == nil {
 			*v = ""
 		} else {
-			*v = "00000000-0000-0000-0000-000000000000"
+			*v = zeroUUID
 		}
 	case 16:
 		*v = decString(p)
@@ -123,7 +126,7 @@ func DecStringR(p []byte, v **string) error {
 		if p == nil {
 			*v = nil
 		} else {
-			tmp := "00000000-0000-0000-0000-000000000000"
+			tmp := zeroUUID
 			*v = &tmp
 		}
 	case 16:
@@ -255,7 +258,7 @@ func decReflectString(p []byte, v reflect.Value) error {
 		if p == nil {
 			v.SetString("")
 		} else {
-			v.SetString("00000000-0000-0000-0000-000000000000")
+			v.SetString(zeroUUID)
 		}
 	case 16:
 		v.SetString(decString(p))
@@ -313,7 +316,7 @@ func decReflectStringR(p []byte, v reflect.Value) error {
 			v.Set(reflect.Zero(v.Type()))
 		} else {
 			val := reflect.New(v.Type().Elem())
-			val.Elem().SetString("00000000-0000-0000-0000-000000000000")
+			val.Elem().SetString(zeroUUID)
 			v.Set(val)
 		}
 	case 16:

--- a/tests/serialization/marshal_13_uuids_test.go
+++ b/tests/serialization/marshal_13_uuids_test.go
@@ -89,7 +89,6 @@ func TestMarshalUUIDs(t *testing.T) {
 			serialization.PositiveSet{
 				Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 				Values: mod.Values{
-					"00000000-0000-0000-0000-000000000000",
 					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 					[16]byte{},
 					gocql.UUID{},
@@ -97,14 +96,52 @@ func TestMarshalUUIDs(t *testing.T) {
 			}.Run("zeros", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
-				Data: []byte("\xb6\xb7\x7c\x23\xc7\x76\x40\xff\x82\x8d\xa3\x85\xf3\xe8\xa2\xaf"),
+				Data: []byte("\xe9\x39\xf5\x2a\xd6\x90\x11\xef\x9c\xd2\x02\x42\xac\x12\x00\x02"),
 				Values: mod.Values{
-					"b6b77c23-c776-40ff-828d-a385f3e8a2af",
-					[]byte{182, 183, 124, 35, 199, 118, 64, 255, 130, 141, 163, 133, 243, 232, 162, 175},
-					[16]byte{182, 183, 124, 35, 199, 118, 64, 255, 130, 141, 163, 133, 243, 232, 162, 175},
-					gocql.UUID{182, 183, 124, 35, 199, 118, 64, 255, 130, 141, 163, 133, 243, 232, 162, 175},
+					"e939f52a-d690-11ef-9cd2-0242ac120002",
+					[]byte{233, 57, 245, 42, 214, 144, 17, 239, 156, 210, 2, 66, 172, 18, 0, 2},
+					[16]byte{233, 57, 245, 42, 214, 144, 17, 239, 156, 210, 2, 66, 172, 18, 0, 2},
+					gocql.UUID{233, 57, 245, 42, 214, 144, 17, 239, 156, 210, 2, 66, 172, 18, 0, 2},
 				}.AddVariants(mod.All...),
 			}.Run("uuid", t, marshal, unmarshal)
+		})
+	}
+}
+
+func TestMarshalTimeUUID(t *testing.T) {
+	tType := gocql.NewNativeType(4, gocql.TypeTimeUUID, "")
+
+	type testSuite struct {
+		name      string
+		marshal   func(interface{}) ([]byte, error)
+		unmarshal func(bytes []byte, i interface{}) error
+	}
+
+	testSuites := [4]testSuite{
+		{
+			name:      "serialization.timeuuid",
+			marshal:   timeuuid.Marshal,
+			unmarshal: timeuuid.Unmarshal,
+		},
+		{
+			name:      "glob.timeuuid",
+			marshal:   func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) },
+			unmarshal: func(bytes []byte, i interface{}) error { return gocql.Unmarshal(tType, bytes, i) },
+		},
+	}
+
+	for _, tSuite := range testSuites {
+		marshal := tSuite.marshal
+		unmarshal := tSuite.unmarshal
+
+		t.Run(tSuite.name, func(t *testing.T) {
+
+			serialization.PositiveSet{
+				Data: make([]byte, 0),
+				Values: mod.Values{
+					"00000000-0000-0000-0000-000000000000",
+				}.AddVariants(mod.All...),
+			}.Run("zero", t, marshal, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_13_uuids_test.go
+++ b/tests/serialization/marshal_13_uuids_test.go
@@ -104,6 +104,16 @@ func TestMarshalUUIDs(t *testing.T) {
 					gocql.UUID{233, 57, 245, 42, 214, 144, 17, 239, 156, 210, 2, 66, 172, 18, 0, 2},
 				}.AddVariants(mod.All...),
 			}.Run("uuid", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					"ffffffff-ffff-ffff-ffff-ffffffffffff",
+					[]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+					[16]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+					gocql.UUID{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+				}.AddVariants(mod.All...),
+			}.Run("max", t, marshal, unmarshal)
 		})
 	}
 }
@@ -142,6 +152,16 @@ func TestMarshalTimeUUID(t *testing.T) {
 					"00000000-0000-0000-0000-000000000000",
 				}.AddVariants(mod.All...),
 			}.Run("zero", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff\xff\xff\x1f\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					"ffffffff-ffff-1fff-ffff-ffffffffffff",
+					[]byte{255, 255, 255, 255, 255, 255, 31, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+					[16]byte{255, 255, 255, 255, 255, 255, 31, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+					gocql.UUID{255, 255, 255, 255, 255, 255, 31, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+				}.AddVariants(mod.All...),
+			}.Run("max", t, marshal, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_14_inet_test.go
+++ b/tests/serialization/marshal_14_inet_test.go
@@ -85,31 +85,14 @@ func TestMarshalsInet(t *testing.T) {
 					net.IP{0, 0, 0, 0},
 					[4]byte{},
 				}.AddVariants(mod.All...),
-			}.Run("zerosV4", t, marshal, unmarshal)
+			}.Run("v4zeros", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte{0, 0, 0, 0},
 				Values: mod.Values{
 					[16]byte{},
 				}.AddVariants(mod.All...),
-			}.Run("zerosV4unmarshal", t, nil, unmarshal)
-
-			serialization.PositiveSet{
-				Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-				Values: mod.Values{
-					"::",
-					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-					net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-					[16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-				}.AddVariants(mod.All...),
-			}.Run("zerosV6", t, marshal, unmarshal)
-
-			serialization.PositiveSet{
-				Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-				Values: mod.Values{
-					[4]byte{0, 0, 0, 0},
-				}.AddVariants(mod.All...),
-			}.Run("zerosV6unmarshal", t, nil, unmarshal)
+			}.Run("v4zerosUnmarshal", t, nil, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte{192, 168, 0, 1},
@@ -119,14 +102,14 @@ func TestMarshalsInet(t *testing.T) {
 					net.IP{192, 168, 0, 1},
 					[4]byte{192, 168, 0, 1},
 				}.AddVariants(mod.All...),
-			}.Run("ipV4", t, marshal, unmarshal)
+			}.Run("v4", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte{192, 168, 0, 1},
 				Values: mod.Values{
 					[16]byte{192, 168, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 				}.AddVariants(mod.All...),
-			}.Run("ipV4unmarshal", t, nil, unmarshal)
+			}.Run("v4unmarshal", t, nil, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte{255, 255, 255, 255},
@@ -136,14 +119,31 @@ func TestMarshalsInet(t *testing.T) {
 					net.IP{255, 255, 255, 255},
 					[4]byte{255, 255, 255, 255},
 				}.AddVariants(mod.All...),
-			}.Run("ipV4max", t, marshal, unmarshal)
+			}.Run("v4max", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte{255, 255, 255, 255},
 				Values: mod.Values{
 					[16]byte{255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 				}.AddVariants(mod.All...),
-			}.Run("ipV4maxUnmarshal", t, nil, unmarshal)
+			}.Run("v4maxUnmarshal", t, nil, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Values: mod.Values{
+					"::",
+					[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					[16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				}.AddVariants(mod.All...),
+			}.Run("v6zeros", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				Values: mod.Values{
+					[4]byte{0, 0, 0, 0},
+				}.AddVariants(mod.All...),
+			}.Run("v6zerosUnmarshal", t, nil, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
@@ -153,7 +153,17 @@ func TestMarshalsInet(t *testing.T) {
 					net.IP("\xfe\x80\xcd\x00\x00\x00\x0c\xde\x12\x57\x00\x00\x21\x1e\x72\x9c"),
 					[16]byte{254, 128, 205, 0, 0, 0, 12, 222, 18, 87, 0, 0, 33, 30, 114, 156},
 				}.AddVariants(mod.All...),
-			}.Run("ipV6", t, marshal, unmarshal)
+			}.Run("v6", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{
+					"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+					[]byte("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+					net.IP("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
+					[16]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+				}.AddVariants(mod.All...),
+			}.Run("v6max", t, marshal, unmarshal)
 		})
 	}
 }

--- a/tests/serialization/marshal_17_date_test.go
+++ b/tests/serialization/marshal_17_date_test.go
@@ -52,7 +52,7 @@ func TestMarshalsDate(t *testing.T) {
 			serialization.PositiveSet{
 				Data: nil,
 				Values: mod.Values{
-					(*uint32)(nil), (*int32)(nil), (*int64)(nil), (*string)(nil), (*time.Time)(nil),
+					(*uint32)(nil), (*int32)(nil), (*int64)(nil), (*string)(nil), "", (*time.Time)(nil),
 				}.AddVariants(mod.CustomType),
 			}.Run("[nil]nullable", t, marshal, unmarshal)
 
@@ -76,6 +76,13 @@ func TestMarshalsDate(t *testing.T) {
 					uint32(0), int32(0), zeroDate.UnixMilli(), zeroDate, "-5877641-06-23",
 				}.AddVariants(mod.All...),
 			}.Run("zeros", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data: []byte("\x00\x00\x00\x01"),
+				Values: mod.Values{
+					uint32(1), int32(1), zeroDate.Add(time.Hour * 24).UnixMilli(), zeroDate.Add(time.Hour * 24), "-5877641-06-24",
+				}.AddVariants(mod.All...),
+			}.Run("1", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data: []byte("\x80\x00\x00\x00"),

--- a/tests/serialization/marshal_18_duration_test.go
+++ b/tests/serialization/marshal_18_duration_test.go
@@ -325,11 +325,34 @@ func TestMarshalsDuration(t *testing.T) {
 	}.Run("nanosMaxInt64", t, marshal, unmarshal)
 
 	serialization.PositiveSet{
+		Data: []byte("\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe"),
+		Values: mod.Values{
+			gocql.Duration{Months: 0, Days: 0, Nanoseconds: math.MaxInt64},
+		}.AddVariants(mod.All...),
+	}.Run("nanosMaxInt64", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
 		Data: []byte("\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: 0, Nanoseconds: math.MinInt64},
 		}.AddVariants(mod.All...),
 	}.Run("nanosMinInt64", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\xc3\x41\xfe\xfc\x9b\xc5\xc4\x9d\xff\xfe"),
+		Values: mod.Values{
+			gocql.Duration{Days: 106751, Months: 0, Nanoseconds: 85636854775807},
+			int64(math.MaxInt64), time.Duration(math.MaxInt64), time.Duration(math.MaxInt64).String(),
+		}.AddVariants(mod.All...),
+	}.Run("nanosMax", t, marshal, unmarshal)
+
+	serialization.PositiveSet{
+		Data: []byte("\x00\xc3\x41\xfd\xfc\x9b\xc5\xc4\x9d\xff\xff"),
+		Values: mod.Values{
+			gocql.Duration{Days: -106751, Months: 0, Nanoseconds: -85636854775808},
+			int64(math.MinInt64), time.Duration(math.MinInt64), time.Duration(math.MinInt64).String(),
+		}.AddVariants(mod.All...),
+	}.Run("nanosMin", t, marshal, unmarshal)
 
 	// sets for full range
 	serialization.PositiveSet{

--- a/tests/serialization/marshal_8_float_test.go
+++ b/tests/serialization/marshal_8_float_test.go
@@ -71,9 +71,19 @@ func TestMarshalFloat(t *testing.T) {
 			}.Run("max", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
+				Data:   []byte("\xff\x7f\xff\xff"),
+				Values: mod.Values{float32(-math.MaxFloat32)}.AddVariants(mod.All...),
+			}.Run("min", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
 				Data:   []byte("\x00\x00\x00\x01"),
 				Values: mod.Values{float32(math.SmallestNonzeroFloat32)}.AddVariants(mod.All...),
-			}.Run("smallest", t, marshal, unmarshal)
+			}.Run("smallest_pos", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x80\x00\x00\x01"),
+				Values: mod.Values{float32(-math.SmallestNonzeroFloat32)}.AddVariants(mod.All...),
+			}.Run("smallest_neg", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data:   []byte("\x7f\x80\x00\x00"),

--- a/tests/serialization/marshal_9_duble_test.go
+++ b/tests/serialization/marshal_9_duble_test.go
@@ -71,9 +71,19 @@ func TestMarshalDouble(t *testing.T) {
 			}.Run("max", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
+				Data:   []byte("\xff\xef\xff\xff\xff\xff\xff\xff"),
+				Values: mod.Values{float64(-math.MaxFloat64)}.AddVariants(mod.All...),
+			}.Run("min", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
 				Data:   []byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
 				Values: mod.Values{float64(math.SmallestNonzeroFloat64)}.AddVariants(mod.All...),
-			}.Run("smallest", t, marshal, unmarshal)
+			}.Run("smallest_pos", t, marshal, unmarshal)
+
+			serialization.PositiveSet{
+				Data:   []byte("\x80\x00\x00\x00\x00\x00\x00\x01"),
+				Values: mod.Values{float64(-math.SmallestNonzeroFloat64)}.AddVariants(mod.All...),
+			}.Run("smallest_neg", t, marshal, unmarshal)
 
 			serialization.PositiveSet{
 				Data:   []byte("\x7f\xf0\x00\x00\x00\x00\x00\x00"),


### PR DESCRIPTION
Changes:
1) Added serialization tests for `cql simple types`. The `counter` type is not included. 
2) Fixed `timeuuid`. Marshaling `zeroUUID` returns `make([]byte,16)` before, now returns `make([]byte,0)`
3) Added values test cases for `uuid`, `timeuuid`, `inet`, `float`, `double` `cql types` into `unit tests`.

Here are the contents of the tables selected by `cqlsh`:
`test_ascii`:
```
test_id | test_col
---------+-------------
     val | test string
     nil |        null
   zeros | 
```

`test_bigint`:
```
 test_id | test_col
---------+----------------------
     min | -9223372036854775808
     nil |                 null
   zeros |                    0
      +1 |                    1
      -1 |                   -1
     max |  9223372036854775807
```

`test_blob`:
```
 test_id | test_col
---------+--------------------------
     val | 0x7465737420737472696e67
     nil |                     null
   zeros |                       0x
```

`test_boolean`:
```
 test_id | test_col
---------+----------
     min |    False
     nil |     null
     max |     True
```

`test_date`:
```
 test_id | test_col
---------+-------------
     nil |        null
   zeros | -2147483648
     mid |  1970-01-01
     max |  2147483647
       1 | -2147483647
```

`test_decimal`:
```
 test_id | test_col
---------+------------------------------
     min | -9.223372036854775808E+32786
     nil |                         null
   zeros |                            0
     max |  9.223372036854775807E-32749
```

`test_double`:
```
 test_id      | test_col
--------------+--------------
          min | -1.7977e+308
          nil |         null
        zeros |            0
          max |  1.7977e+308
 smallest_pos |  4.9407e-324
 smallest_neg | -4.9407e-324
```

`test_duration`:
```
 test_id | test_col
---------+--------------------------------------------------------
     min | -178956970y8mo2147483648d2562047h47m16s854ms775us808ns
     nil |                                                   null
   zeros |                                                       
      +1 |                                               1mo1d1ns
      -1 |                                              -1mo1d1ns
     max |  178956970y7mo2147483647d2562047h47m16s854ms775us807ns
```

`test_float`:
```
 test_id      | test_col
--------------+-------------
          min | -3.4028e+38
          nil |        null
        zeros |           0
          max |  3.4028e+38
 smallest_pos |  1.4013e-45
 smallest_neg | -1.4013e-45
```

`test_inet`:
```
 test_id | test_col
---------+-----------------------------------------
 v4zeros |                                 0.0.0.0
     nil |                                    null
   v4max |                         255.255.255.255
   v6max | ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 v6zeros |                                      ::
```

`test_int`:
```
 test_id | test_col
---------+-------------
     min | -2147483648
     nil |        null
   zeros |           0
      +1 |           1
      -1 |          -1
     max |  2147483647
```

`test_smallint`:
```
 test_id | test_col
---------+----------
     min |   -32768
     nil |     null
   zeros |        0
      +1 |        1
      -1 |       -1
     max |    32767
```

`test_text`:
```
 test_id | test_col
---------+-------------
     val | test string
     nil |        null
   zeros |            
```

`test_time`:
```
 test_id | test_col
---------+--------------------
     nil |               null
   zeros | 00:00:00.000000000
     max | 23:59:59.999999999
```

`test_timestamp`:
```
 test_id | test_col
---------+---------------------------------
     min |            -9223372036854775808
     nil |                            null
   zeros | 1970-01-01 00:00:00.000000+0000
      +1 | 1970-01-01 00:00:00.001000+0000
      -1 | 1969-12-31 23:59:59.999000+0000
     max |             9223372036854775807
```

`test_timeuuid`:
```
 test_id | test_col
---------+--------------------------------------
     val | e939f52a-d690-11ef-9cd2-0242ac120002
     nil |                                 null
   zeros | 00000000-0000-1000-0000-000000000000
     max | ffffffff-ffff-1fff-ffff-ffffffffffff
```

`test_tinyint`:
```
 test_id | test_col
---------+----------
     min |     -128
     nil |     null
   zeros |        0
      +1 |        1
      -1 |       -1
     max |      127
```

`test_uuid`:
```
 test_id | test_col
---------+--------------------------------------
     val | e939f52a-d690-11ef-9cd2-0242ac120002
     nil |                                 null
   zeros | 00000000-0000-0000-0000-000000000000
     max | ffffffff-ffff-ffff-ffff-ffffffffffff
```

`test_varchar`:
```
 test_id | test_col
---------+-------------
     val | test string
     nil |        null
   zeros |          
```

`test_varint`:
```
 test_id | test_col
---------+----------------------
     min | -9223372036854775808
     nil |                 null
   zeros |                    0
      +1 |                    1
      -1 |                   -1
     max |  9223372036854775807
```
