### PR TITLE
Fix calculation of potential executed flag

### DIFF
--- a/query_executor.go
+++ b/query_executor.go
@@ -219,7 +219,7 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 
 		var qErr *QueryError
 		if errors.As(iter.err, &qErr) {
-			potentiallyExecuted = potentiallyExecuted && qErr.PotentiallyExecuted()
+			potentiallyExecuted = potentiallyExecuted || qErr.PotentiallyExecuted()
 			qErr.potentiallyExecuted = potentiallyExecuted
 			qErr.isIdempotent = qry.IsIdempotent()
 			iter.err = qErr


### PR DESCRIPTION
If on any retry this flag become true, it should stay true.

follow up by test issue: https://github.com/scylladb/gocql/issues/453