### PR TITLE
fix `duration` makes `string` marshal, unmarshal in the full range

### DIFF
--- a/internal/tests/serialization/valcases/simple.go
+++ b/internal/tests/serialization/valcases/simple.go
@@ -833,6 +833,7 @@ var simpleTypesCases = SimpleTypes{
 				Data: []byte("\xf0\xff\xff\xff\xfe\xf0\xff\xff\xff\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xfe"),
 				LangCases: []LangCase{
 					{LangType: "duration", Value: duration.Duration{Days: math.MaxInt32, Months: math.MaxInt32, Nanoseconds: math.MaxInt64}},
+					{LangType: "string", Value: "178956970y7mo306783378w1d2562047h47m16.854775807s"},
 				},
 			},
 			{
@@ -840,6 +841,7 @@ var simpleTypesCases = SimpleTypes{
 				Data: []byte("\xf0\xff\xff\xff\xff\xf0\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
 				LangCases: []LangCase{
 					{LangType: "duration", Value: duration.Duration{Days: math.MinInt32, Months: math.MinInt32, Nanoseconds: math.MinInt64}},
+					{LangType: "string", Value: "-178956970y8mo306783378w2d2562047h47m16.854775808s"},
 				},
 			},
 			{
@@ -847,6 +849,7 @@ var simpleTypesCases = SimpleTypes{
 				Data: []byte("\x02\x02\x02"),
 				LangCases: []LangCase{
 					{LangType: "duration", Value: duration.Duration{Days: 1, Months: 1, Nanoseconds: 1}},
+					{LangType: "string", Value: "1mo1d1ns"},
 				},
 			},
 			{
@@ -854,6 +857,7 @@ var simpleTypesCases = SimpleTypes{
 				Data: []byte("\x01\x01\x01"),
 				LangCases: []LangCase{
 					{LangType: "duration", Value: duration.Duration{Days: -1, Months: -1, Nanoseconds: -1}},
+					{LangType: "string", Value: "-1mo1d1ns"},
 				},
 			},
 			{
@@ -863,7 +867,7 @@ var simpleTypesCases = SimpleTypes{
 					{LangType: "duration", Value: duration.Duration{Days: 106751, Months: 0, Nanoseconds: 85636854775807}},
 					{LangType: "int64", Value: int64(math.MaxInt64)},
 					{LangType: "time.Duration", Value: time.Duration(math.MaxInt64)},
-					{LangType: "string", Value: "2562047h47m16.854775807s"},
+					{LangType: "string", Value: "15250w1d23h47m16.854775807s"},
 				},
 			},
 			{
@@ -873,7 +877,7 @@ var simpleTypesCases = SimpleTypes{
 					{LangType: "duration", Value: duration.Duration{Days: -106751, Months: 0, Nanoseconds: -85636854775808}},
 					{LangType: "int64", Value: int64(math.MinInt64)},
 					{LangType: "time.Duration", Value: time.Duration(math.MinInt64)},
-					{LangType: "string", Value: "-2562047h47m16.854775808s"},
+					{LangType: "string", Value: "-15250w1d23h47m16.854775808s"},
 				},
 			},
 			{

--- a/serialization/duration/duration.go
+++ b/serialization/duration/duration.go
@@ -7,10 +7,14 @@ type Duration struct {
 }
 
 func (d Duration) Valid() bool {
-	if d.Months >= 0 && d.Days >= 0 && d.Nanoseconds >= 0 {
+	return validDuration(d.Months, d.Days, d.Nanoseconds)
+}
+
+func validDuration(m, d int32, n int64) bool {
+	if m >= 0 && d >= 0 && n >= 0 {
 		return true
 	}
-	if d.Months <= 0 && d.Days <= 0 && d.Nanoseconds <= 0 {
+	if m <= 0 && d <= 0 && n <= 0 {
 		return true
 	}
 	return false

--- a/serialization/duration/marshal_str.go
+++ b/serialization/duration/marshal_str.go
@@ -1,0 +1,420 @@
+package duration
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	nanosecond  = 1
+	microsecond = 1000 * nanosecond
+	millisecond = 1000 * microsecond
+	second      = 1000 * millisecond
+	minute      = 60 * second
+	hour        = 60 * minute
+	week        = 7
+	year        = 12
+
+	microsecondFloat = float64(microsecond)
+	millisecondFloat = float64(millisecond)
+	secondFloat      = float64(second)
+	minuteFloat      = float64(minute)
+	hourFloat        = float64(hour)
+	weekFloat        = float64(week)
+	yearFloat        = float64(year)
+
+	maxNanosecondsNeg = uint64(9223372036854775808)
+	maxNanosecondsPos = maxNanosecondsNeg - 1
+	maxMonthsDaysNeg  = uint64(2147483648)
+	maxMonthsDaysPos  = maxMonthsDaysNeg - 1
+
+	maxMicrosecondsNeg = maxNanosecondsNeg / microsecond
+	maxMillisecondsNeg = maxMicrosecondsNeg / 1000
+	maxSecondsNeg      = maxMillisecondsNeg / 1000
+	maxMinutesNeg      = maxSecondsNeg / 60
+	maxHoursNeg        = maxMinutesNeg / 60
+	maxWeeksNeg        = maxNanosecondsNeg / 7
+	maxYearsNeg        = maxNanosecondsNeg / 12
+)
+
+type parseReadState byte
+
+const (
+	readInteger parseReadState = iota
+	readFraction
+	readUnit
+	readSkipFraction
+)
+
+type parseWriteState byte
+
+const (
+	writeNanoseconds parseWriteState = iota
+	writeMilliseconds
+	writeMicroseconds
+	writeSeconds
+	writeMinutes
+	writeHours
+	writeDays
+	writeWeeks
+	writeMonths
+	writeYears
+)
+
+func errorOutRange(valName string, integer uint64) error {
+	return fmt.Errorf("%s %d out of the range", valName, integer)
+}
+
+func errorUnknownChars(chars string) error {
+	return fmt.Errorf("unknown charesters \"%s\"", chars)
+}
+
+func encString(s string) ([]byte, error) {
+	months, days, nanos, neg, err := encStringToUints(s)
+	if err != nil {
+		return nil, err
+	}
+	if neg {
+		return encVintMonthsDaysNanosNeg(months, days, nanos), nil
+	}
+	return encVintMonthsDaysNanosPos(months, days, nanos), nil
+}
+
+func encStringToUints(s string) (months uint64, days uint64, nanos uint64, neg bool, err error) {
+	// Special case: if all that is left is "0", this is zero.
+	if s == zeroDuration {
+		return 0, 0, 0, false, nil
+	}
+	// get are sing
+	if c := s[0]; c == '-' || c == '+' {
+		neg = c == '-'
+		s = s[1:]
+	}
+
+	var writeState parseWriteState
+	readState := readInteger
+	scale := float64(1)
+	var integer, fraction uint64
+	var ok bool
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch readState {
+		case readInteger: // Consume [0-9.]* as integer part of value
+			switch {
+			case c >= '0' && c <= '9':
+				integer = integer*10 + uint64(c) - '0'
+				if integer > maxNanosecondsNeg {
+					return 0, 0, 0, false, errorOutRange("value", integer)
+				}
+			case c == '.':
+				readState = readFraction
+			default:
+				i--
+				readState = readUnit
+			}
+		case readFraction: // Consume [0-9]* as fraction part of value
+			if c >= '0' && c <= '9' {
+				scale *= 10
+				fraction = fraction*10 + uint64(c) - '0'
+				if fraction > maxNanosecondsNeg {
+					readState = readSkipFraction
+					fraction /= 10
+				}
+			} else {
+				i--
+				readState = readUnit
+			}
+		case readUnit: // Consume unit part of the string, adding the integer and fraction parts of the value to the output values.
+			// Supported units:
+			// "ns"	nanosecond,
+			// "us"	microsecond,
+			// "µs"	microsecond U+00B5 = micro symbol,
+			// "μs" microsecond U+03BC = Greek letter mu
+			// "ms"	millisecond,
+			// "s"	second,
+			// "m"	minute,
+			// "h"	hour,
+			// "d"	day,
+			// "w"	week,
+			// "mo"	month,
+			// "y"	year,
+
+			switch c {
+			case 'n': // "ns" nanosecond
+				if i+1 == len(s) || s[i+1] != 's' {
+					return 0, 0, 0, false, errorUnknownChars(s[i:])
+				}
+				i++
+				writeState = writeNanoseconds
+			case 'u': // "us" microsecond
+				if i+1 == len(s) || s[i+1] != 's' {
+					return 0, 0, 0, false, errorUnknownChars(s[i:])
+				}
+				i++
+				writeState = writeMicroseconds
+			case 194: // "µs" microsecond U+00B5 = micro symbol
+				if i+2 >= len(s) || s[i+1] != 181 || s[i+2] != 's' {
+					return 0, 0, 0, false, errorUnknownChars(s[i:])
+				}
+				i++
+				writeState = writeMicroseconds
+			case 206: // "μs" microsecond U+03BC = Greek letter mu
+				if i+2 >= len(s) || s[i+1] != 188 || s[i+2] != 's' {
+					return 0, 0, 0, false, errorUnknownChars(s[i:])
+				}
+				i++
+				writeState = writeMicroseconds
+			case 'm': // "ms" millisecond,"mo" month,"m" minute,
+				if i+1 == len(s) { // "m" minute
+					writeState = writeMinutes
+				} else {
+					switch s[i+1] { // "ms" millisecond,"mo" month,"m" minute,
+					case 's': // "ms" millisecond
+						i++
+						writeState = writeMilliseconds
+					case 'o': // "mo" month
+						i++
+						writeState = writeMonths
+					case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.': // "m" minute
+						writeState = writeMinutes
+					default:
+						return 0, 0, 0, false, errorUnknownChars(s[i:])
+					}
+				}
+			case 's': // "s" second
+				writeState = writeSeconds
+			case 'h': // "h" hour
+				writeState = writeHours
+			case 'd': // "d" day
+				writeState = writeDays
+			case 'w': // "w" week
+				writeState = writeWeeks
+			case 'y': // "y" year
+				writeState = writeYears
+			default: // unsupported characters
+				return 0, 0, 0, false, errorUnknownChars(s[i:])
+			}
+
+			switch writeState {
+			case writeNanoseconds:
+				if nanos, ok = addNanoseconds(nanos, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("nanoseconds", nanos)
+				}
+			case writeMicroseconds:
+				if nanos, ok = addMicroseconds(nanos, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("nanoseconds", nanos)
+				}
+			case writeMilliseconds:
+				if nanos, ok = addMilliseconds(nanos, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("nanoseconds", nanos)
+				}
+			case writeSeconds:
+				if nanos, ok = addSeconds(nanos, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("nanoseconds", nanos)
+				}
+			case writeMinutes:
+				if nanos, ok = addMinutes(nanos, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("nanoseconds", nanos)
+				}
+			case writeHours:
+				if nanos, ok = addHours(nanos, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("nanoseconds", nanos)
+				}
+			case writeDays:
+				if days, ok = addDaysMonths(days, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("days", days)
+				}
+			case writeWeeks:
+				if days, ok = addWeeks(days, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("days", days)
+				}
+			case writeMonths:
+				if months, ok = addDaysMonths(months, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("months", months)
+				}
+			default: // writeYears
+				if months, ok = addYears(months, integer, fraction, scale); !ok {
+					return 0, 0, 0, false, errorOutRange("years", months)
+				}
+			}
+
+			// reset the temporary values, after write
+			readState = readInteger
+			integer, fraction, scale = 0, 0, 1
+		default: // Consume [0-9]* in case with overflow of the fraction part of value. Just skip digits.
+			if c < '0' || c > '9' {
+				i--
+				readState = readUnit
+			}
+		}
+	}
+	if integer != 0 || fraction != 0 || scale != 1 { // if the temporary values are not reset, it means that the reading is not fully completed.
+		return 0, 0, 0, false, errors.New("unsupported format")
+	}
+	if !neg {
+		if months > maxMonthsDaysPos {
+			return 0, 0, 0, false, errorOutRange("months", months)
+		}
+		if days > maxMonthsDaysPos {
+			return 0, 0, 0, false, errorOutRange("days", days)
+		}
+		if nanos > maxNanosecondsPos {
+			return 0, 0, 0, false, errorOutRange("nanoseconds", days)
+		}
+	}
+	return
+}
+
+func addNanoseconds(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (float64(1) / scale))
+		if add > maxNanosecondsNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxNanosecondsNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addMicroseconds(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if add > maxMicrosecondsNeg {
+		return add, false
+	}
+	add *= microsecond
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (microsecondFloat / scale))
+		if add > maxNanosecondsNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxNanosecondsNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addMilliseconds(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if add > maxMillisecondsNeg {
+		return add, false
+	}
+	add *= millisecond
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (millisecondFloat / scale))
+		if add > maxNanosecondsNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxNanosecondsNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addSeconds(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if add > maxSecondsNeg {
+		return add, false
+	}
+	add *= second
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (secondFloat / scale))
+		if add > maxNanosecondsNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxNanosecondsNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addMinutes(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if add > maxMinutesNeg {
+		return add, false
+	}
+	add *= minute
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (minuteFloat / scale))
+		if add > maxNanosecondsNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxNanosecondsNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addHours(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if add > maxHoursNeg {
+		return add, false
+	}
+	add *= hour
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (hourFloat / scale))
+		if add > maxNanosecondsNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxNanosecondsNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addDaysMonths(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (float64(1) / scale))
+		if add > maxMonthsDaysNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxMonthsDaysNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addWeeks(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if add > maxWeeksNeg {
+		return add, false
+	}
+	add *= week
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (weekFloat / scale))
+		if add > maxMonthsDaysNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxMonthsDaysNeg {
+		return in, false
+	}
+	return in, true
+}
+
+func addYears(in, add, fraction uint64, scale float64) (uint64, bool) {
+	if add > maxYearsNeg {
+		return add, false
+	}
+	add *= year
+	if fraction > 0 {
+		add += uint64(float64(fraction) * (yearFloat / scale))
+		if add > maxMonthsDaysNeg {
+			return add, false
+		}
+	}
+	in += add
+	if in > maxMonthsDaysNeg {
+		return in, false
+	}
+	return in, true
+}

--- a/serialization/duration/marshal_str_test.go
+++ b/serialization/duration/marshal_str_test.go
@@ -1,0 +1,52 @@
+package duration
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEncStr(t *testing.T) {
+	for n := int64(math.MaxInt64); n != 1; n = n / 2 {
+		m, d := int32(n), int32(n)
+		if n > math.MaxInt32 {
+			m, d = math.MaxInt32, math.MaxInt32
+		}
+		testEncString(t, m, d, n)
+		testEncString(t, 0, d, n)
+		testEncString(t, m, 0, n)
+		testEncString(t, m, d, 0)
+	}
+
+	for n := int64(math.MinInt64); n != -1; n = n / 2 {
+		m, d := int32(n), int32(n)
+		if n < math.MinInt32 {
+			m, d = math.MinInt32, math.MinInt32
+		}
+		testEncString(t, m, d, n)
+		testEncString(t, 0, d, n)
+		testEncString(t, m, 0, n)
+		testEncString(t, m, d, 0)
+	}
+}
+
+func testEncString(t *testing.T, m, d int32, n int64) {
+	t.Helper()
+	testStr := getTestString(m, d, n)
+	mu, du, nu, neg, err := encStringToUints(testStr)
+	if err != nil {
+		t.Fatalf("failed on encoding testcase value:m:%d,d:%d,n:%d\ntest string:%s\nerror:%s", m, d, n, testStr, err)
+	}
+	me, de, ne := int32(mu), int32(du), int64(nu)
+	if neg {
+		me, de, ne = -me, -de, -ne
+	}
+	if me != m {
+		t.Fatalf("testcase:%s\nexpected and recieved months not equal expected:%d received:%d", testStr, m, me)
+	}
+	if de != d {
+		t.Fatalf("testcase:%s\nexpected and recieved days not equal expected:%d received:%d", testStr, d, de)
+	}
+	if ne != n {
+		t.Fatalf("testcase:%s\nexpected and recieved nonoseconds not equal expected:%d received:%d", testStr, n, ne)
+	}
+}

--- a/serialization/duration/marshal_utils.go
+++ b/serialization/duration/marshal_utils.go
@@ -46,11 +46,11 @@ func EncString(v string) ([]byte, error) {
 	if v == "" {
 		return nil, nil
 	}
-	d, err := time.ParseDuration(v)
+	data, err := encString(v)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal duration: the (string)(%s) have invalid format, %v", v, err)
+		return nil, fmt.Errorf("failed to marshal duration: the parse error of the (string)(%s): %v", v, err)
 	}
-	return encDur(d), nil
+	return data, nil
 }
 
 func EncStringR(v *string) ([]byte, error) {
@@ -64,7 +64,7 @@ func EncDuration(v Duration) ([]byte, error) {
 	if !v.Valid() {
 		return nil, fmt.Errorf("failed to marshal duration: the (Duration) values of months (%d), days (%d) and nanoseconds (%d) should have the same sign", v.Months, v.Days, v.Nanoseconds)
 	}
-	return append(append(encVint32(encIntZigZag32(v.Months)), encVint32(encIntZigZag32(v.Days))...), encVint64(encIntZigZag64(v.Nanoseconds))...), nil
+	return encVintMonthsDaysNanos(v.Months, v.Days, v.Nanoseconds), nil
 }
 
 func EncDurationR(v *Duration) ([]byte, error) {
@@ -74,7 +74,7 @@ func EncDurationR(v *Duration) ([]byte, error) {
 	if !v.Valid() {
 		return nil, fmt.Errorf("failed to marshal duration: the (*Duration) values of the months (%d), days (%d) and nanoseconds (%d) should have same sign", v.Months, v.Days, v.Nanoseconds)
 	}
-	return append(append(encVint32(encIntZigZag32(v.Months)), encVint32(encIntZigZag32(v.Days))...), encVint64(encIntZigZag64(v.Nanoseconds))...), nil
+	return encVintMonthsDaysNanos(v.Months, v.Days, v.Nanoseconds), nil
 }
 
 func EncReflect(v reflect.Value) ([]byte, error) {
@@ -86,11 +86,11 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if val == "" {
 			return nil, nil
 		}
-		d, err := time.ParseDuration(val)
+		data, err := encString(val)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal duration: the (%T)(%[1]v) have invalid format, %v", v, err)
 		}
-		return encDur(d), nil
+		return data, nil
 	case reflect.Struct:
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
@@ -124,6 +124,10 @@ func encInt64(v int64) []byte {
 	return encDaysNanos(encIntZigZag32(int32((v-n)/nanoDayPos)), encIntZigZag64(n))
 }
 
+func encZigZagUint64Pos(v uint64) uint64 {
+	return v << 1
+}
+
 func encIntZigZag32(v int32) uint32 {
 	return uint32((v >> 31) ^ (v << 1))
 }
@@ -137,6 +141,21 @@ func encIntZigZagDur(v time.Duration) uint64 {
 }
 
 func encVint32(v uint32) []byte {
+	switch {
+	case byte(v>>28) != 0:
+		return []byte{vintPrefix4, byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+	case byte(v>>21) != 0:
+		return []byte{vintPrefix3 | byte(v>>24), byte(v >> 16), byte(v >> 8), byte(v)}
+	case byte(v>>14) != 0:
+		return []byte{vintPrefix2 | byte(v>>16), byte(v >> 8), byte(v)}
+	case byte(v>>7) != 0:
+		return []byte{vintPrefix1 | byte(v>>8), byte(v)}
+	default:
+		return []byte{byte(v)}
+	}
+}
+
+func encVint64as32(v uint64) []byte {
 	switch {
 	case byte(v>>28) != 0:
 		return []byte{vintPrefix4, byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
@@ -174,11 +193,56 @@ func encVint64(v uint64) []byte {
 	}
 }
 
+func encVintMonthsDaysNanos(m, d int32, n int64) []byte {
+	if m == 0 {
+		if d == 0 {
+			return encNanos(encIntZigZag64(n))
+		}
+		return append(encDays(encIntZigZag32(d)), encVint64(encIntZigZag64(n))...)
+	}
+	return append(append(encVint32(encIntZigZag32(m)), encVint32(encIntZigZag32(d))...), encVint64(encIntZigZag64(n))...)
+}
+
+func encVintMonthsDaysNanosPos(m, d, n uint64) []byte {
+	if m == 0 {
+		if d == 0 {
+			return encNanos(encZigZagUint64Pos(n))
+		}
+		return append(encDays64(encZigZagUint64Pos(d)), encVint64(encZigZagUint64Pos(n))...)
+	}
+	return append(append(encVint64as32(encZigZagUint64Pos(m)), encVint64as32(encZigZagUint64Pos(d))...), encVint64(encZigZagUint64Pos(n))...)
+}
+
+func encVintMonthsDaysNanosNeg(m, d, n uint64) []byte {
+	if m == 0 {
+		if d == 0 {
+			return encNanos(encIntZigZag64(int64(-n)))
+		}
+		return append(encDays(encIntZigZag32(int32(-d))), encVint64(encIntZigZag64(int64(-n)))...)
+	}
+	return append(append(encVint32(encIntZigZag32(int32(-m))), encVint32(encIntZigZag32(int32(-d)))...), encVint64(encIntZigZag64(int64(-n)))...)
+}
+
 func encDaysNanos(d uint32, n uint64) []byte {
 	return append(encDays(d), encVint64(n)...)
 }
 
 func encDays(v uint32) []byte {
+	switch {
+	case byte(v>>28) != 0:
+		return []byte{0, vintPrefix4, byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+	case byte(v>>21) != 0:
+		return []byte{0, vintPrefix3 | byte(v>>24), byte(v >> 16), byte(v >> 8), byte(v)}
+	case byte(v>>14) != 0:
+		return []byte{0, vintPrefix2 | byte(v>>16), byte(v >> 8), byte(v)}
+	case byte(v>>7) != 0:
+		return []byte{0, vintPrefix1 | byte(v>>8), byte(v)}
+	default:
+		return []byte{0, byte(v)}
+	}
+}
+
+func encDays64(v uint64) []byte {
 	switch {
 	case byte(v>>28) != 0:
 		return []byte{0, vintPrefix4, byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}

--- a/serialization/duration/unmarshal_str.go
+++ b/serialization/duration/unmarshal_str.go
@@ -1,0 +1,169 @@
+package duration
+
+func decString(m, d int32, n int64) string {
+	var neg bool
+	var tmp uint64
+	out := new([50]byte) // max string "-178956970y8mo306783378w2d2562047h47m16.854775808s"
+	pos := 49
+	if m < 0 || d < 0 || n < 0 {
+		neg = true
+	}
+	if n != 0 {
+		tmp = uint64(n)
+		if neg {
+			tmp = -tmp
+		}
+		pos = printNanoseconds(out, tmp, pos)
+	}
+	if d != 0 {
+		tmp = uint64(d)
+		if neg {
+			tmp = -tmp
+		}
+		pos = printDays(out, tmp, pos)
+	}
+	if m != 0 {
+		tmp = uint64(m)
+		if neg {
+			tmp = -tmp
+		}
+		pos = printMonths(out, tmp, pos)
+	}
+	if pos == 49 {
+		return zeroDuration
+	}
+	if neg {
+		out[pos] = '-'
+		pos--
+	}
+	return string(out[pos+1:])
+}
+
+func printMonths(out *[50]byte, m uint64, pos int) int {
+	months := m % 12
+	if months == 0 {
+		m--
+		months = 12
+	}
+	out[pos] = 'o'
+	pos--
+	out[pos] = 'm'
+	pos--
+	pos = printInt(out, months, pos)
+	if m > 12 { // print years
+		out[pos] = 'y'
+		pos--
+		pos = printInt(out, m/12, pos)
+	}
+	return pos
+}
+
+func printDays(out *[50]byte, d uint64, pos int) int {
+	days := d % 7
+	if days == 0 {
+		d--
+		days = 7
+	}
+	out[pos] = 'd' // print days
+	pos--
+	out[pos] = byte(days) + '0'
+	pos--
+	if d > 7 { // print weeks
+		out[pos] = 'w'
+		pos--
+		pos = printInt(out, d/7, pos)
+	}
+	return pos
+}
+
+func printNanoseconds(out *[50]byte, n uint64, pos int) int {
+	if n < second {
+		// Special case: if nanoseconds is smaller than a second,
+		// use smaller units, like 1.2ms
+		dotPos := 0
+		out[pos] = 's'
+		pos--
+		switch {
+		case n < microsecond: // case for nanoseconds
+			out[pos] = 'n'
+			pos--
+		case n < millisecond: // case for microseconds
+			copy(out[pos-1:], "µ") // U+00B5 'µ' micro sign == 0xC2 0xB5
+			pos -= 2
+			if n%microsecond == 0 {
+				n /= microsecond
+			} else {
+				dotPos = 3
+			}
+		default: // case for milliseconds
+			out[pos] = 'm'
+			pos--
+			if n%millisecond == 0 {
+				n /= millisecond
+			} else {
+				dotPos = 6
+			}
+		}
+		if dotPos == 0 {
+			return printInt(out, n, pos)
+		}
+		return printIntFrac(out, n, dotPos, pos)
+	}
+	if s := n % 60000000000; s != 0 { // case for seconds
+		out[pos] = 's'
+		pos--
+		pos = printIntFrac(out, s, 9, pos)
+	}
+	if n >= 60000000000 {
+		n /= 60000000000           // n is now integer minutes
+		if mn := n % 60; mn != 0 { // case for minutes
+			out[pos] = 'm'
+			pos--
+			pos = printInt(out, mn, pos)
+		}
+		if n >= 60 {
+			out[pos] = 'h'
+			pos--
+			pos = printInt(out, n/60, pos) // n is now integer hours
+		}
+	}
+	return pos
+}
+
+func printIntFrac(out *[50]byte, n uint64, dotPos, pos int) int {
+	start := false
+	for i := 0; n > 0; i++ {
+		digit := n % 10
+		if start && i == dotPos {
+			out[pos] = '.'
+			pos--
+		}
+		start = start || digit != 0 || i == dotPos
+		if start {
+			out[pos] = byte(digit) + '0'
+			pos--
+		}
+		n /= 10
+	}
+	return pos
+}
+
+func printInt(out *[50]byte, n uint64, pos int) int {
+	switch {
+	case n >= 100:
+		for n > 0 {
+			out[pos] = byte(n%10) + '0'
+			n /= 10
+			pos--
+		}
+	case n >= 10:
+		out[pos] = byte(n%10) + '0'
+		pos--
+		out[pos] = byte(n/10) + '0'
+		pos--
+	default:
+		out[pos] = byte(n) + '0'
+		pos--
+	}
+	return pos
+}

--- a/serialization/duration/unmarshal_str_test.go
+++ b/serialization/duration/unmarshal_str_test.go
@@ -1,0 +1,106 @@
+package duration
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestDecStr(t *testing.T) {
+	for n := int64(math.MaxInt64); n != 1; n = n / 2 {
+		m, d := int32(n), int32(n)
+		if n > math.MaxInt32 {
+			m, d = math.MaxInt32, math.MaxInt32
+		}
+		testDecString(t, m, d, n)
+		testDecString(t, 0, d, n)
+		testDecString(t, m, 0, n)
+		testDecString(t, m, d, 0)
+	}
+
+	for n := int64(math.MinInt64); n != -1; n = n / 2 {
+		m, d := int32(n), int32(n)
+		if n < math.MinInt32 {
+			m, d = math.MinInt32, math.MinInt32
+		}
+		testDecString(t, m, d, n)
+		testDecString(t, 0, d, n)
+		testDecString(t, m, 0, n)
+		testDecString(t, m, d, 0)
+	}
+}
+
+func testDecString(t *testing.T, m, d int32, n int64) {
+	t.Helper()
+	expected := getTestString(m, d, n)
+	received := decString(m, d, n)
+
+	if expected != received {
+		t.Fatalf("expected and recieved strings not equal\nvalue:m:%d,d:%d,n:%d\nexpected:%s\nreceived:%s", m, d, n, expected, received)
+	}
+}
+
+func getTestString(m, d int32, n int64) string {
+	out := ""
+	if m < 0 || d < 0 || n < 0 {
+		out += "-"
+	}
+	if m != 0 {
+		out += getStringMonths(m)
+	}
+	if d != 0 {
+		out += getStringDays(d)
+	}
+	if n != 0 {
+		out += getStringNanos(n)
+	}
+	if out == "" {
+		return zeroDuration
+	}
+	return out
+}
+
+func getStringMonths(m int32) string {
+	out := ""
+	mu := uint64(m)
+	if m < 0 {
+		mu = -mu
+	}
+	y := mu / 12
+	if mu = mu % 12; mu == 0 {
+		y--
+		mu = 12
+	}
+	if y != 0 {
+		out += strconv.FormatUint(y, 10) + "y"
+	}
+	out += strconv.FormatUint(mu, 10) + "mo"
+	return out
+}
+
+func getStringDays(d int32) string {
+	out := ""
+	du := uint64(d)
+	if d < 0 {
+		du = -du
+	}
+	w := du / 7
+	if du = du % 7; du == 0 {
+		w--
+		du = 7
+	}
+	if w != 0 {
+		out += strconv.FormatUint(w, 10) + "w"
+	}
+	out += strconv.FormatUint(du, 10) + "d"
+	return out
+}
+
+func getStringNanos(d int64) string {
+	out := time.Duration(d).String()
+	if d < 0 {
+		out = out[1:]
+	}
+	return out
+}

--- a/serialization/duration/unmarshal_utils.go
+++ b/serialization/duration/unmarshal_utils.go
@@ -113,28 +113,14 @@ func DecString(p []byte, v *string) error {
 	case l < 3:
 		return errWrongDataLen
 	default:
-		if p[0] != 0 {
-			return fmt.Errorf("failed to unmarshal duration: to unmarshal into (string) the months value should be 0")
+		m, d, n, ok := decDuration(p)
+		if !ok {
+			return errBrokenData
 		}
-		if p[1] == 0 {
-			n, ok := decNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			*v = n.String()
-		} else {
-			d, n, ok := decDaysNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			if !validDateNanosDur(d, n) {
-				return errInvalidSign
-			}
-			if n, ok = daysToNanosDur(d, n); !ok {
-				return fmt.Errorf("failed to unmarshal duration: to unmarshal into (string) the data value should be in int64 range")
-			}
-			*v = n.String()
+		if !validDuration(m, d, n) {
+			return errInvalidSign
 		}
+		*v = decString(m, d, n)
 	}
 	return nil
 }
@@ -154,29 +140,15 @@ func DecStringR(p []byte, v **string) error {
 	case l < 3:
 		return errWrongDataLen
 	default:
-		if p[0] != 0 {
-			return fmt.Errorf("failed to unmarshal duration: to unmarshal into (*string) the months value should be 0")
-		}
 		var val string
-		if p[1] == 0 {
-			n, ok := decNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			val = n.String()
-		} else {
-			d, n, ok := decDaysNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			if !validDateNanosDur(d, n) {
-				return errInvalidSign
-			}
-			if n, ok = daysToNanosDur(d, n); !ok {
-				return fmt.Errorf("failed to unmarshal duration: to unmarshal into (*string) the data value should be in int64 range")
-			}
-			val = n.String()
+		m, d, n, ok := decDuration(p)
+		if !ok {
+			return errBrokenData
 		}
+		if !validDuration(m, d, n) {
+			return errInvalidSign
+		}
+		val = decString(m, d, n)
 		*v = &val
 	}
 	return nil
@@ -366,30 +338,14 @@ func decReflectString(p []byte, v reflect.Value) error {
 	case l < 3:
 		return errWrongDataLen
 	default:
-		if p[0] != 0 {
-			return fmt.Errorf("failed to unmarshal duration: to unmarshal into (%T) the months value should be 0", v.Interface())
+		m, d, n, ok := decDuration(p)
+		if !ok {
+			return errBrokenData
 		}
-		var val string
-		if p[1] == 0 {
-			n, ok := decNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			val = n.String()
-		} else {
-			d, n, ok := decDaysNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			if !validDateNanosDur(d, n) {
-				return errInvalidSign
-			}
-			if n, ok = daysToNanosDur(d, n); !ok {
-				return fmt.Errorf("failed to unmarshal duration: to unmarshal into (%T) the data value should be in int64 range", v.Interface())
-			}
-			val = n.String()
+		if !validDuration(m, d, n) {
+			return errInvalidSign
 		}
-		v.SetString(val)
+		v.SetString(decString(m, d, n))
 	}
 	return nil
 }
@@ -464,29 +420,15 @@ func decReflectStringR(p []byte, v reflect.Value) error {
 	case l < 3:
 		return errWrongDataLen
 	default:
-		if p[0] != 0 {
-			return fmt.Errorf("failed to unmarshal duration: to unmarshal into (%T) the months value should be 0", v.Interface())
+		m, d, n, ok := decDuration(p)
+		if !ok {
+			return errBrokenData
+		}
+		if !validDuration(m, d, n) {
+			return errInvalidSign
 		}
 		val := reflect.New(v.Type().Elem().Elem())
-		if p[1] == 0 {
-			n, ok := decNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			val.Elem().SetString(n.String())
-		} else {
-			d, n, ok := decDaysNanosDur(p)
-			if !ok {
-				return errBrokenData
-			}
-			if !validDateNanosDur(d, n) {
-				return errInvalidSign
-			}
-			if n, ok = daysToNanosDur(d, n); !ok {
-				return fmt.Errorf("failed to unmarshal duration: to unmarshal into (%T) the data value should be in int64 range", v.Interface())
-			}
-			val.Elem().SetString(n.String())
-		}
+		val.Elem().SetString(decString(m, d, n))
 		v.Elem().Set(val)
 	}
 	return nil
@@ -534,6 +476,17 @@ func validDateNanosDur(d time.Duration, n time.Duration) bool {
 	return false
 }
 
+func decDuration(p []byte) (m int32, d int32, n int64, ok bool) {
+	if p[0] != 0 {
+		m, d, n, ok = decVints(p)
+	} else if p[1] != 0 {
+		d, n, ok = decDaysNanos(p)
+	} else {
+		n, ok = decNanos64(p)
+	}
+	return
+}
+
 func decVints(p []byte) (int32, int32, int64, bool) {
 	m, read := decVint32(p, 0)
 	if read == 0 {
@@ -548,6 +501,18 @@ func decVints(p []byte) (int32, int32, int64, bool) {
 		return 0, 0, 0, false
 	}
 	return decZigZag32(m), decZigZag32(d), decZigZag64(n), true
+}
+
+func decDaysNanos(p []byte) (int32, int64, bool) {
+	d, read := decVint32(p, 1)
+	if read == 0 {
+		return 0, 0, false
+	}
+	n, read := decVint64(p, read)
+	if read == 0 {
+		return 0, 0, false
+	}
+	return decZigZag32(d), decZigZag64(n), true
 }
 
 func decDaysNanos64(p []byte) (int64, int64, bool) {

--- a/tests/serialization/marshal_18_duration_corrupt_test.go
+++ b/tests/serialization/marshal_18_duration_corrupt_test.go
@@ -22,9 +22,41 @@ func TestMarshalDurationCorrupt(t *testing.T) {
 
 	serialization.NegativeMarshalSet{
 		Values: mod.Values{
-			"23123113", "sda",
+			"23123113f", "sda",
+			gocql.Duration{Months: -1, Days: 1, Nanoseconds: 0},
+			gocql.Duration{Months: -1, Days: 1, Nanoseconds: 1},
+			gocql.Duration{Months: -1, Days: 1, Nanoseconds: -1},
+			gocql.Duration{Months: -1, Days: -1, Nanoseconds: 1},
+			gocql.Duration{Months: -1, Days: 0, Nanoseconds: 1},
+			gocql.Duration{Months: 1, Days: -1, Nanoseconds: 0},
+			gocql.Duration{Months: 1, Days: -1, Nanoseconds: 1},
+			gocql.Duration{Months: 1, Days: -1, Nanoseconds: -1},
+			gocql.Duration{Months: 1, Days: 1, Nanoseconds: -1},
+			gocql.Duration{Months: 1, Days: 0, Nanoseconds: -1},
 		}.AddVariants(mod.All...),
 	}.Run("corrupt_vals", t, marshal)
+
+	serialization.NegativeMarshalSet{
+		Values: mod.Values{
+			"178956971y7mo306783378w1d2562047h47m16.854775807s",
+			"178956970y8mo306783378w1d2562047h47m16.854775807s",
+			"178956970y7mo306783379w1d2562047h47m16.854775807s",
+			"178956970y7mo306783378w2d2562047h47m16.854775807s",
+			"178956970y7mo306783378w1d2562048h47m16.854775807s",
+			"178956970y7mo306783378w1d2562047h48m16.854775807s",
+			"178956970y7mo306783378w1d2562047h47m17.854775807s",
+			"178956970y7mo306783378w1d2562047h47m16.854775808s",
+
+			"-178956971y8mo306783378w2d2562047h47m16.854775808s",
+			"-178956970y9mo306783378w2d2562047h47m16.854775808s",
+			"-178956970y8mo306783379w2d2562047h47m16.854775808s",
+			"-178956970y8mo306783378w3d2562047h47m16.854775808s",
+			"-178956970y8mo306783378w2d2562048h47m16.854775808s",
+			"-178956970y8mo306783378w2d2562047h48m16.854775808s",
+			"-178956970y8mo306783378w2d2562047h47m17.854775808s",
+			"-178956970y8mo306783378w2d2562047h47m16.854775809s",
+		}.AddVariants(mod.All...),
+	}.Run("big_vals", t, marshal)
 
 	serialization.NegativeUnmarshalSet{
 		Data: []byte("\xf1\x00\x00\x00\x00\x00\x00"),
@@ -57,28 +89,28 @@ func TestMarshalDurationCorrupt(t *testing.T) {
 	serialization.NegativeUnmarshalSet{
 		Data: []byte("\x00\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
 		Values: mod.Values{
-			int64(0), time.Duration(0), "",
+			int64(0), time.Duration(0),
 		}.AddVariants(mod.All...),
 	}.Run("big_data_nano1", t, unmarshal)
 
 	serialization.NegativeUnmarshalSet{
 		Data: []byte("\x01\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
 		Values: mod.Values{
-			int64(0), time.Duration(0), "",
+			int64(0), time.Duration(0),
 		}.AddVariants(mod.All...),
 	}.Run("big_data_nano2", t, unmarshal)
 
 	serialization.NegativeUnmarshalSet{
 		Data: []byte("\x01\x00\x41\xfd\xfc\x9b\xc5\xc4\x9e\x00\x00"),
 		Values: mod.Values{
-			int64(0), time.Duration(0), "",
+			int64(0), time.Duration(0), "", gocql.Duration{},
 		}.AddVariants(mod.All...),
 	}.Run("big_data_nano3", t, unmarshal)
 
 	serialization.NegativeUnmarshalSet{
 		Data: []byte("\x00\xc3\x41\xfd\xfc\x9b\xc5\xc4\x9e\x00\x01"),
 		Values: mod.Values{
-			int64(0), time.Duration(0), "",
+			int64(0), time.Duration(0),
 		}.AddVariants(mod.All...),
 	}.Run("big_data_nano4", t, unmarshal)
 

--- a/tests/serialization/marshal_18_duration_test.go
+++ b/tests/serialization/marshal_18_duration_test.go
@@ -55,6 +55,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x02\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 1, Days: 0, Nanoseconds: 0},
+			"1mo",
 		}.AddVariants(mod.All...),
 	}.Run("months1", t, marshal, unmarshal)
 
@@ -62,6 +63,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x01\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: -1, Days: 0, Nanoseconds: 0},
+			"-1mo",
 		}.AddVariants(mod.All...),
 	}.Run("months-1", t, marshal, unmarshal)
 
@@ -69,6 +71,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x80\xfe\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MaxInt8, Days: 0, Nanoseconds: 0},
+			"10y7mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMaxInt8", t, marshal, unmarshal)
 
@@ -76,6 +79,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x80\xff\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MinInt8, Days: 0, Nanoseconds: 0},
+			"-10y8mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMinInt8", t, marshal, unmarshal)
 
@@ -83,6 +87,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x81\xfe\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MaxUint8, Days: 0, Nanoseconds: 0},
+			"21y3mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMaxUint8", t, marshal, unmarshal)
 
@@ -90,6 +95,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x81\xfd\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: -math.MaxUint8, Days: 0, Nanoseconds: 0},
+			"-21y3mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMinUint8", t, marshal, unmarshal)
 
@@ -97,6 +103,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xc0\xff\xfe\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MaxInt16, Days: 0, Nanoseconds: 0},
+			"2730y7mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMaxInt16", t, marshal, unmarshal)
 
@@ -104,6 +111,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xc0\xff\xff\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MinInt16, Days: 0, Nanoseconds: 0},
+			"-2730y8mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMinInt16", t, marshal, unmarshal)
 
@@ -111,6 +119,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xc1\xff\xfe\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MaxUint16, Days: 0, Nanoseconds: 0},
+			"5461y3mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMaxUint16", t, marshal, unmarshal)
 
@@ -118,6 +127,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xc1\xff\xfd\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: -math.MaxUint16, Days: 0, Nanoseconds: 0},
+			"-5461y3mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMinUint16", t, marshal, unmarshal)
 
@@ -125,6 +135,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xf0\xff\xff\xff\xfe\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MaxInt32, Days: 0, Nanoseconds: 0},
+			"178956970y7mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMaxInt32", t, marshal, unmarshal)
 
