### PR TITLE
Tests: relocate assert functions to the test package

### DIFF
--- a/address_translators_test.go
+++ b/address_translators_test.go
@@ -45,7 +45,7 @@ func TestIdentityAddressTranslator_NilAddrAndZeroPort(t *testing.T) {
 	if addr != nil {
 		t.Errorf("expected translated host to be (nil) but was (%+v) instead", addr)
 	}
-	assertEqual(t, "translated port", 0, port)
+	AssertEqual(t, "translated port", 0, port)
 }
 
 func TestIdentityAddressTranslator_HostProvided(t *testing.T) {
@@ -61,5 +61,5 @@ func TestIdentityAddressTranslator_HostProvided(t *testing.T) {
 	if !hostIP.Equal(addr) {
 		t.Errorf("expected translated addr to be (%+v) but was (%+v) instead", hostIP, addr)
 	}
-	assertEqual(t, "translated port", 9042, port)
+	AssertEqual(t, "translated port", 9042, port)
 }

--- a/address_translators_test.go
+++ b/address_translators_test.go
@@ -28,6 +28,7 @@
 package gocql
 
 import (
+	"github.com/gocql/gocql/internal/tests"
 	"net"
 	"testing"
 )
@@ -45,7 +46,7 @@ func TestIdentityAddressTranslator_NilAddrAndZeroPort(t *testing.T) {
 	if addr != nil {
 		t.Errorf("expected translated host to be (nil) but was (%+v) instead", addr)
 	}
-	AssertEqual(t, "translated port", 0, port)
+	tests.AssertEqual(t, "translated port", 0, port)
 }
 
 func TestIdentityAddressTranslator_HostProvided(t *testing.T) {
@@ -61,5 +62,5 @@ func TestIdentityAddressTranslator_HostProvided(t *testing.T) {
 	if !hostIP.Equal(addr) {
 		t.Errorf("expected translated addr to be (%+v) but was (%+v) instead", hostIP, addr)
 	}
-	AssertEqual(t, "translated port", 9042, port)
+	tests.AssertEqual(t, "translated port", 9042, port)
 }

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -32,6 +32,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/gocql/gocql/internal/tests"
 	"math"
 	"math/big"
 	"net"
@@ -1202,20 +1203,20 @@ func TestMapScan(t *testing.T) {
 	if !iter.MapScan(row) {
 		t.Fatal("select:", iter.Close())
 	}
-	AssertEqual(t, "fullname", "Ada Lovelace", row["fullname"])
-	AssertEqual(t, "age", 30, row["age"])
-	AssertEqual(t, "address", "10.0.0.2", row["address"])
-	AssertDeepEqual(t, "data", []byte(`{"foo": "bar"}`), row["data"])
+	tests.AssertEqual(t, "fullname", "Ada Lovelace", row["fullname"])
+	tests.AssertEqual(t, "age", 30, row["age"])
+	tests.AssertEqual(t, "address", "10.0.0.2", row["address"])
+	tests.AssertDeepEqual(t, "data", []byte(`{"foo": "bar"}`), row["data"])
 
 	// Second iteration using a new map
 	row = make(map[string]interface{})
 	if !iter.MapScan(row) {
 		t.Fatal("select:", iter.Close())
 	}
-	AssertEqual(t, "fullname", "Grace Hopper", row["fullname"])
-	AssertEqual(t, "age", 31, row["age"])
-	AssertEqual(t, "address", "10.0.0.1", row["address"])
-	AssertDeepEqual(t, "data", []byte(nil), row["data"])
+	tests.AssertEqual(t, "fullname", "Grace Hopper", row["fullname"])
+	tests.AssertEqual(t, "age", 31, row["age"])
+	tests.AssertEqual(t, "address", "10.0.0.1", row["address"])
+	tests.AssertDeepEqual(t, "data", []byte(nil), row["data"])
 }
 
 func TestSliceMap(t *testing.T) {
@@ -2263,7 +2264,7 @@ func TestBatchObserve(t *testing.T) {
 			t.Fatal("unexpected query", stmt)
 		}
 
-		AssertDeepEqual(t, "observed value", []interface{}{i}, observedBatch.observedValues[i])
+		tests.AssertDeepEqual(t, "observed value", []interface{}{i}, observedBatch.observedValues[i])
 	}
 }
 

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1202,20 +1202,20 @@ func TestMapScan(t *testing.T) {
 	if !iter.MapScan(row) {
 		t.Fatal("select:", iter.Close())
 	}
-	assertEqual(t, "fullname", "Ada Lovelace", row["fullname"])
-	assertEqual(t, "age", 30, row["age"])
-	assertEqual(t, "address", "10.0.0.2", row["address"])
-	assertDeepEqual(t, "data", []byte(`{"foo": "bar"}`), row["data"])
+	AssertEqual(t, "fullname", "Ada Lovelace", row["fullname"])
+	AssertEqual(t, "age", 30, row["age"])
+	AssertEqual(t, "address", "10.0.0.2", row["address"])
+	AssertDeepEqual(t, "data", []byte(`{"foo": "bar"}`), row["data"])
 
 	// Second iteration using a new map
 	row = make(map[string]interface{})
 	if !iter.MapScan(row) {
 		t.Fatal("select:", iter.Close())
 	}
-	assertEqual(t, "fullname", "Grace Hopper", row["fullname"])
-	assertEqual(t, "age", 31, row["age"])
-	assertEqual(t, "address", "10.0.0.1", row["address"])
-	assertDeepEqual(t, "data", []byte(nil), row["data"])
+	AssertEqual(t, "fullname", "Grace Hopper", row["fullname"])
+	AssertEqual(t, "age", 31, row["age"])
+	AssertEqual(t, "address", "10.0.0.1", row["address"])
+	AssertDeepEqual(t, "data", []byte(nil), row["data"])
 }
 
 func TestSliceMap(t *testing.T) {
@@ -2263,7 +2263,7 @@ func TestBatchObserve(t *testing.T) {
 			t.Fatal("unexpected query", stmt)
 		}
 
-		assertDeepEqual(t, "observed value", []interface{}{i}, observedBatch.observedValues[i])
+		AssertDeepEqual(t, "observed value", []interface{}{i}, observedBatch.observedValues[i])
 	}
 }
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -38,20 +38,20 @@ func TestNewCluster_Defaults(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewCluster()
-	assertEqual(t, "cluster config cql version", "3.0.0", cfg.CQLVersion)
-	assertEqual(t, "cluster config timeout", 11*time.Second, cfg.Timeout)
-	assertEqual(t, "cluster config port", 9042, cfg.Port)
-	assertEqual(t, "cluster config num-conns", 2, cfg.NumConns)
-	assertEqual(t, "cluster config consistency", Quorum, cfg.Consistency)
-	assertEqual(t, "cluster config max prepared statements", defaultMaxPreparedStmts, cfg.MaxPreparedStmts)
-	assertEqual(t, "cluster config max routing key info", 1000, cfg.MaxRoutingKeyInfo)
-	assertEqual(t, "cluster config page-size", 5000, cfg.PageSize)
-	assertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
-	assertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
-	assertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
-	assertTrue(t, "cluster config conviction policy",
+	AssertEqual(t, "cluster config cql version", "3.0.0", cfg.CQLVersion)
+	AssertEqual(t, "cluster config timeout", 11*time.Second, cfg.Timeout)
+	AssertEqual(t, "cluster config port", 9042, cfg.Port)
+	AssertEqual(t, "cluster config num-conns", 2, cfg.NumConns)
+	AssertEqual(t, "cluster config consistency", Quorum, cfg.Consistency)
+	AssertEqual(t, "cluster config max prepared statements", defaultMaxPreparedStmts, cfg.MaxPreparedStmts)
+	AssertEqual(t, "cluster config max routing key info", 1000, cfg.MaxRoutingKeyInfo)
+	AssertEqual(t, "cluster config page-size", 5000, cfg.PageSize)
+	AssertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
+	AssertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
+	AssertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
+	AssertTrue(t, "cluster config conviction policy",
 		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
-	assertTrue(t, "cluster config reconnection policy",
+	AssertTrue(t, "cluster config reconnection policy",
 		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second}, cfg.ReconnectionPolicy))
 }
 
@@ -59,19 +59,19 @@ func TestNewCluster_WithHosts(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewCluster("addr1", "addr2")
-	assertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
-	assertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
-	assertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
+	AssertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
+	AssertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
+	AssertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
 }
 
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewCluster()
-	assertNil(t, "cluster config address translator", cfg.AddressTranslator)
+	AssertNil(t, "cluster config address translator", cfg.AddressTranslator)
 	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234)
