### PR TITLE
Address timeout race condition

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -973,7 +973,6 @@ func TestWriteCoalescing(t *testing.T) {
 		writeCh: make(chan writeRequest),
 		c:       client,
 		quit:    ctx.Done(),
-		timeout: 500 * time.Millisecond,
 		testEnqueuedHook: func() {
 			enqueued <- struct{}{}
 		},
@@ -981,6 +980,7 @@ func TestWriteCoalescing(t *testing.T) {
 			client.Close()
 		},
 	}
+	w.setWriteTimeout(500 * time.Millisecond)
 	timerC := make(chan time.Time, 1)
 	go func() {
 		w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })


### PR DESCRIPTION
After #531 timeoutes are being changes after connection is initialized. Which introduced data race over `ConnConfig.readTimeout` and `ConnConfig.writeTimeout`.

This commit address this problem by converting them to atomics.