### PR TITLE
cluster: implement Cluster.ApplicationInfo

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -314,10 +314,18 @@ type ClusterConfig struct {
 	disableInit        bool
 
 	DNSResolver DNSResolver
+
+	ApplicationInfo ApplicationInfo
 }
 
 type DNSResolver interface {
 	LookupIP(host string) ([]net.IP, error)
+}
+
+type ApplicationInfo struct {
+	ApplicationName    string
+	ApplicationVersion string
+	ClientID           string
 }
 
 type SimpleDNSResolver struct {

--- a/conn.go
+++ b/conn.go
@@ -513,6 +513,16 @@ func (s *startupCoordinator) startup(ctx context.Context) error {
 		"DRIVER_VERSION": s.conn.session.cfg.DriverVersion,
 	}
 
+	if s.conn.session.cfg.ApplicationInfo.ApplicationName != "" {
+		m["APPLICATION_NAME"] = s.conn.session.cfg.ApplicationInfo.ApplicationName
+	}
+	if s.conn.session.cfg.ApplicationInfo.ApplicationVersion != "" {
+		m["APPLICATION_VERSION"] = s.conn.session.cfg.ApplicationInfo.ApplicationVersion
+	}
+	if s.conn.session.cfg.ApplicationInfo.ClientID != "" {
+		m["CLIENT_ID"] = s.conn.session.cfg.ApplicationInfo.ClientID
+	}
+
 	if s.conn.compressor != nil {
 		comp := s.conn.supported["COMPRESSION"]
 		name := s.conn.compressor.Name()


### PR DESCRIPTION
Implement `Cluster.ApplicationInfo` to make driver send following startup options to server:
1. `APPLICATION_NAME` - ID what application is using driver, example: repo of the application
2. `APPLICATION_VERSION` - Version of the application, example: release version or commit id of the application
3. `CLIENT_ID` - unique id of the client instance, example: pod name

All strings.