### PR TITLE
Update default value from ClusterConfig.ConnectTimeout

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -412,7 +412,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		Hosts:                        hosts,
 		CQLVersion:                   "3.0.0",
 		Timeout:                      11 * time.Second,
-		ConnectTimeout:               11 * time.Second,
+		ConnectTimeout:               60 * time.Second,
 		ReadTimeout:                  11 * time.Second,
 		WriteTimeout:                 11 * time.Second,
 		Port:                         9042,


### PR DESCRIPTION
It's default of 11 seconds is ok for regular scenaior, but when cluster is under preasure it can take longer.
Let's increase it to 1 minute, which is enough to init connection and run all the queries.