### PR TITLE
Tablets more small optimizations

### DIFF
--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -491,9 +491,7 @@ func (s *metadataDescriber) AddTablet(tablet *tablets.TabletInfo) {
 }
 
 func (s *metadataDescriber) addTablet(tablet *tablets.TabletInfo) {
-	tablets := s.getTablets()
-	tablets = tablets.AddTabletToTabletsList(tablet)
-	s.setTablets(tablets)
+	s.metadata.tabletsMetadata.AddTablet(tablet)
 }
 
 // RemoveTabletsWithHost removes tablets that contains given host.
@@ -507,9 +505,7 @@ func (s *metadataDescriber) RemoveTabletsWithHost(host *HostInfo) {
 // removeTabletsWithHost removes tablets that contains given host.
 // s.mu should be locked
 func (s *metadataDescriber) removeTabletsWithHost(hostID string) {
-	tablets := s.getTablets()
-	tablets = tablets.RemoveTabletsWithHostFromTabletsList(hostID)
-	s.setTablets(tablets)
+	s.metadata.tabletsMetadata.RemoveTabletsWithHost(hostID)
 }
 
 // RemoveTabletsWithKeyspace removes tablets for given keyspace.
@@ -523,9 +519,7 @@ func (s *metadataDescriber) RemoveTabletsWithKeyspace(keyspace string) {
 // removeTabletsWithKeyspace removes tablets for given keyspace.
 // s.mu should be locked
 func (s *metadataDescriber) removeTabletsWithKeyspace(keyspace string) {
-	tablets := s.getTablets()
-	tablets = tablets.RemoveTabletsWithKeyspaceFromTabletsList(keyspace)
-	s.setTablets(tablets)
+	s.metadata.tabletsMetadata.RemoveTabletsWithKeyspace(keyspace)
 }
 
 // RemoveTabletsWithTable removes tablets for given table.
@@ -539,9 +533,7 @@ func (s *metadataDescriber) RemoveTabletsWithTable(keyspace string, table string
 // removeTabletsWithTable removes tablets for given table.
 // s.mu should be locked
 func (s *metadataDescriber) removeTabletsWithTable(keyspace string, table string) {
-	tablets := s.getTablets()
-	tablets = tablets.RemoveTabletsWithTableFromTabletsList(keyspace, table)
-	s.setTablets(tablets)
+	s.metadata.tabletsMetadata.RemoveTabletsWithTableFromTabletsList(keyspace, table)
 }
 
 // clearSchema clears the cached keyspace metadata

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -476,10 +476,6 @@ func (s *metadataDescriber) getSchema(keyspaceName string) (*KeyspaceMetadata, e
 	return metadata, nil
 }
 
-func (s *metadataDescriber) setTablets(tablets tablets.TabletInfoList) {
-	s.metadata.tabletsMetadata.Set(tablets)
-}
-
 func (s *metadataDescriber) getTablets() tablets.TabletInfoList {
 	return s.metadata.tabletsMetadata.Get()
 }

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -485,54 +485,24 @@ func (s *metadataDescriber) getTablets() tablets.TabletInfoList {
 }
 
 func (s *metadataDescriber) AddTablet(tablet *tablets.TabletInfo) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.addTablet(tablet)
-}
-
-func (s *metadataDescriber) addTablet(tablet *tablets.TabletInfo) {
 	s.metadata.tabletsMetadata.AddTablet(tablet)
 }
 
 // RemoveTabletsWithHost removes tablets that contains given host.
 // to be used outside the metadataDescriber
 func (s *metadataDescriber) RemoveTabletsWithHost(host *HostInfo) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.removeTabletsWithHost(host.HostID())
-}
-
-// removeTabletsWithHost removes tablets that contains given host.
-// s.mu should be locked
-func (s *metadataDescriber) removeTabletsWithHost(hostID string) {
-	s.metadata.tabletsMetadata.RemoveTabletsWithHost(hostID)
+	s.metadata.tabletsMetadata.RemoveTabletsWithHost(host.HostID())
 }
 
 // RemoveTabletsWithKeyspace removes tablets for given keyspace.
 // to be used outside the metadataDescriber
 func (s *metadataDescriber) RemoveTabletsWithKeyspace(keyspace string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.removeTabletsWithKeyspace(keyspace)
-}
-
-// removeTabletsWithKeyspace removes tablets for given keyspace.
-// s.mu should be locked
-func (s *metadataDescriber) removeTabletsWithKeyspace(keyspace string) {
 	s.metadata.tabletsMetadata.RemoveTabletsWithKeyspace(keyspace)
 }
 
 // RemoveTabletsWithTable removes tablets for given table.
 // to be used outside the metadataDescriber
 func (s *metadataDescriber) RemoveTabletsWithTable(keyspace string, table string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.removeTabletsWithTable(keyspace, table)
-}
-
-// removeTabletsWithTable removes tablets for given table.
-// s.mu should be locked
-func (s *metadataDescriber) removeTabletsWithTable(keyspace string, table string) {
 	s.metadata.tabletsMetadata.RemoveTabletsWithTableFromTabletsList(keyspace, table)
 }
 
@@ -572,7 +542,7 @@ func (s *metadataDescriber) refreshAllSchema() error {
 		err := s.refreshSchema(keyspaceName)
 		if errors.Is(err, ErrKeyspaceDoesNotExist) {
 			s.clearSchema(keyspaceName)
-			s.removeTabletsWithKeyspace(keyspaceName)
+			s.RemoveTabletsWithKeyspace(keyspaceName)
 			continue
 		} else if err != nil {
 			return err
@@ -584,13 +554,13 @@ func (s *metadataDescriber) refreshAllSchema() error {
 		}
 
 		if !compareInterfaceMaps(metadata.StrategyOptions, updatedMetadata.StrategyOptions) {
-			s.removeTabletsWithKeyspace(keyspaceName)
+			s.RemoveTabletsWithKeyspace(keyspaceName)
 			continue
 		}
 
 		for tableName, tableMetadata := range metadata.Tables {
 			if updatedTableMetadata, ok := updatedMetadata.Tables[tableName]; !ok || tableMetadata.Equals(updatedTableMetadata) {
-				s.removeTabletsWithTable(keyspaceName, tableName)
+				s.RemoveTabletsWithTable(keyspaceName, tableName)
 			}
 		}
 	}

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -451,8 +451,10 @@ type metadataDescriber struct {
 // keyspace metadata and tablets metadata
 func newMetadataDescriber(session *Session) *metadataDescriber {
 	return &metadataDescriber{
-		session:  session,
-		metadata: &Metadata{},
+		session: session,
+		metadata: &Metadata{
+			tabletsMetadata: tablets.NewCowTabletList(),
+		},
 	}
 }
 

--- a/scylla.go
+++ b/scylla.go
@@ -378,18 +378,9 @@ func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
 		}
 
 		if qry != nil && conn.isTabletSupported() {
-			tablets := conn.session.getTablets()
-
-			// Search for tablets with Keyspace and Table from the Query
-			l, r := tablets.FindTablets(qry.Keyspace(), qry.Table())
-
-			if l != -1 {
-				tablet := tablets.FindTabletForToken(int64(mmt), l, r)
-
-				for _, replica := range tablet.Replicas() {
-					if replica.HostID() == p.hostId {
-						idx = replica.ShardID()
-					}
+			for _, replica := range conn.session.findTabletReplicasForToken(qry.Keyspace(), qry.Table(), int64(mmt)) {
+				if replica.HostID() == p.hostId {
+					idx = replica.ShardID()
 				}
 			}
 		}

--- a/scylla.go
+++ b/scylla.go
@@ -372,6 +372,7 @@ func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
 
 	idx := -1
 
+outer:
 	for _, conn := range p.conns {
 		if conn == nil {
 			continue
@@ -381,6 +382,7 @@ func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
 			for _, replica := range conn.session.findTabletReplicasForToken(qry.Keyspace(), qry.Table(), int64(mmt)) {
 				if replica.HostID() == p.hostId {
 					idx = replica.ShardID()
+					break outer
 				}
 			}
 		}

--- a/session.go
+++ b/session.go
@@ -331,11 +331,6 @@ func (s *Session) init() error {
 			}
 
 			hosts = filteredHosts
-
-			if s.tabletsRoutingV1 {
-				tablets := tablets.TabletInfoList{}
-				s.metadataDescriber.setTablets(tablets)
-			}
 		}
 
 		newer, _ := checkSystemSchema(s.control)

--- a/session.go
+++ b/session.go
@@ -717,8 +717,8 @@ func (s *Session) getConn() *Conn {
 	return nil
 }
 
-func (s *Session) getTablets() tablets.TabletInfoList {
-	return s.metadataDescriber.getTablets()
+func (s *Session) findTabletReplicasForToken(keyspace, table string, token int64) []tablets.ReplicaInfo {
+	return s.metadataDescriber.metadata.tabletsMetadata.FindReplicasForToken(keyspace, table, token)
 }
 
 // returns routing key indexes and type info

--- a/tablets/tablets.go
+++ b/tablets/tablets.go
@@ -165,7 +165,7 @@ func (t TabletInfoList) AddTabletToTabletsList(tablet *TabletInfo) TabletInfoLis
 }
 
 // Remove all tablets that have given host as a replica
-func (t TabletInfoList) RemoveTabletsWithHostFromTabletsList(hostID string) TabletInfoList {
+func (t TabletInfoList) RemoveTabletsWithHost(hostID string) TabletInfoList {
 	filteredTablets := make([]*TabletInfo, 0, len(t)) // Preallocate for efficiency
 
 	for _, tablet := range t {
@@ -186,7 +186,7 @@ func (t TabletInfoList) RemoveTabletsWithHostFromTabletsList(hostID string) Tabl
 	return t
 }
 
-func (t TabletInfoList) RemoveTabletsWithKeyspaceFromTabletsList(keyspace string) TabletInfoList {
+func (t TabletInfoList) RemoveTabletsWithKeyspace(keyspace string) TabletInfoList {
 	filteredTablets := make([]*TabletInfo, 0, len(t))
 
 	for _, tablet := range t {
@@ -212,7 +212,6 @@ func (t TabletInfoList) RemoveTabletsWithTableFromTabletsList(keyspace string, t
 	return t
 }
 
-// Search for place in tablets table for token starting from index l to index r
 func (t TabletInfoList) FindTabletForToken(token int64, l int, r int) *TabletInfo {
 	for l < r {
 		var m int
@@ -241,6 +240,30 @@ func (c *CowTabletList) Get() TabletInfoList {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.list
+}
+
+func (c *CowTabletList) AddTablet(tablet *TabletInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.list = c.list.AddTabletToTabletsList(tablet)
+}
+
+func (c *CowTabletList) RemoveTabletsWithHost(hostID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.list = c.list.RemoveTabletsWithHost(hostID)
+}
+
+func (c *CowTabletList) RemoveTabletsWithKeyspace(keyspace string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.list = c.list.RemoveTabletsWithKeyspace(keyspace)
+}
+
+func (c *CowTabletList) RemoveTabletsWithTableFromTabletsList(keyspace string, table string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.list = c.list.RemoveTabletsWithTableFromTabletsList(keyspace, table)
 }
 
 func (c *CowTabletList) Set(tablets TabletInfoList) {

--- a/tablets/tablets.go
+++ b/tablets/tablets.go
@@ -266,6 +266,16 @@ func (c *CowTabletList) RemoveTabletsWithTableFromTabletsList(keyspace string, t
 	c.list = c.list.RemoveTabletsWithTableFromTabletsList(keyspace, table)
 }
 
+func (c *CowTabletList) FindReplicasForToken(keyspace, table string, token int64) []ReplicaInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	l, r := c.list.FindTablets(keyspace, table)
+	if l == -1 {
+		return nil
+	}
+	return c.list.FindTabletForToken(token, l, r).Replicas()
+}
+
 func (c *CowTabletList) Set(tablets TabletInfoList) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/tablets/tablets_test.go
+++ b/tablets/tablets_test.go
@@ -383,7 +383,7 @@ func TestRemoveTabletsWithHost(t *testing.T) {
 		[]ReplicaInfo{{tests.RandomUUID(), 9}, {removed_host_id, 8}, {tests.RandomUUID(), 3}},
 	}}
 
-	tablets = tablets.RemoveTabletsWithHostFromTabletsList(removed_host_id)
+	tablets = tablets.RemoveTabletsWithHost(removed_host_id)
 
 	tests.AssertEqual(t, "TabletsList length", 1, len(tablets))
 }
@@ -411,7 +411,7 @@ func TestRemoveTabletsWithKeyspace(t *testing.T) {
 		[]ReplicaInfo{{tests.RandomUUID(), 9}, {tests.RandomUUID(), 8}, {tests.RandomUUID(), 3}},
 	}}
 
-	tablets = tablets.RemoveTabletsWithKeyspaceFromTabletsList("removed_ks")
+	tablets = tablets.RemoveTabletsWithKeyspace("removed_ks")
 
 	tests.AssertEqual(t, "TabletsList length", 1, len(tablets))
 }


### PR DESCRIPTION
List of changes:
1. Move all logic that reads and writes tablets to `CowTabletList`
2. Remove `metadataDescriber` lock in front of tablets API
3. Remove tablets initialization from `Session.init`
4. Fix `scyllaConnPicker.Pick` to stop iterating when shard is found
5. Drop rw lock from `CowTabletList` in favor of `atomic.Value`
6. Add write lock to `CowTabletList` to ensure there is only one write operation running in parallel

Final fix for: https://github.com/scylladb/gocql/issues/469
