### PR TITLE
Make tests aware of whether tablets are supported by server

### DIFF
--- a/tablet_integration_test.go
+++ b/tablet_integration_test.go
@@ -11,6 +11,9 @@ import (
 
 // Check if TokenAwareHostPolicy works correctly when using tablets
 func TestTablets(t *testing.T) {
+	if !isTabletsSupported() {
+		t.Skip("Tablets are not supported by this server")
+	}
 	cluster := createCluster()
 
 	fallback := RoundRobinHostPolicy()
@@ -101,6 +104,9 @@ func TestTablets(t *testing.T) {
 
 // Check if shard awareness works correctly when using tablets
 func TestTabletsShardAwareness(t *testing.T) {
+	if !isTabletsSupported() {
+		t.Skip("Tablets are not supported by this server")
+	}
 	cluster := createCluster()
 
 	fallback := RoundRobinHostPolicy()


### PR DESCRIPTION
There are three types of tests in regards of the tablts feature:
1. That tablet agnostict. Will work despite the feature.
2. That needs tablets. Need tablets and don't work otherwise.
3. Need some tuning to work with tablets, like ks have to be created in particular way

All these tests need to be aware if server supports tablets or not. This commit makes them aware of the feature and make test work or skip.