### PR TITLE
Optimise schema agreement queries

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1827,21 +1827,15 @@ const qrySystemPeersV2 = "SELECT * FROM system.peers_2"
 
 const qrySystemLocal = "SELECT * FROM system.local WHERE key='local'"
 
-func getSchemaAgreement(queryLocalSchemasRows []string, querySystemPeersRows []map[string]interface{}, connectAddress net.IP, port int, translateAddressPort func(addr net.IP, port int) (net.IP, int), logger StdLogger) (err error) {
+func getSchemaAgreement(queryLocalSchemasRows []string, querySystemPeersRows []schemaAgreementHost, connectAddress net.IP, port int, translateAddressPort func(addr net.IP, port int) (net.IP, int), logger StdLogger) (err error) {
 	versions := make(map[string]struct{})
 
 	for _, row := range querySystemPeersRows {
-		var host *HostInfo
-		host, err = hostInfoFromMap(row, &HostInfo{connectAddress: connectAddress, port: port}, translateAddressPort)
-		if err != nil {
-			return err
-		}
-		if !isValidPeer(host) || host.schemaVersion == "" {
-			logger.Printf("invalid peer or peer with empty schema_version: peer=%q", host)
+		if !row.IsValid() {
+			logger.Printf("invalid peer or peer with empty schema_version: peer=%q", row)
 			continue
 		}
-
-		versions[host.schemaVersion] = struct{}{}
+		versions[row.SchemaVersion.String()] = struct{}{}
 	}
 
 	for _, schemaVersion := range queryLocalSchemasRows {
@@ -1861,11 +1855,19 @@ func getSchemaAgreement(queryLocalSchemasRows []string, querySystemPeersRows []m
 	return nil
 }
 
+type schemaAgreementHost struct {
+	DataCenter    string
+	Rack          string
+	HostID        UUID
+	SchemaVersion UUID
+	RPCAddress    string
+}
+
+func (h *schemaAgreementHost) IsValid() bool {
+	return h.DataCenter != "" && h.Rack != "" && h.HostID.String() != "" && h.SchemaVersion.String() != ""
+}
+
 func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
-	var localSchemas = "SELECT schema_version FROM system.local WHERE key='local'"
-
-	var schemaVersion string
-
 	endDeadline := time.Now().Add(c.session.cfg.MaxWaitSchemaAgreement)
 
 	var err error
@@ -1884,12 +1886,17 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 	for time.Now().Before(endDeadline) {
 		var iter *Iter
 		if c.getIsSchemaV2() {
-			iter = c.querySystem(ctx, qrySystemPeersV2)
+			iter = c.querySystem(ctx, "SELECT host_id, data_center, rack, schema_version, rpc_address FROM system.peers_2")
 		} else {
-			iter = c.querySystem(ctx, qrySystemPeers)
+			iter = c.querySystem(ctx, "SELECT host_id, data_center, rack, schema_version, rpc_address FROM system.peers")
 		}
-		var systemPeersRows []map[string]interface{}
-		systemPeersRows, err = iter.SliceMap()
+		// data_center, rack, host_id, schema_version, rpc_address
+		var hosts []schemaAgreementHost
+		var tmp schemaAgreementHost
+		for iter.Scan(&tmp.HostID, &tmp.DataCenter, &tmp.Rack, &tmp.SchemaVersion, &tmp.RPCAddress) {
+			hosts = append(hosts, tmp)
+		}
+		err = iter.Close()
 		if err != nil {
 			return err
 		}
@@ -1899,7 +1906,9 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 
 		schemaVersions := []string{}
 
-		iter = c.querySystem(ctx, localSchemas)
+		iter = c.querySystem(ctx, "SELECT schema_version FROM system.local WHERE key='local'")
+
+		var schemaVersion string
 		for iter.Scan(&schemaVersion) {
 			schemaVersions = append(schemaVersions, schemaVersion)
 			schemaVersion = ""
@@ -1908,7 +1917,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 		if err = iter.Close(); err != nil {
 			return err
 		}
-		err = getSchemaAgreement(schemaVersions, systemPeersRows, c.host.ConnectAddress(), c.session.cfg.Port, c.session.cfg.translateAddressPort, c.logger)
+		err = getSchemaAgreement(schemaVersions, hosts, c.host.ConnectAddress(), c.session.cfg.Port, c.session.cfg.translateAddressPort, c.logger)
 
 		if err == ErrConnectionClosed || err == nil {
 			return err

--- a/conn_test.go
+++ b/conn_test.go
@@ -1406,39 +1406,27 @@ func (srv *TestServer) readFrame(conn net.Conn) (*framer, error) {
 
 func TestGetSchemaAgreement(t *testing.T) {
 	schema_version1 := ParseUUIDMust("af810386-a694-11ef-81fa-3aea73156247")
-	peersRows := []map[string]interface{}{
+	peersRows := []schemaAgreementHost{
 		{
-			"data_center":     "datacenter1",
-			"host_id":         ParseUUIDMust("b2035fd9-e0ca-4857-8c45-e63c00fb7c43"),
-			"peer":            "127.0.0.3",
-			"preferred_ip":    "127.0.0.3",
-			"rack":            "rack1",
-			"release_version": "3.0.8",
-			"rpc_address":     "127.0.0.3",
-			"schema_version":  schema_version1,
-			"tokens":          []string{"-1296227678594315580994457470329811265"},
+			DataCenter:    "datacenter1",
+			HostID:        ParseUUIDMust("b2035fd9-e0ca-4857-8c45-e63c00fb7c43"),
+			Rack:          "rack1",
+			RPCAddress:    "127.0.0.3",
+			SchemaVersion: schema_version1,
 		},
 		{
-			"data_center":     "datacenter1",
-			"host_id":         ParseUUIDMust("4b21ee4c-acea-4267-8e20-aaed5361a0dd"),
-			"peer":            "127.0.0.2",
-			"preferred_ip":    "127.0.0.2",
-			"rack":            "rack1",
-			"release_version": "3.0.8",
-			"rpc_address":     "127.0.0.2",
-			"schema_version":  schema_version1,
-			"tokens":          []string{"-1129762924682054333"},
+			DataCenter:    "datacenter1",
+			HostID:        ParseUUIDMust("4b21ee4c-acea-4267-8e20-aaed5361a0dd"),
+			Rack:          "rack1",
+			RPCAddress:    "127.0.0.2",
+			SchemaVersion: schema_version1,
 		},
 		{
-			"data_center":     "datacenter2",
-			"host_id":         ParseUUIDMust("dfef4a22-b8d8-47e9-aee5-8c19d4b7a9e3"),
-			"peer":            "127.0.0.5",
-			"preferred_ip":    "127.0.0.5",
-			"rack":            "rack1",
-			"release_version": "3.0.8",
-			"rpc_address":     "127.0.0.5",
-			"schema_version":  ParseUUIDMust("875a938a-a695-11ef-4314-85c8ef0ebaa2"),
-			"tokens":          []string{},
+			DataCenter:    "datacenter2",
+			HostID:        ParseUUIDMust("dfef4a22-b8d8-47e9-aee5-8c19d4b7a9e3"),
+			Rack:          "rack1",
+			RPCAddress:    "127.0.0.5",
+			SchemaVersion: ParseUUIDMust("875a938a-a695-11ef-4314-85c8ef0ebaa2"),
 		},
 	}
 
@@ -1475,7 +1463,7 @@ func TestGetSchemaAgreement(t *testing.T) {
 	})
 
 	t.Run("SchemaConsistent", func(t *testing.T) {
-		peersRows[2]["schema_version"] = schema_version1
+		peersRows[2].SchemaVersion = schema_version1
 		err := getSchemaAgreement(
 			[]string{"af810386-a694-11ef-81fa-3aea73156247"},
 			peersRows,


### PR DESCRIPTION
Currently schema agreement queries pull columns that are not used. In scenarios with big number of nodes it causes cluster and driver being slow.
This commit makes schema agreement code pull only columns that are used.

Fixes: https://github.com/scylladb/gocql/issues/408