### PR TITLE
Introduce ClusterConfig.ReadTimeout

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -82,7 +82,6 @@ type ClusterConfig struct {
 	// Timeout limits the time spent on the client side while executing a query.
 	// Specifically, query or batch execution will return an error if the client does not receive a response
 	// from the server within the Timeout period.
-	// Timeout is also used to configure the read timeout on the underlying network connection.
 	// Client Timeout should always be higher than the request timeouts configured on the server,
 	// so that retries don't overload the server.
 	// Timeout has a default value of 11 seconds, which is higher than default server timeout for most query types.
@@ -102,6 +101,10 @@ type ClusterConfig struct {
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
 	WriteTimeout time.Duration
+
+	// ReadTimeout limits the time the driver waits for data from the connection.
+	// It has only one purpose, identify faulty connection early and drop it.
+	ReadTimeout time.Duration
 
 	// Port used when dialing.
 	// Default: 9042

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -90,6 +90,7 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 		CQLVersion:     cfg.CQLVersion,
 		Timeout:        cfg.Timeout,
 		WriteTimeout:   cfg.WriteTimeout,
+		ReadTimeout:    cfg.ReadTimeout,
 		ConnectTimeout: cfg.ConnectTimeout,
 		Dialer:         cfg.Dialer,
 		HostDialer:     hostDialer,


### PR DESCRIPTION
Driver uses `ClusterConfig.Timeout` as reading timeout for socket operations on connection.
When socket operations fails, driver considers such connection as faulty and will close it.
In low latency use case, when users set `ClusterConfig.Timeout` to low values, it can result in having unstable connection. To address this issue and have more granular control over driver behavior we need to introduce another configuration option that controls socket reading timeout.