### PR TITLE
Merge upstream changes up to commit  `4ad747972`

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -224,7 +224,7 @@ type ClusterConfig struct {
 	// If DisableInitialHostLookup then the driver will not attempt to get host info
 	// from the system.peers table, this will mean that the driver will connect to
 	// hosts supplied and will not attempt to lookup the hosts information, this will
-	// mean that data_centre, rack and token information will not be available and as
+	// mean that data_center, rack and token information will not be available and as
 	// such host filtering and token aware query routing will not be available.
 	DisableInitialHostLookup bool
 

--- a/filters.go
+++ b/filters.go
@@ -53,12 +53,18 @@ func DenyAllFilter() HostFilter {
 	})
 }
 
-// DataCentreHostFilter filters all hosts such that they are in the same data centre
-// as the supplied data centre.
-func DataCentreHostFilter(dataCentre string) HostFilter {
+// DataCenterHostFilter filters all hosts such that they are in the same data center
+// as the supplied data center.
+func DataCenterHostFilter(dataCenter string) HostFilter {
 	return HostFilterFunc(func(host *HostInfo) bool {
-		return host.DataCenter() == dataCentre
+		return host.DataCenter() == dataCenter
 	})
+}
+
+// Deprecated: Use DataCenterHostFilter instead.
+// DataCentreHostFilter is an alias that doesn't use the preferred spelling.
+func DataCentreHostFilter(dataCenter string) HostFilter {
+	return DataCenterHostFilter(dataCenter)
 }
 
 // WhiteListHostFilter filters incoming hosts by checking that their address is

--- a/filters_test.go
+++ b/filters_test.go
@@ -98,8 +98,10 @@ func TestFilter_DenyAll(t *testing.T) {
 	}
 }
 
