### PR TITLE
Add socket file path cli option

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -37,19 +37,19 @@ import (
 )
 
 var (
-	flagCluster      = flag.String("cluster", "127.0.0.1", "a comma-separated list of host:port tuples")
-	flagProto        = flag.Int("proto", 0, "protcol version")
-	flagCQL          = flag.String("cql", "3.0.0", "CQL version")
-	flagRF           = flag.Int("rf", 1, "replication factor for test keyspace")
-	clusterSize      = flag.Int("clusterSize", 1, "the expected size of the cluster")
-	flagRetry        = flag.Int("retries", 5, "number of times to retry queries")
-	flagAutoWait     = flag.Duration("autowait", 1000*time.Millisecond, "time to wait for autodiscovery to fill the hosts poll")
-	flagRunSslTest   = flag.Bool("runssl", false, "Set to true to run ssl test")
-	flagRunAuthTest  = flag.Bool("runauth", false, "Set to true to run authentication test")
-	flagCompressTest = flag.String("compressor", "", "compressor to use")
-	flagTimeout      = flag.Duration("gocql.timeout", 5*time.Second, "sets the connection `timeout` for all operations")
-
-	flagCassVersion cassVersion
+	flagCluster       = flag.String("cluster", "127.0.0.1", "a comma-separated list of host:port tuples")
+	flagProto         = flag.Int("proto", 0, "protcol version")
+	flagCQL           = flag.String("cql", "3.0.0", "CQL version")
+	flagRF            = flag.Int("rf", 1, "replication factor for test keyspace")
+	clusterSize       = flag.Int("clusterSize", 1, "the expected size of the cluster")
+	flagRetry         = flag.Int("retries", 5, "number of times to retry queries")
+	flagAutoWait      = flag.Duration("autowait", 1000*time.Millisecond, "time to wait for autodiscovery to fill the hosts poll")
+	flagRunSslTest    = flag.Bool("runssl", false, "Set to true to run ssl test")
+	flagRunAuthTest   = flag.Bool("runauth", false, "Set to true to run authentication test")
+	flagCompressTest  = flag.String("compressor", "", "compressor to use")
+	flagTimeout       = flag.Duration("gocql.timeout", 5*time.Second, "sets the connection `timeout` for all operations")
+	flagClusterSocket = flag.String("cluster-socket", "", "nodes socket files separated by colon")
+	flagCassVersion   cassVersion
 )
 
 func init() {
@@ -212,6 +212,16 @@ func createSessionFromClusterHelper(cluster *ClusterConfig, tb testing.TB, opts 
 	}
 
 	return session
+}
+
+func getClusterSocketFile() []string {
+	var res []string
+	for _, socketFile := range strings.Split(*flagClusterSocket, ",") {
+		if socketFile != "" {
+			res = append(res, socketFile)
+		}
+	}
+	return res
 }
 
 func createSessionFromClusterTabletsDisabled(cluster *ClusterConfig, tb testing.TB) *Session {

--- a/control_integration_test.go
+++ b/control_integration_test.go
@@ -21,7 +21,10 @@ func (d unixSocketDialer) DialContext(_ context.Context, _, _ string) (net.Conn,
 }
 
 func TestUnixSockets(t *testing.T) {
-	socketPath := "/tmp/scylla_node_1/cql.m"
+	socketFiles := getClusterSocketFile()
+	if len(socketFiles) == 0 {
+		t.Skip("this test needs path to socket file provided into -cluster-socket cli option")
+	}
 
 	c := createCluster()
 	c.NumConns = 1
@@ -43,7 +46,7 @@ func TestUnixSockets(t *testing.T) {
 
 	c.Dialer = unixSocketDialer{
 		dialer:     d,
-		socketPath: socketPath,
+		socketPath: socketFiles[0],
 	}
 
 	sess, err := c.CreateSession()

--- a/integration.sh
+++ b/integration.sh
@@ -35,7 +35,7 @@ readonly clusterSize=3
 readonly scylla_liveset="192.168.100.11,192.168.100.12,192.168.100.13"
 readonly cversion="3.11.4"
 readonly proto=4
-readonly args="-gocql.timeout=60s -proto=${proto} -rf=1 -clusterSize=${clusterSize} -autowait=2000ms -compressor=snappy -gocql.cversion=${cversion} -cluster=${scylla_liveset}"
+readonly args="-cluster-socket /tmp/scylla_node_1/cql.m -gocql.timeout=60s -proto=${proto} -rf=1 -clusterSize=${clusterSize} -autowait=2000ms -compressor=snappy -gocql.cversion=${cversion} -cluster=${scylla_liveset}"
 
 TAGS=$*
 


### PR DESCRIPTION
To make it possible to work with the cluster deployed via CCM we need to make socket file be configurable.