### PR TITLE
Make golangci work for test code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,3 +32,8 @@ linters:
       allow-no-explanation: [ golines ]
       require-explanation: true
       require-specific: true
+
+run:
+  build-tags:
+    - integration
+    - unit

--- a/address_translators_test.go
+++ b/address_translators_test.go
@@ -28,9 +28,10 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/tests"
 	"net"
 	"testing"
+
+	"github.com/gocql/gocql/internal/tests"
 )
 
 func TestIdentityAddressTranslator_NilAddrAndZeroPort(t *testing.T) {

--- a/cloud_cluster_test.go
+++ b/cloud_cluster_test.go
@@ -16,9 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"sigs.k8s.io/yaml"
+
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/scyllacloud"
-	"sigs.k8s.io/yaml"
 )
 
 func TestCloudConnection(t *testing.T) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -28,11 +28,12 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/tests"
 	"net"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/gocql/gocql/internal/tests"
 )
 
 func TestNewCluster_Defaults(t *testing.T) {

--- a/integration_serialization_scylla_test.go
+++ b/integration_serialization_scylla_test.go
@@ -6,11 +6,12 @@ package gocql
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/inf.v0"
 	"math/big"
 	"reflect"
 	"testing"
 	"unsafe"
+
+	"gopkg.in/inf.v0"
 
 	"github.com/gocql/gocql/internal/tests/serialization/valcases"
 )

--- a/internal/tests/err_equal.go
+++ b/internal/tests/err_equal.go
@@ -1,0 +1,8 @@
+package tests
+
+func ErrEqual(err1, err2 error) bool {
+	if err1 != nil && err2 != nil {
+		return err1.Error() == err2.Error()
+	}
+	return err1 == nil && err2 == nil
+}

--- a/keyspace_table_test.go
+++ b/keyspace_table_test.go
@@ -30,8 +30,9 @@ package gocql
 import (
 	"context"
 	"fmt"
-	"github.com/gocql/gocql/internal/tests"
 	"testing"
+
+	"github.com/gocql/gocql/internal/tests"
 )
 
 // Keyspace_table checks if Query.Keyspace() is updated based on prepared statement