@@ -132,6 +143,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xf0\xff\xff\xff\xff\x00\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: math.MinInt32, Days: 0, Nanoseconds: 0},
+			"-178956970y8mo",
 		}.AddVariants(mod.All...),
 	}.Run("monthsMinInt32", t, marshal, unmarshal)
 
@@ -140,6 +152,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x02\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: 1, Nanoseconds: 0},
+			"1d",
 		}.AddVariants(mod.All...),
 	}.Run("days1", t, marshal, unmarshal)
 
@@ -147,6 +160,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x01\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: -1, Nanoseconds: 0},
+			"-1d",
 		}.AddVariants(mod.All...),
 	}.Run("days-1", t, marshal, unmarshal)
 
@@ -154,6 +168,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x80\xfe\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MaxInt8, Nanoseconds: 0},
+			"18w1d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMaxInt8", t, marshal, unmarshal)
 
@@ -161,6 +176,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x80\xff\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MinInt8, Nanoseconds: 0},
+			"-18w2d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMinInt8", t, marshal, unmarshal)
 
@@ -168,6 +184,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x81\xfe\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MaxUint8, Nanoseconds: 0},
+			"36w3d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMaxUint8", t, marshal, unmarshal)
 
@@ -175,6 +192,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x81\xfd\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: -math.MaxUint8, Nanoseconds: 0},
+			"-36w3d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMinUint8", t, marshal, unmarshal)
 