-	assertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
-	assertEqual(t, "translated host and port", 1234, newPort)
+	AssertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
+	AssertEqual(t, "translated host and port", 1234, newPort)
 }
 
 func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
@@ -80,8 +80,8 @@ func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
 	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0)
-	assertTrue(t, "translated address is still empty", len(newAddr) == 0)
-	assertEqual(t, "translated port", 0, newPort)
+	AssertTrue(t, "translated address is still empty", len(newAddr) == 0)
+	AssertEqual(t, "translated port", 0, newPort)
 }
 
 func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
@@ -90,6 +90,6 @@ func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
 	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345)
-	assertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
-	assertEqual(t, "translated port", 5432, newPort)
+	AssertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
+	AssertEqual(t, "translated port", 5432, newPort)
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -28,6 +28,7 @@
 package gocql
 
 import (
+	"github.com/gocql/gocql/internal/tests"
 	"net"
 	"reflect"
 	"testing"
@@ -38,20 +39,20 @@ func TestNewCluster_Defaults(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewCluster()
-	AssertEqual(t, "cluster config cql version", "3.0.0", cfg.CQLVersion)
-	AssertEqual(t, "cluster config timeout", 11*time.Second, cfg.Timeout)
-	AssertEqual(t, "cluster config port", 9042, cfg.Port)
-	AssertEqual(t, "cluster config num-conns", 2, cfg.NumConns)
-	AssertEqual(t, "cluster config consistency", Quorum, cfg.Consistency)
-	AssertEqual(t, "cluster config max prepared statements", defaultMaxPreparedStmts, cfg.MaxPreparedStmts)
-	AssertEqual(t, "cluster config max routing key info", 1000, cfg.MaxRoutingKeyInfo)
-	AssertEqual(t, "cluster config page-size", 5000, cfg.PageSize)
-	AssertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
-	AssertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
-	AssertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
-	AssertTrue(t, "cluster config conviction policy",
+	tests.AssertEqual(t, "cluster config cql version", "3.0.0", cfg.CQLVersion)
+	tests.AssertEqual(t, "cluster config timeout", 11*time.Second, cfg.Timeout)
+	tests.AssertEqual(t, "cluster config port", 9042, cfg.Port)
+	tests.AssertEqual(t, "cluster config num-conns", 2, cfg.NumConns)
+	tests.AssertEqual(t, "cluster config consistency", Quorum, cfg.Consistency)
+	tests.AssertEqual(t, "cluster config max prepared statements", defaultMaxPreparedStmts, cfg.MaxPreparedStmts)
+	tests.AssertEqual(t, "cluster config max routing key info", 1000, cfg.MaxRoutingKeyInfo)
+	tests.AssertEqual(t, "cluster config page-size", 5000, cfg.PageSize)
+	tests.AssertEqual(t, "cluster config default timestamp", true, cfg.DefaultTimestamp)
+	tests.AssertEqual(t, "cluster config max wait schema agreement", 60*time.Second, cfg.MaxWaitSchemaAgreement)
+	tests.AssertEqual(t, "cluster config reconnect interval", 60*time.Second, cfg.ReconnectInterval)
+	tests.AssertTrue(t, "cluster config conviction policy",
 		reflect.DeepEqual(&SimpleConvictionPolicy{}, cfg.ConvictionPolicy))
-	AssertTrue(t, "cluster config reconnection policy",
+	tests.AssertTrue(t, "cluster config reconnection policy",
 		reflect.DeepEqual(&ConstantReconnectionPolicy{MaxRetries: 3, Interval: 1 * time.Second}, cfg.ReconnectionPolicy))
 }
 
@@ -59,19 +60,19 @@ func TestNewCluster_WithHosts(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewCluster("addr1", "addr2")
-	AssertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
-	AssertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
-	AssertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
+	tests.AssertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
+	tests.AssertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
+	tests.AssertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
 }
 
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewCluster()
-	AssertNil(t, "cluster config address translator", cfg.AddressTranslator)
+	tests.AssertNil(t, "cluster config address translator", cfg.AddressTranslator)
 	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 1234)
-	AssertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
-	AssertEqual(t, "translated host and port", 1234, newPort)
+	tests.AssertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr))
+	tests.AssertEqual(t, "translated host and port", 1234, newPort)
 }
 
 func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
