### PR TITLE
Divorce ConnectTimeout and MetadataSchemaRequestTimeout

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -110,6 +110,7 @@ type ClusterConfig struct {
 
 	// ReadTimeout limits the time the driver waits for data from the connection.
 	// It has only one purpose, identify faulty connection early and drop it.
+	// Default: 11 Seconds
 	ReadTimeout time.Duration
 
 	// Port used when dialing.
@@ -412,6 +413,8 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		CQLVersion:                   "3.0.0",
 		Timeout:                      11 * time.Second,
 		ConnectTimeout:               11 * time.Second,
+		ReadTimeout:                  11 * time.Second,
+		WriteTimeout:                 11 * time.Second,
 		Port:                         9042,
 		NumConns:                     2,
 		Consistency:                  Quorum,
@@ -590,10 +593,6 @@ func (cfg *ClusterConfig) Validate() error {
 
 	if cfg.DNSResolver == nil {
 		return fmt.Errorf("DNSResolver is empty")
-	}
-
-	if cfg.WriteTimeout == 0 {
-		cfg.WriteTimeout = cfg.Timeout
 	}
 
 	return cfg.ValidateAndInitSSL()

--- a/conn_test.go
+++ b/conn_test.go
@@ -735,6 +735,7 @@ func TestStream0(t *testing.T) {
 		r:       bufio.NewReader(&buf),
 		streams: streams.New(),
 		logger:  &defaultLogger{},
+		cfg:     &ConnConfig{},
 	}
 
 	err := conn.recv(context.Background())

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -86,18 +86,19 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 	}
 
 	return &ConnConfig{
-		ProtoVersion:  cfg.ProtoVersion,
-		CQLVersion:    cfg.CQLVersion,
-		WriteTimeout:  cfg.WriteTimeout,
-		ReadTimeout:   cfg.ReadTimeout,
-		Dialer:        cfg.Dialer,
-		HostDialer:    hostDialer,
-		Compressor:    cfg.Compressor,
-		Authenticator: cfg.Authenticator,
-		AuthProvider:  cfg.AuthProvider,
-		Keepalive:     cfg.SocketKeepalive,
-		Logger:        cfg.logger(),
-		tlsConfig:     cfg.getActualTLSConfig(),
+		ProtoVersion:   cfg.ProtoVersion,
+		CQLVersion:     cfg.CQLVersion,
+		WriteTimeout:   cfg.WriteTimeout,
+		ReadTimeout:    cfg.ReadTimeout,
+		ConnectTimeout: cfg.ConnectTimeout,
+		Dialer:         cfg.Dialer,
+		HostDialer:     hostDialer,
+		Compressor:     cfg.Compressor,
+		Authenticator:  cfg.Authenticator,
+		AuthProvider:   cfg.AuthProvider,
+		Keepalive:      cfg.SocketKeepalive,
+		Logger:         cfg.logger(),
+		tlsConfig:      cfg.getActualTLSConfig(),
 	}, nil
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -509,7 +509,7 @@ func (h *HostInfo) ScyllaShardAwarePortTLS() uint16 {
 
 // Returns true if we are using system_schema.keyspaces instead of system.schema_keyspaces
 func checkSystemSchema(control controlConnection) (bool, error) {
-	iter := control.query("SELECT * FROM system_schema.keyspaces" + control.getSession().usingTimeoutClause)
+	iter := control.querySystem("SELECT * FROM system_schema.keyspaces")
 	if err := iter.err; err != nil {
 		if errf, ok := err.(*errorFrame); ok {
 			if errf.code == ErrCodeSyntax {

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -790,7 +790,7 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 
 	var replication map[string]string
 
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 	if iter.NumRows() == 0 {
 		return nil, ErrKeyspaceDoesNotExist
 	}
@@ -818,7 +818,7 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 	}
 
 	stmt := `SELECT * FROM system_schema.tables WHERE keyspace_name = ?`
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 
 	var tables []TableMetadata
 	table := TableMetadata{Keyspace: keyspaceName}
@@ -850,7 +850,7 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 
 	stmt = `SELECT * FROM system_schema.scylla_tables WHERE keyspace_name = ? AND table_name = ?`
 	for i, t := range tables {
-		iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName, t.Name)
+		iter := session.control.querySystem(stmt, keyspaceName, t.Name)
 
 		table := TableMetadata{}
 		if iter.MapScan(map[string]interface{}{
@@ -878,7 +878,7 @@ func getColumnMetadata(session *Session, keyspaceName string) ([]ColumnMetadata,
 
 	var columns []ColumnMetadata
 
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 	column := ColumnMetadata{Keyspace: keyspaceName}
 
 	for iter.MapScan(map[string]interface{}{
@@ -907,7 +907,7 @@ func getTypeMetadata(session *Session, keyspaceName string) ([]TypeMetadata, err
 	}
 
 	stmt := `SELECT * FROM system_schema.types WHERE keyspace_name = ?`
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 
 	var types []TypeMetadata
 	tm := TypeMetadata{Keyspace: keyspaceName}
@@ -938,7 +938,7 @@ func getFunctionsMetadata(session *Session, keyspaceName string) ([]FunctionMeta
 	var functions []FunctionMetadata
 	function := FunctionMetadata{Keyspace: keyspaceName}
 
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 	for iter.MapScan(map[string]interface{}{
 		"function_name":        &function.Name,
 		"argument_types":       &function.ArgumentTypes,
@@ -970,7 +970,7 @@ func getAggregatesMetadata(session *Session, keyspaceName string) ([]AggregateMe
 	var aggregates []AggregateMetadata
 	aggregate := AggregateMetadata{Keyspace: keyspaceName}
 
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 	for iter.MapScan(map[string]interface{}{
 		"aggregate_name": &aggregate.Name,
 		"argument_types": &aggregate.ArgumentTypes,
@@ -1002,7 +1002,7 @@ func getIndexMetadata(session *Session, keyspaceName string) ([]IndexMetadata, e
 	var indexes []IndexMetadata
 	index := IndexMetadata{}
 
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 	for iter.MapScan(map[string]interface{}{
 		"index_name":    &index.Name,
 		"keyspace_name": &index.KeyspaceName,
@@ -1058,7 +1058,7 @@ func getViewMetadata(session *Session, keyspaceName string) ([]ViewMetadata, err
 
 	stmt := `SELECT * FROM system_schema.views WHERE keyspace_name = ?`
 
-	iter := session.control.query(stmt+session.usingTimeoutClause, keyspaceName)
+	iter := session.control.querySystem(stmt, keyspaceName)
 
 	var views []ViewMetadata
 	view := ViewMetadata{KeyspaceName: keyspaceName}

--- a/recreate_test.go
+++ b/recreate_test.go
@@ -158,7 +158,7 @@ func TestRecreateSchema(t *testing.T) {
 			dumpQueries := trimQueries(sortQueries(strings.Split(dump, ";")))
 
 			if len(goldenQueries) != len(dumpQueries) {
-				t.Errorf("Expected len(dumpQueries) to be %d, got %d", len(goldenQueries), len(dumpQueries))
+				t.Fatalf("Expected len(dumpQueries) to be %d, got %d", len(goldenQueries), len(dumpQueries))
 			}
 			// Compare with golden
 			for i, dq := range dumpQueries {

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -294,6 +294,10 @@ func (*mockConnection) getScyllaSupported() scyllaSupported { return scyllaSuppo
 
 type mockControlConn struct{}
 
+func (m *mockControlConn) querySystem(statement string, values ...interface{}) (iter *Iter) {
+	return nil
+}
+
 func (m *mockControlConn) reconnect() error {
 	return nil
 }

--- a/tracer.go
+++ b/tracer.go
@@ -66,7 +66,7 @@ func (t *TraceWriter) Trace(traceId []byte) {
 	for i := 0; i < fetchAttempts; i++ {
 		var duration int
 
-		iter := t.session.control.query(`SELECT duration
+		iter := t.session.control.querySystem(`SELECT duration
 			FROM system_traces.sessions
 			WHERE session_id = ?`, traceId)
 		iter.Scan(&duration)
@@ -94,7 +94,7 @@ func (t *TraceWriter) Trace(traceId []byte) {
 		duration    int
 	)
 
-	iter := t.session.control.query(`SELECT coordinator, duration
+	iter := t.session.control.querySystem(`SELECT coordinator, duration
 		FROM system_traces.sessions
 		WHERE session_id = ?`, traceId)
 
@@ -107,7 +107,7 @@ func (t *TraceWriter) Trace(traceId []byte) {
 	fmt.Fprintf(t.w, "Tracing session %016x (coordinator: %s, duration: %v):\n",
 		traceId, coordinator, time.Duration(duration)*time.Microsecond)
 
-	iter = t.session.control.query(`SELECT event_id, activity, source, source_elapsed, thread
+	iter = t.session.control.querySystem(`SELECT event_id, activity, source, source_elapsed, thread
 			FROM system_traces.events
 			WHERE session_id = ?`, traceId)
 
@@ -147,7 +147,7 @@ func (t *TracerEnhanced) IsReady(traceId []byte) (bool, error) {
 	isDone := false
 	var duration int
 
-	iter := t.session.control.query(`SELECT duration
+	iter := t.session.control.querySystem(`SELECT duration
 		FROM system_traces.sessions
 		WHERE session_id = ?`, traceId)
 	iter.Scan(&duration)
@@ -172,7 +172,7 @@ func (t *TracerEnhanced) GetCoordinatorTime(traceId []byte) (string, time.Durati
 		duration    int
 	)
 
-	iter := t.session.control.query(`SELECT coordinator, duration
+	iter := t.session.control.querySystem(`SELECT coordinator, duration
 		FROM system_traces.sessions
 		WHERE session_id = ?`, traceId)
 
@@ -193,7 +193,7 @@ type TraceEntry struct {
 }
 
 func (t *TracerEnhanced) GetActivities(traceId []byte) ([]TraceEntry, error) {
-	iter := t.session.control.query(`SELECT event_id, activity, source, source_elapsed, thread
+	iter := t.session.control.querySystem(`SELECT event_id, activity, source, source_elapsed, thread
 		FROM system_traces.events
 		WHERE session_id = ?`, traceId)
 


### PR DESCRIPTION
Currently, when session is initialized some operations have `ConnectTimeout`, others `MetadataSchemaRequestTimeout`. 
Target of the PR to make it so that only `ConnectTimeout` is used when session is being initialized and afterwards driver should use `MetadataSchemaRequestTimeout`.