### PR TITLE
cicd: update get version step to pull new images

### DIFF
--- a/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
+++ b/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           cd get-version
           if [[ "${{ matrix.scylla-version }}" == "ENTERPRISE-RELEASE" ]]; then
-            echo "value=$(./get-version --source dockerhub-imagetag --repo scylladb/scylla-enterprise -filters "2024.1.LAST" | tr -d '\"')" | tee -a $GITHUB_OUTPUT
+            echo "value=$(./get-version --source dockerhub-imagetag --repo scylladb/scylla-enterprise -filters "^[0-9]{4}$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST" | tr -d '\"')" >> $GITHUB_ENV
           elif [[ "${{ matrix.scylla-version }}" == "OSS-RELEASE" ]]; then
-            echo "value=$(./get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "6.1.LAST" | tr -d '\"')" | tee -a $GITHUB_OUTPUT
+            echo "value=$(./get-version --source dockerhub-imagetag --repo scylladb/scylla -filters "^[0-9]$.^[0-9]+$.^[0-9]+$ and LAST.LAST.LAST" | tr -d '\"')" >> $GITHUB_ENV
           elif echo "${{ matrix.scylla-version }}" | grep -P '^[0-9\.]+'; then # If you want to run specific version do just that
             echo "value=${{ matrix.scylla-version }}" | tee -a $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Currently patterns are outdated and pull `2024.1.x` and old `6.1.x` images. 
Let's relax them to pull what they suppose to pull