### PR TITLE
Merge upstream changes up to commit `8bb171c2`

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -302,7 +302,7 @@ type ClusterConfig struct {
 	DisableShardAwarePort bool
 
 	// Logger for this ClusterConfig.
-	// If not specified, defaults to the global gocql.Logger.
+	// If not specified, defaults to the gocql.defaultLogger.
 	Logger StdLogger
 
 	// The timeout for the requests to the schema tables. (default: 60s)
@@ -358,7 +358,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 
 func (cfg *ClusterConfig) logger() StdLogger {
 	if cfg.Logger == nil {
-		return Logger
+		return &defaultLogger{}
 	}
 	return cfg.Logger
 }
@@ -499,7 +499,7 @@ func (cfg *ClusterConfig) Validate() error {
 	}
 
 	if !cfg.DisableSkipMetadata {
-		Logger.Println("warning: enabling skipping metadata can lead to unpredictible results when executing query and altering columns involved in the query.")
+		cfg.Logger.Println("warning: enabling skipping metadata can lead to unpredictible results when executing query and altering columns involved in the query.")
 	}
 
 	return cfg.ValidateAndInitSSL()

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -549,7 +549,7 @@ func (pool *hostConnPool) initConnPicker(conn *Conn) {
 	}
 
 	if conn.isScyllaConn() {
-		pool.connPicker = newScyllaConnPicker(conn)
+		pool.connPicker = newScyllaConnPicker(conn, pool.logger)
 		return
 	}
 

--- a/example_batch_test.go
+++ b/example_batch_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	"github.com/gocql/gocql"
 )
 
 // Example_batch demonstrates how to execute a batch of statements.

--- a/example_lwt_batch_test.go
+++ b/example_lwt_batch_test.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"log"
 
-	gocql "github.com/gocql/gocql"
+	"github.com/gocql/gocql"
 )
 
 // ExampleSession_MapExecuteBatchCAS demonstrates how to execute a batch lightweight transaction.

--- a/frame.go
+++ b/frame.go
@@ -292,17 +292,6 @@ func ParseConsistencyWrapper(s string) (consistency Consistency, err error) {
 	return
 }
 
-// MustParseConsistency is the same as ParseConsistency except it returns
-// an error (never). It is kept here since breaking changes are not good.
-// DEPRECATED: use ParseConsistency if you want a panic on parse error.
-func MustParseConsistency(s string) (Consistency, error) {
-	c, err := ParseConsistencyWrapper(s)
-	if err != nil {
-		panic(err)
-	}
-	return c, nil
-}
-
 const (
 	apacheCassandraTypePrefix = "org.apache.cassandra.db.marshal."
 )
@@ -430,15 +419,15 @@ func newFramer(compressor Compressor, version byte) *framer {
 	return f
 }
 