-func TestFilter_DataCentre(t *testing.T) {
-	f := DataCentreHostFilter("dc1")
+func TestFilter_DataCenter(t *testing.T) {
+	f := DataCenterHostFilter("dc1")
+	fDeprecated := DataCentreHostFilter("dc1")
+
 	tests := [...]struct {
 		dc     string
 		accept bool
@@ -115,6 +117,10 @@ func TestFilter_DataCentre(t *testing.T) {
 			}
 		} else if test.accept {
 			t.Errorf("%d: should have been accepted but wasn't", i)
+		}
+
+		if f.Accept(&HostInfo{dataCenter: test.dc}) != fDeprecated.Accept(&HostInfo{dataCenter: test.dc}) {
+			t.Errorf("%d: DataCenterHostFilter and DataCentreHostFilter should be the same", i)
 		}
 	}
 }

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -37,9 +37,13 @@ func TestUnmarshalCassVersion(t *testing.T) {
 		data    string
 		version cassVersion
 	}{
-		{"3.2", cassVersion{3, 2, 0}},
-		{"2.10.1-SNAPSHOT", cassVersion{2, 10, 1}},
-		{"1.2.3", cassVersion{1, 2, 3}},
+		{"3.2", cassVersion{3, 2, 0, ""}},
+		{"2.10.1-SNAPSHOT", cassVersion{2, 10, 1, ""}},
+		{"1.2.3", cassVersion{1, 2, 3, ""}},
+		{"4.0-rc2", cassVersion{4, 0, 0, "rc2"}},
+		{"4.3.2-rc1", cassVersion{4, 3, 2, "rc1"}},
+		{"4.3.2-rc1-qualifier1", cassVersion{4, 3, 2, "rc1-qualifier1"}},
+		{"4.3-rc1-qualifier1", cassVersion{4, 3, 0, "rc1-qualifier1"}},
 	}
 
 	for i, test := range tests {
@@ -56,14 +60,17 @@ func TestCassVersionBefore(t *testing.T) {
 	tests := [...]struct {
 		version             cassVersion
 		major, minor, patch int
+		Qualifier           string
 	}{
-		{cassVersion{1, 0, 0}, 0, 0, 0},
-		{cassVersion{0, 1, 0}, 0, 0, 0},
-		{cassVersion{0, 0, 1}, 0, 0, 0},
+		{cassVersion{1, 0, 0, ""}, 0, 0, 0, ""},
+		{cassVersion{0, 1, 0, ""}, 0, 0, 0, ""},
+		{cassVersion{0, 0, 1, ""}, 0, 0, 0, ""},
 
-		{cassVersion{1, 0, 0}, 0, 1, 0},
-		{cassVersion{0, 1, 0}, 0, 0, 1},
-		{cassVersion{4, 1, 0}, 3, 1, 2},
+		{cassVersion{1, 0, 0, ""}, 0, 1, 0, ""},
+		{cassVersion{0, 1, 0, ""}, 0, 0, 1, ""},
+		{cassVersion{4, 1, 0, ""}, 3, 1, 2, ""},
+
+		{cassVersion{4, 1, 0, ""}, 3, 1, 2, ""},
 	}
 
 	for i, test := range tests {

--- a/hostpolicy/hostpool.go
+++ b/hostpolicy/hostpool.go
@@ -1,0 +1,157 @@
+package hostpolicy
+
+import (
+	"sync"
+
+	"github.com/hailocab/go-hostpool"
+
+	"github.com/gocql/gocql"
+)
+
+// HostPool is a host policy which uses the bitly/go-hostpool library
+// to distribute queries between hosts and prevent sending queries to
+// unresponsive hosts. When creating the host pool that is passed to the policy
+// use an empty slice of hosts as the hostpool will be populated later by gocql.
+// See below for examples of usage:
+//
+//	// Create host selection policy using a simple host pool
+//	cluster.PoolConfig.HostSelectionPolicy = HostPool(hostpool.New(nil))
+//
+//	// Create host selection policy using an epsilon greedy pool
+//	cluster.PoolConfig.HostSelectionPolicy = HostPool(
+//	    hostpool.NewEpsilonGreedy(nil, 0, &hostpool.LinearEpsilonValueCalculator{}),
+//	)
+
+func HostPool(hp hostpool.HostPool) gocql.HostSelectionPolicy {
+	return &hostPoolHostPolicy{hostMap: map[string]*gocql.HostInfo{}, hp: hp}
+}
+
+type hostPoolHostPolicy struct {
+	hp      hostpool.HostPool
+	mu      sync.RWMutex
+	hostMap map[string]*gocql.HostInfo
+}
+
+func (r *hostPoolHostPolicy) Init(*gocql.Session)                       {}
+func (r *hostPoolHostPolicy) Reset()                                    {}
+func (r *hostPoolHostPolicy) IsOperational(*gocql.Session) error        { return nil }
+func (r *hostPoolHostPolicy) KeyspaceChanged(gocql.KeyspaceUpdateEvent) {}
+func (r *hostPoolHostPolicy) SetPartitioner(string)                     {}
+func (r *hostPoolHostPolicy) IsLocal(*gocql.HostInfo) bool              { return true }
+
+func (r *hostPoolHostPolicy) SetHosts(hosts []*gocql.HostInfo) {
+	peers := make([]string, len(hosts))
+	hostMap := make(map[string]*gocql.HostInfo, len(hosts))
+
+	for i, host := range hosts {
+		ip := host.ConnectAddress().String()
+		peers[i] = ip
+		hostMap[ip] = host
+	}
+
+	r.mu.Lock()
+	r.hp.SetHosts(peers)
+	r.hostMap = hostMap
+	r.mu.Unlock()
+}
+
+func (r *hostPoolHostPolicy) AddHost(host *gocql.HostInfo) {
+	ip := host.ConnectAddress().String()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// If the host addr is present and isn't nil return
+	if h, ok := r.hostMap[ip]; ok && h != nil {
+		return
+	}
+	// otherwise, add the host to the map
+	r.hostMap[ip] = host
+	// and construct a new peer list to give to the HostPool
+	hosts := make([]string, 0, len(r.hostMap))
+	for addr := range r.hostMap {
+		hosts = append(hosts, addr)
+	}
+
+	r.hp.SetHosts(hosts)
+}
+
+func (r *hostPoolHostPolicy) RemoveHost(host *gocql.HostInfo) {
+	ip := host.ConnectAddress().String()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.hostMap[ip]; !ok {
+		return
+	}
+
+	delete(r.hostMap, ip)
+	hosts := make([]string, 0, len(r.hostMap))
+	for _, host := range r.hostMap {
+		hosts = append(hosts, host.ConnectAddress().String())
+	}
+
+	r.hp.SetHosts(hosts)
+}
+
+func (r *hostPoolHostPolicy) HostUp(host *gocql.HostInfo) {
+	r.AddHost(host)
+}
+
+func (r *hostPoolHostPolicy) HostDown(host *gocql.HostInfo) {
+	r.RemoveHost(host)
+}
+
+func (r *hostPoolHostPolicy) Pick(qry gocql.ExecutableQuery) gocql.NextHost {
+	return func() gocql.SelectedHost {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+
+		if len(r.hostMap) == 0 {
+			return nil
+		}
+
+		hostR := r.hp.Get()
+		host, ok := r.hostMap[hostR.Host()]
+		if !ok {
+			return nil
+		}
+
+		return selectedHostPoolHost{
+			policy: r,
+			info:   host,
+			hostR:  hostR,
+		}
+	}
+}
+
+// selectedHostPoolHost is a host returned by the hostPoolHostPolicy and
+// implements the SelectedHost interface
+type selectedHostPoolHost struct {
+	policy *hostPoolHostPolicy
+	info   *gocql.HostInfo
+	hostR  hostpool.HostPoolResponse
+}
+
+func (host selectedHostPoolHost) Info() *gocql.HostInfo {
+	return host.info
+}
+
+func (host selectedHostPoolHost) Token() gocql.Token {
+	return nil
+}
+
+func (host selectedHostPoolHost) Mark(err error) {
+	ip := host.info.ConnectAddress().String()
+
+	host.policy.mu.RLock()
+	defer host.policy.mu.RUnlock()
+
+	if _, ok := host.policy.hostMap[ip]; !ok {
+		// host was removed between pick and mark
+		return
+	}
+
+	host.hostR.Mark(err)
+}

--- a/hostpolicy/hostpool_test.go
+++ b/hostpolicy/hostpool_test.go
@@ -1,0 +1,58 @@
+package hostpolicy
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/hailocab/go-hostpool"
+
+	"github.com/gocql/gocql"
+)
+
+// Tests of the host pool host selection policy implementation
+func TestHostPolicy_HostPool(t *testing.T) {
+	policy := HostPool(hostpool.New(nil))
+
+	//hosts := []*gocql.HostInfo{
+	//	{hostId: "0", connectAddress: net.IPv4(10, 0, 0, 0)},
+	//	{hostId: "1", connectAddress: net.IPv4(10, 0, 0, 1)},
+	//}
+	firstHost := &gocql.HostInfo{}
+	firstHost.SetHostID("0")
+	firstHost.SetConnectAddress(net.IPv4(10, 0, 0, 0))
+	secHost := &gocql.HostInfo{}
+	secHost.SetHostID("1")
+	secHost.SetConnectAddress(net.IPv4(10, 0, 0, 1))
+	hosts := []*gocql.HostInfo{firstHost, secHost}
+	// Using set host to control the ordering of the hosts as calling "AddHost" iterates the map
+	// which will result in an unpredictable ordering
+	policy.(*hostPoolHostPolicy).SetHosts(hosts)
+
+	// the first host selected is actually at [1], but this is ok for RR
+	// interleaved iteration should always increment the host
+	iter := policy.Pick(nil)
+	actualA := iter()
+	if actualA.Info().HostID() != "0" {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actualA.Info().HostID())
+	}
+	actualA.Mark(nil)
+
+	actualB := iter()
+	if actualB.Info().HostID() != "1" {
+		t.Errorf("Expected hosts[1] but was hosts[%s]", actualB.Info().HostID())
+	}
+	actualB.Mark(fmt.Errorf("error"))
+
+	actualC := iter()
+	if actualC.Info().HostID() != "0" {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actualC.Info().HostID())
+	}
+	actualC.Mark(nil)
+
+	actualD := iter()
+	if actualD.Info().HostID() != "0" {
+		t.Errorf("Expected hosts[0] but was hosts[%s]", actualD.Info().HostID())
+	}
+	actualD.Mark(nil)
+}