@@ -182,6 +200,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xc0\xff\xfe\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MaxInt16, Nanoseconds: 0},
+			"4680w7d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMaxInt16", t, marshal, unmarshal)
 
@@ -189,6 +208,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xc0\xff\xff\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MinInt16, Nanoseconds: 0},
+			"-4681w1d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMinInt16", t, marshal, unmarshal)
 
@@ -196,6 +216,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xc1\xff\xfe\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MaxUint16, Nanoseconds: 0},
+			"9362w1d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMaxUint16", t, marshal, unmarshal)
 
@@ -203,6 +224,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xc1\xff\xfd\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: -math.MaxUint16, Nanoseconds: 0},
+			"-9362w1d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMinUint16", t, marshal, unmarshal)
 
@@ -210,6 +232,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xf0\xff\xff\xff\xfe\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MaxInt32, Nanoseconds: 0},
+			"306783378w1d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMaxInt32", t, marshal, unmarshal)
 
@@ -217,6 +240,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xf0\xff\xff\xff\xff\x00"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: math.MinInt32, Nanoseconds: 0},
+			"-306783378w2d",
 		}.AddVariants(mod.All...),
 	}.Run("daysMinInt32", t, marshal, unmarshal)
 
@@ -272,7 +296,7 @@ func TestMarshalsDuration(t *testing.T) {
 	serialization.PositiveSet{
 		Data: []byte("\x00\x00\xc0\xff\xfe"),
 		Values: mod.Values{
-			int64(math.MaxInt16), time.Duration(math.MaxInt16), time.Duration(math.MaxInt16).String(),
+			int64(math.MaxInt16), time.Duration(math.MaxInt16), "32.767µs",
 			gocql.Duration{Months: 0, Days: 0, Nanoseconds: math.MaxInt16},
 		}.AddVariants(mod.All...),
 	}.Run("nanosMaxInt16", t, marshal, unmarshal)
@@ -321,13 +345,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: 0, Nanoseconds: math.MaxInt64},
-		}.AddVariants(mod.All...),
-	}.Run("nanosMaxInt64", t, marshal, unmarshal)
-
-	serialization.PositiveSet{
-		Data: []byte("\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe"),
-		Values: mod.Values{
-			gocql.Duration{Months: 0, Days: 0, Nanoseconds: math.MaxInt64},
+			"2562047h47m16.854775807s",
 		}.AddVariants(mod.All...),
 	}.Run("nanosMaxInt64", t, marshal, unmarshal)
 
