### PR TITLE
Add DNS tests suite and fix problem it found

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -149,19 +149,20 @@ func createCluster(opts ...func(*ClusterConfig)) *ClusterConfig {
 }
 
 func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string, disableTablets bool) {
-	// TODO: tb.Helper()
+	tb.Helper()
+
 	c := *cluster
 	c.Keyspace = "system"
 	c.Timeout = 30 * time.Second
 	session, err := c.CreateSession()
 	if err != nil {
-		panic(err)
+		tb.Fatalf("failed to create session: %v", err)
 	}
 	defer session.Close()
 
 	err = createTable(session, `DROP KEYSPACE IF EXISTS `+keyspace)
 	if err != nil {
-		panic(fmt.Sprintf("unable to drop keyspace: %v", err))
+		tb.Fatalf("unable to drop keyspace: %v", err)
 	}
 
 	query := fmt.Sprintf(`CREATE KEYSPACE %s
@@ -179,7 +180,7 @@ func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string, disa
 	err = createTable(session, query)
 
 	if err != nil {
-		panic(fmt.Sprintf("unable to create keyspace: %v", err))
+		tb.Fatalf("unable to create table: %v", err)
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -1257,7 +1257,7 @@ func (srv *TestServer) session() (*Session, error) {
 }
 
 func (srv *TestServer) host() *HostInfo {
-	hosts, err := hostInfo(nil, srv.Address, 9042)
+	hosts, err := hostInfo(nil, nil, srv.Address, 9042)
 	if err != nil {
 		srv.t.Fatal(err)
 	}

--- a/control_test.go
+++ b/control_test.go
@@ -44,7 +44,7 @@ func TestHostInfo_Lookup(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		hosts, err := hostInfo(resolver, test.addr, 1)
+		hosts, err := hostInfo(resolver, nil, test.addr, 1)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue

--- a/dial.go
+++ b/dial.go
@@ -29,6 +29,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -69,12 +70,11 @@ func (hd *defaultHostDialer) DialHost(ctx context.Context, host *HostInfo) (*Dia
 		return nil, fmt.Errorf("host missing port: %v", port)
 	}
 
-	connAddr := host.ConnectAddressAndPort()
-	conn, err := hd.dialer.DialContext(ctx, "tcp", connAddr)
+	addr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
+	conn, err := hd.dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err
 	}
-	addr := host.HostnameAndPort()
 	return WrapTLS(ctx, conn, addr, hd.tlsConfig)
 }
 

--- a/dns_test.go
+++ b/dns_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+// +build integration
+
+package gocql
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+)
+
+type mockDNSResolver struct {
+	lock sync.RWMutex
+	data map[string][]net.IP
+}
+
+func newMockDNSResolver() *mockDNSResolver {
+	return &mockDNSResolver{
+		data: make(map[string][]net.IP),
+		lock: sync.RWMutex{},
+	}
+}
+
+func (r *mockDNSResolver) LookupIP(host string) ([]net.IP, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	ips, _ := r.data[host]
+	if len(ips) == 0 {
+		return nil, &net.DNSError{Err: errors.New("no IP addresses").Error(), Name: host}
+	}
+	return ips, nil
+}
+
+func (r *mockDNSResolver) Update(host string, ips ...net.IP) {
+	r.lock.Lock()
+	r.data[host] = ips
+	defer r.lock.Unlock()
+}
+
+func (r *mockDNSResolver) Delete(hosts ...string) {
+	r.lock.Lock()
+	for _, host := range hosts {
+		delete(r.data, host)
+	}
+	defer r.lock.Unlock()
+}
+
+func MustIP(ip string) net.IP {
+	out := net.ParseIP(ip)
+	if out == nil {
+		panic("failed to parse IP: " + ip)
+	}
+	return out
+}
+
+func TestDNS(t *testing.T) {
+	t.Parallel()
+
+	checkIfSessionWorking := func(t *testing.T, cluster *ClusterConfig, hosts []string) {
+		s, err := cluster.CreateSession()
+		if err != nil {
+			t.Fatalf("failed to create session: %v", err)
+		}
+		defer s.Close()
+
+		err = s.refreshRingNow()
+		if err != nil {
+			t.Fatalf("failed to refresh ring: %v", err)
+		}
+
+		err = s.Query("select * from system.peers").Exec()
+		if err != nil {
+			t.Fatalf("failed to execute query: %v", err)
+		}
+		ringHosts := s.hostSource.getHostsList()
+		if len(ringHosts) != len(hosts) {
+			t.Fatalf("wrong number of hosts: got %d, want %d", len(ringHosts), len(hosts))
+		}
+	}
+
+	OneDNSPerNode := func(c *ClusterConfig) {
+		r := newMockDNSResolver()
+		var dnsRecords []string
+		for id, host := range c.Hosts {
+			dns := fmt.Sprintf("node%d.cluster.local", id+1)
+			dnsRecords = append(dnsRecords, dns)
+			r.Update(dns, MustIP(host))
+		}
+		c.DNSResolver = r
+		c.Hosts = dnsRecords
+	}
+
+	OneDNSPerCluster := func(c *ClusterConfig) {
+		r := newMockDNSResolver()
+		var hostIPs []net.IP
+		for _, host := range c.Hosts {
+			hostIPs = append(hostIPs, MustIP(host))
+		}
+		r.Update("cluster.local", hostIPs...)
+		c.DNSResolver = r
+		c.Hosts = []string{"cluster.local"}
+	}
+
+	OneDNSPerClusterFirstBroken := func(c *ClusterConfig) {
+		r := newMockDNSResolver()
+		var hostIPs []net.IP
+		for _, host := range c.Hosts {
+			hostIPs = append(hostIPs, MustIP(host))
+		}
+		hostIPs[0] = MustIP("0.0.0.0")
+		r.Update("cluster.local", hostIPs...)
+		c.DNSResolver = r
+		c.Hosts = []string{"cluster.local"}
+	}
+
+	WithAddressTranslator := func(c *ClusterConfig) {
+		var toAddresses []net.IP
+		var fromAddresses []net.IP
+		var clusterHosts []string
+		for _, host := range c.Hosts {
+			ip := MustIP(host)
+
+			var fromAddress net.IP
+			if ip.To4().String() == ip.String() {
+				ip = ip.To4()
+				fromAddress = net.IPv4(ip[0], ip[1], ip[2]+1, ip[3])
+			} else {
+				fromAddress = net.IP{ip[0], ip[1], ip[2], ip[3], ip[4], ip[5], ip[6], ip[7], ip[8], ip[9], ip[10], ip[11], ip[12] + 1, ip[13], ip[14], ip[15]}
+			}
+			toAddresses = append(toAddresses, ip)
+			fromAddresses = append(fromAddresses, fromAddress)
+			clusterHosts = append(clusterHosts, fromAddress.String())
+		}
+
+		c.AddressTranslator = AddressTranslatorFunc(func(addr net.IP, port int) (net.IP, int) {
+			for id, host := range fromAddresses {
+				if host.Equal(addr) {
+					return toAddresses[id], port
+				}
+			}
+			for _, host := range toAddresses {
+				if host.Equal(addr) {
+					return addr, port
+				}
+			}
+			panic("failed to translate address")
+		})
+		c.Hosts = clusterHosts
+	}
+
+	testCases := []struct {
+		name        string
+		clusterMods []func(*ClusterConfig)
+	}{
+		{
+			name:        "OneDNSPerNode",
+			clusterMods: []func(*ClusterConfig){OneDNSPerNode},
+		},
+		{
+			name:        "OneDNSPerCluster",
+			clusterMods: []func(*ClusterConfig){OneDNSPerCluster},
+		},
+		{
+			name:        "AddressTranslator+OneDNSPerNode",
+			clusterMods: []func(*ClusterConfig){WithAddressTranslator, OneDNSPerNode},
+		},
+		{
+			name:        "AddressTranslator+OneDNSPerCluster",
+			clusterMods: []func(*ClusterConfig){WithAddressTranslator, OneDNSPerCluster},
+		},
+		{
+			name:        "OneDNSPerClusterFirstBroken",
+			clusterMods: []func(*ClusterConfig){OneDNSPerClusterFirstBroken},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := createCluster(tc.clusterMods...)
+			checkIfSessionWorking(t, cluster, getClusterHosts())
+		})
+	}
+}

--- a/exec.go
+++ b/exec.go
@@ -69,7 +69,7 @@ func NewSingleHostQueryExecutor(cfg *ClusterConfig) (e SingleHostQueryExecutor, 
 	}
 
 	var hosts []*HostInfo
-	if hosts, err = addrsToHosts(c.DNSResolver, c.Hosts, c.Port, c.Logger); err != nil {
+	if hosts, err = addrsToHosts(c.DNSResolver, c.translateAddressPort, c.Hosts, c.Port, c.Logger); err != nil {
 		err = fmt.Errorf("addrs to hosts: %w", err)
 		return
 	}

--- a/filters.go
+++ b/filters.go
@@ -70,7 +70,7 @@ func DataCentreHostFilter(dataCenter string) HostFilter {
 // WhiteListHostFilter filters incoming hosts by checking that their address is
 // in the initial hosts whitelist.
 func WhiteListHostFilter(hosts ...string) HostFilter {
-	hostInfos, err := addrsToHosts(defaultDnsResolver, hosts, 9042, nopLogger{})
+	hostInfos, err := addrsToHosts(defaultDnsResolver, nil, hosts, 9042, nopLogger{})
 	if err != nil {
 		// dont want to panic here, but rather not break the API
 		panic(fmt.Errorf("unable to lookup host info from address: %v", err))

--- a/host_source.go
+++ b/host_source.go
@@ -464,53 +464,6 @@ func (h *HostInfo) IsBusy(s *Session) bool {
 	return ok && h != nil && pool.InFlight() >= MAX_IN_FLIGHT_THRESHOLD
 }
 
-func (h *HostInfo) HostnameAndPort() string {
-	// Fast path: in most cases hostname is not empty
-	var (
-		hostname string
-		port     int
-	)
-	h.mu.RLock()
-	hostname = h.hostname
-	port = h.port
-	h.mu.RUnlock()
-
-	if hostname != "" {
-		return net.JoinHostPort(hostname, strconv.Itoa(port))
-	}
-
-	// Slow path: hostname is empty
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.hostname == "" { // recheck is hostname empty
-		// if yes - fill it
-		addr, _ := h.connectAddressLocked()
-		h.hostname = addr.String()
-	}
-	return net.JoinHostPort(h.hostname, strconv.Itoa(h.port))
-}
-
-func (h *HostInfo) Hostname() string {
-	// Fast path: in most cases hostname is not empty
-	var hostname string
-	h.mu.RLock()
-	hostname = h.hostname
-	h.mu.RUnlock()
-
-	if hostname != "" {
-		return hostname
-	}
-
-	// Slow path: hostname is empty
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if h.hostname == "" {
-		addr, _ := h.connectAddressLocked()
-		h.hostname = addr.String()
-	}
-	return h.hostname
-}
-
 func (h *HostInfo) ConnectAddressAndPort() string {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/scylla.go
+++ b/scylla.go
@@ -675,7 +675,7 @@ func (sd *scyllaDialer) DialHost(ctx context.Context, host *HostInfo) (*DialedHo
 		return nil, fmt.Errorf("host missing port: %v", port)
 	}
 
-	addr := host.HostnameAndPort()
+	addr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
 	conn, err := sd.dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err
@@ -694,8 +694,7 @@ func (sd *scyllaDialer) DialShard(ctx context.Context, host *HostInfo, shardID, 
 	}
 
 	iter := newScyllaPortIterator(shardID, nrShards)
-
-	addr := host.HostnameAndPort()
+	addr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
 
 	var shardAwarePort uint16
 	if sd.tlsConfig != nil {

--- a/scylla_shard_aware_port_common_test.go
+++ b/scylla_shard_aware_port_common_test.go
@@ -78,7 +78,7 @@ func testShardAwarePortNoReconnections(t *testing.T, makeCluster makeClusterTest
 				// Verify that there were no duplicate connections to the same shard
 				// Make sure that we didn't connect to the same shard twice
 				// There should be numberOfShards-1 connections to the new port
-				events := dialer.events[host.hostname]
+				events := dialer.events[host.ConnectAddress().String()]
 				shardAwareConnectionCount := 0
 				shardsConnected := make(map[int]testConnectionEvent)
 				for _, evt := range events {
@@ -203,7 +203,7 @@ func testShardAwarePortUnusedIfNotEnabled(t *testing.T, makeCluster makeClusterT
 			continue
 		}
 
-		events, _ := dialer.events[host.hostname]
+		events, _ := dialer.events[host.ConnectAddress().String()]
 
 		for _, evt := range events {
 			if evt.destinationPort == shardAwarePort {
@@ -362,7 +362,7 @@ func newLoggingTestDialer() *loggingTestDialer {
 func (ltd *loggingTestDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	sourcePort := ScyllaGetSourcePort(ctx)
 
-	hostname, destinationPortStr, err := net.SplitHostPort(addr)
+	ipaddr, destinationPortStr, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (ltd *loggingTestDialer) DialContext(ctx context.Context, network, addr str
 			sourcePort:      sourcePort,
 			destinationPort: uint16(destinationPort),
 		}
-		ltd.events[hostname] = append(ltd.events[hostname], evt)
+		ltd.events[ipaddr] = append(ltd.events[ipaddr], evt)
 	}
 
 	return conn, err

--- a/session.go
+++ b/session.go
@@ -116,10 +116,10 @@ var queryPool = &sync.Pool{
 	},
 }
 
-func addrsToHosts(resolver DNSResolver, addrs []string, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
+func addrsToHosts(resolver DNSResolver, translateAddressPort func(addr net.IP, port int) (net.IP, int), addrs []string, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
 	var hosts []*HostInfo
 	for _, hostaddr := range addrs {
-		resolvedHosts, err := hostInfo(resolver, hostaddr, defaultPort)
+		resolvedHosts, err := hostInfo(resolver, translateAddressPort, hostaddr, defaultPort)
 		if err != nil {
 			// Try other hosts if unable to resolve DNS name
 			if _, ok := err.(*net.DNSError); ok {
@@ -259,7 +259,7 @@ func (s *Session) init() error {
 		return nil
 	}
 
-	hosts, err := addrsToHosts(s.cfg.DNSResolver, s.cfg.Hosts, s.cfg.Port, s.logger)
+	hosts, err := addrsToHosts(s.cfg.DNSResolver, s.cfg.translateAddressPort, s.cfg.Hosts, s.cfg.Port, s.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add DNS tests that covers basic cases:
1. Record per node
2. Record per cluster
3. Record per cluster with first record pointing to a broken node

Plus add tests with `AddressTranslator`

Problems fixed:
1. Remove all hostname usage, before this change driver would resolve hostname when connecting to the node, it led to problems with one dns record relates to the whole cluster.
2. Apply address translator to resolved nodes, before that it was not done, as result, if addressTranslator is configured it would be skipped for initial nodes and ip addresses that driver picks up from the dns.

