### PR TITLE
Panic: invalid number of shards during connection pooling

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -272,7 +272,7 @@ func (h *hostConnPool) String() string {
 		h.filling, h.closed, size, h.size, h.host)
 }
 
-func newHostConnPool(session *Session, host *HostInfo, port, size int,
+func newHostConnPool(session *Session, host *HostInfo, port, size int, // FIXME: Remove unused port parameter
 	keyspace string) *hostConnPool {
 
 	pool := &hostConnPool{
@@ -544,7 +544,9 @@ func (pool *hostConnPool) connect() (err error) {
 
 	// lazily initialize the connPicker when we know the required type
 	pool.initConnPicker(conn)
-	pool.connPicker.Put(conn)
+	if err := pool.connPicker.Put(conn); err != nil {
+		return err
+	}
 	conn.finalizeConnection()
 
 	return nil

--- a/connpicker.go
+++ b/connpicker.go
@@ -8,7 +8,7 @@ import (
 
 type ConnPicker interface {
 	Pick(Token, ExecutableQuery) *Conn
-	Put(*Conn)
+	Put(*Conn) error
 	Remove(conn *Conn)
 	InFlight() int
 	Size() (int, int)
@@ -96,10 +96,11 @@ func (p *defaultConnPicker) Pick(Token, ExecutableQuery) *Conn {
 	return leastBusyConn
 }
 
-func (p *defaultConnPicker) Put(conn *Conn) {
+func (p *defaultConnPicker) Put(conn *Conn) error {
 	p.mu.Lock()
 	p.conns = append(p.conns, conn)
 	p.mu.Unlock()
+	return nil
 }
 
 func (*defaultConnPicker) NextShard() (shardID, nrShards int) {
@@ -115,7 +116,8 @@ func (nopConnPicker) Pick(Token, ExecutableQuery) *Conn {
 	return nil
 }
 
-func (nopConnPicker) Put(*Conn) {
+func (nopConnPicker) Put(*Conn) error {
+	return nil
 }
 
 func (nopConnPicker) Remove(conn *Conn) {

--- a/integration_only.go
+++ b/integration_only.go
@@ -45,7 +45,7 @@ func (s *Session) MissingConnections() (int, error) {
 
 type ConnPickerIntegration interface {
 	Pick(Token, ExecutableQuery) *Conn
-	Put(*Conn)
+	Put(*Conn) error
 	Remove(conn *Conn)
 	InFlight() int
 	Size() (int, int)

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -7,10 +7,15 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gocql/gocql/internal/streams"
 )
@@ -128,19 +133,6 @@ func TestScyllaConnPickerRemove(t *testing.T) {
 	}
 }
 
-func mockConn(shard int) *Conn {
-	return &Conn{
-		streams: streams.New(),
-		scyllaSupported: scyllaSupported{
-			shard:             shard,
-			nrShards:          4,
-			msbIgnore:         12,
-			partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
-			shardingAlgorithm: "biased-token-round-robin",
-		},
-	}
-}
-
 func TestScyllaConnPickerShardOf(t *testing.T) {
 	t.Parallel()
 
@@ -155,7 +147,7 @@ func TestScyllaConnPickerShardOf(t *testing.T) {
 	}
 }
 
-func TestScyllaRandomConnPIcker(t *testing.T) {
+func TestScyllaRandomConnPicker(t *testing.T) {
 	t.Parallel()
 
 	t.Run("max iterations", func(t *testing.T) {
@@ -326,5 +318,162 @@ func TestScyllaPortIterator(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestScyllaConnPickerHandleShardTopologyChange(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialShards    int
+		newShards        int
+		initialConns     []int // shard IDs of initial connections
+		expectedMigrated int
+		expectedClosed   int
+	}{
+		{
+			name:             "shard increase from 4 to 8",
+			initialShards:    4,
+			newShards:        8,
+			initialConns:     []int{0, 2, 3},
+			expectedMigrated: 3, // All initial connections survive
+			expectedClosed:   0,
+		},
+		{
+			name:             "shard decrease from 8 to 4",
+			initialShards:    8,
+			newShards:        4,
+			initialConns:     []int{0, 2, 5, 7},
+			expectedMigrated: 2, // Only shards 0, 2 survive
+			expectedClosed:   2, // Shards 5, 7 get closed
+		},
+		{
+			name:             "no change same count",
+			initialShards:    8,
+			newShards:        8,
+			initialConns:     []int{1, 3, 5},
+			expectedMigrated: 4, // All initial connections survive + new one
+			expectedClosed:   0,
+		},
+		{
+			name:             "massive decrease from 16 to 2",
+			initialShards:    16,
+			newShards:        2,
+			initialConns:     []int{0, 1, 5, 8, 12, 15},
+			expectedMigrated: 2, // Only shards 0, 1 survive
+			expectedClosed:   4, // Shards 5, 8, 12, 15 get closed
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := &testLogger{}
+			picker := &scyllaConnPicker{
+				logger:                     logger,
+				disableShardAwarePortUntil: new(atomic.Value),
+				hostId:                     "test-host-id",
+				shardAwareAddress:          "192.168.1.1:19042", // Shard-aware port
+				address:                    "192.168.1.1:9042",  // Regular port
+				conns:                      make([]*Conn, tt.initialShards),
+				excessConns:                make([]*Conn, 0),
+				nrShards:                   tt.initialShards,
+				msbIgnore:                  12,
+				nrConns:                    0,
+				pos:                        0,
+				lastAttemptedShard:         0,
+				shardAwarePortDisabled:     false,
+				excessConnsLimitRate:       0.1,
+			}
+			picker.disableShardAwarePortUntil.Store(time.Time{})
+
+			var connectionsToCheck []*Conn
+
+			// Add initial connections
+			for _, shardID := range tt.initialConns {
+				conn := mockConnForPicker(shardID, tt.initialShards)
+				err := picker.Put(conn)
+				require.NoError(t, err)
+
+				if shardID >= tt.newShards {
+					connectionsToCheck = append(connectionsToCheck, conn)
+				}
+			}
+
+			// Verify initial state
+			assert.Equal(t, tt.initialShards, picker.nrShards)
+			assert.Equal(t, len(tt.initialConns), picker.nrConns)
+
+			// Execute topology change
+			newConn := mockConnForPicker(0, tt.newShards)
+			err := picker.Put(newConn)
+			require.NoError(t, err)
+
+			// Allow background goroutine to complete
+			time.Sleep(50 * time.Millisecond)
+
+			// Verify new topology
+			assert.Equal(t, tt.newShards, picker.nrShards)
+			assert.Equal(t, len(picker.conns), tt.newShards)
+
+			// Count migrated connections
+			migratedCount := 0
+			for _, conn := range picker.conns {
+				if conn != nil {
+					migratedCount++
+				}
+			}
+
+			assert.Equal(t, tt.expectedMigrated, migratedCount)
+
+			// Verify connections that should be closed are actually closed
+			closedCount := 0
+			for _, conn := range connectionsToCheck {
+				if conn.Closed() {
+					closedCount++
+				}
+			}
+
+			assert.Equal(t, tt.expectedClosed, closedCount,
+				"Expected %d connections to be closed, but %d were closed",
+				tt.expectedClosed, closedCount)
+		})
+	}
+}
+
+func mockConn(shard int) *Conn {
+	return &Conn{
+		streams: streams.New(),
+		scyllaSupported: scyllaSupported{
+			shard:             shard,
+			nrShards:          4,
+			msbIgnore:         12,
+			partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
+			shardingAlgorithm: "biased-token-round-robin",
+		},
+	}
+}
+
+func mockConnForPicker(shard, nrShards int) *Conn {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	conn1, conn2 := net.Pipe()
+	_ = conn2.Close()
+
+	return &Conn{
+		scyllaSupported: scyllaSupported{
+			shard:     shard,
+			nrShards:  nrShards,
+			msbIgnore: 12,
+		},
+		conn:    conn1,
+		addr:    fmt.Sprintf("192.168.1.%d:9042", shard+1),
+		closed:  false,
+		mu:      sync.Mutex{},
+		logger:  &testLogger{},
+		ctx:     ctx,
+		cancel:  cancel,
+		calls:   make(map[int]*callReq),
+		streams: streams.New(),
 	}
 }


### PR DESCRIPTION
# Handle Dynamic Shard Topology Changes in ScyllaDB Connection Picker
Addresses #605.

## Problem
The ScyllaDB connection picker (`scyllaConnPicker`) had several critical issues when handling dynamic shard topology changes during cluster operations:

1. **Panics on shard count changes**: When ScyllaDB nodes reported different shard counts than cached values, the driver would panic with "invalid number of shards" during connection pooling
2. **Connection leaks during topology changes**: When ScyllaDB nodes reported different shard counts, the driver would panic immediately without performing any connection cleanup. This left existing connections in memory indefinitely, causing resource leaks. Recovery mechanisms had to establish entirely new connection pools while old connections remained unclosed.

## Impact
- Production crashes: Applications using gocql would panic and crash during cluster topology changes
- Resource exhaustion: Connection leaks could eventually exhaust system resources
- Performance degradation: Unnecessary connection cycling during topology changes may cause latency spikes

## Solution
Implemented comprehensive shard topology change handling in `scyllaConnPicker.Put()`.
**Original code**:
```go
if nrShards != len(p.conns) {
    if nrShards != p.nrShards {
        panic(fmt.Sprintf("scylla: %s invalid number of shards", p.address))  // Immediate panic
    }
    // Array resize logic (only for non-topology changes)
    conns := p.conns
    p.conns = make([]*Conn, nrShards)
    copy(p.conns, conns)
}
```
**New implementation**:
```go
if nrShards != p.nrShards {
    // Handle topology change gracefully with connection migration
    p.handleShardTopologyChange(conn, nrShards)
} else if nrShards != len(p.conns) {
    // Handle array size mismatch without topology change
    conns := p.conns
    p.conns = make([]*Conn, nrShards)
    copy(p.conns, conns)
}
```
**Connection migration (sketch)**:
```go
func (p *scyllaConnPicker) handleShardTopologyChange(newConn *Conn, newShardCount int) {
    // Preserve existing connections during topology changes
    for i, conn := range oldConns {
        if conn != nil && i < newShardCount {
            newConns[i] = conn  // Migrate valid connections
            migratedCount++
        } else if conn != nil {
            toClose = append(toClose, conn)  // Track excess for proper cleanup
        }
    }
    
    // Close excess connections in background to prevent blocking
    if len(toClose) > 0 {
        go closeConns(toClose...)
    }
}
```
**Key Changes:**
1. `handleShardTopologyChange()` intelligently migrates connections during topology transitions
2. Separate logic for topology changes vs array size mismatches
3. Existing connections are migrated rather than lost during topology changes
4. Excess connections are properly closed in background goroutines during shard count decreases to prevent performance impact

## Testing
- All existing tests pass
- New comprehensive unit test suite covers topology change scenarios

