### PR TITLE
Rename TestMockGetHostsFromSystem from ring_describer_test.go

### DIFF
--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -322,7 +322,7 @@ func marshalMetadataMust(metadata resultMetadata, data []interface{}) [][]byte {
 	return res
 }
 
-func TestGetHostsFromSystem(t *testing.T) {
+func TestMockGetHostsFromSystem(t *testing.T) {
 	r := &ringDescriber{control: &mockControlConn{}, cfg: &ClusterConfig{}}
 
 	hosts, _, err := r.GetHostsFromSystem()


### PR DESCRIPTION
There are two test with same name, which can cause `go test` to fail