### PR TITLE
Merge upstream changes up to commit '280f0aa2'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,17 +21,35 @@ The following is a check list of requirements that need to be satisfied in order
 * The merge commit passes the regression test suite on GitHub Actions
 * `go fmt` has been applied to the submitted code
 * A correctly formatted commit message, see below
+* Notable changes (i.e. new features or changed behavior, bugfixes) are appropriately documented in CHANGELOG.md, functional changes also in godoc
 
 If there are any requirements that can't be reasonably satisfied, please state this either on the pull request or as part of discussion on the mailing list. Where appropriate, the core team may apply discretion and make an exception to these requirements.
 
 ## Commit Message
 
-This project has a commit message precendence like
-```
-<One sentence description>
+The commit message format should be:
 
-<More details>
 ```
+<short description>
+
+<reason why the change is needed>
+
+Patch by <authors>; reviewed by <Reviewers> for #####
+```
+
+Short description should:
+* Be a short sentence.
+* Start with a capital letter.
+* Be written in the present tense.
+* Summarize what is changed, not why it is changed.
+
+Short description should not:
+* End with a period.
+* Use the word Fixes . Most commits fix something.
+
+Long description / Reason:
+* Should describe why the change is needed. What is fixed by the change? Why it it was broken before? What use case does the new feature solve?
+* Consider adding details of other options that you considered when implementing the change and why you made the design decisions you made.
 
 ## Beyond The Checklist
 

--- a/NOTICE
+++ b/NOTICE
@@ -163,7 +163,7 @@ Piotr Dulikowski <piodul@scylladb.com>
 Árni Dagur <arni@dagur.eu> *
 Tushar Das <tushar.das5@gmail.com> *
 Maxim Vladimirskiy <horkhe@gmail.com> *
-Bogdan-Ciprian Rusu <bogdanciprian.rusu@crowdstrike.com>
+Bogdan-Ciprian Rusu <bogdanciprian.rusu@crowdstrike.com> *
 Yuto Doi <yutodoi.seattle@gmail.com> *
 Krishna Vadali <tejavadali@gmail.com>
 Jens-W. Schicke-Uffmann <drahflow@gmx.de> *

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -43,6 +43,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/inf.v0"
 )
 
@@ -1199,6 +1200,59 @@ func matchSliceMap(t *testing.T, sliceMap []map[string]interface{}, testMap map[
 	}
 	if sliceMap[0]["testint"] != testMap["testint"] {
 		t.Fatal("returned testint did not match")
+	}
+}
+
+type MyRetryPolicy struct {
+}
+
+func (*MyRetryPolicy) Attempt(q RetryableQuery) bool {
+	if q.Attempts() > 5 {
+		return false
+	}
+	return true
+}
+
+func (*MyRetryPolicy) GetRetryType(err error) RetryType {
+	var executedErr *QueryError
+	if errors.As(err, &executedErr) && !executedErr.IsIdempotent() {
+		return Ignore
+	}
+	return Retry
+}
+
+func Test_RetryPolicyIdempotence(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+
+	testCases := []struct {
+		name                  string
+		idempotency           bool
+		expectedNumberOfTries int
+	}{
+		{
+			name:                  "with retry",
+			idempotency:           true,
+			expectedNumberOfTries: 6,
+		},
+		{
+			name:                  "without retry",
+			idempotency:           false,
+			expectedNumberOfTries: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := session.Query("INSERT INTO  gocql_test.not_existing_table(event_id, time, args) VALUES (?,?,?)", 4, UUIDFromTime(time.Now()), "test")
+
+			q.Idempotent(tc.idempotency)
+			q.RetryPolicy(&MyRetryPolicy{})
+			q.Consistency(All)
+
+			_ = q.Exec()
+			require.Equal(t, tc.expectedNumberOfTries, q.Attempts())
+		})
 	}
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -106,7 +106,7 @@ func createTable(s *Session, table string) error {
 		return err
 	}
 
-	if err := s.Query(table).RetryPolicy(&SimpleRetryPolicy{}).Exec(); err != nil {
+	if err := s.Query(table).RetryPolicy(&SimpleRetryPolicy{NumRetries: 3}).Idempotent(true).Exec(); err != nil {
 		log.Printf("error creating table table=%q err=%v\n", table, err)
 		return err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -438,7 +438,7 @@ func TestQueryMultinodeWithMetrics(t *testing.T) {
 	// 1 retry per host
 	rt := &SimpleRetryPolicy{NumRetries: 3}
 	observer := &testQueryObserver{metrics: make(map[string]*hostMetrics), verbose: false, logger: log}
-	qry := db.Query("kill").RetryPolicy(rt).Observer(observer)
+	qry := db.Query("kill").RetryPolicy(rt).Observer(observer).Idempotent(true)
 	if err := qry.Exec(); err == nil {
 		t.Fatalf("expected error")
 	}

--- a/policies.go
+++ b/policies.go
@@ -128,7 +128,7 @@ type RetryType uint16
 const (
 	Retry         RetryType = 0x00 // retry on same connection
 	RetryNextHost RetryType = 0x01 // retry on another connection
-	Ignore        RetryType = 0x02 // ignore error and return result
+	Ignore        RetryType = 0x02 // same as Rethrow
 	Rethrow       RetryType = 0x03 // raise error and stop retrying
 )
 


### PR DESCRIPTION
Original commit list:
**1. Commit: https://github.com/apache/cassandra-gocql-driver/commit/253be521e1142cf4f0ef8fe30310c4e7675715f2**
Message: 
```
Add Bogdan-Ciprian Rusu as agreed to donate contributions to ASF

