### PR TITLE
Enable cache on docs workflows

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -21,10 +21,21 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
+
+      - uses: actions/cache@v4
+        # actions/setup-python@v6 poetry cache feature requires poetry to be installed beforehand
+        # which makes use of it extremely awkward.
+        with:
+          path: |
+            /home/runner/.cache/pip
+            /home/runner/.cache/pypoetry
+          # python and poetry version are in docs/pyproject.toml
+          key: docs-cache-${{ runner.os }}-${{ hashFiles('docs/pyproject.toml', 'docs/Makefile') }}
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version-file: docs/pyproject.toml
 
       - name: Set up env
         run: make -C docs setupenv

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -24,10 +24,20 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - uses: actions/cache@v4
+        # actions/setup-python@v6 poetry cache feature requires poetry to be installed beforehand
+        # which makes use of it extremely awkward.
+        with:
+          path: |
+            /home/runner/.cache/pip
+            /home/runner/.cache/pypoetry
+          # python and poetry version are in docs/pyproject.toml
+          key: docs-cache-${{ runner.os }}-${{ hashFiles('docs/pyproject.toml', 'docs/Makefile') }}
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version-file: docs/pyproject.toml
 
       - name: Set up env
         run: make -C docs setupenv

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,4 @@
+SHELL=bash
 # Global variables
 # You can set these variables from the command line.
 POETRY        = poetry
@@ -19,7 +20,20 @@ all: dirhtml
 # Setup commands
 .PHONY: setupenv
 setupenv:
-	pip install -q poetry==2.2.0
+	@while IFS= read -r line; do \
+      if [[ "$${line}" =~ ^[[:space:]]*requires[[:space:]]*= ]]; then\
+        content="$${line#*=}";\
+        content="$${content//[[:space:]]/}";\
+        content="$${content#[}";\
+        content="$${content%]}";\
+        IFS=',' read -ra items <<< "$$content";\
+        for item in "$${items[@]}"; do\
+          item="$${item%\"}";\
+          item="$${item#\"}";\
+          pip install "$$item";\
+        done;\
+      fi;\
+    done < pyproject.toml
 
 .PHONY: setup
 setup:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ all: dirhtml
 # Setup commands
 .PHONY: setupenv
 setupenv:
-	pip install -q poetry
+	pip install -q poetry==2.2.0
 
 .PHONY: setup
 setup:

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -17,5 +17,5 @@ sphinx-sitemap = "^2.6.0"
 redirects_cli ="^0.1.3"
 
 [build-system]
-requires = ["poetry>=1.8.0"]
+requires = ["poetry==2.2.0"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Target: cache dependencies both for pip and poetry 
`setup-python` poetry cache feature requires poetry to be installed before `setup-python`.
Which means that:
1. We will have `Install poetry` before `setup-python` and after, which looks awkward.
2.  `poetry` as pip dependency will not be cached

That is why `actions/cache` was used instead.

To make caching properly work I made `docs/pyproject.toml` to be source of truth for `poetry` and `python versions` and calculated cache hash from `docs/pyproject.toml` and `docs/Makefile`
