### PR TITLE
(improvement) remove redundant len() calls from compression code

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -746,7 +746,8 @@ func (f *framer) setLength(length int) {
 }
 
 func (f *framer) finish() error {
-	if len(f.buf) > maxFrameSize {
+	bufLen := len(f.buf)
+	if bufLen > maxFrameSize {
 		// huge app frame, lets remove it so it doesn't bloat the heap
 		f.buf = make([]byte, defaultBufSize)
 		return ErrFrameTooBig
@@ -764,8 +765,9 @@ func (f *framer) finish() error {
 		}
 
 		f.buf = append(f.buf[:headSize], compressed...)
+		bufLen = len(f.buf)
 	}
-	length := len(f.buf) - headSize
+	length := bufLen - headSize
 	f.setLength(length)
 
 	return nil

--- a/lz4/lz4.go
+++ b/lz4/lz4.go
@@ -48,7 +48,8 @@ func (s LZ4Compressor) Name() string {
 }
 
 func (s LZ4Compressor) Encode(data []byte) ([]byte, error) {
-	buf := make([]byte, lz4.CompressBlockBound(len(data)+4))
+	dataLen := len(data)
+	buf := make([]byte, lz4.CompressBlockBound(dataLen)+4)
 	var compressor lz4.Compressor
 	n, err := compressor.CompressBlock(data, buf[4:])
 	// According to lz4.CompressBlock doc, it doesn't fail as long as the dst
@@ -57,7 +58,7 @@ func (s LZ4Compressor) Encode(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	binary.BigEndian.PutUint32(buf, uint32(len(data)))
+	binary.BigEndian.PutUint32(buf, uint32(dataLen))
 	return buf[:n+4], nil
 }
 


### PR DESCRIPTION
Very similar changes to the Python driver (https://github.com/scylladb/python-driver/pull/520 ), there are redundant calls to len(). Removed them.

Follow-up patch will hopefully change the Encode() functions to accept the length of the buffer, to remove another len() call (just as done in the Python change mentioned above).