ref: https://github.com/apache/cassandra-gocql-driver/issues/1751#issuecomment-2370352287

patch by Mick Semb Wever; reviewed by João Reis for CASSANDRA-19723
```
Status: `APPLIED`
**2. Commit: https://github.com/apache/cassandra-gocql-driver/commit/47886e5b59559ed1fde9c48363fbe4be352fe76b** 
Message: 
```
Update CONTRIBUTING.md

The section for the commit message format is too generic,
so this commit adds more details and a clear example of
how a commit message should be structured.

This commit also makes it clear in CONTRIBUTING.md that
JIRA should be used instead of GH issues and encourages
contributors to seek feedback and discussion on the proposed
changes early.

patch by João Reis; reviewed by Mick Semb Wever and Martin Sucha for CASSGO-10
```
Status: `SKIPPED`
**3. Commit: https://github.com/apache/cassandra-gocql-driver/commit/42755a5b6531463bedb8f861579af5bc1f93c96d** Message: 
```
Autolink CASSGO JIRA issues

Autolink JIRA issues is enabled for the CASSANDRA project but not the new CASSGO project.

This patch enables autolink for CASSGO issues while keeping the autolink for CASSANDRA issues since there's existing commits that reference them (and for potential future tickets that overlap between both projects).

Patch by João Reis; Reviewed by Mick Semb Wever for CASSGO-31
```
Status: `SKIPPED`
**4. Commit: https://github.com/apache/cassandra-gocql-driver/commit/445d97428fb6eb28de06a06e24743caf4c479270** Message: 
```
Don't restrict server authenticator in PasswordAuthenticator

Currently gocql will only allow authenticating with authenticators
defined in defaultApprovedAuthenticators in conn.go.

There have been multiple occurrences of implementers needing to update
this list, either when a vendor would like to add their authenticator,
or a new authenticator being added.

It would probably reduce friction to just accept any authenticator
provided by the server. From what I know, other drivers behave in this
way.

If a user wanted to restrict this, they could use the existing
configuration PasswordAuthenticator.AllowedAuthenticators.

patch by Andy Tolbert; reviewed by Joao Reis, Lukasz Antoniak for CASSGO-19
```
Status: `SKIPPED`
**5. Commit: https://github.com/apache/cassandra-gocql-driver/commit/7b7e6affbfddf36e9cbc1068e96ecb9c7cc0af18** 
Message: 
```
Add [CASSGO-19](https://issues.apache.org/jira/browse/CASSGO-19) to CHANGELOG.md
patch by João Reis; reviewed by Andy Tolbert for CASSGO-19
```
Status: `SKIPPED`
**6. Commit: https://github.com/apache/cassandra-gocql-driver/commit/adda8ea30ec455bdc82277627ac33e8c45fff88b** 
Message: 
```
Remove global NewBatch function
Batch should behave like Query, and need to be created from a session.

patch by Oleksandr Luzhniy; reviewed by João Reis, Danylo Savchenko, Jackson Fleming, for CASSGO-15
```
Status: `SKIPPED`
**7. Commit: https://github.com/apache/cassandra-gocql-driver/commit/109a89255a7c931e16d64d4c6df2fe3c2a5408ae** 
Message: 
```
Change RetryPolicy so it checks query idempotence
RetryPolicy doesn't check the query's idempotency,
but according to the specification queries with false idempotence shouldn't be retried.

patch by Mykyta Oleksiienko; reviewed by João Reis and Jackson Fleming for CASSGO-27
```
Status: `APPLIED` tests changes only
**8. Commit: https://github.com/apache/cassandra-gocql-driver/commit/c34640dc8ca1047334da1d7b5689725c2be21061** Message: 
```
Don't return error to caller with RetryType Ignore
RetryType Ignore is documented and should work according to the documentation. Error is not returned to caller on ignore but can be seen in ObservedQuery. RetryType should be checked even if RetryPolicy.Attempt returns false, otherwise Ignore will not work on last attempt.

Patch by Rikkuru; reviewed by João Reis, Jackson Fleming for CASSGO-28
```
Status: `APPLIED`
**9. Commit: https://github.com/apache/cassandra-gocql-driver/commit/280f0aa2e7477c193b4c5d0e9f3961e4f86ecb56**
Message: 
```
Detailed description for NumConns.
NumConns doesn`t have a proper description,
so it could cause misunderstanding and confusion about this option.

patch by Mykyta Oleksiienko; reviewed by Joao Reis and Jackson Fleming for CASSGO-3
```
Status: `APPLIED`