### PR TITLE
Tablets: use string in `ReplicaInfo.hostId`

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1557,7 +1557,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 				}
 				if hostId, ok := replica[0].(UUID); ok {
 					if shardId, ok := replica[1].(int); ok {
-						repInfo := ReplicaInfo{hostId, shardId}
+						repInfo := ReplicaInfo{hostId.String(), shardId}
 						tabletReplicas = append(tabletReplicas, repInfo)
 					} else {
 						return &Iter{err: err}

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -500,14 +500,14 @@ func (s *metadataDescriber) addTablet(tablet *TabletInfo) {
 func (s *metadataDescriber) RemoveTabletsWithHost(host *HostInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.removeTabletsWithHost(host)
+	s.removeTabletsWithHost(host.HostID())
 }
 
 // removeTabletsWithHost removes tablets that contains given host.
 // s.mu should be locked
-func (s *metadataDescriber) removeTabletsWithHost(host *HostInfo) {
+func (s *metadataDescriber) removeTabletsWithHost(hostID string) {
 	tablets := s.getTablets()
-	tablets = tablets.removeTabletsWithHostFromTabletsList(host)
+	tablets = tablets.removeTabletsWithHostFromTabletsList(hostID)
 	s.setTablets(tablets)
 }
 

--- a/policies.go
+++ b/policies.go
@@ -748,7 +748,7 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 			hosts := t.hosts.get()
 			for _, replica := range tablet.Replicas() {
 				for _, host := range hosts {
-					if host.hostId == replica.hostId.String() {
+					if host.hostId == replica.hostId {
 						replicas = append(replicas, host)
 						break
 					}

--- a/scylla.go
+++ b/scylla.go
@@ -387,7 +387,7 @@ func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
 				tablet := tablets.findTabletForToken(mmt, l, r)
 
 				for _, replica := range tablet.replicas {
-					if replica.hostId.String() == p.hostId {
+					if replica.hostId == p.hostId {
 						idx = replica.shardId
 					}
 				}

--- a/tablet_test.go
+++ b/tablet_test.go
@@ -13,112 +13,112 @@ var tablets = TabletInfoList{
 		"table1",
 		-7917529027641081857,
 		-6917529027641081857,
-		[]ReplicaInfo{{TimeUUID(), 9}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}},
 	},
 	{
 		"test1",
 		"table1",
 		-6917529027641081857,
 		-4611686018427387905,
-		[]ReplicaInfo{{TimeUUID(), 8}},
+		[]ReplicaInfo{{TimeUUID().String(), 8}},
 	},
 	{
 		"test1",
 		"table1",
 		-4611686018427387905,
 		-2305843009213693953,
-		[]ReplicaInfo{{TimeUUID(), 9}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}},
 	},
 	{
 		"test1",
 		"table1",
 		-2305843009213693953,
 		-1,
-		[]ReplicaInfo{{TimeUUID(), 8}},
+		[]ReplicaInfo{{TimeUUID().String(), 8}},
 	},
 	{
 		"test1",
 		"table1",
 		-1,
 		2305843009213693951,
-		[]ReplicaInfo{{TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 3}},
 	},
 	{
 		"test1",
 		"table1",
 		2305843009213693951,
 		4611686018427387903,
-		[]ReplicaInfo{{TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 3}},
 	},
 	{
 		"test1",
 		"table1",
 		4611686018427387903,
 		6917529027641081855,
-		[]ReplicaInfo{{TimeUUID(), 7}},
+		[]ReplicaInfo{{TimeUUID().String(), 7}},
 	},
 	{
 		"test1",
 		"table1",
 		6917529027641081855,
 		9223372036854775807,
-		[]ReplicaInfo{{TimeUUID(), 7}},
+		[]ReplicaInfo{{TimeUUID().String(), 7}},
 	},
 	{
 		"test2",
 		"table1",
 		-7917529027641081857,
 		-6917529027641081857,
-		[]ReplicaInfo{{TimeUUID(), 9}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}},
 	},
 	{
 		"test2",
 		"table1",
 		-6917529027641081857,
 		-4611686018427387905,
-		[]ReplicaInfo{{TimeUUID(), 8}},
+		[]ReplicaInfo{{TimeUUID().String(), 8}},
 	},
 	{
 		"test2",
 		"table1",
 		-4611686018427387905,
 		-2305843009213693953,
-		[]ReplicaInfo{{TimeUUID(), 9}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}},
 	},
 	{
 		"test2",
 		"table1",
 		-2305843009213693953,
 		-1,
-		[]ReplicaInfo{{TimeUUID(), 8}},
+		[]ReplicaInfo{{TimeUUID().String(), 8}},
 	},
 	{
 		"test2",
 		"table1",
 		-1,
 		2305843009213693951,
-		[]ReplicaInfo{{TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 3}},
 	},
 	{
 		"test2",
 		"table1",
 		2305843009213693951,
 		4611686018427387903,
-		[]ReplicaInfo{{TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 3}},
 	},
 	{
 		"test2",
 		"table1",
 		4611686018427387903,
 		6917529027641081855,
-		[]ReplicaInfo{{TimeUUID(), 7}},
+		[]ReplicaInfo{{TimeUUID().String(), 7}},
 	},
 	{
 		"test2",
 		"table1",
 		6917529027641081855,
 		9223372036854775807,
-		[]ReplicaInfo{{TimeUUID(), 7}},
+		[]ReplicaInfo{{TimeUUID().String(), 7}},
 	},
 }
 
@@ -359,31 +359,29 @@ func TestAddTabletIntersectingWithLast(t *testing.T) {
 func TestRemoveTabletsWithHost(t *testing.T) {
 	t.Parallel()
 
-	removed_host_id := TimeUUID()
+	removed_host_id := TimeUUID().String()
 
 	tablets := TabletInfoList{{
 		"test_ks",
 		"test_tb",
 		-8611686018427387905,
 		-7917529027641081857,
-		[]ReplicaInfo{{TimeUUID(), 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}, {
 		"test_ks",
 		"test_tb",
 		-6917529027641081857,
 		-4611686018427387905,
-		[]ReplicaInfo{{removed_host_id, 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{removed_host_id, 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}, {
 		"test_ks",
 		"test_tb",
 		-4611686018427387905,
 		-2305843009213693953,
-		[]ReplicaInfo{{TimeUUID(), 9}, {removed_host_id, 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {removed_host_id, 8}, {TimeUUID().String(), 3}},
 	}}
 
-	tablets = tablets.removeTabletsWithHostFromTabletsList(&HostInfo{
-		hostId: removed_host_id.String(),
-	})
+	tablets = tablets.removeTabletsWithHostFromTabletsList(removed_host_id)
 
 	assertEqual(t, "TabletsList length", 1, len(tablets))
 }
@@ -396,19 +394,19 @@ func TestRemoveTabletsWithKeyspace(t *testing.T) {
 		"test_tb",
 		-8611686018427387905,
 		-7917529027641081857,
-		[]ReplicaInfo{{TimeUUID(), 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}, {
 		"removed_ks",
 		"test_tb",
 		-6917529027641081857,
 		-4611686018427387905,
-		[]ReplicaInfo{{TimeUUID(), 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}, {
 		"test_ks",
 		"test_tb",
 		-4611686018427387905,
 		-2305843009213693953,
-		[]ReplicaInfo{{TimeUUID(), 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}}
 
 	tablets = tablets.removeTabletsWithKeyspaceFromTabletsList("removed_ks")
@@ -424,19 +422,19 @@ func TestRemoveTabletsWithTable(t *testing.T) {
 		"test_tb",
 		-8611686018427387905,
 		-7917529027641081857,
-		[]ReplicaInfo{{TimeUUID(), 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}, {
 		"test_ks",
 		"test_tb",
 		-6917529027641081857,
 		-4611686018427387905,
-		[]ReplicaInfo{{TimeUUID(), 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}, {
 		"test_ks",
 		"removed_tb",
 		-4611686018427387905,
 		-2305843009213693953,
-		[]ReplicaInfo{{TimeUUID(), 9}, {TimeUUID(), 8}, {TimeUUID(), 3}},
+		[]ReplicaInfo{{TimeUUID().String(), 9}, {TimeUUID().String(), 8}, {TimeUUID().String(), 3}},
 	}}
 
 	tablets = tablets.removeTabletsWithTableFromTabletsList("test_ks", "removed_tb")

--- a/tablets.go
+++ b/tablets.go
@@ -5,7 +5,8 @@ import (
 )
 
 type ReplicaInfo struct {
-	hostId  UUID
+	// hostId for sake of better performance, it has to be same type as HostInfo.hostId
+	hostId  string
 	shardId int
 }
 
@@ -112,14 +113,14 @@ func (t TabletInfoList) addTabletToTabletsList(tablet *TabletInfo) TabletInfoLis
 }
 
 // Remove all tablets that have given host as a replica
-func (t TabletInfoList) removeTabletsWithHostFromTabletsList(host *HostInfo) TabletInfoList {
+func (t TabletInfoList) removeTabletsWithHostFromTabletsList(hostID string) TabletInfoList {
 	filteredTablets := make([]*TabletInfo, 0, len(t)) // Preallocate for efficiency
 
 	for _, tablet := range t {
 		// Check if any replica matches the given host ID
 		shouldExclude := false
 		for _, replica := range tablet.replicas {
-			if replica.hostId.String() == host.HostID() {
+			if replica.hostId == hostID {
 				shouldExclude = true
 				break
 			}


### PR DESCRIPTION
Since `HostInfo.hostID` is a string, in all cases when driver address `ReplicaInfo.hostId` it converts UUID to a string. 
Which is unnecessary, let's store them in the same type. 
Later we can optimize it by storing it as `gocql.UUID` or `google/uuid`.

Related to: https://github.com/scylladb/gocql/issues/469