### PR TITLE
Evacuate some frames to a separate package

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -43,6 +43,7 @@ import (
 	"time"
 	"unicode"
 
+	frm "github.com/gocql/gocql/internal/frame"
 	"github.com/gocql/gocql/internal/tests"
 
 	"github.com/stretchr/testify/require"
@@ -2484,7 +2485,7 @@ func TestNegativeStream(t *testing.T) {
 
 	const stream = -50
 	writer := frameWriterFunc(func(f *framer, streamID int) error {
-		f.writeHeader(0, opOptions, stream)
+		f.writeHeader(0, frm.OpOptions, stream)
 		return f.finish()
 	})
 

--- a/control.go
+++ b/control.go
@@ -38,6 +38,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql/internal/debug"
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 var (
@@ -124,7 +125,7 @@ func (c *controlConn) heartBeat() {
 		}
 
 		switch resp.(type) {
-		case *supportedFrame:
+		case *frm.SupportedFrame:
 			// Everything ok
 			sleepTime = 30 * time.Second
 			continue
@@ -216,7 +217,7 @@ func parseProtocolFromError(err error) int {
 	matches := protocolSupportRe.FindAllStringSubmatch(err.Error(), -1)
 	if len(matches) != 1 || len(matches[0]) != 2 {
 		if verr, ok := err.(*protocolError); ok {
-			return int(verr.frame.Header().version.version())
+			return int(verr.frame.Header().Version.Version())
 		}
 		return 0
 	}
@@ -378,7 +379,7 @@ func (c *controlConn) registerEvents(conn *Conn) error {
 	frame, err := framer.parseFrame()
 	if err != nil {
 		return err
-	} else if _, ok := frame.(*readyFrame); !ok {
+	} else if _, ok := frame.(*frm.ReadyFrame); !ok {
 		return fmt.Errorf("unexpected frame in response to register: got %T: %v\n", frame, frame)
 	}
 

--- a/control_test.go
+++ b/control_test.go
@@ -30,6 +30,8 @@ package gocql
 import (
 	"net"
 	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 func TestHostInfo_Lookup(t *testing.T) {
@@ -68,21 +70,21 @@ func TestParseProtocol(t *testing.T) {
 	}{
 		{
 			err: &protocolError{
-				frame: errorFrame{
-					code:    0x10,
-					message: "Invalid or unsupported protocol version (5); the lowest supported version is 3 and the greatest is 4",
+				frame: frm.ErrorFrame{
+					Code:    0x10,
+					Message: "Invalid or unsupported protocol version (5); the lowest supported version is 3 and the greatest is 4",
 				},
 			},
 			proto: protoVersion4,
 		},
 		{
 			err: &protocolError{
-				frame: errorFrame{
-					frameHeader: frameHeader{
-						version: 0x83,
+				frame: frm.ErrorFrame{
+					FrameHeader: frm.FrameHeader{
+						Version: 0x83,
 					},
-					code:    0x10,
-					message: "Invalid or unsupported protocol version: 5",
+					Code:    0x10,
+					Message: "Invalid or unsupported protocol version: 5",
 				},
 			},
 			proto: protoVersion3,

--- a/errors.go
+++ b/errors.go
@@ -24,7 +24,11 @@
 
 package gocql
 
-import "fmt"
+import (
+	"fmt"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
 
 // See CQL Binary Protocol v5, section 8 for more details.
 // https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec
@@ -117,30 +121,8 @@ type RequestError interface {
 	Error() string
 }
 
-type errorFrame struct {
-	message string
-	frameHeader
-	code int
-}
-
-func (e errorFrame) Code() int {
-	return e.code
-}
-
-func (e errorFrame) Message() string {
-	return e.message
-}
-
-func (e errorFrame) Error() string {
-	return e.Message()
-}
-
-func (e errorFrame) String() string {
-	return fmt.Sprintf("[error code=%x message=%q]", e.code, e.message)
-}
-
 type RequestErrUnavailable struct {
-	errorFrame
+	frm.ErrorFrame
 	Consistency Consistency
 	Required    int
 	Alive       int
@@ -154,7 +136,7 @@ type ErrorMap map[string]uint16
 
 type RequestErrWriteTimeout struct {
 	WriteType string
-	errorFrame
+	frm.ErrorFrame
 	Received    int
 	BlockFor    int
 	Consistency Consistency
@@ -163,7 +145,7 @@ type RequestErrWriteTimeout struct {
 type RequestErrWriteFailure struct {
 	ErrorMap  ErrorMap
 	WriteType string
-	errorFrame
+	frm.ErrorFrame
 	Received    int
 	BlockFor    int
 	NumFailures int
@@ -171,11 +153,11 @@ type RequestErrWriteFailure struct {
 }
 
 type RequestErrCDCWriteFailure struct {
-	errorFrame
+	frm.ErrorFrame
 }
 
 type RequestErrReadTimeout struct {
-	errorFrame
+	frm.ErrorFrame
 	Received    int
 	BlockFor    int
 	Consistency Consistency
@@ -185,17 +167,17 @@ type RequestErrReadTimeout struct {
 type RequestErrAlreadyExists struct {
 	Keyspace string
 	Table    string
-	errorFrame
+	frm.ErrorFrame
 }
 
 type RequestErrUnprepared struct {
 	StatementId []byte
-	errorFrame
+	frm.ErrorFrame
 }
 
 type RequestErrReadFailure struct {
 	ErrorMap ErrorMap
-	errorFrame
+	frm.ErrorFrame
 	Received    int
 	BlockFor    int
 	NumFailures int
@@ -207,21 +189,21 @@ type RequestErrFunctionFailure struct {
 	Keyspace string
 	Function string
 	ArgTypes []string
-	errorFrame
+	frm.ErrorFrame
 }
 
 // RequestErrCASWriteUnknown is distinct error for ErrCodeCasWriteUnknown.
 //
 // See https://github.com/apache/cassandra/blob/7337fc0/doc/native_protocol_v5.spec#L1387-L1397
 type RequestErrCASWriteUnknown struct {
-	errorFrame
+	frm.ErrorFrame
 	Consistency Consistency
 	Received    int
 	BlockFor    int
 }
 
 type UnknownServerError struct {
-	errorFrame
+	frm.ErrorFrame
 }
 
 type OpType uint8
@@ -232,7 +214,7 @@ const (
 )
 
 type RequestErrRateLimitReached struct {
-	errorFrame
+	frm.ErrorFrame
 	OpType                OpType
 	RejectedByCoordinator bool
 }

--- a/events_test.go
+++ b/events_test.go
@@ -31,6 +31,8 @@ import (
 	"net"
 	"sync"
 	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 func TestEventDebounce(t *testing.T) {
@@ -48,10 +50,10 @@ func TestEventDebounce(t *testing.T) {
 	defer debouncer.stop()
 
 	for i := 0; i < eventCount; i++ {
-		debouncer.debounce(&statusChangeEventFrame{
-			change: "UP",
-			host:   net.IPv4(127, 0, 0, 1),
-			port:   9042,
+		debouncer.debounce(&frm.StatusChangeEventFrame{
+			Change: "UP",
+			Host:   net.IPv4(127, 0, 0, 1),
+			Port:   9042,
 		})
 	}
 

--- a/frame.go
+++ b/frame.go
@@ -35,6 +35,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 type unsetColumn struct{}
@@ -71,124 +73,6 @@ const (
 	protoVersion5      = 0x05
 
 	maxFrameSize = 256 * 1024 * 1024
-)
-
-type protoVersion byte
-
-func (p protoVersion) request() bool {
-	return p&protoDirectionMask == 0x00
-}
-
-func (p protoVersion) response() bool {
-	return p&protoDirectionMask == 0x80
-}
-
-func (p protoVersion) version() byte {
-	return byte(p) & protoVersionMask
-}
-
-func (p protoVersion) String() string {
-	dir := "REQ"
-	if p.response() {
-		dir = "RESP"
-	}
-
-	return fmt.Sprintf("[version=%d direction=%s]", p.version(), dir)
-}
-
-type frameOp byte
-
-const (
-	// header ops
-	opError         frameOp = 0x00
-	opStartup       frameOp = 0x01
-	opReady         frameOp = 0x02
-	opAuthenticate  frameOp = 0x03
-	opOptions       frameOp = 0x05
-	opSupported     frameOp = 0x06
-	opQuery         frameOp = 0x07
-	opResult        frameOp = 0x08
-	opPrepare       frameOp = 0x09
-	opExecute       frameOp = 0x0A
-	opRegister      frameOp = 0x0B
-	opEvent         frameOp = 0x0C
-	opBatch         frameOp = 0x0D
-	opAuthChallenge frameOp = 0x0E
-	opAuthResponse  frameOp = 0x0F
-	opAuthSuccess   frameOp = 0x10
-)
-
-func (f frameOp) String() string {
-	switch f {
-	case opError:
-		return "ERROR"
-	case opStartup:
-		return "STARTUP"
-	case opReady:
-		return "READY"
-	case opAuthenticate:
-		return "AUTHENTICATE"
-	case opOptions:
-		return "OPTIONS"
-	case opSupported:
-		return "SUPPORTED"
-	case opQuery:
-		return "QUERY"
-	case opResult:
-		return "RESULT"
-	case opPrepare:
-		return "PREPARE"
-	case opExecute:
-		return "EXECUTE"
-	case opRegister:
-		return "REGISTER"
-	case opEvent:
-		return "EVENT"
-	case opBatch:
-		return "BATCH"
-	case opAuthChallenge:
-		return "AUTH_CHALLENGE"
-	case opAuthResponse:
-		return "AUTH_RESPONSE"
-	case opAuthSuccess:
-		return "AUTH_SUCCESS"
-	default:
-		return fmt.Sprintf("UNKNOWN_OP_%d", f)
-	}
-}
-
-const (
-	// result kind
-	resultKindVoid          = 1
-	resultKindRows          = 2
-	resultKindKeyspace      = 3
-	resultKindPrepared      = 4
-	resultKindSchemaChanged = 5
-
-	// rows flags
-	flagGlobalTableSpec int = 0x01
-	flagHasMorePages    int = 0x02
-	flagNoMetaData      int = 0x04
-
-	// query flags
-	flagValues                byte = 0x01
-	flagSkipMetaData          byte = 0x02
-	flagPageSize              byte = 0x04
-	flagWithPagingState       byte = 0x08
-	flagWithSerialConsistency byte = 0x10
-	flagDefaultTimestamp      byte = 0x20
-	flagWithNameValues        byte = 0x40
-	flagWithKeyspace          byte = 0x80
-
-	// prepare flags
-	flagWithPreparedKeyspace uint32 = 0x01
-
-	// header flags
-	flagCompress      byte = 0x01
-	flagTracing       byte = 0x02
-	flagCustomPayload byte = 0x04
-	flagWarning       byte = 0x08
-	flagBetaProtocol  byte = 0x10
 )
 
 // DEPRECATED use Consistency type, SerialConsistency is now an alias for backwards compatibility.
@@ -304,23 +188,6 @@ func readInt(p []byte) int32 {
 	return int32(p[0])<<24 | int32(p[1])<<16 | int32(p[2])<<8 | int32(p[3])
 }
 
-type frameHeader struct {
-	warnings []string
-	stream   int
-	length   int
-	version  protoVersion
-	flags    byte
-	op       frameOp
-}
-
-func (f frameHeader) String() string {
-	return fmt.Sprintf("[header version=%s flags=0x%x stream=%d op=%s length=%d]", f.version, f.flags, f.stream, f.op, f.length)
-}
-
-func (f frameHeader) Header() frameHeader {
-	return f
-}
-
 const defaultBufSize = 128
 
 type ObservedFrameHeader struct {
@@ -332,9 +199,9 @@ type ObservedFrameHeader struct {
 	Host    *HostInfo
 	Length  int32
 	Stream  int16
-	Version protoVersion
+	Version frm.ProtoVersion
 	Flags   byte
-	Opcode  frameOp
+	Opcode  frm.Op
 }
 
 func (f ObservedFrameHeader) String() string {
@@ -361,7 +228,7 @@ const headSize = 9
 type framer struct {
 	compres Compressor
 	// if this frame was read then the header will be here
-	header        *frameHeader
+	header        *frm.FrameHeader
 	customPayload map[string][]byte
 	// if tracing flag is set this is not nil
 	traceID []byte
@@ -385,10 +252,10 @@ func newFramer(compressor Compressor, version byte) *framer {
 	}
 	var flags byte
 	if compressor != nil {
-		flags |= flagCompress
+		flags |= frm.FlagCompress
 	}
 	if version == protoVersion5 {
-		flags |= flagBetaProtocol
+		flags |= frm.FlagBetaProtocol
 	}
 
 	version &= protoVersionMask
@@ -444,79 +311,79 @@ func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlPr
 }
 
 type frame interface {
-	Header() frameHeader
+	Header() frm.FrameHeader
 }
 
-func readHeader(r io.Reader, p []byte) (head frameHeader, err error) {
+func readHeader(r io.Reader, p []byte) (head frm.FrameHeader, err error) {
 	_, err = io.ReadFull(r, p[:1])
 	if err != nil {
-		return frameHeader{}, err
+		return frm.FrameHeader{}, err
 	}
 
 	version := p[0] & protoVersionMask
 
 	if version < protoVersion3 || version > protoVersion5 {
-		return frameHeader{}, fmt.Errorf("gocql: unsupported protocol response version: %d", version)
+		return frm.FrameHeader{}, fmt.Errorf("gocql: unsupported protocol response version: %d", version)
 	}
 
 	_, err = io.ReadFull(r, p[1:headSize])
 	if err != nil {
-		return frameHeader{}, err
+		return frm.FrameHeader{}, err
 	}
 
 	p = p[:headSize]
 
-	head.version = protoVersion(p[0])
-	head.flags = p[1]
+	head.Version = frm.ProtoVersion(p[0])
+	head.Flags = p[1]
 
 	if len(p) != 9 {
-		return frameHeader{}, fmt.Errorf("not enough bytes to read header require 9 got: %d", len(p))
+		return frm.FrameHeader{}, fmt.Errorf("not enough bytes to read header require 9 got: %d", len(p))
 	}
 
-	head.stream = int(int16(p[2])<<8 | int16(p[3]))
-	head.op = frameOp(p[4])
-	head.length = int(readInt(p[5:]))
+	head.Stream = int(int16(p[2])<<8 | int16(p[3]))
+	head.Op = frm.Op(p[4])
+	head.Length = int(readInt(p[5:]))
 
 	return head, nil
 }
 
 // explicitly enables tracing for the framers outgoing requests
 func (f *framer) trace() {
-	f.flags |= flagTracing
+	f.flags |= frm.FlagTracing
 }
 
 // explicitly enables the custom payload flag
 func (f *framer) payload() {
-	f.flags |= flagCustomPayload
+	f.flags |= frm.FlagCustomPayload
 }
 
 // reads a frame form the wire into the framers buffer
-func (f *framer) readFrame(r io.Reader, head *frameHeader) error {
-	if head.length < 0 {
-		return fmt.Errorf("frame body length can not be less than 0: %d", head.length)
-	} else if head.length > maxFrameSize {
+func (f *framer) readFrame(r io.Reader, head *frm.FrameHeader) error {
+	if head.Length < 0 {
+		return fmt.Errorf("frame body length can not be less than 0: %d", head.Length)
+	} else if head.Length > maxFrameSize {
 		// need to free up the connection to be used again
-		_, err := io.CopyN(ioutil.Discard, r, int64(head.length))
+		_, err := io.CopyN(ioutil.Discard, r, int64(head.Length))
 		if err != nil {
 			return fmt.Errorf("error whilst trying to discard frame with invalid length: %v", err)
 		}
 		return ErrFrameTooBig
 	}
 
-	if cap(f.readBuffer) >= head.length {
-		f.buf = f.readBuffer[:head.length]
+	if cap(f.readBuffer) >= head.Length {
+		f.buf = f.readBuffer[:head.Length]
 	} else {
-		f.readBuffer = make([]byte, head.length)
+		f.readBuffer = make([]byte, head.Length)
 		f.buf = f.readBuffer
 	}
 
 	// assume the underlying reader takes care of timeouts and retries
 	n, err := io.ReadFull(r, f.buf)
 	if err != nil {
-		return fmt.Errorf("unable to read frame body: read %d/%d bytes: %v", n, head.length, err)
+		return fmt.Errorf("unable to read frame body: read %d/%d bytes: %v", n, head.Length, err)
 	}
 
-	if head.flags&flagCompress == flagCompress {
+	if head.Flags&frm.FlagCompress == frm.FlagCompress {
 		if f.compres == nil {
 			return NewErrProtocol("no compressor available with compressed frame body")
 		}
@@ -541,42 +408,42 @@ func (f *framer) parseFrame() (frame frame, err error) {
 		}
 	}()
 
-	if f.header.version.request() {
-		return nil, NewErrProtocol("got a request frame from server: %v", f.header.version)
+	if f.header.Version.Request() {
+		return nil, NewErrProtocol("got a request frame from server: %v", f.header.Version)
 	}
 
-	if f.header.flags&flagTracing == flagTracing {
+	if f.header.Flags&frm.FlagTracing == frm.FlagTracing {
 		f.readTrace()
 	}
 
-	if f.header.flags&flagWarning == flagWarning {
-		f.header.warnings = f.readStringList()
+	if f.header.Flags&frm.FlagWarning == frm.FlagWarning {
+		f.header.Warnings = f.readStringList()
 	}
 
-	if f.header.flags&flagCustomPayload == flagCustomPayload {
+	if f.header.Flags&frm.FlagCustomPayload == frm.FlagCustomPayload {
 		f.customPayload = f.readBytesMap()
 	}
 
 	// assumes that the frame body has been read into rbuf
-	switch f.header.op {
-	case opError:
+	switch f.header.Op {
+	case frm.OpError:
 		frame = f.parseErrorFrame()
-	case opReady:
+	case frm.OpReady:
 		frame = f.parseReadyFrame()
-	case opResult:
+	case frm.OpResult:
 		frame, err = f.parseResultFrame()
-	case opSupported:
+	case frm.OpSupported:
 		frame = f.parseSupportedFrame()
-	case opAuthenticate:
+	case frm.OpAuthenticate:
 		frame = f.parseAuthenticateFrame()
-	case opAuthChallenge:
+	case frm.OpAuthChallenge:
 		frame = f.parseAuthChallengeFrame()
-	case opAuthSuccess:
+	case frm.OpAuthSuccess:
 		frame = f.parseAuthSuccessFrame()
-	case opEvent:
+	case frm.OpEvent:
 		frame = f.parseEventFrame()
 	default:
-		return nil, NewErrProtocol("unknown op in frame header: %s", f.header.op)
+		return nil, NewErrProtocol("unknown op in frame header: %s", f.header.Op)
 	}
 
 	return
@@ -586,10 +453,10 @@ func (f *framer) parseErrorFrame() frame {
 	code := f.readInt()
 	msg := f.readString()
 
-	errD := errorFrame{
-		frameHeader: *f.header,
-		code:        code,
-		message:     msg,
+	errD := frm.ErrorFrame{
+		FrameHeader: *f.header,
+		Code:        code,
+		Message:     msg,
 	}
 
 	switch code {
@@ -598,7 +465,7 @@ func (f *framer) parseErrorFrame() frame {
 		required := f.readInt()
 		alive := f.readInt()
 		return &RequestErrUnavailable{
-			errorFrame:  errD,
+			ErrorFrame:  errD,
 			Consistency: cl,
 			Required:    required,
 			Alive:       alive,
@@ -609,7 +476,7 @@ func (f *framer) parseErrorFrame() frame {
 		blockfor := f.readInt()
 		writeType := f.readString()
 		return &RequestErrWriteTimeout{
-			errorFrame:  errD,
+			ErrorFrame:  errD,
 			Consistency: cl,
 			Received:    received,
 			BlockFor:    blockfor,
@@ -621,7 +488,7 @@ func (f *framer) parseErrorFrame() frame {
 		blockfor := f.readInt()
 		dataPresent := f.readByte()
 		return &RequestErrReadTimeout{
-			errorFrame:  errD,
+			ErrorFrame:  errD,
 			Consistency: cl,
 			Received:    received,
 			BlockFor:    blockfor,
@@ -631,19 +498,19 @@ func (f *framer) parseErrorFrame() frame {
 		ks := f.readString()
 		table := f.readString()
 		return &RequestErrAlreadyExists{
-			errorFrame: errD,
+			ErrorFrame: errD,
 			Keyspace:   ks,
 			Table:      table,
 		}
 	case ErrCodeUnprepared:
 		stmtId := f.readShortBytes()
 		return &RequestErrUnprepared{
-			errorFrame:  errD,
+			ErrorFrame:  errD,
 			StatementId: copyBytes(stmtId), // defensively copy
 		}
 	case ErrCodeReadFailure:
 		res := &RequestErrReadFailure{
-			errorFrame: errD,
+			ErrorFrame: errD,
 		}
 		res.Consistency = f.readConsistency()
 		res.Received = f.readInt()
@@ -659,7 +526,7 @@ func (f *framer) parseErrorFrame() frame {
 		return res
 	case ErrCodeWriteFailure:
 		res := &RequestErrWriteFailure{
-			errorFrame: errD,
+			ErrorFrame: errD,
 		}
 		res.Consistency = f.readConsistency()
 		res.Received = f.readInt()
@@ -674,7 +541,7 @@ func (f *framer) parseErrorFrame() frame {
 		return res
 	case ErrCodeFunctionFailure:
 		res := &RequestErrFunctionFailure{
-			errorFrame: errD,
+			ErrorFrame: errD,
 		}
 		res.Keyspace = f.readString()
 		res.Function = f.readString()
@@ -683,12 +550,12 @@ func (f *framer) parseErrorFrame() frame {
 
 	case ErrCodeCDCWriteFailure:
 		res := &RequestErrCDCWriteFailure{
-			errorFrame: errD,
+			ErrorFrame: errD,
 		}
 		return res
 	case ErrCodeCASWriteUnknown:
 		res := &RequestErrCASWriteUnknown{
-			errorFrame: errD,
+			ErrorFrame: errD,
 		}
 		res.Consistency = f.readConsistency()
 		res.Received = f.readInt()
@@ -701,14 +568,14 @@ func (f *framer) parseErrorFrame() frame {
 	default:
 		if f.rateLimitingErrorCode != 0 && code == f.rateLimitingErrorCode {
 			res := &RequestErrRateLimitReached{
-				errorFrame: errD,
+				ErrorFrame: errD,
 			}
 			res.OpType = OpType(f.readByte())
 			res.RejectedByCoordinator = f.readByte() != 0
 			return res
 		} else {
 			return &UnknownServerError{
-				errorFrame: errD,
+				ErrorFrame: errD,
 			}
 		}
 	}
@@ -724,7 +591,7 @@ func (f *framer) readErrorMap() (errMap ErrorMap) {
 	return
 }
 
-func (f *framer) writeHeader(flags byte, op frameOp, stream int) {
+func (f *framer) writeHeader(flags byte, op frm.Op, stream int) {
 	f.buf = append(f.buf[:0],
 		f.proto, flags, byte(stream>>8), byte(stream),
 		// pad out length
@@ -747,7 +614,7 @@ func (f *framer) finish() error {
 		return ErrFrameTooBig
 	}
 
-	if f.buf[1]&flagCompress == flagCompress {
+	if f.buf[1]&frm.FlagCompress == frm.FlagCompress {
 		if f.compres == nil {
 			panic("compress flag set with no compressor")
 		}
@@ -783,28 +650,19 @@ func (f *framer) readTrace() {
 	f.buf = f.buf[16:]
 }
 
-type readyFrame struct {
-	frameHeader
-}
-
 func (f *framer) parseReadyFrame() frame {
-	return &readyFrame{
-		frameHeader: *f.header,
+	return &frm.ReadyFrame{
+		FrameHeader: *f.header,
 	}
-}
-
-type supportedFrame struct {
-	supported map[string][]string
-	frameHeader
 }
 
 // TODO: if we move the body buffer onto the frameHeader then we only need a single
 // framer, and can move the methods onto the header.
 func (f *framer) parseSupportedFrame() frame {
-	return &supportedFrame{
-		frameHeader: *f.header,
+	return &frm.SupportedFrame{
+		FrameHeader: *f.header,
 
-		supported: f.readStringMultiMap(),
+		Supported: f.readStringMultiMap(),
 	}
 }
 
@@ -817,7 +675,7 @@ func (w writeStartupFrame) String() string {
 }
 
 func (w *writeStartupFrame) buildFrame(f *framer, streamID int) error {
-	f.writeHeader(f.flags&^flagCompress, opStartup, streamID)
+	f.writeHeader(f.flags&^frm.FlagCompress, frm.OpStartup, streamID)
 	f.writeStringMap(w.opts)
 
 	return f.finish()
@@ -833,14 +691,14 @@ func (w *writePrepareFrame) buildFrame(f *framer, streamID int) error {
 	if len(w.customPayload) > 0 {
 		f.payload()
 	}
-	f.writeHeader(f.flags, opPrepare, streamID)
+	f.writeHeader(f.flags, frm.OpPrepare, streamID)
 	f.writeCustomPayload(&w.customPayload)
 	f.writeLongString(w.statement)
 
 	var flags uint32 = 0
 	if w.keyspace != "" {
 		if f.proto > protoVersion4 {
-			flags |= flagWithPreparedKeyspace
+			flags |= frm.FlagWithPreparedKeyspace
 		} else {
 			panic(fmt.Errorf("the keyspace can only be set with protocol 5 or higher"))
 		}
@@ -972,15 +830,15 @@ func (f *framer) parsePreparedMetadata() preparedMetadata {
 
 	meta.lwt = meta.flags&f.flagLWT == f.flagLWT
 
-	if meta.flags&flagHasMorePages == flagHasMorePages {
+	if meta.flags&frm.FlagHasMorePages == frm.FlagHasMorePages {
 		meta.pagingState = f.readBytesCopy()
 	}
 
-	if meta.flags&flagNoMetaData == flagNoMetaData {
+	if meta.flags&frm.FlagNoMetaData == frm.FlagNoMetaData {
 		return meta
 	}
 
-	globalSpec := meta.flags&flagGlobalTableSpec == flagGlobalTableSpec
+	globalSpec := meta.flags&frm.FlagGlobalTableSpec == frm.FlagGlobalTableSpec
 	if globalSpec {
 		meta.keyspace = f.readString()
 		meta.table = f.readString()
@@ -1020,7 +878,7 @@ type resultMetadata struct {
 }
 
 func (r *resultMetadata) morePages() bool {
-	return r.flags&flagHasMorePages == flagHasMorePages
+	return r.flags&frm.FlagHasMorePages == frm.FlagHasMorePages
 }
 
 func (r resultMetadata) String() string {
@@ -1056,16 +914,16 @@ func (f *framer) parseResultMetadata() resultMetadata {
 	}
 	meta.actualColCount = meta.colCount
 
-	if meta.flags&flagHasMorePages == flagHasMorePages {
+	if meta.flags&frm.FlagHasMorePages == frm.FlagHasMorePages {
 		meta.pagingState = f.readBytesCopy()
 	}
 
-	if meta.flags&flagNoMetaData == flagNoMetaData {
+	if meta.flags&frm.FlagNoMetaData == frm.FlagNoMetaData {
 		return meta
 	}
 
 	var keyspace, table string
-	globalSpec := meta.flags&flagGlobalTableSpec == flagGlobalTableSpec
+	globalSpec := meta.flags&frm.FlagGlobalTableSpec == frm.FlagGlobalTableSpec
 	if globalSpec {
 		keyspace = f.readString()
 		table = f.readString()
@@ -1095,7 +953,7 @@ func (f *framer) parseResultMetadata() resultMetadata {
 }
 
 type resultVoidFrame struct {
-	frameHeader
+	frm.FrameHeader
 }
 
 func (f *resultVoidFrame) String() string {
@@ -1106,15 +964,15 @@ func (f *framer) parseResultFrame() (frame, error) {
 	kind := f.readInt()
 
 	switch kind {
-	case resultKindVoid:
-		return &resultVoidFrame{frameHeader: *f.header}, nil
-	case resultKindRows:
+	case frm.ResultKindVoid:
+		return &resultVoidFrame{FrameHeader: *f.header}, nil
+	case frm.ResultKindRows:
 		return f.parseResultRows(), nil
-	case resultKindKeyspace:
+	case frm.ResultKindKeyspace:
 		return f.parseResultSetKeyspace(), nil
-	case resultKindPrepared:
+	case frm.ResultKindPrepared:
 		return f.parseResultPrepared(), nil
-	case resultKindSchemaChanged:
+	case frm.ResultKindSchemaChanged:
 		return f.parseResultSchemaChange(), nil
 	}
 
@@ -1122,7 +980,7 @@ func (f *framer) parseResultFrame() (frame, error) {
 }
 
 type resultRowsFrame struct {
-	frameHeader
+	frm.FrameHeader
 
 	meta resultMetadata
 	// dont parse the rows here as we only need to do it once
@@ -1147,7 +1005,7 @@ func (f *framer) parseResultRows() frame {
 
 type resultKeyspaceFrame struct {
 	keyspace string
-	frameHeader
+	frm.FrameHeader
 }
 
 func (r *resultKeyspaceFrame) String() string {
@@ -1156,7 +1014,7 @@ func (r *resultKeyspaceFrame) String() string {
 
 func (f *framer) parseResultSetKeyspace() frame {
 	return &resultKeyspaceFrame{
-		frameHeader: *f.header,
+		FrameHeader: *f.header,
 		keyspace:    f.readString(),
 	}
 }
@@ -1164,13 +1022,13 @@ func (f *framer) parseResultSetKeyspace() frame {
 type resultPreparedFrame struct {
 	preparedID []byte
 	respMeta   resultMetadata
-	frameHeader
+	frm.FrameHeader
 	reqMeta preparedMetadata
 }
 
 func (f *framer) parseResultPrepared() frame {
 	frame := &resultPreparedFrame{
-		frameHeader: *f.header,
+		FrameHeader: *f.header,
 		preparedID:  f.readShortBytes(),
 		reqMeta:     f.parsePreparedMetadata(),
 	}
@@ -1180,50 +1038,6 @@ func (f *framer) parseResultPrepared() frame {
 	return frame
 }
 
-type schemaChangeKeyspace struct {
-	change   string
-	keyspace string
-	frameHeader
-}
-
-func (f schemaChangeKeyspace) String() string {
-	return fmt.Sprintf("[event schema_change_keyspace change=%q keyspace=%q]", f.change, f.keyspace)
-}
-
-type schemaChangeTable struct {
-	change   string
-	keyspace string
-	object   string
-	frameHeader
-}
-
-func (f schemaChangeTable) String() string {
-	return fmt.Sprintf("[event schema_change change=%q keyspace=%q object=%q]", f.change, f.keyspace, f.object)
-}
-
-type schemaChangeType struct {
-	change   string
-	keyspace string
-	object   string
-	frameHeader
-}
-
-type schemaChangeFunction struct {
-	change   string
-	keyspace string
-	name     string
-	args     []string
-	frameHeader
-}
-
-type schemaChangeAggregate struct {
-	change   string
-	keyspace string
-	name     string
-	args     []string
-	frameHeader
-}
-
 func (f *framer) parseResultSchemaChange() frame {
 	change := f.readString()
 	target := f.readString()
@@ -1231,131 +1045,65 @@ func (f *framer) parseResultSchemaChange() frame {
 	// TODO: could just use a separate type for each target
 	switch target {
 	case "KEYSPACE":
-		frame := &schemaChangeKeyspace{
-			frameHeader: *f.header,
-			change:      change,
+		return &frm.SchemaChangeKeyspace{
+			FrameHeader: *f.header,
+			Change:      change,
+			Keyspace:    f.readString(),
 		}
-
-		frame.keyspace = f.readString()
-
-		return frame
 	case "TABLE":
-		frame := &schemaChangeTable{
-			frameHeader: *f.header,
-			change:      change,
+		return &frm.SchemaChangeTable{
+			FrameHeader: *f.header,
+			Change:      change,
+			Keyspace:    f.readString(),
+			Object:      f.readString(),
 		}
-
-		frame.keyspace = f.readString()
-		frame.object = f.readString()
-
-		return frame
 	case "TYPE":
-		frame := &schemaChangeType{
-			frameHeader: *f.header,
-			change:      change,
+		return &frm.SchemaChangeType{
+			FrameHeader: *f.header,
+			Change:      change,
+			Keyspace:    f.readString(),
+			Object:      f.readString(),
 		}
-
-		frame.keyspace = f.readString()
-		frame.object = f.readString()
-
-		return frame
 	case "FUNCTION":
-		frame := &schemaChangeFunction{
-			frameHeader: *f.header,
-			change:      change,
+		return &frm.SchemaChangeFunction{
+			FrameHeader: *f.header,
+			Change:      change,
+			Keyspace:    f.readString(),
+			Name:        f.readString(),
+			Args:        f.readStringList(),
 		}
-
-		frame.keyspace = f.readString()
-		frame.name = f.readString()
-		frame.args = f.readStringList()
-
-		return frame
 	case "AGGREGATE":
-		frame := &schemaChangeAggregate{
-			frameHeader: *f.header,
-			change:      change,
+		return &frm.SchemaChangeAggregate{
+			FrameHeader: *f.header,
+			Change:      change,
+			Keyspace:    f.readString(),
+			Name:        f.readString(),
+			Args:        f.readStringList(),
 		}
-
-		frame.keyspace = f.readString()
-		frame.name = f.readString()
-		frame.args = f.readStringList()
-
-		return frame
 	default:
 		panic(fmt.Errorf("gocql: unknown SCHEMA_CHANGE target: %q change: %q", target, change))
 	}
-
-}
-
-type authenticateFrame struct {
-	class string
-	frameHeader
-}
-
-func (a *authenticateFrame) String() string {
-	return fmt.Sprintf("[authenticate class=%q]", a.class)
 }
 
 func (f *framer) parseAuthenticateFrame() frame {
-	return &authenticateFrame{
-		frameHeader: *f.header,
-		class:       f.readString(),
+	return &frm.AuthenticateFrame{
+		FrameHeader: *f.header,
+		Class:       f.readString(),
 	}
-}
-
-type authSuccessFrame struct {
-	data []byte
-	frameHeader
-}
-
-func (a *authSuccessFrame) String() string {
-	return fmt.Sprintf("[auth_success data=%q]", a.data)
 }
 
 func (f *framer) parseAuthSuccessFrame() frame {
-	return &authSuccessFrame{
-		frameHeader: *f.header,
-		data:        f.readBytes(),
+	return &frm.AuthSuccessFrame{
+		FrameHeader: *f.header,
+		Data:        f.readBytes(),
 	}
-}
-
-type authChallengeFrame struct {
-	data []byte
-	frameHeader
-}
-
-func (a *authChallengeFrame) String() string {
-	return fmt.Sprintf("[auth_challenge data=%q]", a.data)
 }
 
 func (f *framer) parseAuthChallengeFrame() frame {
-	return &authChallengeFrame{
-		frameHeader: *f.header,
-		data:        f.readBytes(),
+	return &frm.AuthChallengeFrame{
+		FrameHeader: *f.header,
+		Data:        f.readBytes(),
 	}
-}
-
-type statusChangeEventFrame struct {
-	change string
-	host   net.IP
-	frameHeader
-	port int
-}
-
-func (t statusChangeEventFrame) String() string {
-	return fmt.Sprintf("[status_change change=%s host=%v port=%v]", t.change, t.host, t.port)
-}
-
-// essentially the same as statusChange
-type topologyChangeEventFrame struct {
-	change string
-	host   net.IP
-	frameHeader
-	port int
-}
-
-func (t topologyChangeEventFrame) String() string {
-	return fmt.Sprintf("[topology_change change=%s host=%v port=%v]", t.change, t.host, t.port)
 }
 
 func (f *framer) parseEventFrame() frame {
@@ -1363,15 +1111,15 @@ func (f *framer) parseEventFrame() frame {
 
 	switch eventType {
 	case "TOPOLOGY_CHANGE":
-		frame := &topologyChangeEventFrame{frameHeader: *f.header}
-		frame.change = f.readString()
-		frame.host, frame.port = f.readInet()
+		frame := &frm.TopologyChangeEventFrame{FrameHeader: *f.header}
+		frame.Change = f.readString()
+		frame.Host, frame.Port = f.readInet()
 
 		return frame
 	case "STATUS_CHANGE":
-		frame := &statusChangeEventFrame{frameHeader: *f.header}
-		frame.change = f.readString()
-		frame.host, frame.port = f.readInet()
+		frame := &frm.StatusChangeEventFrame{FrameHeader: *f.header}
+		frame.Change = f.readString()
+		frame.Host, frame.Port = f.readInet()
 
 		return frame
 	case "SCHEMA_CHANGE":
@@ -1396,7 +1144,7 @@ func (a *writeAuthResponseFrame) buildFrame(framer *framer, streamID int) error 
 }
 
 func (f *framer) writeAuthResponseFrame(streamID int, data []byte) error {
-	f.writeHeader(f.flags, opAuthResponse, streamID)
+	f.writeHeader(f.flags, frm.OpAuthResponse, streamID)
 	f.writeBytes(data)
 	return f.finish()
 }
@@ -1429,36 +1177,36 @@ func (f *framer) writeQueryParams(opts *queryParams) {
 
 	var flags byte
 	if len(opts.values) > 0 {
-		flags |= flagValues
+		flags |= frm.FlagValues
 	}
 	if opts.skipMeta {
-		flags |= flagSkipMetaData
+		flags |= frm.FlagSkipMetaData
 	}
 	if opts.pageSize > 0 {
-		flags |= flagPageSize
+		flags |= frm.FlagPageSize
 	}
 	if len(opts.pagingState) > 0 {
-		flags |= flagWithPagingState
+		flags |= frm.FlagWithPagingState
 	}
 	if opts.serialConsistency > 0 {
-		flags |= flagWithSerialConsistency
+		flags |= frm.FlagWithSerialConsistency
 	}
 
 	names := false
 
 	// protoV3 specific things
 	if opts.defaultTimestamp {
-		flags |= flagDefaultTimestamp
+		flags |= frm.FlagDefaultTimestamp
 	}
 
 	if len(opts.values) > 0 && opts.values[0].name != "" {
-		flags |= flagWithNameValues
+		flags |= frm.FlagWithNameValues
 		names = true
 	}
 
 	if opts.keyspace != "" {
 		if f.proto > protoVersion4 {
-			flags |= flagWithKeyspace
+			flags |= frm.FlagWithKeyspace
 		} else {
 			panic(fmt.Errorf("the keyspace can only be set with protocol 5 or higher"))
 		}
@@ -1531,7 +1279,7 @@ func (f *framer) writeQueryFrame(streamID int, statement string, params *queryPa
 	if len(customPayload) > 0 {
 		f.payload()
 	}
-	f.writeHeader(f.flags, opQuery, streamID)
+	f.writeHeader(f.flags, frm.OpQuery, streamID)
 	f.writeCustomPayload(&customPayload)
 	f.writeLongString(statement)
 	f.writeQueryParams(params)
@@ -1567,7 +1315,7 @@ func (f *framer) writeExecuteFrame(streamID int, preparedID []byte, params *quer
 	if len(*customPayload) > 0 {
 		f.payload()
 	}
-	f.writeHeader(f.flags, opExecute, streamID)
+	f.writeHeader(f.flags, frm.OpExecute, streamID)
 	f.writeCustomPayload(customPayload)
 	f.writeShortBytes(preparedID)
 	f.writeQueryParams(params)
@@ -1601,7 +1349,7 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 	if len(customPayload) > 0 {
 		f.payload()
 	}
-	f.writeHeader(f.flags, opBatch, streamID)
+	f.writeHeader(f.flags, frm.OpBatch, streamID)
 	f.writeCustomPayload(&customPayload)
 	f.writeByte(byte(w.typ))
 
@@ -1629,7 +1377,7 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 				if f.proto <= protoVersion5 {
 					return fmt.Errorf("gocql: named query values are not supported in batches, please see https://issues.apache.org/jira/browse/CASSANDRA-10246")
 				}
-				flags |= flagWithNameValues
+				flags |= frm.FlagWithNameValues
 				f.writeString(col.name)
 			}
 			if col.isUnset {
@@ -1643,10 +1391,10 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 	f.writeConsistency(w.consistency)
 
 	if w.serialConsistency > 0 {
-		flags |= flagWithSerialConsistency
+		flags |= frm.FlagWithSerialConsistency
 	}
 	if w.defaultTimestamp {
-		flags |= flagDefaultTimestamp
+		flags |= frm.FlagDefaultTimestamp
 	}
 
 	if f.proto > protoVersion4 {
@@ -1679,7 +1427,7 @@ func (w *writeOptionsFrame) buildFrame(framer *framer, streamID int) error {
 }
 
 func (f *framer) writeOptionsFrame(stream int, _ *writeOptionsFrame) error {
-	f.writeHeader(f.flags&^flagCompress, opOptions, stream)
+	f.writeHeader(f.flags&^frm.FlagCompress, frm.OpOptions, stream)
 	return f.finish()
 }
 
@@ -1692,7 +1440,7 @@ func (w *writeRegisterFrame) buildFrame(framer *framer, streamID int) error {
 }
 
 func (f *framer) writeRegisterFrame(streamID int, w *writeRegisterFrame) error {
-	f.writeHeader(f.flags, opRegister, streamID)
+	f.writeHeader(f.flags, frm.OpRegister, streamID)
 	f.writeStringList(w.events)
 
 	return f.finish()
@@ -1941,7 +1689,7 @@ func (f *framer) GetCustomPayload() map[string][]byte {
 }
 
 func (f *framer) GetHeaderWarnings() []string {
-	return f.header.warnings
+	return f.header.Warnings
 }
 
 // these are protocol level binary types

--- a/frame_test.go
+++ b/frame_test.go
@@ -31,6 +31,8 @@ import (
 	"bytes"
 	"os"
 	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 func TestFuzzBugs(t *testing.T) {
@@ -68,7 +70,7 @@ func TestFuzzBugs(t *testing.T) {
 			continue
 		}
 
-		framer := newFramer(nil, byte(head.version))
+		framer := newFramer(nil, byte(head.Version))
 		err = framer.readFrame(r, &head)
 		if err != nil {
 			continue
@@ -93,7 +95,7 @@ func TestFrameWriteTooLong(t *testing.T) {
 
 	framer := newFramer(nil, 3)
 
-	framer.writeHeader(0, opStartup, 1)
+	framer.writeHeader(0, frm.OpStartup, 1)
 	framer.writeBytes(make([]byte, maxFrameSize+1))
 	err := framer.finish()
 	if err != ErrFrameTooBig {
@@ -111,14 +113,14 @@ func TestFrameReadTooLong(t *testing.T) {
 	r := &bytes.Buffer{}
 	r.Write(make([]byte, maxFrameSize+1))
 	// write a new header right after this frame to verify that we can read it
-	r.Write([]byte{0x03, 0x00, 0x00, 0x00, byte(opReady), 0x00, 0x00, 0x00, 0x00})
+	r.Write([]byte{0x03, 0x00, 0x00, 0x00, byte(frm.OpReady), 0x00, 0x00, 0x00, 0x00})
 
 	framer := newFramer(nil, 3)
 
-	head := frameHeader{
-		version: protoVersion3,
-		op:      opReady,
-		length:  r.Len() - 9,
+	head := frm.FrameHeader{
+		Version: protoVersion3,
+		Op:      frm.OpReady,
+		Length:  r.Len() - 9,
 	}
 
 	err := framer.readFrame(r, &head)
@@ -130,7 +132,7 @@ func TestFrameReadTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if head.op != opReady {
-		t.Fatalf("expected to get header %v got %v", opReady, head.op)
+	if head.Op != frm.OpReady {
+		t.Fatalf("expected to get header %v got %v", frm.OpReady, head.Op)
 	}
 }

--- a/framer_bench_test.go
+++ b/framer_bench_test.go
@@ -61,7 +61,7 @@ func BenchmarkParseRowsFrame(b *testing.B) {
 		framer := &framer{
 			header: &frameHeader{
 				version: protoVersion4 | 0x80,
-				op:      opResult,
+				op:      frm.OpResult,
 				length:  len(data),
 			},
 			buf: data,

--- a/host_source.go
+++ b/host_source.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 var (
@@ -522,8 +524,8 @@ func (h *HostInfo) ScyllaShardCount() int {
 func checkSystemSchema(control controlConnection) (bool, error) {
 	iter := control.querySystem("SELECT * FROM system_schema.keyspaces")
 	if err := iter.err; err != nil {
-		if errf, ok := err.(*errorFrame); ok {
-			if errf.code == ErrCodeSyntax {
+		if errf, ok := err.(*frm.ErrorFrame); ok {
+			if errf.Code == ErrCodeSyntax {
 				return false, nil
 			}
 		}

--- a/internal/frame/frames.go
+++ b/internal/frame/frames.go
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Content before git sha 34fdeebefcbf183ed7f916f931aa0586fdaa1b40
+ * Copyright (c) 2012, The Gocql authors,
+ * provided under the BSD-3-Clause License.
+ * See the NOTICE file distributed with this work for additional information.
+ */
+
+package frame
+
+import (
+	"fmt"
+	"net"
+)
+
+const (
+	protoDirectionMask = 0x80
+	protoVersionMask   = 0x7F
+	protoVersion1      = 0x01
+	protoVersion2      = 0x02
+	protoVersion3      = 0x03
+	protoVersion4      = 0x04
+	protoVersion5      = 0x05
+
+	maxFrameSize = 256 * 1024 * 1024
+)
+
+const (
+	// result kind
+	ResultKindVoid          = 1
+	ResultKindRows          = 2
+	ResultKindKeyspace      = 3
+	ResultKindPrepared      = 4
+	ResultKindSchemaChanged = 5
+
+	// rows flags
+	FlagGlobalTableSpec int = 0x01
+	FlagHasMorePages    int = 0x02
+	FlagNoMetaData      int = 0x04
+
+	// query flags
+	FlagValues                byte = 0x01
+	FlagSkipMetaData          byte = 0x02
+	FlagPageSize              byte = 0x04
+	FlagWithPagingState       byte = 0x08
+	FlagWithSerialConsistency byte = 0x10
+	FlagDefaultTimestamp      byte = 0x20
+	FlagWithNameValues        byte = 0x40
+	FlagWithKeyspace          byte = 0x80
+
+	// prepare flags
+	FlagWithPreparedKeyspace uint32 = 0x01
+
+	// header flags
+	FlagCompress      byte = 0x01
+	FlagTracing       byte = 0x02
+	FlagCustomPayload byte = 0x04
+	FlagWarning       byte = 0x08
+	FlagBetaProtocol  byte = 0x10
+)
+
+type ProtoVersion byte
+
+func (p ProtoVersion) Request() bool {
+	return p&protoDirectionMask == 0x00
+}
+
+func (p ProtoVersion) Response() bool {
+	return p&protoDirectionMask == 0x80
+}
+
+func (p ProtoVersion) Version() byte {
+	return byte(p) & protoVersionMask
+}
+
+func (p ProtoVersion) String() string {
+	dir := "REQ"
+	if p.Response() {
+		dir = "RESP"
+	}
+
+	return fmt.Sprintf("[version=%d direction=%s]", p.Version(), dir)
+}
+
+type Op byte
+
+const (
+	// header ops
+	OpError         Op = 0x00
+	OpStartup       Op = 0x01
+	OpReady         Op = 0x02
+	OpAuthenticate  Op = 0x03
+	OpOptions       Op = 0x05
+	OpSupported     Op = 0x06
+	OpQuery         Op = 0x07
+	OpResult        Op = 0x08
+	OpPrepare       Op = 0x09
+	OpExecute       Op = 0x0A
+	OpRegister      Op = 0x0B
+	OpEvent         Op = 0x0C
+	OpBatch         Op = 0x0D
+	OpAuthChallenge Op = 0x0E
+	OpAuthResponse  Op = 0x0F
+	OpAuthSuccess   Op = 0x10
+)
+
+func (f Op) String() string {
+	switch f {
+	case OpError:
+		return "ERROR"
+	case OpStartup:
+		return "STARTUP"
+	case OpReady:
+		return "READY"
+	case OpAuthenticate:
+		return "AUTHENTICATE"
+	case OpOptions:
+		return "OPTIONS"
+	case OpSupported:
+		return "SUPPORTED"
+	case OpQuery:
+		return "QUERY"
+	case OpResult:
+		return "RESULT"
+	case OpPrepare:
+		return "PREPARE"
+	case OpExecute:
+		return "EXECUTE"
+	case OpRegister:
+		return "REGISTER"
+	case OpEvent:
+		return "EVENT"
+	case OpBatch:
+		return "BATCH"
+	case OpAuthChallenge:
+		return "AUTH_CHALLENGE"
+	case OpAuthResponse:
+		return "AUTH_RESPONSE"
+	case OpAuthSuccess:
+		return "AUTH_SUCCESS"
+	default:
+		return fmt.Sprintf("UNKNOWN_OP_%d", f)
+	}
+}
+
+type FrameHeader struct {
+	Warnings []string
+	Stream   int
+	Length   int
+	Version  ProtoVersion
+	Flags    byte
+	Op       Op
+}
+
+func (f FrameHeader) String() string {
+	return fmt.Sprintf("[header version=%s flags=0x%x stream=%d op=%s length=%d]", f.Version, f.Flags, f.Stream, f.Op, f.Length)
+}
+
+func (f FrameHeader) Header() FrameHeader {
+	return f
+}
+
+type Frame interface {
+	Header() FrameHeader
+}
+
+type ReadyFrame struct {
+	FrameHeader
+}
+
+type SupportedFrame struct {
+	Supported map[string][]string
+	FrameHeader
+}
+
+type SchemaChangeKeyspace struct {
+	Change   string
+	Keyspace string
+	FrameHeader
+}
+
+func (f SchemaChangeKeyspace) String() string {
+	return fmt.Sprintf("[event schema_change_keyspace change=%q keyspace=%q]", f.Change, f.Keyspace)
+}
+
+type SchemaChangeTable struct {
+	Change   string
+	Keyspace string
+	Object   string
+	FrameHeader
+}
+
+func (f SchemaChangeTable) String() string {
+	return fmt.Sprintf("[event schema_change change=%q keyspace=%q object=%q]", f.Change, f.Keyspace, f.Object)
+}
+
+type SchemaChangeType struct {
+	Change   string
+	Keyspace string
+	Object   string
+	FrameHeader
+}
+
+type SchemaChangeFunction struct {
+	Change   string
+	Keyspace string
+	Name     string
+	Args     []string
+	FrameHeader
+}
+
+type SchemaChangeAggregate struct {
+	Change   string
+	Keyspace string
+	Name     string
+	Args     []string
+	FrameHeader
+}
+
+type AuthenticateFrame struct {
+	Class string
+	FrameHeader
+}
+
+func (a *AuthenticateFrame) String() string {
+	return fmt.Sprintf("[authenticate class=%q]", a.Class)
+}
+
+type AuthSuccessFrame struct {
+	Data []byte
+	FrameHeader
+}
+
+func (a *AuthSuccessFrame) String() string {
+	return fmt.Sprintf("[auth_success data=%q]", a.Data)
+}
+
+type AuthChallengeFrame struct {
+	Data []byte
+	FrameHeader
+}
+
+func (a *AuthChallengeFrame) String() string {
+	return fmt.Sprintf("[auth_challenge data=%q]", a.Data)
+}
+
+type StatusChangeEventFrame struct {
+	Change string
+	Host   net.IP
+	FrameHeader
+	Port int
+}
+
+func (t StatusChangeEventFrame) String() string {
+	return fmt.Sprintf("[status_change change=%s host=%v port=%v]", t.Change, t.Host, t.Port)
+}
+
+// essentially the same as statusChange
+type TopologyChangeEventFrame struct {
+	Change string
+	Host   net.IP
+	FrameHeader
+	Port int
+}
+
+func (t TopologyChangeEventFrame) String() string {
+	return fmt.Sprintf("[topology_change change=%s host=%v port=%v]", t.Change, t.Host, t.Port)
+}
+
+type ErrorFrame struct {
+	Message string
+	FrameHeader
+	Code int
+}
+
+func (e ErrorFrame) GetCode() int {
+	return e.Code
+}
+
+func (e ErrorFrame) GetMessage() string {
+	return e.Message
+}
+
+func (e ErrorFrame) Error() string {
+	return e.GetMessage()
+}
+
+func (e ErrorFrame) String() string {
+	return fmt.Sprintf("[error code=%x message=%q]", e.Code, e.Message)
+}

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	frm "github.com/gocql/gocql/internal/frame"
 	"github.com/gocql/gocql/tablets"
 )
 
@@ -1041,7 +1042,7 @@ func getCreateStatements(session *Session, keyspaceName string) ([]byte, error) 
 	}
 
 	if err := iter.Close(); err != nil {
-		if errFrame, ok := err.(errorFrame); ok && errFrame.code == ErrCodeSyntax {
+		if errFrame, ok := err.(frm.ErrorFrame); ok && errFrame.Code == ErrCodeSyntax {
 			// DESCRIBE KEYSPACE is not supported on older versions of Cassandra and Scylla
 			// For such case schema statement is going to be recreated on the client side
 			return nil, nil

--- a/recreate_test.go
+++ b/recreate_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 var updateGolden = flag.Bool("update-golden", false, "update golden files")
@@ -223,7 +225,7 @@ func isDescribeKeyspaceSupported(t *testing.T, s *Session) bool {
 
 	err := s.control.query(fmt.Sprintf(`DESCRIBE KEYSPACE system WITH INTERNALS`)).Close()
 	if err != nil {
-		if errFrame, ok := err.(errorFrame); ok && errFrame.code == ErrCodeSyntax {
+		if errFrame, ok := err.(frm.ErrorFrame); ok && errFrame.Code == ErrCodeSyntax {
 			// DESCRIBE KEYSPACE is not supported on older versions of Cassandra and Scylla
 			// For such case schema statement is going to be recreated on the client side
 			return false


### PR DESCRIPTION
We need that to be able to implement code that target these frames on a separate package.

Fixes: https://github.com/scylladb/gocql/issues/621