--- a/policies_test.go
+++ b/policies_test.go
@@ -34,12 +34,13 @@ package gocql
 import (
 	"errors"
 	"fmt"
-	"github.com/gocql/gocql/internal/tests"
 	"net"
 	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gocql/gocql/internal/tests"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/schema_queries_test.go
+++ b/schema_queries_test.go
@@ -4,8 +4,9 @@
 package gocql
 
 import (
-	"github.com/gocql/gocql/internal/tests"
 	"testing"
+
+	"github.com/gocql/gocql/internal/tests"
 )
 
 func TestSchemaQueries(t *testing.T) {

--- a/scyllacloud/config_test.go
+++ b/scyllacloud/config_test.go
@@ -11,8 +11,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gocql/gocql"
 	"sigs.k8s.io/yaml"
+
+	"github.com/gocql/gocql/internal/tests"
+
+	"github.com/gocql/gocql"
 )
 
 func TestCloudCluster(t *testing.T) {
@@ -217,7 +220,7 @@ func TestCloudCluster(t *testing.T) {
 			defer os.RemoveAll(path)
 
 			cloudConfig, err := NewCloudCluster(path)
-			if !reflect.DeepEqual(test.expectedError, err) {
+			if !tests.ErrEqual(err, test.expectedError) {
 				t.Errorf("expected error %#v, got %#v", test.expectedError, err)
 			}
 			if test.verifyClusterConfig != nil {
@@ -275,7 +278,7 @@ func TestConnectionConfig_GetCurrentContextConfig(t *testing.T) {
 		tc := tt[i]
 		t.Run(tc.name, func(t *testing.T) {
 			contextConf, err := tc.connConfig.GetCurrentContextConfig()
-			if !reflect.DeepEqual(tc.expectedError, err) {
+			if !tests.ErrEqual(err, tc.expectedError) {
 				t.Errorf("expected error %#v, got %#v", tc.expectedError, err)
 			}
 			if !reflect.DeepEqual(tc.expectedContext, contextConf) {
@@ -368,7 +371,7 @@ func TestConnectionConfig_GetCurrentAuthInfo(t *testing.T) {
 		tc := tt[i]
 		t.Run(tc.name, func(t *testing.T) {
 			ai, err := tc.connConfig.GetCurrentAuthInfo()
-			if !reflect.DeepEqual(tc.expectedError, err) {
+			if !tests.ErrEqual(err, tc.expectedError) {
 				t.Errorf("expected error %#v, got %#v", tc.expectedError, err)
 			}
 			if !reflect.DeepEqual(tc.expectedAuthInfo, ai) {
@@ -465,7 +468,7 @@ func TestConnectionConfig_GetCurrentDatacenterConfig(t *testing.T) {
 		tc := tt[i]
 		t.Run(tc.name, func(t *testing.T) {
 			dc, err := tc.connConfig.GetCurrentDatacenterConfig()
-			if !reflect.DeepEqual(tc.expectedError, err) {
+			if !tests.ErrEqual(err, tc.expectedError) {
 				t.Errorf("expected error %#v, got %#v", tc.expectedError, err)
 			}
 			if !reflect.DeepEqual(tc.expectedDatacenter, dc) {

--- a/scyllacloud/hostdialer_test.go
+++ b/scyllacloud/hostdialer_test.go
@@ -17,12 +17,12 @@ import (
 	"net"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/gocql/gocql"
+	"github.com/gocql/gocql/internal/tests"
 )
 
 const (
@@ -125,7 +125,7 @@ func TestHostSNIDialer_InvalidConnectionConfig(t *testing.T) {
 
 			hostDialer := NewSniHostDialer(tc.connConfig, dialer)
 			_, err := hostDialer.DialHost(ctx, tc.hostInfo)
-			if !reflect.DeepEqual(err, tc.expectedError) {
+			if !tests.ErrEqual(err, tc.expectedError) {
 				t.Errorf("expected error to be %#v, got %#v", tc.expectedError, err)
 			}
 		})

--- a/tests/bench/go.sum
+++ b/tests/bench/go.sum
@@ -27,6 +27,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/net v0.0.0-20220526153639-5463443f8c37 h1:lUkvobShwKsOesNfWWlCS5q7fnbG1MEliIzwu886fn8=
 golang.org/x/net v0.0.0-20220526153639-5463443f8c37/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -138,10 +138,10 @@ func TestTuple_TupleNotSet(t *testing.T) {
 	if err := iter.Scan(x, y); err != nil {
 		t.Fatal(err)
 	}
-	if x == nil || *x != 1 {
+	if *x != 1 {
 		t.Fatalf("x should be %d got %+#v, value=%d", 1, x, *x)
 	}
-	if y == nil || *y != 2 {
+	if *y != 2 {
 		t.Fatalf("y should be %d got %+#v, value=%d", 2, y, *y)
 	}
 
@@ -150,10 +150,10 @@ func TestTuple_TupleNotSet(t *testing.T) {
 	if err := iter.Scan(x, y); err != nil {
 		t.Fatal(err)
 	}
-	if x == nil || *x != 0 {
+	if *x != 0 {
 		t.Fatalf("x should be %d got %+#v, value=%d", 0, x, *x)
 	}
-	if y == nil || *y != 0 {
+	if *y != 0 {
 		t.Fatalf("y should be %d got %+#v, value=%d", 0, y, *y)
 	}
 }


### PR DESCRIPTION
All tests reside in files that require `unit` or `integration` tag:
```
//go:build integration
// +build integration

```

Since these tags was not provided to golangci, it did not check test code.

This commit:
1. Makes it work for tests
2. Addresses linting problems it found