### PR TITLE
Disable avoiding slow replica for LWT queries

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -767,7 +767,7 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		replicas = shuffleHosts(replicas)
 	}
 
-	if s := qry.GetSession(); s != nil && t.avoidSlowReplicas {
+	if s := qry.GetSession(); s != nil && !qry.IsLWT() && t.avoidSlowReplicas {
 		healthyReplicas := make([]*HostInfo, 0, len(replicas))
 		unhealthyReplicas := make([]*HostInfo, 0, len(replicas))
 


### PR DESCRIPTION
Switching to less loaded replica for LWT will only increase LWT congestion. 
As quick solution it is better to use slow replica anyways. 
Better solution should be synchronized between clietns so that all clients would start avoid slow replica all at the same time.