### PR TITLE
Split client-side timeout for driver and user queries

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -32,7 +32,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gocql/gocql/internal/tests"
 	"math"
 	"math/big"
 	"net"
@@ -43,6 +42,8 @@ import (
 	"testing"
 	"time"
 	"unicode"
+
+	"github.com/gocql/gocql/internal/tests"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/inf.v0"
@@ -1703,7 +1704,7 @@ func TestPrepare_MissingSchemaPrepare(t *testing.T) {
 	defer s.Close()
 
 	insertQry := s.Query("INSERT INTO invalidschemaprep (val) VALUES (?)", 5)
-	if err := conn.executeQuery(ctx, insertQry).err; err == nil {
+	if err := conn.executeQuery(ctx, insertQry, conn.getTimeout(), conn.getWriteTimeout()).err; err == nil {
 		t.Fatal("expected error, but got nil.")
 	}
 
@@ -1711,7 +1712,7 @@ func TestPrepare_MissingSchemaPrepare(t *testing.T) {
 		t.Fatal("create table:", err)
 	}
 
-	if err := conn.executeQuery(ctx, insertQry).err; err != nil {
+	if err := conn.executeQuery(ctx, insertQry, conn.getTimeout(), conn.getWriteTimeout()).err; err != nil {
 		t.Fatal(err) // unconfigured columnfamily
 	}
 }
@@ -1725,7 +1726,7 @@ func TestPrepare_ReprepareStatement(t *testing.T) {
 
 	stmt, conn := injectInvalidPreparedStatement(t, session, "test_reprepare_statement")
 	query := session.Query(stmt, "bar")
-	if err := conn.executeQuery(ctx, query).Close(); err != nil {
+	if err := conn.executeQuery(ctx, query, conn.getTimeout(), conn.getWriteTimeout()).Close(); err != nil {
 		t.Fatalf("Failed to execute query for reprepare statement: %v", err)
 	}
 }
@@ -2470,7 +2471,7 @@ func TestNegativeStream(t *testing.T) {
 		return f.finish()
 	})
 
-	frame, err := conn.exec(context.Background(), writer, nil)
+	frame, err := conn.exec(context.Background(), conn.getTimeout(), conn.getWriteTimeout(), writer, nil)
 	if err == nil {
 		t.Fatalf("expected to get an error on stream %d", stream)
 	} else if frame != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -439,7 +439,6 @@ func TestNewConnectWithLowTimeout(t *testing.T) {
 					})
 
 					t.Run("Query from control connection after reconnect", func(t *testing.T) {
-						t.Skip("Enable it when https://github.com/scylladb/gocql/issues/528 is fixed")
 						err = s.control.reconnect()
 						if err != nil {
 							t.Fatalf("failed to reconnect to control connection: %v", err)

--- a/ring_describer.go
+++ b/ring_describer.go
@@ -158,7 +158,8 @@ func (r *ringDescriber) getHostInfo(hostID UUID) (*HostInfo, error) {
 				iter = ch.conn.querySystem(context.TODO(), qrySystemPeers)
 			}
 		} else {
-			iter = ch.conn.query(context.TODO(), fmt.Sprintf("SELECT * FROM %s WHERE key='local'", table))
+			iter = ch.conn.query(context.TODO(), r.cfg.MetadataSchemaRequestTimeout, r.cfg.MetadataSchemaRequestTimeout, fmt.Sprintf("SELECT * FROM %s WHERE key='local'", table))
+			ch.conn.finalizeConnection()
 		}
 
 		if iter != nil {

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -94,11 +94,13 @@ func TestGetClusterPeerInfoZeroToken(t *testing.T) {
 type mockConnection struct{}
 
 func (*mockConnection) Close() {}
-func (*mockConnection) exec(ctx context.Context, req frameBuilder, tracer Tracer) (*framer, error) {
+func (*mockConnection) exec(ctx context.Context, timeout time.Duration, writeTimeout time.Duration, req frameBuilder, tracer Tracer) (*framer, error) {
 	return nil, nil
 }
-func (*mockConnection) awaitSchemaAgreement(ctx context.Context) error     { return nil }
-func (*mockConnection) executeQuery(ctx context.Context, qry *Query) *Iter { return nil }
+func (*mockConnection) awaitSchemaAgreement(ctx context.Context) error { return nil }
+func (*mockConnection) executeQuery(ctx context.Context, qry *Query, timeout time.Duration, writeTimeout time.Duration) *Iter {
+	return nil
+}
 
 var systemLocalResultMetadata = resultMetadata{
 	flags:          0,
@@ -290,13 +292,13 @@ func (*mockConnection) querySystem(ctx context.Context, query string) *Iter {
 
 func (*mockConnection) getIsSchemaV2() bool { return false }
 func (*mockConnection) setSchemaV2(s bool)  {}
-func (*mockConnection) query(ctx context.Context, statement string, values ...interface{}) (iter *Iter) {
+func (*mockConnection) query(ctx context.Context, timeout time.Duration, writeTimeout time.Duration, statement string, values ...interface{}) (iter *Iter) {
 	return nil
 }
 func (*mockConnection) finalizeConnection()                 {}
 func (*mockConnection) getScyllaSupported() scyllaSupported { return scyllaSupported{} }
-func (*mockConnection) getTimeout() { return 11*time.Second }
-func (*mockConnection) getWriteTimeout() { return 11*time.Second }
+func (*mockConnection) getTimeout() time.Duration { return 11*time.Second }
+func (*mockConnection) getWriteTimeout() time.Duration { return 11*time.Second }
 
 type mockControlConn struct{}
 

--- a/session.go
+++ b/session.go
@@ -1309,7 +1309,7 @@ func (q *Query) Cancel() {
 }
 
 func (q *Query) execute(ctx context.Context, conn *Conn) *Iter {
-	return conn.executeQuery(ctx, q)
+	return conn.executeQuery(ctx, q, conn.getTimeout(), conn.getWriteTimeout())
 }
 
 func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
@@ -1549,7 +1549,7 @@ func (q *Query) executeQuery() *Iter {
 	if q.conn != nil {
 		// if the query was specifically run on a connection then re-use that
 		// connection when fetching the next results
-		return q.conn.executeQuery(q.Context(), q)
+		return q.conn.executeQuery(q.Context(), q, q.conn.getTimeout(), q.conn.getWriteTimeout())
 	}
 	return q.session.executeQuery(q)
 }
@@ -1980,7 +1980,7 @@ func (n *nextIter) fetch() *Iter {
 		// if the query was specifically run on a connection then re-use that
 		// connection when fetching the next results
 		if n.qry.conn != nil {
-			n.next = n.qry.conn.executeQuery(n.qry.Context(), n.qry)
+			n.next = n.qry.conn.executeQuery(n.qry.Context(), n.qry, n.qry.conn.getTimeout(), n.qry.conn.getWriteTimeout())
 		} else {
 			n.next = n.qry.session.executeQuery(n.qry)
 		}


### PR DESCRIPTION
* Added new configurable client-side timeout for driver queries
* Use it every time we query system tables, for heartbeats etc.

Fixes: #528 