### PR TITLE
Rollback zero timestamp serialization changes

### DIFF
--- a/serialization/timestamp/marshal_utils.go
+++ b/serialization/timestamp/marshal_utils.go
@@ -7,9 +7,8 @@ import (
 )
 
 var (
-	maxTimestamp  = time.Date(292278994, 8, 17, 7, 12, 55, 807*1000000, time.UTC)
-	zeroTimestamp = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
-	minTimestamp  = time.Date(-292275055, 5, 16, 16, 47, 4, 192*1000000, time.UTC)
+	maxTimestamp = time.Date(292278994, 8, 17, 7, 12, 55, 807*1000000, time.UTC)
+	minTimestamp = time.Date(-292275055, 5, 16, 16, 47, 4, 192*1000000, time.UTC)
 )
 
 func EncInt64(v int64) ([]byte, error) {
@@ -27,7 +26,11 @@ func EncTime(v time.Time) ([]byte, error) {
 	if v.After(maxTimestamp) || v.Before(minTimestamp) {
 		return nil, fmt.Errorf("failed to marshal timestamp: the (%T)(%s) value should be in the range from -292275055-05-16T16:47:04.192Z to 292278994-08-17T07:12:55.807", v, v.Format(time.RFC3339Nano))
 	}
-	ms := v.Unix()*1e3 + int64(v.Nanosecond())/1e6
+	// It supposed to be v.UTC().UnixMilli(), for backward compatibility map `time.Time{}` to nil value
+	if v.IsZero() {
+		return nil, nil
+	}
+	ms := v.UTC().UnixMilli()
 	return []byte{byte(ms >> 56), byte(ms >> 48), byte(ms >> 40), byte(ms >> 32), byte(ms >> 24), byte(ms >> 16), byte(ms >> 8), byte(ms)}, nil
 }
 

--- a/serialization/timestamp/unmarshal_utils.go
+++ b/serialization/timestamp/unmarshal_utils.go
@@ -55,7 +55,8 @@ func DecTime(p []byte, v *time.Time) error {
 	}
 	switch len(p) {
 	case 0:
-		*v = zeroTimestamp
+		// supposed to be zero timestamp `time.UnixMilli(0).UTC()`, but for backward compatibility mapped to zero time
+		*v = time.Time{}
 	case 8:
 		*v = decTime(p)
 	default:
@@ -73,7 +74,8 @@ func DecTimeR(p []byte, v **time.Time) error {
 		if p == nil {
 			*v = nil
 		} else {
-			val := zeroTimestamp
+			// supposed to be zero timestamp `time.UnixMilli(0).UTC()`, but for backward compatibility mapped to zero time
+			val := time.Time{}
 			*v = &val
 		}
 	case 8:

--- a/tests/serialization/marshal_16_timestamp_test.go
+++ b/tests/serialization/marshal_16_timestamp_test.go
@@ -57,14 +57,14 @@ func TestMarshalsTimestamp(t *testing.T) {
 			serialization.PositiveSet{
 				Data: nil,
 				Values: mod.Values{
-					int64(0), zeroTimestamp,
+					int64(0), time.Time{},
 				}.AddVariants(mod.CustomType),
 			}.Run("[nil]unmarshal", t, nil, unmarshal)
 
 			serialization.PositiveSet{
 				Data: make([]byte, 0),
 				Values: mod.Values{
-					int64(0), zeroTimestamp,
+					int64(0), time.Time{},
 				}.AddVariants(mod.All...),
 			}.Run("[]unmarshal", t, nil, unmarshal)
 


### PR DESCRIPTION
Due to the changes in serialization:
https://github.com/scylladb/gocql/pull/375 we have mapped nil timestamp to `time.UnixMilli(0).UTC()`.
What we have overseen is some of user logic could relay on `.IsZero()` and such change could cause regression.
To void this we roll back this change to preserve old behavior.