@@ -335,6 +353,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
 		Values: mod.Values{
 			gocql.Duration{Months: 0, Days: 0, Nanoseconds: math.MinInt64},
+			"-2562047h47m16.854775808s",
 		}.AddVariants(mod.All...),
 	}.Run("nanosMinInt64", t, marshal, unmarshal)
 
@@ -342,7 +361,8 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xc3\x41\xfe\xfc\x9b\xc5\xc4\x9d\xff\xfe"),
 		Values: mod.Values{
 			gocql.Duration{Days: 106751, Months: 0, Nanoseconds: 85636854775807},
-			int64(math.MaxInt64), time.Duration(math.MaxInt64), time.Duration(math.MaxInt64).String(),
+			int64(math.MaxInt64), time.Duration(math.MaxInt64),
+			"15250w1d23h47m16.854775807s",
 		}.AddVariants(mod.All...),
 	}.Run("nanosMax", t, marshal, unmarshal)
 
@@ -350,7 +370,8 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x00\xc3\x41\xfd\xfc\x9b\xc5\xc4\x9d\xff\xff"),
 		Values: mod.Values{
 			gocql.Duration{Days: -106751, Months: 0, Nanoseconds: -85636854775808},
-			int64(math.MinInt64), time.Duration(math.MinInt64), time.Duration(math.MinInt64).String(),
+			int64(math.MinInt64), time.Duration(math.MinInt64),
+			"-15250w1d23h47m16.854775808s",
 		}.AddVariants(mod.All...),
 	}.Run("nanosMin", t, marshal, unmarshal)
 
