### PR TITLE
uuid: add IsEmpty() api

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -257,6 +257,12 @@ func (u UUID) Bytes() []byte {
 	return u[:]
 }
 
+var emptyUUID = UUID{}
+
+func (u UUID) IsEmpty() bool {
+	return u == emptyUUID
+}
+
 // Variant returns the variant of this UUID. This package will only generate
 // UUIDs in the IETF variant.
 func (u UUID) Variant() int {


### PR DESCRIPTION
There is a need to check if UUID is empty or not.
To make it convenient for users we need to add an API for that.

Closes: https://github.com/scylladb/gocql/issues/514