### PR TITLE
fix: possible panic on session.Close

### DIFF
--- a/session.go
+++ b/session.go
@@ -606,10 +606,6 @@ func (s *Session) Close() {
 		s.cancel()
 	}
 
-	if s.policy != nil {
-		s.policy.Reset()
-	}
-
 	s.sessionStateMu.Lock()
 	s.isClosed = true
 	s.sessionStateMu.Unlock()


### PR DESCRIPTION
After session is closed, it is still could be used by event handlers. So, reseting policy will lead to following error:
```
github.com/gocql/gocql.(*tokenAwareHostPolicy).updateReplicas(0xc0004c2180, 0xc00039f830, {0xc00002ade0, 0x1b})
	/home/runner/work/gocql/gocql/policies.go:600 +0x90
github.com/gocql/gocql.(*tokenAwareHostPolicy).KeyspaceChanged(0xc0004c2180, {{0xc00002ade0?, 0x2000107?}, {0xc0004d1090?, 0xffffffffffffffff?}})
	/home/runner/work/gocql/gocql/policies.go:587 +0xb3
github.com/gocql/gocql.(*Session).handleKeyspaceChange(0xc0000f4408, {0xc00002ade0, 0x1b}, {0xc0004d1090, 0x7})
	/home/runner/work/gocql/gocql/events.go:157 +0xe2
github.com/gocql/gocql.(*Session).handleSchemaEvent(0xc0000f4408, {0xc00039ed70?, 0xc0002848c0?, 0x30d40?})
	/home/runner/work/gocql/gocql/events.go:138 +0xa6
created by github.com/gocql/gocql.(*eventDebouncer).flush in goroutine 1238
	/home/runner/work/gocql/gocql/events.go:91 +0xaa
```
Since policy reusability is not a feature we can void `Reset` on the `session.Close`