@@ -80,8 +81,8 @@ func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
 	newAddr, newPort := cfg.translateAddressPort(net.IP([]byte{}), 0)
-	AssertTrue(t, "translated address is still empty", len(newAddr) == 0)
-	AssertEqual(t, "translated port", 0, newPort)
+	tests.AssertTrue(t, "translated address is still empty", len(newAddr) == 0)
+	tests.AssertEqual(t, "translated port", 0, newPort)
 }
 
 func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
@@ -90,6 +91,6 @@ func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
 	newAddr, newPort := cfg.translateAddressPort(net.ParseIP("10.0.0.1"), 2345)
-	AssertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
-	AssertEqual(t, "translated port", 5432, newPort)
+	tests.AssertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr))
+	tests.AssertEqual(t, "translated port", 5432, newPort)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -414,32 +413,4 @@ func staticAddressTranslator(newAddr net.IP, newPort int) AddressTranslator {
 	return AddressTranslatorFunc(func(addr net.IP, port int) (net.IP, int) {
 		return newAddr, newPort
 	})
-}
-
-func AssertTrue(t *testing.T, description string, value bool) {
-	t.Helper()
-	if !value {
-		t.Fatalf("expected %s to be true", description)
-	}
-}
-
-func AssertEqual(t *testing.T, description string, expected, actual interface{}) {
-	t.Helper()
-	if expected != actual {
-		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
-	}
-}
-
-func AssertDeepEqual(t *testing.T, description string, expected, actual interface{}) {
-	t.Helper()
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
-	}
-}
-
-func AssertNil(t *testing.T, description string, actual interface{}) {
-	t.Helper()
-	if actual != nil {
-		t.Fatalf("expected %s to be (nil) but was (%+v) instead", description, actual)
-	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -416,28 +416,28 @@ func staticAddressTranslator(newAddr net.IP, newPort int) AddressTranslator {
 	})
 }
 
