### PR TITLE
Fix inserting time.Time{}

### DIFF
--- a/serialization/timestamp/marshal_utils.go
+++ b/serialization/timestamp/marshal_utils.go
@@ -28,7 +28,7 @@ func EncTime(v time.Time) ([]byte, error) {
 	}
 	// It supposed to be v.UTC().UnixMilli(), for backward compatibility map `time.Time{}` to nil value
 	if v.IsZero() {
-		return nil, nil
+		return make([]byte, 0), nil
 	}
 	ms := v.UTC().UnixMilli()
 	return []byte{byte(ms >> 56), byte(ms >> 48), byte(ms >> 40), byte(ms >> 32), byte(ms >> 24), byte(ms >> 16), byte(ms >> 8), byte(ms)}, nil


### PR DESCRIPTION
The rollback in https://github.com/scylladb/gocql/pull/420 instead of returning to old behavior (returning `make([]byte, 0)`) changed it to return `nil` value when inserting `time.Time{}` which caused scylla to fail. This commit fixes that.

Refs: https://github.com/scylladb/scylla-cdc-go/pull/36