### PR DESCRIPTION
Original commit list:
**1. https://github.com/apache/cassandra-gocql-driver/commit/fb11fadaf4e42b57d2b4186052ec7fc40c77aafe**
Message:
```
Remove HostPoolHostPolicy from gocql package
HostPoolHostPolicy was moved to a separate package, and users don't need to download dependency if they aren't using it.

patch by Oleksandr Luzhniy; reviewed by João Reis, Stanislav Bychkov, James Hartig, for CASSGO-21
```
Status: `APPLIED`

**2. https://github.com/apache/cassandra-gocql-driver/commit/cb139a396ee9ac76fdcd5fcddfeaafd877578bb1**
Message:
```
standardize datacenter spelling
This change keeps the repo internally consistent in the spelling of "datacenter". The public interface is kept to prevent breakage.

Patch by Brendan Gerrity; reviewed by João Reis, James Hartig for CASSGO-35
```
Status: `APPLIED`

**3. https://github.com/apache/cassandra-gocql-driver/commit/4ad7479729a7fabcf3bf2e8126c6695ba719bf4c**
Message:
```
Cassandra version unmarshal fix
FIx for the issue, when the driver is unable to unmarshal Cassandra version,
which contains additional annotation (suffix).

patch by Oleksandr Luzhniy; reviewed by João Reis, James Hartig, Danylo Savchenko, for CASSGO-49
```
Status: `APPLIED`