### PR TITLE
Add Makefile step to cleanup old docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ export JAVA11_HOME=${JAVA_HOME_11_X64}
 export JAVA17_HOME=${JAVA_HOME_17_X64}
 export JAVA_HOME=${JAVA_HOME_11_X64}
 
+clean-old-temporary-docker-images:
+	@echo "Running Docker Hub image cleanup script..."
+	python ci/clean-old-temporary-docker-images.py
+
 cassandra-start: .prepare-pki .prepare-cassandra-ccm .prepare-java
 	@if [ -d ${CCM_CONFIG_DIR}/${CCM_CASSANDRA_CLUSTER_NAME} ] && ccm switch ${CCM_CASSANDRA_CLUSTER_NAME} 2>/dev/null 1>&2 && ccm status | grep UP 2>/dev/null 1>&2; then \
 		echo "Cassandra cluster is already started"; \


### PR DESCRIPTION
Previously removed by mistake in https://github.com/scylladb/gocql/commit/145695c248c9da8c867d0848aeaa29a3cdcf756d#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52