### PR TITLE
Disable tablets for tests with LWT

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -497,7 +497,7 @@ func TestPagingWithBind(t *testing.T) {
 func TestCAS(t *testing.T) {
 	cluster := createCluster()
 	cluster.SerialConsistency = LocalSerial
-	session := createSessionFromCluster(cluster, t)
+	session := createSessionFromClusterTabletsDisabled(cluster, t)
 	defer session.Close()
 
 	if session.cfg.ProtoVersion == 1 {
@@ -669,7 +669,7 @@ func TestDurationType(t *testing.T) {
 }
 
 func TestMapScanCAS(t *testing.T) {
-	session := createSession(t)
+	session := createSessionFromClusterTabletsDisabled(createCluster(), t)
 	defer session.Close()
 
 	if session.cfg.ProtoVersion == 1 {
@@ -1240,7 +1240,7 @@ func TestScanWithNilArguments(t *testing.T) {
 }
 
 func TestScanCASWithNilArguments(t *testing.T) {
-	session := createSession(t)
+	session := createSessionFromClusterTabletsDisabled(createCluster(), t)
 	defer session.Close()
 
 	if session.cfg.ProtoVersion == 1 {
@@ -1709,7 +1709,7 @@ func TestPrepare_PreparedCacheKey(t *testing.T) {
 
 	// create a second keyspace
 	cluster2 := createCluster()
-	createKeyspace(t, cluster2, "gocql_test2")
+	createKeyspace(t, cluster2, "gocql_test2", false)
 	cluster2.Keyspace = "gocql_test2"
 	session2, err := cluster2.CreateSession()
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -130,7 +130,7 @@ func TestHostFilterInitial(t *testing.T) {
 func TestWriteFailure(t *testing.T) {
 	t.Skip("skipped due to unknown purpose")
 	cluster := createCluster()
-	createKeyspace(t, cluster, "test")
+	createKeyspace(t, cluster, "test", false)
 	cluster.Keyspace = "test"
 	session, err := cluster.CreateSession()
 	if err != nil {


### PR DESCRIPTION
Tests that are using lwt are failing in gocql-driver-matrix-test due to tablets being enabled by default.
This PR disables tablets for those tests.