-func assertTrue(t *testing.T, description string, value bool) {
+func AssertTrue(t *testing.T, description string, value bool) {
 	t.Helper()
 	if !value {
 		t.Fatalf("expected %s to be true", description)
 	}
 }
 
-func assertEqual(t *testing.T, description string, expected, actual interface{}) {
+func AssertEqual(t *testing.T, description string, expected, actual interface{}) {
 	t.Helper()
 	if expected != actual {
 		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
 	}
 }
 
-func assertDeepEqual(t *testing.T, description string, expected, actual interface{}) {
+func AssertDeepEqual(t *testing.T, description string, expected, actual interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
 	}
 }
 
-func assertNil(t *testing.T, description string, actual interface{}) {
+func AssertNil(t *testing.T, description string, actual interface{}) {
 	t.Helper()
 	if actual != nil {
 		t.Fatalf("expected %s to be (nil) but was (%+v) instead", description, actual)

--- a/integration_test.go
+++ b/integration_test.go
@@ -31,6 +31,7 @@ package gocql
 import (
 	"context"
 	"errors"
+	"github.com/gocql/gocql/internal/tests"
 	"reflect"
 	"testing"
 	"time"
@@ -70,9 +71,9 @@ func TestGetHostsFromSystem(t *testing.T) {
 
 	hosts, partitioner, err := session.hostSource.GetHostsFromSystem()
 
-	AssertTrue(t, "err == nil", err == nil)
-	AssertEqual(t, "len(hosts)", len(clusterHosts), len(hosts))
-	AssertTrue(t, "len(partitioner) != 0", len(partitioner) != 0)
+	tests.AssertTrue(t, "err == nil", err == nil)
+	tests.AssertEqual(t, "len(hosts)", len(clusterHosts), len(hosts))
+	tests.AssertTrue(t, "len(partitioner) != 0", len(partitioner) != 0)
 }
 
 // TestRingDiscovery makes sure that you can autodiscover other cluster members
@@ -124,7 +125,7 @@ func TestHostFilterDiscovery(t *testing.T) {
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
 
-	AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
+	tests.AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
 }
 
 // TestHostFilterInitial ensures that host filtering works for the initial
@@ -148,7 +149,7 @@ func TestHostFilterInitial(t *testing.T) {
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
 
-	AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
+	tests.AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
 }
 
 func TestWriteFailure(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -70,9 +70,9 @@ func TestGetHostsFromSystem(t *testing.T) {
 
 	hosts, partitioner, err := session.hostSource.GetHostsFromSystem()
 
-	assertTrue(t, "err == nil", err == nil)
-	assertEqual(t, "len(hosts)", len(clusterHosts), len(hosts))
-	assertTrue(t, "len(partitioner) != 0", len(partitioner) != 0)
+	AssertTrue(t, "err == nil", err == nil)
+	AssertEqual(t, "len(hosts)", len(clusterHosts), len(hosts))
+	AssertTrue(t, "len(partitioner) != 0", len(partitioner) != 0)
 }
 
 // TestRingDiscovery makes sure that you can autodiscover other cluster members
@@ -124,7 +124,7 @@ func TestHostFilterDiscovery(t *testing.T) {
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
 
-	assertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
+	AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
 }
 
 // TestHostFilterInitial ensures that host filtering works for the initial
@@ -148,7 +148,7 @@ func TestHostFilterInitial(t *testing.T) {
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
 
-	assertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
+	AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
 }
 
 func TestWriteFailure(t *testing.T) {

--- a/internal/tests/common.go
+++ b/internal/tests/common.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"reflect"
+	"testing"
+)
+
+func AssertTrue(t *testing.T, description string, value bool) {
+	t.Helper()
+	if !value {
+		t.Fatalf("expected %s to be true", description)
+	}
+}
+
+func AssertEqual(t *testing.T, description string, expected, actual interface{}) {
+	t.Helper()
+	if expected != actual {
+		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
+	}
+}
+
+func AssertDeepEqual(t *testing.T, description string, expected, actual interface{}) {
+	t.Helper()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
+	}
+}
+
+func AssertNil(t *testing.T, description string, actual interface{}) {
+	t.Helper()
+	if actual != nil {
+		t.Fatalf("expected %s to be (nil) but was (%+v) instead", description, actual)
+	}
+}

--- a/keyspace_table_test.go
+++ b/keyspace_table_test.go
@@ -30,6 +30,7 @@ package gocql
 import (
 	"context"
 	"fmt"
+	"github.com/gocql/gocql/internal/tests"
 	"testing"
 )
 
@@ -100,6 +101,6 @@ func TestKeyspaceTable(t *testing.T) {
 
 	// cluster.Keyspace was set to "wrong_keyspace", but during prepering statement
 	// Keyspace in Query should be changed to "test" and Table should be changed to table1
-	assertEqual(t, "qry.Keyspace()", "test1", qry.Keyspace())
-	assertEqual(t, "qry.Table()", "table1", qry.Table())
+	tests.assertEqual(t, "qry.Keyspace()", "test1", qry.Keyspace())
+	tests.assertEqual(t, "qry.Table()", "table1", qry.Table())
 }

--- a/keyspace_table_test.go
+++ b/keyspace_table_test.go
@@ -101,6 +101,6 @@ func TestKeyspaceTable(t *testing.T) {
 
 	// cluster.Keyspace was set to "wrong_keyspace", but during prepering statement
 	// Keyspace in Query should be changed to "test" and Table should be changed to table1
-	tests.assertEqual(t, "qry.Keyspace()", "test1", qry.Keyspace())
-	tests.assertEqual(t, "qry.Table()", "table1", qry.Table())
+	tests.AssertEqual(t, "qry.Keyspace()", "test1", qry.Keyspace())
+	tests.AssertEqual(t, "qry.Table()", "table1", qry.Table())
 }

--- a/policies_test.go
+++ b/policies_test.go
@@ -34,6 +34,7 @@ package gocql
 import (
 	"errors"
 	"fmt"
+	"github.com/gocql/gocql/internal/tests"
 	"net"
 	"sort"
 	"strings"
@@ -155,7 +156,7 @@ func TestHostPolicy_TokenAware_SimpleStrategy(t *testing.T) {
 
 	// The SimpleStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	tests.AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		"myKeyspace": {
 			{orderedToken("00"), []*HostInfo{hosts[0], hosts[1]}},
 			{orderedToken("25"), []*HostInfo{hosts[1], hosts[2]}},
@@ -430,7 +431,7 @@ func TestLWTSimpleRetryPolicy(t *testing.T) {
 	// Verify that SimpleRetryPolicy implements both interfaces
 	var _ RetryPolicy = ebrp
 	var lwt_rt LWTRetryPolicy = ebrp
-	AssertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
+	tests.AssertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
 }
 
 func TestExponentialBackoffPolicy(t *testing.T) {
@@ -470,7 +471,7 @@ func TestLWTExponentialBackoffPolicy(t *testing.T) {
 	// Verify that ExponentialBackoffRetryPolicy implements both interfaces
 	var _ RetryPolicy = ebrp
 	var lwt_rt LWTRetryPolicy = ebrp
-	AssertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
+	tests.AssertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
 }
 
 func TestDowngradingConsistencyRetryPolicy(t *testing.T) {
@@ -746,7 +747,7 @@ func TestHostPolicy_TokenAware(t *testing.T) {
 
 	// The NetworkTopologyStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	tests.AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		"myKeyspace": {
 			{orderedToken("05"), []*HostInfo{hosts[0], hosts[1], hosts[2]}},
 			{orderedToken("10"), []*HostInfo{hosts[1], hosts[2], hosts[3]}},
@@ -839,7 +840,7 @@ func TestHostPolicy_TokenAware_NetworkStrategy(t *testing.T) {
 
 	// The NetworkTopologyStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	tests.AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		keyspace: {
 			{orderedToken("05"), []*HostInfo{hosts[0], hosts[1], hosts[2], hosts[3], hosts[4], hosts[5]}},
 			{orderedToken("10"), []*HostInfo{hosts[1], hosts[2], hosts[3], hosts[4], hosts[5], hosts[6]}},
@@ -984,7 +985,7 @@ func TestHostPolicy_TokenAware_RackAware(t *testing.T) {
 
 	// The NetworkTopologyStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	tests.AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		"myKeyspace": {
 			{orderedToken("05"), []*HostInfo{hosts[0], hosts[1], hosts[2], hosts[3]}},
 			{orderedToken("10"), []*HostInfo{hosts[1], hosts[2], hosts[3], hosts[4]}},

--- a/policies_test.go
+++ b/policies_test.go
@@ -155,7 +155,7 @@ func TestHostPolicy_TokenAware_SimpleStrategy(t *testing.T) {
 
 	// The SimpleStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	assertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		"myKeyspace": {
 			{orderedToken("00"), []*HostInfo{hosts[0], hosts[1]}},
 			{orderedToken("25"), []*HostInfo{hosts[1], hosts[2]}},
@@ -430,7 +430,7 @@ func TestLWTSimpleRetryPolicy(t *testing.T) {
 	// Verify that SimpleRetryPolicy implements both interfaces
 	var _ RetryPolicy = ebrp
 	var lwt_rt LWTRetryPolicy = ebrp
-	assertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
+	AssertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
 }
 
 func TestExponentialBackoffPolicy(t *testing.T) {
@@ -470,7 +470,7 @@ func TestLWTExponentialBackoffPolicy(t *testing.T) {
 	// Verify that ExponentialBackoffRetryPolicy implements both interfaces
 	var _ RetryPolicy = ebrp
 	var lwt_rt LWTRetryPolicy = ebrp
-	assertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
+	AssertEqual(t, "retry type of LWT policy", lwt_rt.GetRetryTypeLWT(nil), Retry)
 }
 
 func TestDowngradingConsistencyRetryPolicy(t *testing.T) {
@@ -746,7 +746,7 @@ func TestHostPolicy_TokenAware(t *testing.T) {
 
 	// The NetworkTopologyStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	assertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		"myKeyspace": {
 			{orderedToken("05"), []*HostInfo{hosts[0], hosts[1], hosts[2]}},
 			{orderedToken("10"), []*HostInfo{hosts[1], hosts[2], hosts[3]}},
@@ -839,7 +839,7 @@ func TestHostPolicy_TokenAware_NetworkStrategy(t *testing.T) {
 
 	// The NetworkTopologyStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	assertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		keyspace: {
 			{orderedToken("05"), []*HostInfo{hosts[0], hosts[1], hosts[2], hosts[3], hosts[4], hosts[5]}},
 			{orderedToken("10"), []*HostInfo{hosts[1], hosts[2], hosts[3], hosts[4], hosts[5], hosts[6]}},
@@ -984,7 +984,7 @@ func TestHostPolicy_TokenAware_RackAware(t *testing.T) {
 
 	// The NetworkTopologyStrategy above should generate the following replicas.
 	// It's handy to have as reference here.
-	assertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
+	AssertDeepEqual(t, "replicas", map[string]tokenRingReplicas{
 		"myKeyspace": {
 			{orderedToken("05"), []*HostInfo{hosts[0], hosts[1], hosts[2], hosts[3]}},
 			{orderedToken("10"), []*HostInfo{hosts[1], hosts[2], hosts[3], hosts[4]}},

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -6,6 +6,7 @@ package gocql
 import (
 	"context"
 	"fmt"
+	"github.com/gocql/gocql/internal/tests"
 	"net"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestGetClusterPeerInfoZeroToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to get peers: %v", err)
 		}
-		AssertEqual(t, "peers length", 2, len(peers))
+		tests.AssertEqual(t, "peers length", 2, len(peers))
 	})
 
 	t.Run("NoZeroTokenNodes", func(t *testing.T) {
@@ -84,7 +85,7 @@ func TestGetClusterPeerInfoZeroToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to get peers: %v", err)
 		}
-		AssertEqual(t, "peers length", 3, len(peers))
+		tests.AssertEqual(t, "peers length", 3, len(peers))
 	})
 }
 
@@ -335,8 +336,8 @@ func TestMockGetHostsFromSystem(t *testing.T) {
 	}
 
 	// local host and one of the peers are zero token so only one peer should be returned with 2 tokens
-	AssertEqual(t, "hosts length", 1, len(hosts))
-	AssertEqual(t, "host token length", 2, len(hosts[0].tokens))
+	tests.AssertEqual(t, "hosts length", 1, len(hosts))
+	tests.AssertEqual(t, "host token length", 2, len(hosts[0].tokens))
 }
 
 func TestRing_AddHostIfMissing_Missing(t *testing.T) {

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -69,7 +69,7 @@ func TestGetClusterPeerInfoZeroToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to get peers: %v", err)
 		}
-		assertEqual(t, "peers length", 2, len(peers))
+		AssertEqual(t, "peers length", 2, len(peers))
 	})
 
 	t.Run("NoZeroTokenNodes", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestGetClusterPeerInfoZeroToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to get peers: %v", err)
 		}
-		assertEqual(t, "peers length", 3, len(peers))
+		AssertEqual(t, "peers length", 3, len(peers))
 	})
 }
 
@@ -335,8 +335,8 @@ func TestMockGetHostsFromSystem(t *testing.T) {
 	}
 
 	// local host and one of the peers are zero token so only one peer should be returned with 2 tokens
-	assertEqual(t, "hosts length", 1, len(hosts))
-	assertEqual(t, "host token length", 2, len(hosts[0].tokens))
+	AssertEqual(t, "hosts length", 1, len(hosts))
+	AssertEqual(t, "host token length", 2, len(hosts[0].tokens))
 }
 
 func TestRing_AddHostIfMissing_Missing(t *testing.T) {

--- a/schema_queries_test.go
+++ b/schema_queries_test.go
@@ -20,5 +20,5 @@ func TestSchemaQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to get keyspace metadata for keyspace: ", err)
 	}
-	assertTrue(t, "keyspace present in metadataDescriber", keyspaceMetadata.Name == "gocql_test")
+	AssertTrue(t, "keyspace present in metadataDescriber", keyspaceMetadata.Name == "gocql_test")
 }

--- a/schema_queries_test.go
+++ b/schema_queries_test.go
@@ -4,6 +4,7 @@
 package gocql
 
 import (
+	"github.com/gocql/gocql/internal/tests"
 	"testing"
 )
 
@@ -20,5 +21,5 @@ func TestSchemaQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal("unable to get keyspace metadata for keyspace: ", err)
 	}
-	AssertTrue(t, "keyspace present in metadataDescriber", keyspaceMetadata.Name == "gocql_test")
+	tests.AssertTrue(t, "keyspace present in metadataDescriber", keyspaceMetadata.Name == "gocql_test")
 }

--- a/tablet_test.go
+++ b/tablet_test.go
@@ -126,29 +126,29 @@ func TestFindTablets(t *testing.T) {
 	t.Parallel()
 
 	id, id2 := tablets.findTablets("test1", "table1")
-	assertEqual(t, "id", 0, id)
-	assertEqual(t, "id2", 7, id2)
+	AssertEqual(t, "id", 0, id)
+	AssertEqual(t, "id2", 7, id2)
 
 	id, id2 = tablets.findTablets("test2", "table1")
-	assertEqual(t, "id", 8, id)
-	assertEqual(t, "id2", 15, id2)
+	AssertEqual(t, "id", 8, id)
+	AssertEqual(t, "id2", 15, id2)
 
 	id, id2 = tablets.findTablets("test3", "table1")
-	assertEqual(t, "id", -1, id)
-	assertEqual(t, "id2", -1, id2)
+	AssertEqual(t, "id", -1, id)
+	AssertEqual(t, "id2", -1, id2)
 }
 
 func TestFindTabletForToken(t *testing.T) {
 	t.Parallel()
 
 	tablet := tablets.findTabletForToken(0, 0, 7)
-	assertTrue(t, "tablet.lastToken == 2305843009213693951", tablet.lastToken == 2305843009213693951)
+	AssertTrue(t, "tablet.lastToken == 2305843009213693951", tablet.lastToken == 2305843009213693951)
 
 	tablet = tablets.findTabletForToken(9223372036854775807, 0, 7)
-	assertTrue(t, "tablet.lastToken == 9223372036854775807", tablet.lastToken == 9223372036854775807)
+	AssertTrue(t, "tablet.lastToken == 9223372036854775807", tablet.lastToken == 9223372036854775807)
 
 	tablet = tablets.findTabletForToken(-4611686018427387904, 0, 7)
-	assertTrue(t, "tablet.lastToken == -2305843009213693953", tablet.lastToken == -2305843009213693953)
+	AssertTrue(t, "tablet.lastToken == -2305843009213693953", tablet.lastToken == -2305843009213693953)
 }
 
 func CompareRanges(tablets TabletInfoList, ranges [][]int64) bool {
@@ -176,7 +176,7 @@ func TestAddTabletToEmptyTablets(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905}}))
+	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905}}))
 }
 
 func TestAddTabletAtTheBeggining(t *testing.T) {
@@ -198,7 +198,7 @@ func TestAddTabletAtTheBeggining(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	assertTrue(t, "Token range in tablets table not correct",
+	AssertTrue(t, "Token range in tablets table not correct",
 		CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857}, {-6917529027641081857, -4611686018427387905}}))
 }
 
