### PR TITLE
Run control connection reconnect in background

### DIFF
--- a/control.go
+++ b/control.go
@@ -476,7 +476,7 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 		return
 	}
 
-	c.reconnect()
+	go c.reconnect()
 }
 
 func (c *controlConn) getConn() *connHost {


### PR DESCRIPTION
When `ringDescriber.GetHostsFromSystem` reading `system.peers` on connection from the control connection that have `controlConn.HandleError` in the `errorHandler`. This `controlConn.HandleError` calls `controlConn.reconnect` which calls `controlConn.attemptReconnect` which calls `ringDescriber.getHostsList`. When it happens `ringDescriber.GetHostsFromSystem` call is already obtained `r.mu.Lock()` on `ringDescriber`, and `ringDescriber.getHostsList` will request same lock via `r.mu.RLock()`, as result `Session` will deadlock.

To address that we need to separate context between two locks, best place for it is to call `controlConn.reconnect` on the background in `controlConn.HandleError`.

Fix: https://github.com/scylladb/gocql/issues/521