### PR TITLE
Merge upstream changes up to commit  `d3456309`

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -612,7 +612,7 @@ func TestCAS(t *testing.T) {
 	if applied, _, err := session.ExecuteBatchCAS(successBatch, &titleCAS, &revidCAS, &modifiedCAS); err != nil {
 		t.Fatal("insert:", err)
 	} else if applied {
-		t.Fatalf("insert should have been applied: title=%v revID=%v modified=%v", titleCAS, revidCAS, modifiedCAS)
+		t.Fatalf("insert should have not been applied: title=%v revID=%v modified=%v", titleCAS, revidCAS, modifiedCAS)
 	}
 
 	insertBatch := session.Batch(LoggedBatch)
@@ -628,7 +628,7 @@ func TestCAS(t *testing.T) {
 	if applied, iter, err := session.ExecuteBatchCAS(failBatch, &titleCAS, &revidCAS, &modifiedCAS); err != nil {
 		t.Fatal("insert:", err)
 	} else if applied {
-		t.Fatalf("insert should have been applied: title=%v revID=%v modified=%v", titleCAS, revidCAS, modifiedCAS)
+		t.Fatalf("insert should have not been applied: title=%v revID=%v modified=%v", titleCAS, revidCAS, modifiedCAS)
 	} else {
 		if scan := iter.Scan(&applied, &titleCAS, &revidCAS, &modifiedCAS); scan && applied {
 			t.Fatalf("insert should have been applied: title=%v revID=%v modified=%v", titleCAS, revidCAS, modifiedCAS)
@@ -638,6 +638,55 @@ func TestCAS(t *testing.T) {
 		if err := iter.Close(); err != nil {
 			t.Fatal("scan:", err)
 		}
+	}
+
+	casMap = make(map[string]interface{})
+	if applied, err := session.Query(`SELECT revid FROM cas_table WHERE title = ?`,
+		title+"_foo").MapScanCAS(casMap); err != nil {
+		t.Fatal("select:", err)
+	} else if applied {
+		t.Fatal("select shouldn't have returned applied")
+	}
+
+	if _, err := session.Query(`SELECT revid FROM cas_table WHERE title = ?`,
+		title+"_foo").ScanCAS(&revidCAS); err == nil {
+		t.Fatal("select: should have returned an error")
+	}
+
+	notCASBatch := session.Batch(LoggedBatch)
+	notCASBatch.Query("INSERT INTO cas_table (title, revid, last_modified) VALUES (?, ?, ?)", title+"_baz", revid, modified)
+	casMap = make(map[string]interface{})
+	if _, _, err := session.MapExecuteBatchCAS(notCASBatch, casMap); err != ErrNotFound {
+		t.Fatal("insert should have returned not found:", err)
+	}
+
+	notCASBatch = session.Batch(LoggedBatch)
+	notCASBatch.Query("INSERT INTO cas_table (title, revid, last_modified) VALUES (?, ?, ?)", title+"_baz", revid, modified)
+	casMap = make(map[string]interface{})
+	if _, _, err := session.ExecuteBatchCAS(notCASBatch, &revidCAS); err != ErrNotFound {
+		t.Fatal("insert should have returned not found:", err)
+	}
+
+	failBatch = session.Batch(LoggedBatch)
+	failBatch.Query("UPDATE cas_table SET last_modified = DATEOF(NOW()) WHERE title='_foo' AND revid=3e4ad2f1-73a4-11e5-9381-29463d90c3f0 IF last_modified = ?", modified)
+	if _, _, err := session.ExecuteBatchCAS(failBatch, new(bool)); err == nil {
+		t.Fatal("update should have errored")
+	}
+	// make sure MapScanCAS does not panic when MapScan fails
+	casMap = make(map[string]interface{})
+	casMap["last_modified"] = false
+	if _, err := session.Query(`UPDATE cas_table SET last_modified = DATEOF(NOW()) WHERE title='_foo' AND revid=3e4ad2f1-73a4-11e5-9381-29463d90c3f0 IF last_modified = ?`,
+		modified).MapScanCAS(casMap); err == nil {
+		t.Fatal("update should hvae errored", err)
+	}
+
+	// make sure MapExecuteBatchCAS does not panic when MapScan fails
+	failBatch = session.Batch(LoggedBatch)
+	failBatch.Query("UPDATE cas_table SET last_modified = DATEOF(NOW()) WHERE title='_foo' AND revid=3e4ad2f1-73a4-11e5-9381-29463d90c3f0 IF last_modified = ?", modified)
+	casMap = make(map[string]interface{})
+	casMap["last_modified"] = false
+	if _, _, err := session.MapExecuteBatchCAS(failBatch, casMap); err == nil {
+		t.Fatal("update should have errored")
 	}
 }
 
@@ -1046,6 +1095,7 @@ func TestMapScan(t *testing.T) {
 			fullname       text PRIMARY KEY,
 			age            int,
 			address        inet,
+			data           blob,
 		)`); err != nil {
 		t.Fatal("create table:", err)
 	}
@@ -1054,8 +1104,8 @@ func TestMapScan(t *testing.T) {
 		"Grace Hopper", 31, net.ParseIP("10.0.0.1")).Exec(); err != nil {
 		t.Fatal("insert:", err)
 	}
-	if err := session.Query(`INSERT INTO scan_map_table (fullname, age, address) values (?,?,?)`,
-		"Ada Lovelace", 30, net.ParseIP("10.0.0.2")).Exec(); err != nil {
+	if err := session.Query(`INSERT INTO scan_map_table (fullname, age, address, data) values (?,?,?,?)`,
+		"Ada Lovelace", 30, net.ParseIP("10.0.0.2"), []byte(`{"foo": "bar"}`)).Exec(); err != nil {
 		t.Fatal("insert:", err)
 	}
 
@@ -1069,6 +1119,7 @@ func TestMapScan(t *testing.T) {
 	assertEqual(t, "fullname", "Ada Lovelace", row["fullname"])
 	assertEqual(t, "age", 30, row["age"])
 	assertEqual(t, "address", "10.0.0.2", row["address"])
+	assertDeepEqual(t, "data", []byte(`{"foo": "bar"}`), row["data"])
 
 	// Second iteration using a new map
 	row = make(map[string]interface{})
@@ -1078,6 +1129,7 @@ func TestMapScan(t *testing.T) {
 	assertEqual(t, "fullname", "Grace Hopper", row["fullname"])
 	assertEqual(t, "age", 31, row["age"])
 	assertEqual(t, "address", "10.0.0.1", row["address"])
+	assertDeepEqual(t, "data", []byte(nil), row["data"])
 }
 
 func TestSliceMap(t *testing.T) {

--- a/cluster.go
+++ b/cluster.go
@@ -351,6 +351,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		MetadataSchemaRequestTimeout: 60 * time.Second,
 		DisableSkipMetadata:          true,
 		WarningsHandlerBuilder:       DefaultWarningHandlerBuilder,
+		Logger:                       &defaultLogger{},
 	}
 
 	return cfg

--- a/conn.go
+++ b/conn.go
@@ -1484,7 +1484,8 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 			}
 		}
 
-		params.skipMeta = !(c.session.cfg.DisableSkipMetadata || qry.disableSkipMetadata)
+		// if the metadata was not present in the response then we should not skip it
+		params.skipMeta = !(c.session.cfg.DisableSkipMetadata || qry.disableSkipMetadata) && len(info.response.columns) != 0
 
 		frame = &writeExecuteFrame{
 			preparedID:    info.id,
@@ -1594,8 +1595,6 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 			} else {
 				return &Iter{framer: framer, err: errors.New("gocql: did not receive metadata but prepared info is nil")}
 			}
-		} else {
-			iter.meta = x.meta
 		}
 
 		if x.meta.morePages() && !qry.disableAutoPage {

--- a/conn_test.go
+++ b/conn_test.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -1037,6 +1038,31 @@ func TestWriteCoalescing_WriteAfterClose(t *testing.T) {
 	}
 }
 
+func TestSkipMetadata(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := NewTestServer(t, protoVersion4, ctx)
+	defer srv.Stop()
+
+	cfg := testCluster(protoVersion4, srv.Address)
+	cfg.DisableSkipMetadata = false
+
+	db, err := cfg.CreateSession()
+	if err != nil {
+		t.Fatalf("NewCluster: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Query("select nometadata").Exec(); err != nil {
+		t.Fatalf("expected no error got: %v", err)
+	}
+
+	if err := db.Query("select metadata").Exec(); err != nil {
+		t.Fatalf("expected no error got: %v", err)
+	}
+}
+
 type recordingFrameHeaderObserver struct {
 	t      *testing.T
 	mu     sync.Mutex
@@ -1385,6 +1411,99 @@ func (srv *TestServer) process(conn net.Conn, reqFrame *framer, exts map[string]
 	case opError:
 		respFrame.writeHeader(0, opError, head.stream)
 		respFrame.buf = append(respFrame.buf, reqFrame.buf...)
+	case opPrepare:
+		query := reqFrame.readLongString()
+		name := strings.TrimPrefix(query, "select ")
+		if n := strings.Index(name, " "); n > 0 {
+			name = name[:n]
+		}
+		switch strings.ToLower(name) {
+		case "nometadata":
+			respFrame.writeHeader(0, opResult, head.stream)
+			respFrame.writeInt(resultKindPrepared)
+			// <id>
+			respFrame.writeShortBytes(binary.BigEndian.AppendUint64(nil, 1))
+			// <metadata>
+			respFrame.writeInt(0) // <flags>
+			respFrame.writeInt(0) // <columns_count>
+			if srv.protocol >= protoVersion4 {
+				respFrame.writeInt(0) // <pk_count>
+			}
+			// <result_metadata>
+			respFrame.writeInt(int32(flagNoMetaData)) // <flags>
+			respFrame.writeInt(0)
+		case "metadata":
+			respFrame.writeHeader(0, opResult, head.stream)
+			respFrame.writeInt(resultKindPrepared)
+			// <id>
+			respFrame.writeShortBytes(binary.BigEndian.AppendUint64(nil, 2))
+			// <metadata>
+			respFrame.writeInt(0) // <flags>
+			respFrame.writeInt(0) // <columns_count>
+			if srv.protocol >= protoVersion4 {
+				respFrame.writeInt(0) // <pk_count>
+			}
+			// <result_metadata>
+			respFrame.writeInt(int32(flagGlobalTableSpec)) // <flags>
+			respFrame.writeInt(1)                          // <columns_count>
+			// <global_table_spec>
+			respFrame.writeString("keyspace")
+			respFrame.writeString("table")
+			// <col_spec_0>
+			respFrame.writeString("col0")             // <name>
+			respFrame.writeShort(uint16(TypeBoolean)) // <type>
+		default:
+			respFrame.writeHeader(0, opError, head.stream)
+			respFrame.writeInt(0)
+			respFrame.writeString("unsupported query: " + name)
+		}
+	case opExecute:
+		b := reqFrame.readShortBytes()
+		id := binary.BigEndian.Uint64(b)
+		// <query_parameters>
+		reqFrame.readConsistency() // <consistency>
+		var flags byte
+		if srv.protocol > protoVersion4 {
+			ui := reqFrame.readInt()
+			flags = byte(ui)
+		} else {
+			flags = reqFrame.readByte()
+		}
+		switch id {
+		case 1:
+			if flags&flagSkipMetaData != 0 {
+				respFrame.writeHeader(0, opError, head.stream)
+				respFrame.writeInt(0)
+				respFrame.writeString("skip metadata unexpected")
+			} else {
+				respFrame.writeHeader(0, opResult, head.stream)
+				respFrame.writeInt(resultKindRows)
+				// <metadata>
+				respFrame.writeInt(0) // <flags>
+				respFrame.writeInt(0) // <columns_count>
+				// <rows_count>
+				respFrame.writeInt(0)
+			}
+		case 2:
+			if flags&flagSkipMetaData != 0 {
+				respFrame.writeHeader(0, opResult, head.stream)
+				respFrame.writeInt(resultKindRows)
+				// <metadata>
+				respFrame.writeInt(0) // <flags>
+				respFrame.writeInt(0) // <columns_count>
+				// <rows_count>
+				respFrame.writeInt(0)
+			} else {
+				respFrame.writeHeader(0, opError, head.stream)
+				respFrame.writeInt(0)
+				respFrame.writeString("skip metadata expected")
+			}
+		default:
+			respFrame.writeHeader(0, opError, head.stream)
+			respFrame.writeInt(ErrCodeUnprepared)
+			respFrame.writeString("unprepared")
+			respFrame.writeShortBytes(binary.BigEndian.AppendUint64(nil, id))
+		}
 	default:
 		respFrame.writeHeader(0, opError, head.stream)
 		respFrame.writeInt(0)

--- a/helpers.go
+++ b/helpers.go
@@ -305,7 +305,7 @@ func getApacheCassandraType(class string) Type {
 func (r *RowData) rowMap(m map[string]interface{}) {
 	for i, column := range r.Columns {
 		val := dereference(r.Values[i])
-		if valVal := reflect.ValueOf(val); valVal.Kind() == reflect.Slice {
+		if valVal := reflect.ValueOf(val); valVal.Kind() == reflect.Slice && !valVal.IsNil() {
 			valCopy := reflect.MakeSlice(valVal.Type(), valVal.Len(), valVal.Cap())
 			reflect.Copy(valCopy, valVal)
 			m[column] = valCopy.Interface()
@@ -322,6 +322,7 @@ func TupleColumnName(c string, n int) string {
 	return fmt.Sprintf("%s[%d]", c, n)
 }
 
+// RowData returns the RowData for the iterator.
 func (iter *Iter) RowData() (RowData, error) {
 	if iter.err != nil {
 		return RowData{}, iter.err
@@ -334,6 +335,7 @@ func (iter *Iter) RowData() (RowData, error) {
 		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
 			val, err := column.TypeInfo.NewWithError()
 			if err != nil {
+				iter.err = err
 				return RowData{}, err
 			}
 			columns = append(columns, column.Name)
@@ -343,6 +345,7 @@ func (iter *Iter) RowData() (RowData, error) {
 				columns = append(columns, TupleColumnName(column.Name, i))
 				val, err := elem.NewWithError()
 				if err != nil {
+					iter.err = err
 					return RowData{}, err
 				}
 				values = append(values, val)
@@ -364,7 +367,10 @@ func (iter *Iter) rowMap() (map[string]interface{}, error) {
 		return nil, iter.err
 	}
 
-	rowData, _ := iter.RowData()
+	rowData, err := iter.RowData()
+	if err != nil {
+		return nil, err
+	}
 	iter.Scan(rowData.Values...)
 	m := make(map[string]interface{}, len(rowData.Columns))
 	rowData.rowMap(m)
@@ -379,7 +385,10 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 	}
 
 	// Not checking for the error because we just did
-	rowData, _ := iter.RowData()
+	rowData, err := iter.RowData()
+	if err != nil {
+		return nil, err
+	}
 	dataToReturn := make([]map[string]interface{}, 0)
 	for iter.Scan(rowData.Values...) {
 		m := make(map[string]interface{}, len(rowData.Columns))
@@ -435,8 +444,10 @@ func (iter *Iter) MapScan(m map[string]interface{}) bool {
 		return false
 	}
 
-	// Not checking for the error because we just did
-	rowData, _ := iter.RowData()
+	rowData, err := iter.RowData()
+	if err != nil {
+		return false
+	}
 
 	for i, col := range rowData.Columns {
 		if dest, ok := m[col]; ok {

--- a/marshal.go
+++ b/marshal.go
@@ -123,7 +123,7 @@ func (d *DirectUnmarshal) UnmarshalCQL(_ TypeInfo, data []byte) error {
 //	tinyint, smallint, int      | integer types      |
 //	tinyint, smallint, int      | string             | formatted as base 10 number
 //	bigint, counter             | integer types      |
-//	bigint, counter             | big.Int            |
+//	bigint, counter             | big.Int            | value limited as int64
 //	bigint, counter             | string             | formatted as base 10 number
 //	float                       | float32            |
 //	double                      | float64            |
@@ -156,6 +156,9 @@ func (d *DirectUnmarshal) UnmarshalCQL(_ TypeInfo, data []byte) error {
 //	duration                    | time.Duration      |
 //	duration                    | gocql.Duration     |
 //	duration                    | string             | parsed with time.ParseDuration
+//
+// The marshal/unmarshal error provides a list of supported types when an unsupported type is attempted.
+
 func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 	if info.Version() < protoVersion1 {
 		panic("protocol version not set")

--- a/serialization/ascii/marshal_utils.go
+++ b/serialization/ascii/marshal_utils.go
@@ -33,16 +33,16 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		return encString(v.String()), nil
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 		}
 		return EncBytes(v.Bytes())
 	case reflect.Struct:
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/ascii/unmarshal.go
+++ b/serialization/ascii/unmarshal.go
@@ -23,7 +23,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal ascii: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/ascii/unmarshal_utils.go
+++ b/serialization/ascii/unmarshal_utils.go
@@ -60,11 +60,11 @@ func DecReflect(p []byte, v reflect.Value) error {
 		v.SetString(decString(p))
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		v.SetBytes(decBytes(p))
 	default:
-		return fmt.Errorf("failed to unmarshal ascii: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 	return errInvalidData(p)
 }
@@ -79,11 +79,11 @@ func DecReflectR(p []byte, v reflect.Value) error {
 		return decReflectStringR(p, v)
 	case reflect.Slice:
 		if ev.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		return decReflectBytesR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal ascii: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal ascii: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 }
 

--- a/serialization/bigint/marshal_utils.go
+++ b/serialization/bigint/marshal_utils.go
@@ -2,16 +2,12 @@ package bigint
 
 import (
 	"fmt"
-	"math"
 	"math/big"
 	"reflect"
 	"strconv"
 )
 
-var (
-	maxBigInt = big.NewInt(math.MaxInt64)
-	minBigInt = big.NewInt(math.MinInt64)
-)
+const supportedTypes = "~int8, ~int16, ~int32, ~int64, ~int, ~uint8, ~uint16, ~uint32, ~uint64, ~uint, ~string, big.Int"
 
 func EncInt8(v int8) ([]byte, error) {
 	if v < 0 {
@@ -133,7 +129,7 @@ func EncUintR(v *uint) ([]byte, error) {
 }
 
 func EncBigInt(v big.Int) ([]byte, error) {
-	if v.Cmp(maxBigInt) == 1 || v.Cmp(minBigInt) == -1 {
+	if !v.IsInt64() {
 		return nil, fmt.Errorf("failed to marshal bigint: value (%T)(%s) out of range", v, v.String())
 	}
 	return encInt64(v.Int64()), nil
@@ -143,7 +139,7 @@ func EncBigIntR(v *big.Int) ([]byte, error) {
 	if v == nil {
 		return nil, nil
 	}
-	if v.Cmp(maxBigInt) == 1 || v.Cmp(minBigInt) == -1 {
+	if !v.IsInt64() {
 		return nil, fmt.Errorf("failed to marshal bigint: value (%T)(%s) out of range", v, v.String())
 	}
 	return encInt64(v.Int64()), nil
@@ -188,9 +184,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	default:
-		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal bigint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/bigint/unmarshal.go
+++ b/serialization/bigint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v)", value)
+			return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v), supported types: %s", value, supportedTypes)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/bigint/unmarshal_utils.go
+++ b/serialization/bigint/unmarshal_utils.go
@@ -505,7 +505,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 
@@ -667,7 +667,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/blob/marshal_utils.go
+++ b/serialization/blob/marshal_utils.go
@@ -33,16 +33,16 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		return encString(v.String()), nil
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 		}
 		return EncBytes(v.Bytes())
 	case reflect.Struct:
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/blob/unmarshal.go
+++ b/serialization/blob/unmarshal.go
@@ -25,7 +25,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/blob/unmarshal_utils.go
+++ b/serialization/blob/unmarshal_utils.go
@@ -59,13 +59,13 @@ func DecReflect(p []byte, v reflect.Value) error {
 		v.SetString(decString(p))
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		v.SetBytes(decBytes(p))
 	case reflect.Interface:
 		v.Set(reflect.ValueOf(decBytes(p)))
 	default:
-		return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 	return nil
 }
@@ -80,11 +80,11 @@ func DecReflectR(p []byte, v reflect.Value) error {
 		return decReflectStringR(p, v)
 	case reflect.Slice:
 		if ev.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		return decReflectBytesR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal blob: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 }
 

--- a/serialization/boolean/marshal_utils.go
+++ b/serialization/boolean/marshal_utils.go
@@ -24,9 +24,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal boolean: unsupported value type (%T)(%[1]v), supported types: ~bool, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal boolean: unsupported value type (%T)(%[1]v), supported types: ~bool, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/boolean/unmarshal_utils.go
+++ b/serialization/boolean/unmarshal_utils.go
@@ -55,7 +55,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.Bool:
 		return decReflectBool(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal boolean: unsupported value type (%T)(%[1]v), supported types: ~bool", v.Interface())
 	}
 }
 
@@ -68,7 +68,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.Bool:
 		return decReflectBoolR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal boolean: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal boolean: unsupported value type (%T)(%[1]v), supported types: ~bool", v.Interface())
 	}
 }
 

--- a/serialization/counter/marshal_utils.go
+++ b/serialization/counter/marshal_utils.go
@@ -2,16 +2,12 @@ package counter
 
 import (
 	"fmt"
-	"math"
 	"math/big"
 	"reflect"
 	"strconv"
 )
 
-var (
-	maxBigInt = big.NewInt(math.MaxInt64)
-	minBigInt = big.NewInt(math.MinInt64)
-)
+const supportedTypes = "~int8, ~int16, ~int32, ~int64, ~int, ~uint8, ~uint16, ~uint32, ~uint64, ~uint, ~string, big.Int"
 
 func EncInt8(v int8) ([]byte, error) {
 	if v < 0 {
@@ -133,7 +129,7 @@ func EncUintR(v *uint) ([]byte, error) {
 }
 
 func EncBigInt(v big.Int) ([]byte, error) {
-	if v.Cmp(maxBigInt) == 1 || v.Cmp(minBigInt) == -1 {
+	if !v.IsInt64() {
 		return nil, fmt.Errorf("failed to marshal counter: value (%T)(%s) out of range", v, v.String())
 	}
 	return encInt64(v.Int64()), nil
@@ -143,7 +139,7 @@ func EncBigIntR(v *big.Int) ([]byte, error) {
 	if v == nil {
 		return nil, nil
 	}
-	if v.Cmp(maxBigInt) == 1 || v.Cmp(minBigInt) == -1 {
+	if !v.IsInt64() {
 		return nil, fmt.Errorf("failed to marshal counter: value (%T)(%s) out of range", v, v.String())
 	}
 	return encInt64(v.Int64()), nil
@@ -188,9 +184,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	default:
-		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal counter: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/counter/unmarshal.go
+++ b/serialization/counter/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v)", value)
+			return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v), supported types: %s", value, supportedTypes)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/counter/unmarshal_utils.go
+++ b/serialization/counter/unmarshal_utils.go
@@ -505,7 +505,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 
@@ -667,7 +667,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal counter: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/cqlint/marshal_utils.go
+++ b/serialization/cqlint/marshal_utils.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+const supportedTypes = "~int8, ~int16, ~int32, ~int64, ~int, ~uint8, ~uint16, ~uint32, ~uint64, ~uint, ~string, big.Int"
+
 var (
 	maxBigInt = big.NewInt(math.MaxInt32)
 	minBigInt = big.NewInt(math.MinInt32)
@@ -227,9 +229,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	default:
-		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal int: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/cqlint/unmarshal.go
+++ b/serialization/cqlint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v)", value)
+			return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v), supported types: %s", value, supportedTypes)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/cqlint/unmarshal_utils.go
+++ b/serialization/cqlint/unmarshal_utils.go
@@ -492,7 +492,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 
@@ -517,7 +517,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal int: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/cqltime/marshal_utils.go
+++ b/serialization/cqltime/marshal_utils.go
@@ -58,9 +58,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal time: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Duration, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal time: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Duration, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/cqltime/unmarshal.go
+++ b/serialization/cqltime/unmarshal.go
@@ -26,7 +26,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v)", value)
+			return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Duration", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/cqltime/unmarshal_utils.go
+++ b/serialization/cqltime/unmarshal_utils.go
@@ -107,7 +107,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.Int64, reflect.Int:
 		return decReflectInt64(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Duration", v.Interface())
 	}
 }
 
@@ -136,7 +136,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.Int64, reflect.Int:
 		return decReflectIntsR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal time: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Duration", v.Interface())
 	}
 }
 

--- a/serialization/date/marshal_utils.go
+++ b/serialization/date/marshal_utils.go
@@ -144,9 +144,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal date: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal date: unsupported value type (%T)(%[1]v), supported types: ~int32, ~int64, ~uint32,  ~string, time.Time, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal date: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal date: unsupported value type (%T)(%[1]v), supported types: ~int32, ~int64, ~uint32,  ~string, time.Time, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/date/unmarshal.go
+++ b/serialization/date/unmarshal.go
@@ -39,7 +39,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal date: unsupported value type (%T)(%[1]v)", value)
+			return fmt.Errorf("failed to unmarshal date: unsupported value type (%T)(%[1]v), supported types: ~int32, ~int64, ~uint32,  ~string, time.Time", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/date/unmarshal_utils.go
+++ b/serialization/date/unmarshal_utils.go
@@ -216,7 +216,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal date: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal date: unsupported value type (%T)(%[1]v), supported types: ~int32, ~int64, ~uint32,  ~string, time.Time", v.Interface())
 	}
 }
 
@@ -287,7 +287,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal date: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal date: unsupported value type (%T)(%[1]v), supported types: ~int32, ~int64, ~uint32,  ~string, time.Time", v.Interface())
 	}
 }
 

--- a/serialization/decimal/marshal_utils.go
+++ b/serialization/decimal/marshal_utils.go
@@ -61,9 +61,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal decimal: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal decimal: unsupported value type (%T)(%[1]v), supported types: ~string, inf.Dec, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal decimal: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal decimal: unsupported value type (%T)(%[1]v), supported types: ~string, inf.Dec, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/decimal/unmarshal.go
+++ b/serialization/decimal/unmarshal.go
@@ -24,7 +24,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal decimal: unsupported value type (%T)(%#[1]v)", value)
+			return fmt.Errorf("failed to unmarshal decimal: unsupported value type (%T)(%#[1]v), supported types: ~string, inf.Dec", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/decimal/unmarshal_utils.go
+++ b/serialization/decimal/unmarshal_utils.go
@@ -185,7 +185,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal decimal: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal decimal: unsupported value type (%T)(%#[1]v), supported types: ~string, inf.Dec", v.Interface())
 	}
 }
 
@@ -198,7 +198,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal decimal: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal decimal: unsupported value type (%T)(%[1]v), supported types: ~string, inf.Dec", v.Interface())
 	}
 }
 

--- a/serialization/double/marshal_utils.go
+++ b/serialization/double/marshal_utils.go
@@ -25,9 +25,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal double: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal double: unsupported value type (%T)(%[1]v), supported types: ~float64, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal double: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal double: unsupported value type (%T)(%[1]v), supported types: ~float64, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/double/unmarshal.go
+++ b/serialization/double/unmarshal.go
@@ -19,7 +19,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v), supported types: ~float64", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/double/unmarshal_utils.go
+++ b/serialization/double/unmarshal_utils.go
@@ -55,7 +55,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.Float64:
 		return decReflectFloat32(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v), supported types: ~float64", v.Interface())
 	}
 }
 
@@ -68,7 +68,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.Float64:
 		return decReflectFloat32R(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v), supported types: ~float64", v.Interface())
 	}
 }
 

--- a/serialization/duration/marshal_utils.go
+++ b/serialization/duration/marshal_utils.go
@@ -95,9 +95,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal duration: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal duration: unsupported value type (%T)(%[1]v), supported types: ~int64, ~string, time.Duration, gocql.Duration, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal duration: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal duration: unsupported value type (%T)(%[1]v), supported types: ~int64, ~string, time.Duration, gocql.Duration, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/duration/unmarshal.go
+++ b/serialization/duration/unmarshal.go
@@ -35,7 +35,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal duration: unsupported value type (%T)(%[1]v)", value)
+			return fmt.Errorf("failed to unmarshal duration: unsupported value type (%T)(%[1]v), supported types: ~int64, ~string, time.Duration, gocql.Duration", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/duration/unmarshal_utils.go
+++ b/serialization/duration/unmarshal_utils.go
@@ -290,7 +290,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal duration: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal duration: unsupported value type (%T)(%[1]v), supported types: ~int64, ~string, time.Duration, gocql.Duration", v.Interface())
 	}
 }
 
@@ -361,7 +361,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal duration: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal duration: unsupported value type (%T)(%[1]v), supported types: ~int64, ~string, time.Duration, gocql.Duration", v.Interface())
 	}
 }
 

--- a/serialization/float/marshal_utils.go
+++ b/serialization/float/marshal_utils.go
@@ -25,9 +25,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal float: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal float: unsupported value type (%T)(%[1]v), supported types: ~float32, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal float: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal float: unsupported value type (%T)(%[1]v), supported types: ~float32, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/float/unmarshal.go
+++ b/serialization/float/unmarshal.go
@@ -19,7 +19,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal float: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal float: unsupported value type (%T)(%[1]v), supported types: ~float32", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/float/unmarshal_utils.go
+++ b/serialization/float/unmarshal_utils.go
@@ -55,7 +55,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.Float32:
 		return decReflectFloat32(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal float: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal float: unsupported value type (%T)(%[1]v), supported types: ~float32", v.Interface())
 	}
 }
 
@@ -68,7 +68,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.Float32:
 		return decReflectFloat32R(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal float: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal float: unsupported value type (%T)(%[1]v), supported types: ~float32", v.Interface())
 	}
 }
 

--- a/serialization/inet/marshal_utils.go
+++ b/serialization/inet/marshal_utils.go
@@ -110,14 +110,14 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Array:
 		if l := v.Len(); v.Type().Elem().Kind() != reflect.Uint8 || (l != 16 && l != 4) {
-			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP, unsetColumn", v.Interface())
 		}
 		nv := reflect.New(v.Type())
 		nv.Elem().Set(v)
 		return nv.Elem().Bytes(), nil
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP, unsetColumn", v.Interface())
 		}
 		return encReflectBytes(v)
 	case reflect.String:
@@ -126,9 +126,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP, unsetColumn", v.Interface())
 	}
 }
 
@@ -139,18 +139,18 @@ func EncReflectR(v reflect.Value) ([]byte, error) {
 	switch ev := v.Elem(); ev.Kind() {
 	case reflect.Array:
 		if l := v.Len(); ev.Type().Elem().Kind() != reflect.Uint8 || (l != 16 && l != 4) {
-			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP, unsetColumn", v.Interface())
 		}
 		return v.Elem().Bytes(), nil
 	case reflect.Slice:
 		if ev.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP, unsetColumn", v.Interface())
 		}
 		return encReflectBytes(ev)
 	case reflect.String:
 		return encReflectString(ev)
 	default:
-		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/inet/unmarshal.go
+++ b/serialization/inet/unmarshal.go
@@ -36,7 +36,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/inet/unmarshal_utils.go
+++ b/serialization/inet/unmarshal_utils.go
@@ -255,7 +255,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	switch v = v.Elem(); v.Kind() {
 	case reflect.Array:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 		}
 		switch v.Len() {
 		case 4:
@@ -263,17 +263,17 @@ func DecReflect(p []byte, v reflect.Value) error {
 		case 16:
 			return decReflectArray16(p, v)
 		default:
-			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 		}
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 		}
 		return decReflectBytes(p, v)
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 	}
 }
 
@@ -286,7 +286,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	switch evt := ev.Type().Elem(); evt.Kind() {
 	case reflect.Array:
 		if evt.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 		}
 		switch ev.Len() {
 		case 4:
@@ -294,17 +294,17 @@ func DecReflectR(p []byte, v reflect.Value) error {
 		case 16:
 			return decReflectArray16R(p, ev)
 		default:
-			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 		}
 	case reflect.Slice:
 		if evt.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 		}
 		return decReflectBytesR(p, ev)
 	case reflect.String:
 		return decReflectStringR(p, ev)
 	default:
-		return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal inet: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[4]byte, ~[16]byte, ~string, net.IP", v.Interface())
 	}
 }
 

--- a/serialization/smallint/marshal_utils.go
+++ b/serialization/smallint/marshal_utils.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+const supportedTypes = "~int8, ~int16, ~int32, ~int64, ~int, ~uint8, ~uint16, ~uint32, ~uint64, ~uint, ~string, big.Int"
+
 var (
 	maxBigInt = big.NewInt(math.MaxInt16)
 	minBigInt = big.NewInt(math.MinInt16)
@@ -221,9 +223,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	default:
-		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal smallint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/smallint/unmarshal_utils.go
+++ b/serialization/smallint/unmarshal_utils.go
@@ -475,13 +475,13 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 
 func DecReflectR(p []byte, v reflect.Value) error {
 	if v.IsNil() {
-		return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal smallint: can not unmarshal into nil reference (%T)(%[1]v)", v.Interface())
 	}
 
 	switch v.Type().Elem().Elem().Kind() {
@@ -496,7 +496,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal smallint: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/text/marshal_utils.go
+++ b/serialization/text/marshal_utils.go
@@ -33,16 +33,16 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		return encString(v.String()), nil
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 		}
 		return EncBytes(v.Bytes())
 	case reflect.Struct:
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/text/unmarshal.go
+++ b/serialization/text/unmarshal.go
@@ -25,7 +25,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/text/unmarshal_utils.go
+++ b/serialization/text/unmarshal_utils.go
@@ -59,13 +59,13 @@ func DecReflect(p []byte, v reflect.Value) error {
 		v.SetString(decString(p))
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		v.SetBytes(decBytes(p))
 	case reflect.Interface:
 		v.Set(reflect.ValueOf(decBytes(p)))
 	default:
-		return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 	return nil
 }
@@ -80,11 +80,11 @@ func DecReflectR(p []byte, v reflect.Value) error {
 		return decReflectStringR(p, v)
 	case reflect.Slice:
 		if ev.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		return decReflectBytesR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal text: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 }
 

--- a/serialization/timestamp/marshal_utils.go
+++ b/serialization/timestamp/marshal_utils.go
@@ -46,9 +46,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal timestamp: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal timestamp: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Time, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal timestamp: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal timestamp: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Time, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/timestamp/unmarshal.go
+++ b/serialization/timestamp/unmarshal.go
@@ -26,7 +26,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal timestamp: unsupported value type (%T)(%[1]v)", value)
+			return fmt.Errorf("failed to unmarshal timestamp: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Time", value)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/timestamp/unmarshal_utils.go
+++ b/serialization/timestamp/unmarshal_utils.go
@@ -94,7 +94,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.Int64:
 		return decReflectInt64(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal timestamp: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal timestamp: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Time", v.Interface())
 	}
 }
 
@@ -119,7 +119,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.Int64:
 		return decReflectIntsR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal timestamp: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal timestamp: unsupported value type (%T)(%[1]v), supported types: ~int64, time.Time", v.Interface())
 	}
 }
 

--- a/serialization/timeuuid/marshal_utils.go
+++ b/serialization/timeuuid/marshal_utils.go
@@ -53,14 +53,14 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Array:
 		if v.Type().Elem().Kind() != reflect.Uint8 || v.Len() != 16 {
-			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		nv := reflect.New(v.Type())
 		nv.Elem().Set(v)
 		return nv.Elem().Bytes(), nil
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		return encReflectBytes(v)
 	case reflect.String:
@@ -69,9 +69,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal timeuuid: timeuuid value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal timeuuid: timeuuid value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 	}
 }
 
@@ -82,18 +82,18 @@ func EncReflectR(v reflect.Value) ([]byte, error) {
 	switch ev := v.Elem(); ev.Kind() {
 	case reflect.Array:
 		if ev.Type().Elem().Kind() != reflect.Uint8 || ev.Len() != 16 {
-			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		return v.Elem().Bytes(), nil
 	case reflect.Slice:
 		if ev.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		return encReflectBytes(ev)
 	case reflect.String:
 		return encReflectString(ev)
 	default:
-		return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/timeuuid/unmarshal.go
+++ b/serialization/timeuuid/unmarshal.go
@@ -31,7 +31,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		// Later, when generic-based serialization is introduced we can do that via generics.
 		rv := reflect.ValueOf(value)
 		if rv.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v)
 		}
 		if rv.Type().Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/timeuuid/unmarshal_utils.go
+++ b/serialization/timeuuid/unmarshal_utils.go
@@ -181,18 +181,18 @@ func DecReflect(p []byte, v reflect.Value) error {
 	switch v = v.Elem(); v.Kind() {
 	case reflect.Array:
 		if v.Type().Elem().Kind() != reflect.Uint8 || v.Len() != 16 {
-			return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectArray(p, v)
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectBytes(p, v)
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 	}
 }
 
@@ -205,18 +205,18 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	switch evt := ev.Type().Elem(); evt.Kind() {
 	case reflect.Array:
 		if evt.Elem().Kind() != reflect.Uint8 || ev.Len() != 16 {
-			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectArrayR(p, ev)
 	case reflect.Slice:
 		if evt.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectBytesR(p, ev)
 	case reflect.String:
 		return decReflectStringR(p, ev)
 	default:
-		return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 	}
 }
 

--- a/serialization/tinyint/marshal_utils.go
+++ b/serialization/tinyint/marshal_utils.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+const supportedTypes = "~int8, ~int16, ~int32, ~int64, ~int, ~uint8, ~uint16, ~uint32, ~uint64, ~uint, ~string, big.Int"
+
 var (
 	maxBigInt = big.NewInt(math.MaxInt8)
 	minBigInt = big.NewInt(math.MinInt8)
@@ -213,9 +215,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	default:
-		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal tinyint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/tinyint/unmarshal.go
+++ b/serialization/tinyint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v), supported types: %s", v, supportedTypes)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/tinyint/unmarshal_utils.go
+++ b/serialization/tinyint/unmarshal_utils.go
@@ -458,7 +458,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 
@@ -475,7 +475,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal tinyint: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/uuid/marshal_utils.go
+++ b/serialization/uuid/marshal_utils.go
@@ -53,14 +53,14 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Kind() {
 	case reflect.Array:
 		if v.Type().Elem().Kind() != reflect.Uint8 || v.Len() != 16 {
-			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		nv := reflect.New(v.Type())
 		nv.Elem().Set(v)
 		return nv.Elem().Bytes(), nil
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		return encReflectBytes(v)
 	case reflect.String:
@@ -69,9 +69,9 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal uuid: timeuuid value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal uuid: timeuuid value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 	}
 }
 
@@ -82,18 +82,18 @@ func EncReflectR(v reflect.Value) ([]byte, error) {
 	switch ev := v.Elem(); ev.Kind() {
 	case reflect.Array:
 		if ev.Type().Elem().Kind() != reflect.Uint8 || ev.Len() != 16 {
-			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		return v.Elem().Bytes(), nil
 	case reflect.Slice:
 		if ev.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 		}
 		return encReflectBytes(ev)
 	case reflect.String:
 		return encReflectString(ev)
 	default:
-		return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/uuid/unmarshal.go
+++ b/serialization/uuid/unmarshal.go
@@ -26,7 +26,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		// Later, when generic-based serialization is introduced we can do that via generics.
 		rv := reflect.ValueOf(value)
 		if rv.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v)
 		}
 		if rv.Type().Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/uuid/unmarshal_utils.go
+++ b/serialization/uuid/unmarshal_utils.go
@@ -140,18 +140,18 @@ func DecReflect(p []byte, v reflect.Value) error {
 	switch v = v.Elem(); v.Kind() {
 	case reflect.Array:
 		if v.Type().Elem().Kind() != reflect.Uint8 || v.Len() != 16 {
-			return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectArray(p, v)
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectBytes(p, v)
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal uuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 	}
 }
 
@@ -164,18 +164,18 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	switch evt := ev.Type().Elem(); evt.Kind() {
 	case reflect.Array:
 		if evt.Elem().Kind() != reflect.Uint8 || ev.Len() != 16 {
-			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectArrayR(p, ev)
 	case reflect.Slice:
 		if evt.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 		}
 		return decReflectBytesR(p, ev)
 	case reflect.String:
 		return decReflectStringR(p, ev)
 	default:
-		return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal timeuuid: unsupported value type (%T)(%[1]v), supported types: ~[]byte, ~[16]byte, ~string", v.Interface())
 	}
 }
 

--- a/serialization/varchar/marshal_utils.go
+++ b/serialization/varchar/marshal_utils.go
@@ -33,16 +33,16 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		return encString(v.String()), nil
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+			return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 		}
 		return EncBytes(v.Bytes())
 	case reflect.Struct:
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	default:
-		return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte, unsetColumn", v.Interface())
 	}
 }
 

--- a/serialization/varchar/unmarshal.go
+++ b/serialization/varchar/unmarshal.go
@@ -25,7 +25,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v)", v)
+			return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/varchar/unmarshal_utils.go
+++ b/serialization/varchar/unmarshal_utils.go
@@ -59,13 +59,13 @@ func DecReflect(p []byte, v reflect.Value) error {
 		v.SetString(decString(p))
 	case reflect.Slice:
 		if v.Type().Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		v.SetBytes(decBytes(p))
 	case reflect.Interface:
 		v.Set(reflect.ValueOf(decBytes(p)))
 	default:
-		return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 	return nil
 }
@@ -80,11 +80,11 @@ func DecReflectR(p []byte, v reflect.Value) error {
 		return decReflectStringR(p, v)
 	case reflect.Slice:
 		if ev.Elem().Kind() != reflect.Uint8 {
-			return fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+			return fmt.Errorf("failed to marshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 		}
 		return decReflectBytesR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal varchar: unsupported value type (%T)(%[1]v), supported types: ~string, ~[]byte", v.Interface())
 	}
 }
 

--- a/serialization/varint/marshal_custom.go
+++ b/serialization/varint/marshal_custom.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 )
 
+const supportedTypes = "~int8, ~int16, ~int32, ~int64, ~int, ~uint8, ~uint16, ~uint32, ~uint64, ~uint, ~string, big.Int"
+
 func EncReflect(v reflect.Value) ([]byte, error) {
 	switch v.Type().Kind() {
 	case reflect.Int8:
@@ -31,10 +33,10 @@ func EncReflect(v reflect.Value) ([]byte, error) {
 		if v.Type().String() == "gocql.unsetColumn" {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to marshal varint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal varint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 
 	default:
-		return nil, fmt.Errorf("failed to marshal varint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return nil, fmt.Errorf("failed to marshal varint: unsupported value type (%T)(%[1]v), supported types: %s, unsetColumn", v.Interface(), supportedTypes)
 	}
 }
 

--- a/serialization/varint/unmarshal.go
+++ b/serialization/varint/unmarshal.go
@@ -71,7 +71,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		rv := reflect.ValueOf(value)
 		rt := rv.Type()
 		if rt.Kind() != reflect.Ptr {
-			return fmt.Errorf("failed to unmarshal varint: unsupported value type (%T)(%#[1]v)", value)
+			return fmt.Errorf("failed to unmarshal varint: unsupported value type (%T)(%#[1]v), supported types: %s", value, supportedTypes)
 		}
 		if rt.Elem().Kind() != reflect.Ptr {
 			return DecReflect(data, rv)

--- a/serialization/varint/unmarshal_custom.go
+++ b/serialization/varint/unmarshal_custom.go
@@ -31,7 +31,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectString(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal varint: unsupported value type (%T)(%#[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal varint: unsupported value type (%T)(%#[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 
@@ -270,7 +270,7 @@ func DecReflectR(p []byte, v reflect.Value) error {
 	case reflect.String:
 		return decReflectStringR(p, v)
 	default:
-		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v)", v.Interface())
+		return fmt.Errorf("failed to unmarshal bigint: unsupported value type (%T)(%[1]v), supported types: %s", v.Interface(), supportedTypes)
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -933,7 +933,7 @@ func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bo
 		iter.Scan(&applied)
 	}
 
-	return applied, iter, nil
+	return applied, iter, iter.err
 }
 
 // MapExecuteBatchCAS executes a batch operation much like ExecuteBatchCAS,
@@ -946,8 +946,14 @@ func (s *Session) MapExecuteBatchCAS(batch *Batch, dest map[string]interface{}) 
 		return false, nil, err
 	}
 	iter.MapScan(dest)
-	applied = dest["[applied]"].(bool)
-	delete(dest, "[applied]")
+	if iter.err != nil {
+		return false, iter, iter.err
+	}
+	// check if [applied] was returned, otherwise it might not be CAS
+	if _, ok := dest["[applied]"]; ok {
+		applied = dest["[applied]"].(bool)
+		delete(dest, "[applied]")
+	}
 
 	// we usually close here, but instead of closing, just returin an error
 	// if MapScan failed. Although Close just returns err, using Close
@@ -1587,8 +1593,14 @@ func (q *Query) MapScanCAS(dest map[string]interface{}) (applied bool, err error
 		return false, err
 	}
 	iter.MapScan(dest)
-	applied = dest["[applied]"].(bool)
-	delete(dest, "[applied]")
+	if iter.err != nil {
+		return false, iter.err
+	}
+	// check if [applied] was returned, otherwise it might not be CAS
+	if _, ok := dest["[applied]"]; ok {
+		applied = dest["[applied]"].(bool)
+		delete(dest, "[applied]")
+	}
 
 	return applied, iter.Close()
 }


### PR DESCRIPTION
Original commit list:
**1. https://github.com/apache/cassandra-gocql-driver/commit/3a475c75aefc97b2961bae3a2d53b3e87c9274d0**
Message:
```
CASSGO-44: keep nil slices in MapScan
Previously if you read a NULL column as a varchar using MapScan it
would store the value []byte{} in the map rather than []byte() which
made it impossible to know if the value was NULL or not.

Patch by James Hartig; reviewed by João Reis for CASSGO-44
```
Status: `APPLIED`

**2. https://github.com/apache/cassandra-gocql-driver/commit/c63468d9ce9dca353f55a3371aa97a30eedd7d4b**
Message:
```
CASSGO-42: don't panic if no applied column is returned
I also added checks against MapScan failing which could also trigger this bug.

Several integration tests were added to validate various edge cases.

Patch by James Hartig; reviewed by João Reis for CASSGO-42
```
Status: `APPLIED`

**3. https://github.com/apache/cassandra-gocql-driver/commit/91cbf12722ef7a53cfd0f0e94fe86233426dd34f**
Message:
```
skip metadata only if prepared result included metadata
If the prepare result doesn't include metadata we shouldn't skip metadata
when executing the query. Fixes CASSGO-40.

Patch by James Hartig; reviewed by João Reis for CASSGO-40
```
Status: `APPLIED`

**4. https://github.com/apache/cassandra-gocql-driver/commit/16366d4eff6a21c769203299330f6109de9f2401**
Message:
```
Improve error messages for marshalling
Enhancement for marshal/unmarshal error messages.
Errors were updated by the supported types list.

patch by Oleksandr Luzhniy; reviewed by João Reis, James Hartig, Bohdan Siryk, for [CASSGO-38](https://issues.apache.org/jira/browse/CASSGO-38)
```
Status: `APPLIED`

**5. https://github.com/apache/cassandra-gocql-driver/commit/d3456309946b01151c8d0329c2e11c1d192001ff**
Message:
```
CASSGO-2 Marshal big int returns variable length slice.
The marshalBigInt return 8 bytes slice in all cases except for big.Int,
which returns a variable length slice, but should be 8 bytes slice as well.

patch by Mykyta Oleksiienko; reviewed by João Reis, James Harting for CASSGO-2
```
Status: `APPLIED`
