### PR TITLE
Merge upstream changes up to commit  `f35d4637` 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1928,7 +1928,13 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 		if err = iter.Close(); err != nil {
 			return err
 		}
-		err = getSchemaAgreement(schemaVersions, hosts, c.host.ConnectAddress(), c.session.cfg.Port, c.session.cfg.translateAddressPort, c.logger)
+
+		var addr net.IP
+		if addr, err = c.host.ConnectAddressWithError(); err != nil {
+			return err
+		}
+
+		err = getSchemaAgreement(schemaVersions, hosts, addr, c.session.cfg.Port, c.session.cfg.translateAddressPort, c.logger)
 
 		if err == ErrConnectionClosed || err == nil {
 			return err

--- a/host_source.go
+++ b/host_source.go
@@ -249,6 +249,17 @@ func (h *HostInfo) ConnectAddress() net.IP {
 	panic(fmt.Sprintf("no valid connect address for host: %v. Is your cluster configured correctly?", h))
 }
 
+// ConnectAddressWithError same as ConnectAddress, but an error instead of panic.
+func (h *HostInfo) ConnectAddressWithError() (net.IP, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if addr, source := h.connectAddressLocked(); source != "invalid" {
+		return addr, nil
+	}
+	return nil, fmt.Errorf("no valid connect address for host: %v", h)
+}
+
 func (h *HostInfo) UntranslatedConnectAddress() net.IP {
 	h.mu.RLock()
 	defer h.mu.RUnlock()

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -94,19 +94,21 @@ func (t *TableMetadataOptions) Equals(other *TableMetadataOptions) bool {
 }
 
 type ViewMetadata struct {
-	KeyspaceName      string
-	ViewName          string
-	BaseTableID       string
-	BaseTableName     string
-	ID                string
-	IncludeAllColumns bool
-	Columns           map[string]*ColumnMetadata
-	OrderedColumns    []string
-	PartitionKey      []*ColumnMetadata
-	ClusteringColumns []*ColumnMetadata
-	WhereClause       string
-	Options           TableMetadataOptions
-	Extensions        map[string]interface{}
+	KeyspaceName            string
+	ViewName                string
+	BaseTableID             string
+	BaseTableName           string
+	ID                      string
+	IncludeAllColumns       bool
+	Columns                 map[string]*ColumnMetadata
+	OrderedColumns          []string
+	PartitionKey            []*ColumnMetadata
+	ClusteringColumns       []*ColumnMetadata
+	WhereClause             string
+	Options                 TableMetadataOptions
+	Extensions              map[string]interface{}
+	DcLocalReadRepairChance float64 // After Scylla 4.2 by default read_repair turned off
+	ReadRepairChance        float64 // After Scylla 4.2 by default read_repair turned off
 }
 
 // schema metadata for a column
@@ -1085,6 +1087,8 @@ func getViewMetadata(session *Session, keyspaceName string) ([]ViewMetadata, err
 		"min_index_interval":          &view.Options.MinIndexInterval,
 		"speculative_retry":           &view.Options.SpeculativeRetry,
 		"extensions":                  &view.Extensions,
+		"dclocal_read_repair_chance":  &view.DcLocalReadRepairChance,
+		"read_repair_chance":          &view.ReadRepairChance,
 	}) {
 		views = append(views, view)
 		view = ViewMetadata{KeyspaceName: keyspaceName}


### PR DESCRIPTION
Original commit list:
**1. https://github.com/apache/cassandra-gocql-driver/commit/f3d13d4d0bf4e4cee186a47ed5a2c5e5a7fe3e54**
Message:
```
Add support for cassandra 4.0 table options
In the PR implemented backward compatibility with previous versions,
and added new types support. To make metadata table support easier for
future Cassandra versions, hardcode scan from Cassandra were replaced
with new "parseSystemSchemaViews" method which is much easier to expand,
even if some fields were added in the middle of the table it wouldn`t be an issue anymore.

patch by Mykyta Oleksiienko; reviewed by Joao Reis and James Harting CASSGO-13
```
Status: `APPLIED`

**2. https://github.com/apache/cassandra-gocql-driver/commit/65e2cafa8c46534a1aef83d5483302d23f7cb792**
Message:
```
Refactor HostInfo creation and ConnectAddress() method
HostInfo struct creation was refactored to create via constructor to make sure the connectAddress is valid.
Panic in case of invalid connect address inside of ConnectAddress() method was removed.

patch by Oleksandr Luzhniy; reviewed by João Reis, James Hartig, for CASSGO-45
```
Status: `APPLIED`

**3. https://github.com/apache/cassandra-gocql-driver/commit/f35d4637473831d0f6fbd3182ad5958f62588e1f**
Message:
```
Move the lz4 compressor into a separate go package
Currently, the LZ4 compressor is maintained as a separate module under gocql/lz4.
However, its implementation is tightly coupled with Cassandra's specific requirements.
To streamline development, reduce dependency management complexity,
and better encapsulate Cassandra-specific logic,
the lz4 compressor has been moved to a lz4 package within the main gocql module.

Patch by Mykyta Oleksiienko; reviewed by Joao Reis, Bohdan Siryk, Stanislav Bychkov and James Hartig for CASSGO-32
```
Status: `APPLIED`