### PR TITLE
cluster: generalize application information API

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -322,10 +322,34 @@ type DNSResolver interface {
 	LookupIP(host string) ([]net.IP, error)
 }
 
-type ApplicationInfo struct {
-	ApplicationName    string
-	ApplicationVersion string
-	ClientID           string
+type ApplicationInfo interface {
+	UpdateStartupOptions(map[string]string)
+}
+
+type StaticApplicationInfo struct {
+	applicationName    string
+	applicationVersion string
+	clientID           string
+}
+
+func NewStaticApplicationInfo(name, version, clientID string) *StaticApplicationInfo {
+	return &StaticApplicationInfo{
+		applicationName:    name,
+		applicationVersion: version,
+		clientID:           clientID,
+	}
+}
+
+func (i *StaticApplicationInfo) UpdateStartupOptions(opts map[string]string) {
+	if i.applicationName != "" {
+		opts["APPLICATION_NAME"] = i.applicationName
+	}
+	if i.applicationVersion != "" {
+		opts["APPLICATION_VERSION"] = i.applicationVersion
+	}
+	if i.clientID != "" {
+		opts["CLIENT_ID"] = i.clientID
+	}
 }
 
 type SimpleDNSResolver struct {

--- a/conn.go
+++ b/conn.go
@@ -513,14 +513,8 @@ func (s *startupCoordinator) startup(ctx context.Context) error {
 		"DRIVER_VERSION": s.conn.session.cfg.DriverVersion,
 	}
 
-	if s.conn.session.cfg.ApplicationInfo.ApplicationName != "" {
-		m["APPLICATION_NAME"] = s.conn.session.cfg.ApplicationInfo.ApplicationName
-	}
-	if s.conn.session.cfg.ApplicationInfo.ApplicationVersion != "" {
-		m["APPLICATION_VERSION"] = s.conn.session.cfg.ApplicationInfo.ApplicationVersion
-	}
-	if s.conn.session.cfg.ApplicationInfo.ClientID != "" {
-		m["CLIENT_ID"] = s.conn.session.cfg.ApplicationInfo.ClientID
+	if s.conn.session.cfg.ApplicationInfo != nil {
+		s.conn.session.cfg.ApplicationInfo.UpdateStartupOptions(m)
 	}
 
 	if s.conn.compressor != nil {


### PR DESCRIPTION
define `ApplicationInfo` as interface with single method to update startup options.
This way it allows to have customer application information implementations, for example ones that read this information from file or environment.