### PR TITLE
Add `DNSResolver` to Cluster config

### DIFF
--- a/control_test.go
+++ b/control_test.go
@@ -33,8 +33,7 @@ import (
 )
 
 func TestHostInfo_Lookup(t *testing.T) {
-	hostLookupPreferV4 = true
-	defer func() { hostLookupPreferV4 = false }()
+	resolver := NewSimpleDNSResolver(true)
 
 	tests := [...]struct {
 		addr string
@@ -45,7 +44,7 @@ func TestHostInfo_Lookup(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		hosts, err := hostInfo(test.addr, 1)
+		hosts, err := hostInfo(resolver, test.addr, 1)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue

--- a/exec.go
+++ b/exec.go
@@ -69,7 +69,7 @@ func NewSingleHostQueryExecutor(cfg *ClusterConfig) (e SingleHostQueryExecutor, 
 	}
 
 	var hosts []*HostInfo
-	if hosts, err = addrsToHosts(c.Hosts, c.Port, c.Logger); err != nil {
+	if hosts, err = addrsToHosts(c.DNSResolver, c.Hosts, c.Port, c.Logger); err != nil {
 		err = fmt.Errorf("addrs to hosts: %w", err)
 		return
 	}

--- a/filters.go
+++ b/filters.go
@@ -70,7 +70,7 @@ func DataCentreHostFilter(dataCenter string) HostFilter {
 // WhiteListHostFilter filters incoming hosts by checking that their address is
 // in the initial hosts whitelist.
 func WhiteListHostFilter(hosts ...string) HostFilter {
-	hostInfos, err := addrsToHosts(hosts, 9042, nopLogger{})
+	hostInfos, err := addrsToHosts(defaultDnsResolver, hosts, 9042, nopLogger{})
 	if err != nil {
 		// dont want to panic here, but rather not break the API
 		panic(fmt.Errorf("unable to lookup host info from address: %v", err))

--- a/helpers.go
+++ b/helpers.go
@@ -27,7 +27,6 @@ package gocql
 import (
 	"fmt"
 	"math/big"
-	"net"
 	"reflect"
 	"strings"
 	"time"
@@ -466,14 +465,4 @@ func copyBytes(p []byte) []byte {
 	b := make([]byte, len(p))
 	copy(b, p)
 	return b
-}
-
-var failDNS = false
-
-func LookupIP(host string) ([]net.IP, error) {
-	if failDNS {
-		return nil, &net.DNSError{}
-	}
-	return net.LookupIP(host)
-
 }

--- a/session.go
+++ b/session.go
@@ -116,10 +116,10 @@ var queryPool = &sync.Pool{
 	},
 }
 
-func addrsToHosts(addrs []string, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
+func addrsToHosts(resolver DNSResolver, addrs []string, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
 	var hosts []*HostInfo
 	for _, hostaddr := range addrs {
-		resolvedHosts, err := hostInfo(hostaddr, defaultPort)
+		resolvedHosts, err := hostInfo(resolver, hostaddr, defaultPort)
 		if err != nil {
 			// Try other hosts if unable to resolve DNS name
 			if _, ok := err.(*net.DNSError); ok {
@@ -259,7 +259,7 @@ func (s *Session) init() error {
 		return nil
 	}
 
-	hosts, err := addrsToHosts(s.cfg.Hosts, s.cfg.Port, s.logger)
+	hosts, err := addrsToHosts(s.cfg.DNSResolver, s.cfg.Hosts, s.cfg.Port, s.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It will allow to override default DNSResolver, whether for testing purposes or user convenience.
All behavior preserved.