### PR TITLE
Fix metedata describer deadlock

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1570,7 +1570,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 			tablet.keyspaceName = qry.routingInfo.keyspace
 			tablet.tableName = qry.routingInfo.table
 
-			c.session.metadataDescriber.addTablet(&tablet)
+			c.session.metadataDescriber.AddTablet(&tablet)
 		}
 	}
 

--- a/events.go
+++ b/events.go
@@ -152,14 +152,14 @@ func (s *Session) handleSchemaEvent(frames []frame) {
 func (s *Session) handleKeyspaceChange(keyspace, change string) {
 	s.control.awaitSchemaAgreement()
 	if change == "DROPPED" || change == "UPDATED" {
-		s.metadataDescriber.removeTabletsWithKeyspace(keyspace)
+		s.metadataDescriber.RemoveTabletsWithKeyspace(keyspace)
 	}
 	s.policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: keyspace, Change: change})
 }
 
 func (s *Session) handleTableChange(keyspace, table, change string) {
 	if change == "DROPPED" || change == "UPDATED" {
-		s.metadataDescriber.removeTabletsWithTable(keyspace, table)
+		s.metadataDescriber.RemoveTabletsWithTable(keyspace, table)
 	}
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -717,7 +717,7 @@ func (s *Session) refreshRing() error {
 	}
 
 	for _, host := range prevHosts {
-		s.metadataDescriber.removeTabletsWithHost(host)
+		s.metadataDescriber.RemoveTabletsWithHost(host)
 		s.removeHost(host)
 	}
 	s.policy.SetPartitioner(partitioner)

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -524,11 +524,8 @@ func (s *metadataDescriber) removeTabletsWithTable(keyspace string, table string
 	return nil
 }
 
-// clears the already cached keyspace metadata
+// clearSchema clears the cached keyspace metadata
 func (s *metadataDescriber) clearSchema(keyspaceName string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.metadata.keyspaceMetadata.remove(keyspaceName)
 }
 

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -5,6 +5,7 @@
 package gocql
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -576,7 +577,7 @@ func (s *metadataDescriber) refreshAllSchema() error {
 	for keyspaceName, metadata := range copiedMap {
 		// refresh the cache for this keyspace
 		err := s.refreshSchema(keyspaceName)
-		if err == ErrKeyspaceDoesNotExist {
+		if errors.Is(err, ErrKeyspaceDoesNotExist) {
 			s.clearSchema(keyspaceName)
 			s.removeTabletsWithKeyspace(keyspaceName)
 			continue

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -475,53 +475,71 @@ func (s *metadataDescriber) getSchema(keyspaceName string) (*KeyspaceMetadata, e
 }
 
 func (s *metadataDescriber) setTablets(tablets TabletInfoList) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.metadata.tabletsMetadata.set(tablets)
 }
 
 func (s *metadataDescriber) getTablets() TabletInfoList {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	return s.metadata.tabletsMetadata.get()
 }
 
-func (s *metadataDescriber) addTablet(tablet *TabletInfo) error {
+func (s *metadataDescriber) AddTablet(tablet *TabletInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.addTablet(tablet)
+}
+
+func (s *metadataDescriber) addTablet(tablet *TabletInfo) {
 	tablets := s.getTablets()
 	tablets = tablets.addTabletToTabletsList(tablet)
-
 	s.setTablets(tablets)
-
-	return nil
 }
 
-func (s *metadataDescriber) removeTabletsWithHost(host *HostInfo) error {
+// RemoveTabletsWithHost removes tablets that contains given host.
+// to be used outside the metadataDescriber
+func (s *metadataDescriber) RemoveTabletsWithHost(host *HostInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removeTabletsWithHost(host)
+}
+
+// removeTabletsWithHost removes tablets that contains given host.
+// s.mu should be locked
+func (s *metadataDescriber) removeTabletsWithHost(host *HostInfo) {
 	tablets := s.getTablets()
 	tablets = tablets.removeTabletsWithHostFromTabletsList(host)
-
 	s.setTablets(tablets)
-
-	return nil
 }
 
-func (s *metadataDescriber) removeTabletsWithKeyspace(keyspace string) error {
+// RemoveTabletsWithKeyspace removes tablets for given keyspace.
+// to be used outside the metadataDescriber
+func (s *metadataDescriber) RemoveTabletsWithKeyspace(keyspace string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removeTabletsWithKeyspace(keyspace)
+}
+
+// removeTabletsWithKeyspace removes tablets for given keyspace.
+// s.mu should be locked
+func (s *metadataDescriber) removeTabletsWithKeyspace(keyspace string) {
 	tablets := s.getTablets()
 	tablets = tablets.removeTabletsWithKeyspaceFromTabletsList(keyspace)
-
 	s.setTablets(tablets)
-
-	return nil
 }
 
-func (s *metadataDescriber) removeTabletsWithTable(keyspace string, table string) error {
+// RemoveTabletsWithTable removes tablets for given table.
+// to be used outside the metadataDescriber
+func (s *metadataDescriber) RemoveTabletsWithTable(keyspace string, table string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removeTabletsWithTable(keyspace, table)
+}
+
+// removeTabletsWithTable removes tablets for given table.
+// s.mu should be locked
+func (s *metadataDescriber) removeTabletsWithTable(keyspace string, table string) {
 	tablets := s.getTablets()
 	tablets = tablets.removeTabletsWithTableFromTabletsList(keyspace, table)
-
 	s.setTablets(tablets)
-
-	return nil
 }
 
 // clearSchema clears the cached keyspace metadata

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -454,12 +454,9 @@ func newMetadataDescriber(session *Session) *metadataDescriber {
 	}
 }
 
-// returns the cached KeyspaceMetadata held by the describer for the named
-// keyspace.
+// getSchema returns the KeyspaceMetadata for the keyspace, if it is not present, loads it from `system_schema`
+// does not require holding a lock
 func (s *metadataDescriber) getSchema(keyspaceName string) (*KeyspaceMetadata, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	metadata, found := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
 	if !found {
 		// refresh the cache for this keyspace


### PR DESCRIPTION
Changes to metadataDescriber:
1. Removed unnecessary lock from `getSchema`
2. Removed unnecessary lock from `clearSchema`
3. Split the tablets API into internal and external parts; moved the lock from internal to external
4. Fixed error matching in `refreshAllSchema`

These changes collectively eliminate the possibility of a deadlock on `metadataDescriber.mu`.
Previously, when a query executed on a keyspace with tablets enabled, any schema update could lead to a deadlock.

To be followed by: https://github.com/scylladb/gocql/issues/451
Fixes: https://github.com/scylladb/gocql/issues/444