### PR TITLE
Fix token aware policy initialization

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -540,7 +540,12 @@ func (t *tokenAwareHostPolicy) Init(s *Session) {
 		// See https://github.com/scylladb/gocql/issues/94.
 		panic("sharing token aware host selection policy between sessions is not supported")
 	}
-	t.getKeyspaceMetadata = s.KeyspaceMetadata
+	t.getKeyspaceMetadata = func(keyspace string) (*KeyspaceMetadata, error) {
+		if keyspace == "" {
+			return nil, ErrNoKeyspace
+		}
+		return s.metadataDescriber.getSchema(keyspace)
+	}
 	t.getKeyspaceName = func() string { return s.cfg.Keyspace }
 	t.logger = s.logger
 }

--- a/session.go
+++ b/session.go
@@ -336,6 +336,9 @@ func (s *Session) init() error {
 				s.metadataDescriber.setTablets(tablets)
 			}
 		}
+
+		newer, _ := checkSystemSchema(s.control)
+		s.useSystemSchema = newer
 	}
 
 	for _, host := range hosts {
@@ -390,6 +393,12 @@ func (s *Session) init() error {
 		close(connectedCh)
 	}
 
+	if s.cfg.disableControlConn {
+		version := s.hostSource.getHostsList()[0].Version()
+		s.useSystemSchema = version.AtLeast(3, 0, 0)
+		s.hasAggregatesAndFunctions = version.AtLeast(2, 2, 0)
+	}
+
 	// before waiting for them to connect, add them all to the policy so we can
 	// utilize efficiencies by calling AddHosts if the policy supports it
 	type bulkAddHosts interface {
@@ -417,19 +426,6 @@ func (s *Session) init() error {
 	// See if there are any connections in the pool
 	if s.cfg.ReconnectInterval > 0 {
 		go s.reconnectDownedHosts(s.cfg.ReconnectInterval)
-	}
-
-	// If we disable the initial host lookup, we need to still check if the
-	// cluster is using the newer system schema or not... however, if control
-	// connection is disable, we really have no choice, so we just make our
-	// best guess...
-	if !s.cfg.disableControlConn && s.cfg.DisableInitialHostLookup {
-		newer, _ := checkSystemSchema(s.control)
-		s.useSystemSchema = newer
-	} else {
-		version := s.hostSource.getHostsList()[0].Version()
-		s.useSystemSchema = version.AtLeast(3, 0, 0)
-		s.hasAggregatesAndFunctions = version.AtLeast(2, 2, 0)
 	}
 
 	if s.pool.Size() == 0 {


### PR DESCRIPTION
Token aware policy is not properly initialized, cluster metadata if effectively empty right after session is being created.
Following fixes:
1. Initialize `Session.useSystemSchema` early
2. Change `getKeyspaceMetadata` to make it possible read keyspace metadata when session is not fully initialized
3. Run `SetPartitioner` after `Session.useSystemSchema` is initialized to enable it's proper handling

