### PR TITLE
Expose live node information at session level

### DIFF
--- a/connpicker.go
+++ b/connpicker.go
@@ -18,6 +18,10 @@ type ConnPicker interface {
 	// nrShard specifies how many shards the host has.
 	// If nrShards is zero, the caller shouldn't use shard-aware port.
 	NextShard() (shardID, nrShards int)
+
+	GetConnectionCount() int
+	GetExcessConnectionCount() int
+	GetShardCount() int
 }
 
 type defaultConnPicker struct {
@@ -25,6 +29,21 @@ type defaultConnPicker struct {
 	pos   uint32
 	size  int
 	mu    sync.RWMutex
+}
+
+func (p *defaultConnPicker) GetConnectionCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.conns)
+}
+
+func (p *defaultConnPicker) GetExcessConnectionCount() int {
+	return 0
+}
+
+func (p *defaultConnPicker) GetShardCount() int {
+	// It is not supposed to be used for scylla nodes and therefore does not know anything about shards count
+	return 0
 }
 
 func newDefaultConnPicker(size int) *defaultConnPicker {
@@ -110,6 +129,18 @@ func (*defaultConnPicker) NextShard() (shardID, nrShards int) {
 // hostConnPool is created to allow deferring creation of the actual ConnPicker
 // to the point where we have first connection.
 type nopConnPicker struct{}
+
+func (p nopConnPicker) GetConnectionCount() int {
+	return 0
+}
+
+func (p nopConnPicker) GetExcessConnectionCount() int {
+	return 0
+}
+
+func (p nopConnPicker) GetShardCount() int {
+	return 0
+}
 
 func (nopConnPicker) Pick(Token, ExecutableQuery) *Conn {
 	return nil

--- a/host_source.go
+++ b/host_source.go
@@ -176,6 +176,7 @@ type HostInfo struct {
 	state                   nodeState
 	scyllaShardAwarePort    uint16
 	scyllaShardAwarePortTLS uint16
+	scyllaShardCount        int
 	graph                   bool
 }
 
@@ -488,8 +489,10 @@ func (h *HostInfo) String() string {
 func (h *HostInfo) setScyllaSupported(s scyllaSupported) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	h.partitioner = s.partitioner
 	h.scyllaShardAwarePort = s.shardAwarePort
 	h.scyllaShardAwarePortTLS = s.shardAwarePortSSL
+	h.scyllaShardCount = s.nrShards
 }
 
 // ScyllaShardAwarePort returns the shard aware port of this host.
@@ -506,6 +509,13 @@ func (h *HostInfo) ScyllaShardAwarePortTLS() uint16 {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.scyllaShardAwarePortTLS
+}
+
+// ScyllaShardCount returns count of shards on the node.
+func (h *HostInfo) ScyllaShardCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.scyllaShardCount
 }
 
 // Returns true if we are using system_schema.keyspaces instead of system.schema_keyspaces

--- a/integration_only.go
+++ b/integration_only.go
@@ -8,17 +8,6 @@ package gocql
 
 import "fmt"
 
-func (pool *hostConnPool) MissingConnections() (int, error) {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
-
-	if pool.closed {
-		return 0, fmt.Errorf("pool is closed")
-	}
-	_, missing := pool.connPicker.Size()
-	return missing, nil
-}
-
 func (p *policyConnPool) MissingConnections() (int, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -27,9 +16,9 @@ func (p *policyConnPool) MissingConnections() (int, error) {
 
 	// close the pools
 	for _, pool := range p.hostConnPools {
-		missing, err := pool.MissingConnections()
-		if err != nil {
-			return 0, err
+		missing := pool.GetShardCount() - pool.GetConnectionCount()
+		if pool.IsClosed() {
+			return 0, fmt.Errorf("pool for %s is closed", pool.host.HostID())
 		}
 		total += missing
 	}

--- a/scylla.go
+++ b/scylla.go
@@ -518,6 +518,18 @@ func (p *scyllaConnPicker) shouldCloseExcessConns() bool {
 	return len(p.excessConns) > int(p.excessConnsLimitRate*float32(p.nrShards))
 }
 
+func (p *scyllaConnPicker) GetConnectionCount() int {
+	return p.nrConns
+}
+
+func (p *scyllaConnPicker) GetExcessConnectionCount() int {
+	return len(p.excessConns)
+}
+
+func (p *scyllaConnPicker) GetShardCount() int {
+	return p.nrShards
+}
+
 func (p *scyllaConnPicker) Remove(conn *Conn) {
 	shard := conn.scyllaSupported.shard
 

--- a/session.go
+++ b/session.go
@@ -2425,6 +2425,47 @@ func (s *Session) GetHosts() []*HostInfo {
 	return s.hostSource.getHostsList()
 }
 
+type HostInformation interface {
+	Peer() net.IP
+	ConnectAddress() net.IP
+	UntranslatedConnectAddress() net.IP
+	BroadcastAddress() net.IP
+	ListenAddress() net.IP
+	RPCAddress() net.IP
+	PreferredIP() net.IP
+	DataCenter() string
+	Rack() string
+	HostID() string
+	WorkLoad() string
+	Partitioner() string
+	ClusterName() string
+	Tokens() []string
+	Port() int
+	IsUp() bool
+	ScyllaShardAwarePort() uint16
+	ScyllaShardAwarePortTLS() uint16
+	ScyllaShardCount() int
+}
+
+type HostPoolInfo interface {
+	GetConnectionCount() int
+	GetExcessConnectionCount() int
+	GetShardCount() int
+	String() string
+	InFlight() int
+	Host() HostInformation
+	IsClosed() bool
+}
+
+func (s *Session) GetHostPoolByID(hostID string) HostPoolInfo {
+	hostPool, _ := s.pool.getPoolByHostID(hostID)
+	return hostPool
+}
+
+func (s *Session) IterateHostPools(iter func(info HostPoolInfo) bool) {
+	s.pool.iteratePool(iter)
+}
+
 type ObservedQuery struct {
 	// Start is a time when the query was attempted
 	Start time.Time


### PR DESCRIPTION
Have an API to get host pool information from the session.
It needs to have a clue of session health.

Adds API to `HostPoolInfo`:
- GetConnectionCount() int
- GetExcessConnectionCount() int
- GetShardCount() int
- String() string
- InFlight() int
- Host() HostInformation
- IsClosed() bool

Adding API to `hostConnPool`:
- GetConnectionCount() int
- GetExcessConnectionCount() int
- GetShardCount() int
- Host() HostInformation
- IsClosed() bool

Adds API to `connPicker`:
- GetConnectionCount() int
- GetExcessConnectionCount() int
- GetShardCount() int

Adds API to `HostInfo`:
- ScyllaShardCount() int

Adds API to `Session`:
- GetHostPoolByID(hostID string) HostPoolInfo
- IterateHostPools(iter func(info HostPoolInfo) bool)

