### PR TITLE
Tablets: switch lookup API to use int64 instead of gocql.Token

### DIFF
--- a/scylla.go
+++ b/scylla.go
@@ -384,7 +384,7 @@ func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
 			l, r := tablets.findTablets(qry.Keyspace(), qry.Table())
 
 			if l != -1 {
-				tablet := tablets.findTabletForToken(mmt, l, r)
+				tablet := tablets.findTabletForToken(int64(mmt), l, r)
 
 				for _, replica := range tablet.replicas {
 					if replica.hostId.String() == p.hostId {

--- a/tablet_test.go
+++ b/tablet_test.go
@@ -141,13 +141,13 @@ func TestFindTablets(t *testing.T) {
 func TestFindTabletForToken(t *testing.T) {
 	t.Parallel()
 
-	tablet := tablets.findTabletForToken(parseInt64Token("0"), 0, 7)
+	tablet := tablets.findTabletForToken(0, 0, 7)
 	assertTrue(t, "tablet.lastToken == 2305843009213693951", tablet.lastToken == 2305843009213693951)
 
-	tablet = tablets.findTabletForToken(parseInt64Token("9223372036854775807"), 0, 7)
+	tablet = tablets.findTabletForToken(9223372036854775807, 0, 7)
 	assertTrue(t, "tablet.lastToken == 9223372036854775807", tablet.lastToken == 9223372036854775807)
 
-	tablet = tablets.findTabletForToken(parseInt64Token("-4611686018427387904"), 0, 7)
+	tablet = tablets.findTabletForToken(-4611686018427387904, 0, 7)
 	assertTrue(t, "tablet.lastToken == -2305843009213693953", tablet.lastToken == -2305843009213693953)
 }
 

--- a/tablets.go
+++ b/tablets.go
@@ -160,7 +160,7 @@ func (t TabletInfoList) removeTabletsWithTableFromTabletsList(keyspace string, t
 }
 
 // Search for place in tablets table for token starting from index l to index r
-func (t TabletInfoList) findTabletForToken(token Token, l int, r int) *TabletInfo {
+func (t TabletInfoList) findTabletForToken(token int64, l int, r int) *TabletInfo {
 	for l < r {
 		var m int
 		if r*l > 0 {
@@ -168,7 +168,7 @@ func (t TabletInfoList) findTabletForToken(token Token, l int, r int) *TabletInf
 		} else {
 			m = (r + l) / 2
 		}
-		if int64Token(t[m].LastToken()).Less(token) {
+		if t[m].LastToken() < token {
 			l = m + 1
 		} else {
 			r = m


### PR DESCRIPTION
Two purposes:
1. It speeds up lookup operation. Due to having no interface casting
2. It decouples API from `gocql` package and enables it to be relocated to another package

Related to: https://github.com/scylladb/gocql/issues/469 and https://github.com/scylladb/gocql/issues/470