@@ -359,6 +380,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x02\x02\x02"),
 		Values: mod.Values{
 			gocql.Duration{Days: 1, Months: 1, Nanoseconds: 1},
+			"1mo1d1ns",
 		}.AddVariants(mod.All...),
 	}.Run("111", t, marshal, unmarshal)
 
@@ -366,6 +388,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\x01\x01\x01"),
 		Values: mod.Values{
 			gocql.Duration{Days: -1, Months: -1, Nanoseconds: -1},
+			"-1mo1d1ns",
 		}.AddVariants(mod.All...),
 	}.Run("-111", t, marshal, unmarshal)
 
@@ -373,6 +396,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xf0\xff\xff\xff\xfe\xf0\xff\xff\xff\xfe\xff\xff\xff\xff\xff\xff\xff\xff\xfe"),
 		Values: mod.Values{
 			gocql.Duration{Days: math.MaxInt32, Months: math.MaxInt32, Nanoseconds: math.MaxInt64},
+			"178956970y7mo306783378w1d2562047h47m16.854775807s",
 		}.AddVariants(mod.All...),
 	}.Run("max", t, marshal, unmarshal)
 
@@ -380,6 +404,7 @@ func TestMarshalsDuration(t *testing.T) {
 		Data: []byte("\xf0\xff\xff\xff\xff\xf0\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"),
 		Values: mod.Values{
 			gocql.Duration{Days: math.MinInt32, Months: math.MinInt32, Nanoseconds: math.MinInt64},
+			"-178956970y8mo306783378w2d2562047h47m16.854775808s",
 		}.AddVariants(mod.All...),
 	}.Run("min", t, marshal, unmarshal)
 }


### PR DESCRIPTION
Marshalling and unmarshalling  `string` and `custom string` `go types` was done using the "time" package before, months and days was unsupported.
Now marshalling and unmarshalling  `string` and `custom string` with months and days is supported.