@@ -221,7 +221,7 @@ func TestAddTabletAtTheEnd(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
+	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
 		{-1, 2305843009213693951}}))
 }
 
@@ -250,7 +250,7 @@ func TestAddTabletInTheMiddle(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
+	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
 		{-4611686018427387905, -2305843009213693953},
 		{-1, 2305843009213693951}}))
 }
@@ -292,7 +292,7 @@ func TestAddTabletIntersecting(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	assertTrue(t, "Token range in tablets table not correct",
+	AssertTrue(t, "Token range in tablets table not correct",
 		CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
 			{-3611686018427387905, -6},
 			{-1, 2305843009213693951}}))
@@ -323,7 +323,7 @@ func TestAddTabletIntersectingWithFirst(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8011686018427387905, -7987529027641081857},
+	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8011686018427387905, -7987529027641081857},
 		{-6917529027641081857, -4611686018427387905}}))
 }
 
@@ -352,7 +352,7 @@ func TestAddTabletIntersectingWithLast(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	assertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857},
+	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857},
 		{-5011686018427387905, -2987529027641081857}}))
 }
 
@@ -383,7 +383,7 @@ func TestRemoveTabletsWithHost(t *testing.T) {
 
 	tablets = tablets.removeTabletsWithHostFromTabletsList(removed_host_id)
 
-	assertEqual(t, "TabletsList length", 1, len(tablets))
+	AssertEqual(t, "TabletsList length", 1, len(tablets))
 }
 
 func TestRemoveTabletsWithKeyspace(t *testing.T) {
@@ -411,7 +411,7 @@ func TestRemoveTabletsWithKeyspace(t *testing.T) {
 
 	tablets = tablets.removeTabletsWithKeyspaceFromTabletsList("removed_ks")
 
-	assertEqual(t, "TabletsList length", 1, len(tablets))
+	AssertEqual(t, "TabletsList length", 1, len(tablets))
 }
 
 func TestRemoveTabletsWithTable(t *testing.T) {
@@ -439,5 +439,5 @@ func TestRemoveTabletsWithTable(t *testing.T) {
 
 	tablets = tablets.removeTabletsWithTableFromTabletsList("test_ks", "removed_tb")
 
-	assertEqual(t, "TabletsList length", 2, len(tablets))
+	AssertEqual(t, "TabletsList length", 2, len(tablets))
 }

--- a/tablet_test.go
+++ b/tablet_test.go
@@ -4,6 +4,7 @@
 package gocql
 
 import (
+	"github.com/gocql/gocql/internal/tests"
 	"testing"
 )
 
@@ -126,29 +127,29 @@ func TestFindTablets(t *testing.T) {
 	t.Parallel()
 
 	id, id2 := tablets.findTablets("test1", "table1")
-	AssertEqual(t, "id", 0, id)
-	AssertEqual(t, "id2", 7, id2)
+	tests.AssertEqual(t, "id", 0, id)
+	tests.AssertEqual(t, "id2", 7, id2)
 
 	id, id2 = tablets.findTablets("test2", "table1")
-	AssertEqual(t, "id", 8, id)
-	AssertEqual(t, "id2", 15, id2)
+	tests.AssertEqual(t, "id", 8, id)
+	tests.AssertEqual(t, "id2", 15, id2)
 
 	id, id2 = tablets.findTablets("test3", "table1")
-	AssertEqual(t, "id", -1, id)
-	AssertEqual(t, "id2", -1, id2)
+	tests.AssertEqual(t, "id", -1, id)
+	tests.AssertEqual(t, "id2", -1, id2)
 }
 
 func TestFindTabletForToken(t *testing.T) {
 	t.Parallel()
 
 	tablet := tablets.findTabletForToken(0, 0, 7)
-	AssertTrue(t, "tablet.lastToken == 2305843009213693951", tablet.lastToken == 2305843009213693951)
+	tests.AssertTrue(t, "tablet.lastToken == 2305843009213693951", tablet.lastToken == 2305843009213693951)
 
 	tablet = tablets.findTabletForToken(9223372036854775807, 0, 7)
-	AssertTrue(t, "tablet.lastToken == 9223372036854775807", tablet.lastToken == 9223372036854775807)
+	tests.AssertTrue(t, "tablet.lastToken == 9223372036854775807", tablet.lastToken == 9223372036854775807)
 
 	tablet = tablets.findTabletForToken(-4611686018427387904, 0, 7)
-	AssertTrue(t, "tablet.lastToken == -2305843009213693953", tablet.lastToken == -2305843009213693953)
+	tests.AssertTrue(t, "tablet.lastToken == -2305843009213693953", tablet.lastToken == -2305843009213693953)
 }
 
 func CompareRanges(tablets TabletInfoList, ranges [][]int64) bool {
@@ -176,7 +177,7 @@ func TestAddTabletToEmptyTablets(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905}}))
+	tests.AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905}}))
 }
 
 func TestAddTabletAtTheBeggining(t *testing.T) {
@@ -198,7 +199,7 @@ func TestAddTabletAtTheBeggining(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	AssertTrue(t, "Token range in tablets table not correct",
+	tests.AssertTrue(t, "Token range in tablets table not correct",
 		CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857}, {-6917529027641081857, -4611686018427387905}}))
 }
 