-func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension) *framer {
+func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension, logger StdLogger) *framer {
 
 	f := newFramer(compressor, version)
 
 	if lwtExt := findCQLProtoExtByName(cqlProtoExts, lwtAddMetadataMarkKey); lwtExt != nil {
 		castedExt, ok := lwtExt.(*lwtAddMetadataMarkExt)
 		if !ok {
-			Logger.Println(
-				fmt.Errorf("Failed to cast CQL protocol extension identified by name %s to type %T",
+			logger.Println(
+				fmt.Errorf("failed to cast CQL protocol extension identified by name %s to type %T",
 					lwtAddMetadataMarkKey, lwtAddMetadataMarkExt{}))
 			return f
 		}
@@ -448,8 +437,8 @@ func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlPr
 	if rateLimitErrorExt := findCQLProtoExtByName(cqlProtoExts, rateLimitError); rateLimitErrorExt != nil {
 		castedExt, ok := rateLimitErrorExt.(*rateLimitExt)
 		if !ok {
-			Logger.Println(
-				fmt.Errorf("Failed to cast CQL protocol extension identified by name %s to type %T",
+			logger.Println(
+				fmt.Errorf("failed to cast CQL protocol extension identified by name %s to type %T",
 					rateLimitError, rateLimitExt{}))
 			return f
 		}
@@ -459,8 +448,8 @@ func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlPr
 	if tabletsExt := findCQLProtoExtByName(cqlProtoExts, tabletsRoutingV1); tabletsExt != nil {
 		_, ok := tabletsExt.(*tabletsRoutingV1Ext)
 		if !ok {
-			Logger.Println(
-				fmt.Errorf("Failed to cast CQL protocol extension identified by name %s to type %T",
+			logger.Println(
+				fmt.Errorf("failed to cast CQL protocol extension identified by name %s to type %T",
 					tabletsRoutingV1, tabletsRoutingV1Ext{}))
 			return f
 		}

--- a/logger.go
+++ b/logger.go
@@ -58,7 +58,3 @@ type defaultLogger struct{}
 func (l *defaultLogger) Print(v ...interface{})                 { log.Print(v...) }
 func (l *defaultLogger) Printf(format string, v ...interface{}) { log.Printf(format, v...) }
 func (l *defaultLogger) Println(v ...interface{})               { log.Println(v...) }
-
-// Logger for logging messages.
-// Deprecated: Use ClusterConfig.Logger instead.
-var Logger StdLogger = &defaultLogger{}

--- a/marshal.go
+++ b/marshal.go
@@ -1510,14 +1510,6 @@ type TypeInfo interface {
 	Version() byte
 	Custom() string
 
-	// New creates a pointer to an empty version of whatever type
-	// is referenced by the TypeInfo receiver.
-	//
-	// If there is no corresponding Go type for the CQL type, New panics.
-	//
-	// Deprecated: Use NewWithError instead.
-	New() interface{}
-
 	// NewWithError creates a pointer to an empty version of whatever type
 	// is referenced by the TypeInfo receiver.
 	//
@@ -1541,14 +1533,6 @@ func (t NativeType) NewWithError() (interface{}, error) {
 		return nil, err
 	}
 	return reflect.New(typ).Interface(), nil
-}
-
-func (t NativeType) New() interface{} {
-	val, err := t.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
 }
 
 func (s NativeType) Type() Type {
@@ -1592,14 +1576,6 @@ func (t CollectionType) NewWithError() (interface{}, error) {
 		return nil, err
 	}
 	return reflect.New(typ).Interface(), nil
-}
-
-func (t CollectionType) New() interface{} {
-	val, err := t.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
 }
 
 func (c CollectionType) String() string {
@@ -1646,14 +1622,6 @@ func (t TupleTypeInfo) NewWithError() (interface{}, error) {
 	return reflect.New(typ).Interface(), nil
 }
 
-func (t TupleTypeInfo) New() interface{} {
-	val, err := t.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
-}
-
 type UDTField struct {
 	Name string
 	Type TypeInfo
@@ -1681,14 +1649,6 @@ func (u UDTTypeInfo) NewWithError() (interface{}, error) {
 		return nil, err
 	}
 	return reflect.New(typ).Interface(), nil
-}
-
-func (u UDTTypeInfo) New() interface{} {
-	val, err := u.NewWithError()
-	if err != nil {
-		panic(err.Error())
-	}
-	return val
 }
 
 func (u UDTTypeInfo) String() string {

--- a/scylla.go
+++ b/scylla.go
@@ -96,7 +96,7 @@ var _ cqlProtocolExtension = &rateLimitExt{}
 
 // Factory function to deserialize and create an `rateLimitExt` instance
 // from SUPPORTED message payload.
-func newRateLimitExt(supported map[string][]string) *rateLimitExt {
+func newRateLimitExt(supported map[string][]string, logger StdLogger) *rateLimitExt {
 	const rateLimitErrorCode = "ERROR_CODE"
 
 	if v, found := supported[rateLimitError]; found {
@@ -109,7 +109,7 @@ func newRateLimitExt(supported map[string][]string) *rateLimitExt {
 				)
 				if errorCode, err = strconv.Atoi(splitVal[1]); err != nil {
 					if gocqlDebug {
-						Logger.Printf("scylla: failed to parse %s value %v: %s", rateLimitErrorCode, splitVal[1], err)
+						logger.Printf("scylla: failed to parse %s value %v: %s", rateLimitErrorCode, splitVal[1], err)
 						return nil
 					}
 				}
@@ -150,7 +150,7 @@ var _ cqlProtocolExtension = &lwtAddMetadataMarkExt{}
 
 // Factory function to deserialize and create an `lwtAddMetadataMarkExt` instance
 // from SUPPORTED message payload.
-func newLwtAddMetaMarkExt(supported map[string][]string) *lwtAddMetadataMarkExt {
+func newLwtAddMetaMarkExt(supported map[string][]string, logger StdLogger) *lwtAddMetadataMarkExt {
 	const lwtOptMetaBitMaskKey = "LWT_OPTIMIZATION_META_BIT_MASK"
 
 	if v, found := supported[lwtAddMetadataMarkKey]; found {
@@ -163,7 +163,7 @@ func newLwtAddMetaMarkExt(supported map[string][]string) *lwtAddMetadataMarkExt 
 				)
 				if bitMask, err = strconv.Atoi(splitVal[1]); err != nil {
 					if gocqlDebug {
-						Logger.Printf("scylla: failed to parse %s value %v: %s", lwtOptMetaBitMaskKey, splitVal[1], err)
+						logger.Printf("scylla: failed to parse %s value %v: %s", lwtOptMetaBitMaskKey, splitVal[1], err)
 						return nil
 					}
 				}
@@ -186,7 +186,7 @@ func (ext *lwtAddMetadataMarkExt) name() string {
 	return lwtAddMetadataMarkKey
 }
 
-func parseSupported(supported map[string][]string) scyllaSupported {
+func parseSupported(supported map[string][]string, logger StdLogger) scyllaSupported {
 	const (
 		scyllaShard             = "SCYLLA_SHARD"
 		scyllaNrShards          = "SCYLLA_NR_SHARDS"
@@ -205,21 +205,21 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	if s, ok := supported[scyllaShard]; ok {
 		if si.shard, err = strconv.Atoi(s[0]); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShard, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShard, s, err)
 			}
 		}
 	}
 	if s, ok := supported[scyllaNrShards]; ok {
 		if si.nrShards, err = strconv.Atoi(s[0]); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaNrShards, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaNrShards, s, err)
 			}
 		}
 	}
 	if s, ok := supported[scyllaShardingIgnoreMSB]; ok {
 		if si.msbIgnore, err = strconv.ParseUint(s[0], 10, 64); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardingIgnoreMSB, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardingIgnoreMSB, s, err)
 			}
 		}
 	}
@@ -233,7 +233,7 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	if s, ok := supported[scyllaShardAwarePort]; ok {
 		if shardAwarePort, err := strconv.ParseUint(s[0], 10, 16); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePort, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePort, s, err)
 			}
 		} else {
 			si.shardAwarePort = uint16(shardAwarePort)
@@ -242,7 +242,7 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	if s, ok := supported[scyllaShardAwarePortSSL]; ok {
 		if shardAwarePortSSL, err := strconv.ParseUint(s[0], 10, 16); err != nil {
 			if gocqlDebug {
-				Logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePortSSL, s, err)
+				logger.Printf("scylla: failed to parse %s value %v: %s", scyllaShardAwarePortSSL, s, err)
 			}
 		} else {
 			si.shardAwarePortSSL = uint16(shardAwarePortSSL)
@@ -251,7 +251,7 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 
 	if si.partitioner != "org.apache.cassandra.dht.Murmur3Partitioner" || si.shardingAlgorithm != "biased-token-round-robin" || si.nrShards == 0 || si.msbIgnore == 0 {
 		if gocqlDebug {
-			Logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d",
+			logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d",
 				si.partitioner, si.shardingAlgorithm, si.nrShards, si.msbIgnore)
 		}
 		return scyllaSupported{}
@@ -260,15 +260,15 @@ func parseSupported(supported map[string][]string) scyllaSupported {
 	return si
 }
 
-func parseCQLProtocolExtensions(supported map[string][]string) []cqlProtocolExtension {
+func parseCQLProtocolExtensions(supported map[string][]string, logger StdLogger) []cqlProtocolExtension {
 	exts := []cqlProtocolExtension{}
 
-	lwtExt := newLwtAddMetaMarkExt(supported)
+	lwtExt := newLwtAddMetaMarkExt(supported, logger)
 	if lwtExt != nil {
 		exts = append(exts, lwtExt)
 	}
 
-	rateLimitExt := newRateLimitExt(supported)
+	rateLimitExt := newRateLimitExt(supported, logger)
 	if rateLimitExt != nil {
 		exts = append(exts, rateLimitExt)
 	}
@@ -310,12 +310,13 @@ type scyllaConnPicker struct {
 	pos                    uint64
 	lastAttemptedShard     int
 	shardAwarePortDisabled bool
+	logger                 StdLogger
 
 	// Used to disable new connections to the shard-aware port temporarily
 	disableShardAwarePortUntil *atomic.Value
 }
 
-func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
+func newScyllaConnPicker(conn *Conn, logger StdLogger) *scyllaConnPicker {
 	addr := conn.Address()
 	hostId := conn.host.hostId
 
@@ -324,7 +325,7 @@ func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
 	}
 
 	if gocqlDebug {
-		Logger.Printf("scylla: %s new conn picker sharding options %+v", addr, conn.scyllaSupported)
+		logger.Printf("scylla: %s new conn picker sharding options %+v", addr, conn.scyllaSupported)
 	}
 
 	var shardAwarePort uint16
@@ -348,6 +349,7 @@ func newScyllaConnPicker(conn *Conn) *scyllaConnPicker {
 		msbIgnore:              conn.scyllaSupported.msbIgnore,
 		lastAttemptedShard:     0,
 		shardAwarePortDisabled: conn.session.cfg.DisableShardAwarePort,
+		logger:                 logger,
 
 		disableShardAwarePortUntil: new(atomic.Value),
 	}
@@ -483,7 +485,7 @@ func (p *scyllaConnPicker) Put(conn *Conn) {
 			// changes the source port along the way, therefore we can't trust
 			// the shard-aware port to return connection to the shard
 			// that we requested. Fall back to non-shard-aware port for some time.
-			Logger.Printf(
+			p.logger.Printf(
 				"scylla: %s connection to shard-aware address %s resulted in wrong shard being assigned; please check that you are not behind a NAT or AddressTranslater which changes source ports; falling back to non-shard-aware port for %v",
 				p.address,
 				p.shardAwareAddress,
@@ -499,14 +501,14 @@ func (p *scyllaConnPicker) Put(conn *Conn) {
 		} else {
 			p.excessConns = append(p.excessConns, conn)
 			if gocqlDebug {
-				Logger.Printf("scylla: %s put shard %d excess connection total: %d missing: %d excess: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns, len(p.excessConns))
+				p.logger.Printf("scylla: %s put shard %d excess connection total: %d missing: %d excess: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns, len(p.excessConns))
 			}
 		}
 	} else {
 		p.conns[shard] = conn
 		p.nrConns++
 		if gocqlDebug {
-			Logger.Printf("scylla: %s put shard %d connection total: %d missing: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns)
+			p.logger.Printf("scylla: %s put shard %d connection total: %d missing: %d", p.address, shard, p.nrConns, p.nrShards-p.nrConns)
 		}
 	}
 
@@ -531,12 +533,12 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
 		// It is possible for Remove to be called before the connection is added to the pool.
 		// Ignoring these connections here is safe.
 		if gocqlDebug {
-			Logger.Printf("scylla: %s has unknown sharding state, ignoring it", p.address)
+			p.logger.Printf("scylla: %s has unknown sharding state, ignoring it", p.address)
 		}
 		return
 	}
 	if gocqlDebug {
-		Logger.Printf("scylla: %s remove shard %d connection", p.address, shard)
+		p.logger.Printf("scylla: %s remove shard %d connection", p.address, shard)
 	}
 
 	if p.conns[shard] != nil {
@@ -567,7 +569,7 @@ func (p *scyllaConnPicker) Close() {
 func (p *scyllaConnPicker) closeConns() {
 	if len(p.conns) == 0 {
 		if gocqlDebug {
-			Logger.Printf("scylla: %s no connections to close", p.address)
+			p.logger.Printf("scylla: %s no connections to close", p.address)
 		}
 		return
 	}
@@ -577,7 +579,7 @@ func (p *scyllaConnPicker) closeConns() {
 	p.nrConns = 0
 
 	if gocqlDebug {
-		Logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
+		p.logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
 	}
 	go closeConns(conns...)
 }
@@ -585,7 +587,7 @@ func (p *scyllaConnPicker) closeConns() {
 func (p *scyllaConnPicker) closeExcessConns() {
 	if len(p.excessConns) == 0 {
 		if gocqlDebug {
-			Logger.Printf("scylla: %s no excess connections to close", p.address)
+			p.logger.Printf("scylla: %s no excess connections to close", p.address)
 		}
 		return
 	}
@@ -594,7 +596,7 @@ func (p *scyllaConnPicker) closeExcessConns() {
 	p.excessConns = nil
 
 	if gocqlDebug {
-		Logger.Printf("scylla: %s closing %d excess connections", p.address, len(conns))
+		p.logger.Printf("scylla: %s closing %d excess connections", p.address, len(conns))
 	}
 	go closeConns(conns...)
 }

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -221,7 +221,7 @@ func TestScyllaRateLimitingExtParsing(t *testing.T) {
 		// mock connection without cql extensions, expected to have the `rateLimitingErrorCode`
 		// field set to 0 (default, signifying no code)
 		conn := mockConn(0)
-		f := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts)
+		f := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts, conn.logger)
 		if f.rateLimitingErrorCode != 0 {
 			t.Error("expected to have rateLimitingErrorCode set to 0 (no code) after framer init")
 		}
@@ -238,7 +238,7 @@ func TestScyllaRateLimitingExtParsing(t *testing.T) {
 				rateLimitErrorCode: mockCode,
 			},
 		}
-		framerWithRateLimitExt := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts)
+		framerWithRateLimitExt := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts, conn.logger)
 		if framerWithRateLimitExt.rateLimitingErrorCode != mockCode {
 			t.Error("expected to have rateLimitingErrorCode set to mockCode after framer init")
 		}
@@ -253,7 +253,7 @@ func TestScyllaLWTExtParsing(t *testing.T) {
 		// mock connection without cql extensions, expected not to have
 		// the `flagLWT` field being set in the framer created out of it
 		conn := mockConn(0)
-		f := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts)
+		f := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts, conn.logger)
 		if f.flagLWT != 0 {
 			t.Error("expected to have LWT flag uninitialized after framer init")
 		}
@@ -269,7 +269,7 @@ func TestScyllaLWTExtParsing(t *testing.T) {
 				lwtOptMetaBitMask: 1,
 			},
 		}
-		framerWithLwtExt := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts)
+		framerWithLwtExt := newFramerWithExts(conn.compressor, conn.version, conn.cqlProtoExts, conn.logger)
 		if framerWithLwtExt.flagLWT == 0 {
 			t.Error("expected to have LWT flag to be set after framer init")
 		}


### PR DESCRIPTION
Original commit list:
1. https://github.com/apache/cassandra-gocql-driver/commit/48bb2bc2b499d9f96764d64944be769f3d8068bc
Message:
```
Change Batch API to be consistent with Query()
Exec() method for batch was added & Query() method was refactored.
Batch for now behaves the same way as query.

patch by Oleksandr Luzhniy; reviewed by João Reis, Danylo Savchenko, Bohdan Siryk, Jackson Fleming, for CASSGO-7
```
Status: `APPLIED`
2. https://github.com/apache/cassandra-gocql-driver/commit/37030fbc17a180cc18728a914641be8f86b7f643
Message:
```
Update CCM installation after Python and Java upgrades on GitHub Actions
Patch by Lukasz Antoniak; reviewed by Joao Reis, Jackson Fleming for CASSGO-20
```
Status: `SKIPPED`
3. https://github.com/apache/cassandra-gocql-driver/commit/ba7d5634e98df911989d0f219cd3d1cdff279a83
Message:
```
Remove global logger
By default, if the logger in the cluster config is not set,
the NewSession() method sets a default logger instance
which is a deprecated global variable.

patch by Oleksandr Luzhniy; reviewed by João Reis, Stanislav Bychkov, Jackson Fleming, for CASSGO-24
```
Status: `APPLIED`
4. https://github.com/apache/cassandra-gocql-driver/commit/3e2178170146ca3510ded729bfe5e841454e4067
Message:
```
Bump actions/upload-artifact and actions/cache versions to v4
Bumped due to cancelation of running CI workflows with the deprecated version of
actions/upload-artifact@v3 and in order to prevent future interruptions with
deprecation of actions/cache@v2.

Patch by Bohdan Siryk; Reviewed by João Reis, Stanislav Bychkov for CASSGO-48
```
Status: `APPLIED`
5. https://github.com/apache/cassandra-gocql-driver/commit/8bb171c2edfc696f96dc99c8db3499742d69db13
Message:
```
Remove deprecated features
Some features marked as "Deprecated" were removed:
Global TimeoutLimit variable;
MustParseConsistency() function;
New() method for typeInfo{} interface;
View field for the KeyspaceMetadata structure;

patch by Oleksandr Luzhniy; reviewed by João Reis, James Hartig, for CASSGO-12
```
Status: `APPLIED`