### PR TITLE
Fix every query to system.local to have WHERE clause

### DIFF
--- a/cloud_cluster_test.go
+++ b/cloud_cluster_test.go
@@ -45,7 +45,7 @@ func TestCloudConnection(t *testing.T) {
 
 	var localAddress string
 	var localHostID gocql.UUID
-	scanner := session.Query("SELECT broadcast_address, host_id FROM system.local").Iter().Scanner()
+	scanner := session.Query("SELECT broadcast_address, host_id FROM system.local WHERE key='local'").Iter().Scanner()
 	if scanner.Next() {
 		if err := scanner.Scan(&localAddress, &localHostID); err != nil {
 			t.Fatal(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       source: ./testdata/pki/cassandra.key
       target: /etc/scylla/db.key
     healthcheck:
-      test: [ "CMD", "cqlsh", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "-e", "select * from system.local where key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 18
@@ -43,7 +43,7 @@ services:
       public:
         ipv4_address: 192.168.100.12
     healthcheck:
-      test: [ "CMD", "cqlsh", "192.168.100.12", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "192.168.100.12", "-e", "select * from system.local where key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 18
@@ -57,7 +57,7 @@ services:
       public:
         ipv4_address: 192.168.100.13
     healthcheck:
-      test: [ "CMD", "cqlsh", "192.168.100.13", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "192.168.100.13", "-e", "select * from system.local where key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 18
@@ -74,7 +74,7 @@ services:
       public:
         ipv4_address: 192.168.100.14
     healthcheck:
-      test: [ "CMD", "cqlsh", "192.168.100.14", "-e", "select * from system.local" ]
+      test: [ "CMD", "cqlsh", "192.168.100.14", "-e", "select * from system.local where key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 18

--- a/events_ccm_test.go
+++ b/events_ccm_test.go
@@ -290,7 +290,7 @@ func TestEventDownQueryable(t *testing.T) {
 	}
 
 	var rows int
-	if err := session.Query("SELECT COUNT(*) FROM system.local").Scan(&rows); err != nil {
+	if err := session.Query("SELECT COUNT(*) FROM system.local WHERE key='local'").Scan(&rows); err != nil {
 		t.Fatal(err)
 	} else if rows != 1 {
 		t.Fatalf("expected to get 1 row got %d", rows)

--- a/ring_describer.go
+++ b/ring_describer.go
@@ -158,7 +158,7 @@ func (r *ringDescriber) getHostInfo(hostID UUID) (*HostInfo, error) {
 				iter = ch.conn.querySystem(context.TODO(), qrySystemPeers)
 			}
 		} else {
-			iter = ch.conn.query(context.TODO(), fmt.Sprintf("SELECT * FROM %s", table))
+			iter = ch.conn.query(context.TODO(), fmt.Sprintf("SELECT * FROM %s WHERE key='local'", table))
 		}
 
 		if iter != nil {


### PR DESCRIPTION
Full scan queries are slower even when there is only one record

Fixes: https://github.com/scylladb/gocql/issues/389