@@ -221,7 +222,7 @@ func TestAddTabletAtTheEnd(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
+	tests.AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
 		{-1, 2305843009213693951}}))
 }
 
@@ -250,7 +251,7 @@ func TestAddTabletInTheMiddle(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
+	tests.AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
 		{-4611686018427387905, -2305843009213693953},
 		{-1, 2305843009213693951}}))
 }
@@ -292,7 +293,7 @@ func TestAddTabletIntersecting(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	AssertTrue(t, "Token range in tablets table not correct",
+	tests.AssertTrue(t, "Token range in tablets table not correct",
 		CompareRanges(tablets, [][]int64{{-6917529027641081857, -4611686018427387905},
 			{-3611686018427387905, -6},
 			{-1, 2305843009213693951}}))
@@ -323,7 +324,7 @@ func TestAddTabletIntersectingWithFirst(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8011686018427387905, -7987529027641081857},
+	tests.AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8011686018427387905, -7987529027641081857},
 		{-6917529027641081857, -4611686018427387905}}))
 }
 
@@ -352,7 +353,7 @@ func TestAddTabletIntersectingWithLast(t *testing.T) {
 		[]ReplicaInfo{},
 	})
 
-	AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857},
+	tests.AssertTrue(t, "Token range in tablets table not correct", CompareRanges(tablets, [][]int64{{-8611686018427387905, -7917529027641081857},
 		{-5011686018427387905, -2987529027641081857}}))
 }
 
