### PR TITLE
Use TokenAwarePolicy by default

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2373,6 +2373,8 @@ func TestRoutingKey(t *testing.T) {
 		t.Fatalf("failed to create table with error '%v'", err)
 	}
 
+	initCacheSize := session.routingKeyInfoCache.lru.Len()
+
 	routingKeyInfo, err := session.routingKeyInfo(context.Background(), "SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?")
 	if err != nil {
 		t.Fatalf("failed to get routing key info due to error: %v", err)
@@ -2417,8 +2419,8 @@ func TestRoutingKey(t *testing.T) {
 		t.Fatalf("Expected routing key types[0] to be %v but was %v", TypeInt, routingKeyInfo.types[0].Type())
 	}
 	cacheSize := session.routingKeyInfoCache.lru.Len()
-	if cacheSize != 1 {
-		t.Errorf("Expected cache size to be 1 but was %d", cacheSize)
+	if cacheSize != initCacheSize+1 {
+		t.Errorf("Expected cache size to be %d but was %d", initCacheSize+1, cacheSize)
 	}
 
 	query := session.Query("SELECT * FROM test_single_routing_key WHERE second_id=? AND first_id=?", 1, 2)
@@ -2475,8 +2477,8 @@ func TestRoutingKey(t *testing.T) {
 
 	// verify the cache is working
 	cacheSize = session.routingKeyInfoCache.lru.Len()
-	if cacheSize != 2 {
-		t.Errorf("Expected cache size to be 2 but was %d", cacheSize)
+	if cacheSize != initCacheSize+2 {
+		t.Errorf("Expected cache size to be %d but was %d", initCacheSize+2, cacheSize)
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -106,6 +106,7 @@ func testCluster(proto protoVersion, addresses ...string) *ClusterConfig {
 	cluster := NewCluster(addresses...)
 	cluster.ProtoVersion = int(proto)
 	cluster.disableControlConn = true
+	cluster.PoolConfig.HostSelectionPolicy = RoundRobinHostPolicy()
 	return cluster
 }
 

--- a/recreate_test.go
+++ b/recreate_test.go
@@ -6,6 +6,7 @@
 package gocql
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -101,6 +102,15 @@ func TestRecreateSchema(t *testing.T) {
 				qr.Release()
 			}
 
+			err = session.AwaitSchemaAgreement(context.Background())
+			if err != nil {
+				t.Fatal("failed to await for schema agreement", err)
+			}
+			err = session.metadataDescriber.refreshSchema(test.Keyspace)
+			if err != nil {
+				t.Fatal("failed to read schema for keyspace", err)
+			}
+
 			if tabletsAutoEnabled && test.FailWithTablets {
 				if err == nil {
 					t.Errorf("did not get expected error or tablets")
@@ -172,6 +182,14 @@ func TestRecreateSchema(t *testing.T) {
 			}
 
 			// Check if new dump is the same as previous
+			err = session.AwaitSchemaAgreement(context.Background())
+			if err != nil {
+				t.Fatal("failed to await for schema agreement", err)
+			}
+			err = session.metadataDescriber.refreshSchema(test.Keyspace)
+			if err != nil {
+				t.Fatal("failed to read schema for keyspace", err)
+			}
 			km, err = session.KeyspaceMetadata(test.Keyspace)
 			if err != nil {
 				t.Fatal("dump schema", err)

--- a/session.go
+++ b/session.go
@@ -180,7 +180,7 @@ func newSessionCommon(cfg ClusterConfig) (*Session, error) {
 	})
 
 	if cfg.PoolConfig.HostSelectionPolicy == nil {
-		cfg.PoolConfig.HostSelectionPolicy = RoundRobinHostPolicy()
+		cfg.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
 	}
 	s.pool = cfg.PoolConfig.buildPool(s)
 


### PR DESCRIPTION
Since this driver mostly targets scylla,
it would be better to enable it by default.

Fixes: https://github.com/scylladb/gocql/issues/481