### PR TITLE
Switch query metrics to use hostid, instead of ip address

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -451,7 +451,13 @@ func TestQueryMultinodeWithMetrics(t *testing.T) {
 	}
 
 	for i, ip := range addresses {
-		host := &HostInfo{connectAddress: net.ParseIP(ip)}
+		var host *HostInfo
+		for _, clusterHost := range db.GetHosts() {
+			if clusterHost.connectAddress.String() == ip {
+				host = clusterHost
+			}
+		}
+
 		queryMetric := qry.metrics.hostMetrics(host)
 		observedMetrics := observer.GetMetrics(host)
 

--- a/session.go
+++ b/session.go
@@ -1011,11 +1011,11 @@ func (qm *queryMetrics) hostMetrics(host *HostInfo) *hostMetrics {
 // hostMetricsLocked gets or creates host metrics for given host.
 // It must be called only while holding qm.l lock.
 func (qm *queryMetrics) hostMetricsLocked(host *HostInfo) *hostMetrics {
-	metrics, exists := qm.m[host.ConnectAddress().String()]
+	metrics, exists := qm.m[host.HostID()]
 	if !exists {
 		// if the host is not in the map, it means it's been accessed for the first time
 		metrics = &hostMetrics{}
-		qm.m[host.ConnectAddress().String()] = metrics
+		qm.m[host.HostID()] = metrics
 	}
 
 	return metrics


### PR DESCRIPTION
IP address requires casting from `net.IP` to `string`. 
Which is completely unnecessary.

Performance results showed drop from `4.6%` to `2.6%` for `Query.AddAttempts` from parent `Conn.executeQuery`:
Before
![metrics-before](https://github.com/user-attachments/assets/f5c0edbb-b6bc-4b24-9746-a1690f034d43)
After
![metrics-after](https://github.com/user-attachments/assets/356d8ee1-038a-474a-a639-dea16ce5ab3e)
