### PR TITLE
Align receivers

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1510,24 +1510,24 @@ func (t NativeType) NewWithError() (interface{}, error) {
 	return reflect.New(typ).Interface(), nil
 }
 
-func (s NativeType) Type() Type {
-	return s.typ
+func (t NativeType) Type() Type {
+	return t.typ
 }
 
-func (s NativeType) Version() byte {
-	return s.proto
+func (t NativeType) Version() byte {
+	return t.proto
 }
 
-func (s NativeType) Custom() string {
-	return s.custom
+func (t NativeType) Custom() string {
+	return t.custom
 }
 
-func (s NativeType) String() string {
-	switch s.typ {
+func (t NativeType) String() string {
+	switch t.typ {
 	case TypeCustom:
-		return fmt.Sprintf("%s(%s)", s.typ, s.custom)
+		return fmt.Sprintf("%s(%s)", t.typ, t.custom)
 	default:
-		return s.typ.String()
+		return t.typ.String()
 	}
 }
 
@@ -1553,16 +1553,16 @@ func (t CollectionType) NewWithError() (interface{}, error) {
 	return reflect.New(typ).Interface(), nil
 }
 
-func (c CollectionType) String() string {
-	switch c.typ {
+func (t CollectionType) String() string {
+	switch t.typ {
 	case TypeMap:
-		return fmt.Sprintf("%s(%s, %s)", c.typ, c.Key, c.Elem)
+		return fmt.Sprintf("%s(%s, %s)", t.typ, t.Key, t.Elem)
 	case TypeList, TypeSet:
-		return fmt.Sprintf("%s(%s)", c.typ, c.Elem)
+		return fmt.Sprintf("%s(%s)", t.typ, t.Elem)
 	case TypeCustom:
-		return fmt.Sprintf("%s(%s)", c.typ, c.custom)
+		return fmt.Sprintf("%s(%s)", t.typ, t.custom)
 	default:
-		return c.typ.String()
+		return t.typ.String()
 	}
 }
 
@@ -1618,20 +1618,20 @@ type UDTTypeInfo struct {
 	Elements []UDTField
 }
 
-func (u UDTTypeInfo) NewWithError() (interface{}, error) {
-	typ, err := goType(u)
+func (t UDTTypeInfo) NewWithError() (interface{}, error) {
+	typ, err := goType(t)
 	if err != nil {
 		return nil, err
 	}
 	return reflect.New(typ).Interface(), nil
 }
 
-func (u UDTTypeInfo) String() string {
+func (t UDTTypeInfo) String() string {
 	buf := &bytes.Buffer{}
 
-	fmt.Fprintf(buf, "%s.%s{", u.KeySpace, u.Name)
+	fmt.Fprintf(buf, "%s.%s{", t.KeySpace, t.Name)
 	first := true
-	for _, e := range u.Elements {
+	for _, e := range t.Elements {
 		if !first {
 			fmt.Fprint(buf, ",")
 		} else {

--- a/scylla.go
+++ b/scylla.go
@@ -282,8 +282,8 @@ func parseCQLProtocolExtensions(supported map[string][]string, logger StdLogger)
 }
 
 // isScyllaConn checks if conn is suitable for scyllaConnPicker.
-func (conn *Conn) isScyllaConn() bool {
-	return conn.getScyllaSupported().nrShards != 0
+func (c *Conn) isScyllaConn() bool {
+	return c.getScyllaSupported().nrShards != 0
 }
 
 // scyllaConnPicker is a specialised ConnPicker that selects connections based


### PR DESCRIPTION
In some parts of the code one type can have receivers with different names.
It is not a bug, but better to fix it, if we go for better linting it will pop up.