@@ -383,7 +384,7 @@ func TestRemoveTabletsWithHost(t *testing.T) {
 
 	tablets = tablets.removeTabletsWithHostFromTabletsList(removed_host_id)
 
-	AssertEqual(t, "TabletsList length", 1, len(tablets))
+	tests.AssertEqual(t, "TabletsList length", 1, len(tablets))
 }
 
 func TestRemoveTabletsWithKeyspace(t *testing.T) {
@@ -411,7 +412,7 @@ func TestRemoveTabletsWithKeyspace(t *testing.T) {
 
 	tablets = tablets.removeTabletsWithKeyspaceFromTabletsList("removed_ks")
 
-	AssertEqual(t, "TabletsList length", 1, len(tablets))
+	tests.AssertEqual(t, "TabletsList length", 1, len(tablets))
 }
 
 func TestRemoveTabletsWithTable(t *testing.T) {
@@ -439,5 +440,5 @@ func TestRemoveTabletsWithTable(t *testing.T) {
 
 	tablets = tablets.removeTabletsWithTableFromTabletsList("test_ks", "removed_tb")
 
-	AssertEqual(t, "TabletsList length", 2, len(tablets))
+	tests.AssertEqual(t, "TabletsList length", 2, len(tablets))
 }


### PR DESCRIPTION
It will allow to reuse them outside of `gocql` package, in particular for tablets tests

Related to: https://github.com/scylladb/gocql/issues/470