### PR TITLE
Add event bus

### DIFF
--- a/events/event_converter.go
+++ b/events/event_converter.go
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+// FrameToEvent converts an internal frame to a public Event interface.
+// This function has access to internal frame types and can perform
+// type-safe conversions.
+// Returns nil if the frame is not an event frame.
+func FrameToEvent(f interface{}) Event {
+	if f == nil {
+		return nil
+	}
+
+	switch frame := f.(type) {
+	case *frm.TopologyChangeEventFrame:
+		return &TopologyChangeEvent{
+			Change: frame.Change,
+			Host:   frame.Host,
+			Port:   frame.Port,
+		}
+
+	case *frm.StatusChangeEventFrame:
+		return &StatusChangeEvent{
+			Change: frame.Change,
+			Host:   frame.Host,
+			Port:   frame.Port,
+		}
+
+	case *frm.SchemaChangeKeyspace:
+		return &SchemaChangeKeyspaceEvent{
+			Change:   frame.Change,
+			Keyspace: frame.Keyspace,
+		}
+
+	case *frm.SchemaChangeTable:
+		return &SchemaChangeTableEvent{
+			Change:   frame.Change,
+			Keyspace: frame.Keyspace,
+			Table:    frame.Object,
+		}
+
+	case *frm.SchemaChangeType:
+		return &SchemaChangeTypeEvent{
+			Change:   frame.Change,
+			Keyspace: frame.Keyspace,
+			TypeName: frame.Object,
+		}
+
+	case *frm.SchemaChangeFunction:
+		return &SchemaChangeFunctionEvent{
+			Change:    frame.Change,
+			Keyspace:  frame.Keyspace,
+			Function:  frame.Name,
+			Arguments: frame.Args,
+		}
+
+	case *frm.SchemaChangeAggregate:
+		return &SchemaChangeAggregateEvent{
+			Change:    frame.Change,
+			Keyspace:  frame.Keyspace,
+			Aggregate: frame.Name,
+			Arguments: frame.Args,
+		}
+
+	default:
+		return nil
+	}
+}

--- a/events/event_converter_test.go
+++ b/events/event_converter_test.go
@@ -1,0 +1,267 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/gocql/gocql/events"
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+func TestFrameToEvent_TopologyChange(t *testing.T) {
+	frame := &frm.TopologyChangeEventFrame{
+		Change: "NEW_NODE",
+		Host:   net.ParseIP("192.168.1.1"),
+		Port:   9042,
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	topologyEvent, ok := event.(*events.TopologyChangeEvent)
+	if !ok {
+		t.Fatalf("Expected *TopologyChangeEvent, got %T", event)
+	}
+
+	if topologyEvent.Change != "NEW_NODE" {
+		t.Errorf("Change = %v, want NEW_NODE", topologyEvent.Change)
+	}
+	if !topologyEvent.Host.Equal(net.ParseIP("192.168.1.1")) {
+		t.Errorf("Host = %v, want 192.168.1.1", topologyEvent.Host)
+	}
+	if topologyEvent.Port != 9042 {
+		t.Errorf("Port = %v, want 9042", topologyEvent.Port)
+	}
+	if topologyEvent.Type() != events.ClusterEventTypeTopologyChange {
+		t.Errorf("Type() = %v, want EventTypeTopologyChange", topologyEvent.Type())
+	}
+}
+
+func TestFrameToEvent_StatusChange(t *testing.T) {
+	frame := &frm.StatusChangeEventFrame{
+		Change: "UP",
+		Host:   net.ParseIP("192.168.1.2"),
+		Port:   9042,
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	statusEvent, ok := event.(*events.StatusChangeEvent)
+	if !ok {
+		t.Fatalf("Expected *StatusChangeEvent, got %T", event)
+	}
+
+	if statusEvent.Change != "UP" {
+		t.Errorf("Change = %v, want UP", statusEvent.Change)
+	}
+	if !statusEvent.Host.Equal(net.ParseIP("192.168.1.2")) {
+		t.Errorf("Host = %v, want 192.168.1.2", statusEvent.Host)
+	}
+	if statusEvent.Port != 9042 {
+		t.Errorf("Port = %v, want 9042", statusEvent.Port)
+	}
+	if statusEvent.Type() != events.ClusterEventTypeStatusChange {
+		t.Errorf("Type() = %v, want EventTypeStatusChange", statusEvent.Type())
+	}
+}
+
+func TestFrameToEvent_SchemaChangeKeyspace(t *testing.T) {
+	frame := &frm.SchemaChangeKeyspace{
+		Change:   "CREATED",
+		Keyspace: "test_keyspace",
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	schemaEvent, ok := event.(*events.SchemaChangeKeyspaceEvent)
+	if !ok {
+		t.Fatalf("Expected *SchemaChangeKeyspaceEvent, got %T", event)
+	}
+
+	if schemaEvent.Change != "CREATED" {
+		t.Errorf("Change = %v, want CREATED", schemaEvent.Change)
+	}
+	if schemaEvent.Keyspace != "test_keyspace" {
+		t.Errorf("Keyspace = %v, want test_keyspace", schemaEvent.Keyspace)
+	}
+	if schemaEvent.Type() != events.ClusterEventTypeSchemaChangeKeyspace {
+		t.Errorf("Type() = %v, want EventTypeSchemaChangeKeyspace", schemaEvent.Type())
+	}
+}
+
+func TestFrameToEvent_SchemaChangeTable(t *testing.T) {
+	frame := &frm.SchemaChangeTable{
+		Change:   "UPDATED",
+		Keyspace: "test_keyspace",
+		Object:   "test_table",
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	schemaEvent, ok := event.(*events.SchemaChangeTableEvent)
+	if !ok {
+		t.Fatalf("Expected *SchemaChangeTableEvent, got %T", event)
+	}
+
+	if schemaEvent.Change != "UPDATED" {
+		t.Errorf("Change = %v, want UPDATED", schemaEvent.Change)
+	}
+	if schemaEvent.Keyspace != "test_keyspace" {
+		t.Errorf("Keyspace = %v, want test_keyspace", schemaEvent.Keyspace)
+	}
+	if schemaEvent.Table != "test_table" {
+		t.Errorf("Table = %v, want test_table", schemaEvent.Table)
+	}
+	if schemaEvent.Type() != events.ClusterEventTypeSchemaChangeTable {
+		t.Errorf("Type() = %v, want EventTypeSchemaChangeTable", schemaEvent.Type())
+	}
+}
+
+func TestFrameToEvent_SchemaChangeType(t *testing.T) {
+	frame := &frm.SchemaChangeType{
+		Change:   "DROPPED",
+		Keyspace: "test_keyspace",
+		Object:   "test_type",
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	schemaEvent, ok := event.(*events.SchemaChangeTypeEvent)
+	if !ok {
+		t.Fatalf("Expected *SchemaChangeTypeEvent, got %T", event)
+	}
+
+	if schemaEvent.Change != "DROPPED" {
+		t.Errorf("Change = %v, want DROPPED", schemaEvent.Change)
+	}
+	if schemaEvent.Keyspace != "test_keyspace" {
+		t.Errorf("Keyspace = %v, want test_keyspace", schemaEvent.Keyspace)
+	}
+	if schemaEvent.TypeName != "test_type" {
+		t.Errorf("TypeName = %v, want test_type", schemaEvent.TypeName)
+	}
+	if schemaEvent.Type() != events.ClusterEventTypeSchemaChangeType {
+		t.Errorf("Type() = %v, want EventTypeSchemaChangeType", schemaEvent.Type())
+	}
+}
+
+func TestFrameToEvent_SchemaChangeFunction(t *testing.T) {
+	frame := &frm.SchemaChangeFunction{
+		Change:   "CREATED",
+		Keyspace: "test_keyspace",
+		Name:     "test_function",
+		Args:     []string{"int", "text"},
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	schemaEvent, ok := event.(*events.SchemaChangeFunctionEvent)
+	if !ok {
+		t.Fatalf("Expected *SchemaChangeFunctionEvent, got %T", event)
+	}
+
+	if schemaEvent.Change != "CREATED" {
+		t.Errorf("Change = %v, want CREATED", schemaEvent.Change)
+	}
+	if schemaEvent.Keyspace != "test_keyspace" {
+		t.Errorf("Keyspace = %v, want test_keyspace", schemaEvent.Keyspace)
+	}
+	if schemaEvent.Function != "test_function" {
+		t.Errorf("Function = %v, want test_function", schemaEvent.Function)
+	}
+	if len(schemaEvent.Arguments) != 2 {
+		t.Errorf("len(Arguments) = %v, want 2", len(schemaEvent.Arguments))
+	}
+	if schemaEvent.Type() != events.ClusterEventTypeSchemaChangeFunction {
+		t.Errorf("Type() = %v, want EventTypeSchemaChangeFunction", schemaEvent.Type())
+	}
+}
+
+func TestFrameToEvent_SchemaChangeAggregate(t *testing.T) {
+	frame := &frm.SchemaChangeAggregate{
+		Change:   "UPDATED",
+		Keyspace: "test_keyspace",
+		Name:     "test_aggregate",
+		Args:     []string{"int"},
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	schemaEvent, ok := event.(*events.SchemaChangeAggregateEvent)
+	if !ok {
+		t.Fatalf("Expected *SchemaChangeAggregateEvent, got %T", event)
+	}
+
+	if schemaEvent.Change != "UPDATED" {
+		t.Errorf("Change = %v, want UPDATED", schemaEvent.Change)
+	}
+	if schemaEvent.Keyspace != "test_keyspace" {
+		t.Errorf("Keyspace = %v, want test_keyspace", schemaEvent.Keyspace)
+	}
+	if schemaEvent.Aggregate != "test_aggregate" {
+		t.Errorf("Aggregate = %v, want test_aggregate", schemaEvent.Aggregate)
+	}
+	if len(schemaEvent.Arguments) != 1 {
+		t.Errorf("len(Arguments) = %v, want 1", len(schemaEvent.Arguments))
+	}
+	if schemaEvent.Type() != events.ClusterEventTypeSchemaChangeAggregate {
+		t.Errorf("Type() = %v, want EventTypeSchemaChangeAggregate", schemaEvent.Type())
+	}
+}
+
+func TestFrameToEvent_Nil(t *testing.T) {
+	event := events.FrameToEvent(nil)
+	if event != nil {
+		t.Errorf("FrameToEvent(nil) = %v, want nil", event)
+	}
+}
+
+func TestFrameToEvent_NonEventFrame(t *testing.T) {
+	// Test with a non-event frame type
+	frame := &frm.ErrorFrame{}
+	event := events.FrameToEvent(frame)
+	if event != nil {
+		t.Errorf("FrameToEvent(non-event) = %v, want nil", event)
+	}
+}

--- a/events/events.go
+++ b/events/events.go
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package events provides public event types for Cassandra/ScyllaDB server events.
+// These events are sent by the server to notify clients of topology changes, status changes,
+// and schema changes.
+package events
+
+import (
+	"fmt"
+	"net"
+)
+
+// EventType represents the type of event
+type EventType int
+
+const (
+	// ClusterEventTypeTopologyChange represents a topology change event (NEW_NODE, REMOVED_NODE, MOVED_NODE)
+	ClusterEventTypeTopologyChange EventType = iota
+	// ClusterEventTypeStatusChange represents a status change event (UP, DOWN)
+	ClusterEventTypeStatusChange
+	// ClusterEventTypeSchemaChangeKeyspace represents a keyspace schema change
+	ClusterEventTypeSchemaChangeKeyspace
+	// ClusterEventTypeSchemaChangeTable represents a table schema change
+	ClusterEventTypeSchemaChangeTable
+	// ClusterEventTypeSchemaChangeType represents a UDT schema change
+	ClusterEventTypeSchemaChangeType
+	// ClusterEventTypeSchemaChangeFunction represents a function schema change
+	ClusterEventTypeSchemaChangeFunction
+	// ClusterEventTypeSchemaChangeAggregate represents an aggregate schema change
+	ClusterEventTypeSchemaChangeAggregate
+	// SessionEventTypeControlConnectionRecreated is fired when the session loses it's control connection to the cluster and has just been re-established it.
+	SessionEventTypeControlConnectionRecreated
+)
+
+func (t EventType) IsClusterEvent() bool {
+	switch t {
+	case ClusterEventTypeTopologyChange:
+		return true
+	case ClusterEventTypeStatusChange:
+		return true
+	case ClusterEventTypeSchemaChangeKeyspace:
+		return true
+	case ClusterEventTypeSchemaChangeTable:
+		return true
+	case ClusterEventTypeSchemaChangeType:
+		return true
+	case ClusterEventTypeSchemaChangeFunction:
+		return true
+	case ClusterEventTypeSchemaChangeAggregate:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t EventType) String() string {
+	switch t {
+	case ClusterEventTypeTopologyChange:
+		return "CLUSTER<TOPOLOGY_CHANGE>"
+	case ClusterEventTypeStatusChange:
+		return "CLUSTER<STATUS_CHANGE>"
+	case ClusterEventTypeSchemaChangeKeyspace:
+		return "CLUSTER<SCHEMA_CHANGE_KEYSPACE>"
+	case ClusterEventTypeSchemaChangeTable:
+		return "CLUSTER<SCHEMA_CHANGE_TABLE>"
+	case ClusterEventTypeSchemaChangeType:
+		return "CLUSTER<SCHEMA_CHANGE_TYPE>"
+	case ClusterEventTypeSchemaChangeFunction:
+		return "CLUSTER<SCHEMA_CHANGE_FUNCTION>"
+	case ClusterEventTypeSchemaChangeAggregate:
+		return "CLUSTER<SCHEMA_CHANGE_AGGREGATE>"
+	case SessionEventTypeControlConnectionRecreated:
+		return "SESSION<CONTROL_CONNECTION_RECREATED>"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", t)
+	}
+}
+
+// Event is the common interface for all event types
+type Event interface {
+	// Type returns the type of event
+	Type() EventType
+	// String returns a string representation of the event
+	String() string
+}
+
+// TopologyChangeEvent represents a topology change in the cluster
+type TopologyChangeEvent struct {
+	// Change is the type of topology change (NEW_NODE, REMOVED_NODE, MOVED_NODE)
+	Change string
+	// Host is the IP address of the node
+	Host net.IP
+	// Port is the port number
+	Port int
+}
+
+// Type returns ClusterEventTypeTopologyChange
+func (e *TopologyChangeEvent) Type() EventType {
+	return ClusterEventTypeTopologyChange
+}
+
+// String returns a string representation of the event
+func (e *TopologyChangeEvent) String() string {
+	return fmt.Sprintf("TopologyChange{change=%s, host=%s, port=%d}", e.Change, e.Host, e.Port)
+}
+
+// StatusChangeEvent represents a status change of a node
+type StatusChangeEvent struct {
+	// Change is the type of status change (UP, DOWN)
+	Change string
+	// Host is the IP address of the node
+	Host net.IP
+	// Port is the port number
+	Port int
+}
+
+// Type returns ClusterEventTypeStatusChange
+func (e *StatusChangeEvent) Type() EventType {
+	return ClusterEventTypeStatusChange
+}
+
+// String returns a string representation of the event
+func (e *StatusChangeEvent) String() string {
+	return fmt.Sprintf("StatusChange{change=%s, host=%s, port=%d}", e.Change, e.Host, e.Port)
+}
+
+// SchemaChangeKeyspaceEvent represents a keyspace schema change
+type SchemaChangeKeyspaceEvent struct {
+	// Change is the type of change (CREATED, UPDATED, DROPPED)
+	Change string
+	// Keyspace is the name of the keyspace
+	Keyspace string
+}
+
+// Type returns ClusterEventTypeSchemaChangeKeyspace
+func (e *SchemaChangeKeyspaceEvent) Type() EventType {
+	return ClusterEventTypeSchemaChangeKeyspace
+}
+
+// String returns a string representation of the event
+func (e *SchemaChangeKeyspaceEvent) String() string {
+	return fmt.Sprintf("SchemaChangeKeyspace{change=%s, keyspace=%s}", e.Change, e.Keyspace)
+}
+
+// SchemaChangeTableEvent represents a table schema change
+type SchemaChangeTableEvent struct {
+	// Change is the type of change (CREATED, UPDATED, DROPPED)
+	Change string
+	// Keyspace is the name of the keyspace
+	Keyspace string
+	// Table is the name of the table
+	Table string
+}
+
+// Type returns ClusterEventTypeSchemaChangeTable
+func (e *SchemaChangeTableEvent) Type() EventType {
+	return ClusterEventTypeSchemaChangeTable
+}
+
+// String returns a string representation of the event
+func (e *SchemaChangeTableEvent) String() string {
+	return fmt.Sprintf("SchemaChangeTable{change=%s, keyspace=%s, table=%s}", e.Change, e.Keyspace, e.Table)
+}
+
+// SchemaChangeTypeEvent represents a UDT (User Defined Type) schema change
+type SchemaChangeTypeEvent struct {
+	// Change is the type of change (CREATED, UPDATED, DROPPED)
+	Change string
+	// Keyspace is the name of the keyspace
+	Keyspace string
+	// TypeName is the name of the UDT
+	TypeName string
+}
+
+// Type returns ClusterEventTypeSchemaChangeType
+func (e *SchemaChangeTypeEvent) Type() EventType {
+	return ClusterEventTypeSchemaChangeType
+}
+
+// String returns a string representation of the event
+func (e *SchemaChangeTypeEvent) String() string {
+	return fmt.Sprintf("SchemaChangeType{change=%s, keyspace=%s, type=%s}", e.Change, e.Keyspace, e.TypeName)
+}
+
+// SchemaChangeFunctionEvent represents a function schema change
+type SchemaChangeFunctionEvent struct {
+	// Change is the type of change (CREATED, UPDATED, DROPPED)
+	Change string
+	// Keyspace is the name of the keyspace
+	Keyspace string
+	// Function is the name of the function
+	Function string
+	// Arguments is the list of argument types
+	Arguments []string
+}
+
+// Type returns ClusterEventTypeSchemaChangeFunction
+func (e *SchemaChangeFunctionEvent) Type() EventType {
+	return ClusterEventTypeSchemaChangeFunction
+}
+
+// String returns a string representation of the event
+func (e *SchemaChangeFunctionEvent) String() string {
+	return fmt.Sprintf("SchemaChangeFunction{change=%s, keyspace=%s, function=%s, args=%v}",
+		e.Change, e.Keyspace, e.Function, e.Arguments)
+}
+
+// SchemaChangeAggregateEvent represents an aggregate schema change
+type SchemaChangeAggregateEvent struct {
+	// Change is the type of change (CREATED, UPDATED, DROPPED)
+	Change string
+	// Keyspace is the name of the keyspace
+	Keyspace string
+	// Aggregate is the name of the aggregate
+	Aggregate string
+	// Arguments is the list of argument types
+	Arguments []string
+}
+
+// Type returns ClusterEventTypeSchemaChangeAggregate
+func (e *SchemaChangeAggregateEvent) Type() EventType {
+	return ClusterEventTypeSchemaChangeAggregate
+}
+
+// String returns a string representation of the event
+func (e *SchemaChangeAggregateEvent) String() string {
+	return fmt.Sprintf("SchemaChangeAggregate{change=%s, keyspace=%s, aggregate=%s, args=%v}",
+		e.Change, e.Keyspace, e.Aggregate, e.Arguments)
+}
+
+type HostInfo struct {
+	HostID string
+	Host   net.IP
+	Port   int
+}
+
+// String returns a string representation of the event
+func (h *HostInfo) String() string {
+	return fmt.Sprintf("HostInfo{Host=%s, Port=%d, HostID=%s}", h.Host, h.Port, h.HostID)
+}
+
+// ControlConnectionRecreatedEvent represents a control connection reconnection event.
+type ControlConnectionRecreatedEvent struct {
+	OldHost HostInfo
+	NewHost HostInfo
+}
+
+// Type returns SessionEventTypeControlConnectionRecreated
+func (e *ControlConnectionRecreatedEvent) Type() EventType {
+	return SessionEventTypeControlConnectionRecreated
+}
+
+// String returns a string representation of the event
+func (e *ControlConnectionRecreatedEvent) String() string {
+	return fmt.Sprintf("ControlConnectionRecreatedEvent{OldHost=%s, NewHost=%s}", e.OldHost.String(), e.NewHost.String())
+}

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,0 +1,175 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"net"
+	"testing"
+)
+
+func TestTopologyChangeEvent(t *testing.T) {
+	event := &TopologyChangeEvent{
+		Change: "NEW_NODE",
+		Host:   net.ParseIP("192.168.1.1"),
+		Port:   9042,
+	}
+
+	if event.Type() != ClusterEventTypeTopologyChange {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeTopologyChange)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("TopologyChangeEvent.String() = %s", str)
+}
+
+func TestStatusChangeEvent(t *testing.T) {
+	event := &StatusChangeEvent{
+		Change: "UP",
+		Host:   net.ParseIP("192.168.1.2"),
+		Port:   9042,
+	}
+
+	if event.Type() != ClusterEventTypeStatusChange {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeStatusChange)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("StatusChangeEvent.String() = %s", str)
+}
+
+func TestSchemaChangeKeyspaceEvent(t *testing.T) {
+	event := &SchemaChangeKeyspaceEvent{
+		Change:   "CREATED",
+		Keyspace: "test_keyspace",
+	}
+
+	if event.Type() != ClusterEventTypeSchemaChangeKeyspace {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeSchemaChangeKeyspace)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("SchemaChangeKeyspaceEvent.String() = %s", str)
+}
+
+func TestSchemaChangeTableEvent(t *testing.T) {
+	event := &SchemaChangeTableEvent{
+		Change:   "UPDATED",
+		Keyspace: "test_keyspace",
+		Table:    "test_table",
+	}
+
+	if event.Type() != ClusterEventTypeSchemaChangeTable {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeSchemaChangeTable)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("SchemaChangeTableEvent.String() = %s", str)
+}
+
+func TestSchemaChangeTypeEvent(t *testing.T) {
+	event := &SchemaChangeTypeEvent{
+		Change:   "DROPPED",
+		Keyspace: "test_keyspace",
+		TypeName: "test_type",
+	}
+
+	if event.Type() != ClusterEventTypeSchemaChangeType {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeSchemaChangeType)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("SchemaChangeTypeEvent.String() = %s", str)
+}
+
+func TestSchemaChangeFunctionEvent(t *testing.T) {
+	event := &SchemaChangeFunctionEvent{
+		Change:    "CREATED",
+		Keyspace:  "test_keyspace",
+		Function:  "test_function",
+		Arguments: []string{"int", "text"},
+	}
+
+	if event.Type() != ClusterEventTypeSchemaChangeFunction {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeSchemaChangeFunction)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("SchemaChangeFunctionEvent.String() = %s", str)
+}
+
+func TestSchemaChangeAggregateEvent(t *testing.T) {
+	event := &SchemaChangeAggregateEvent{
+		Change:    "UPDATED",
+		Keyspace:  "test_keyspace",
+		Aggregate: "test_aggregate",
+		Arguments: []string{"int"},
+	}
+
+	if event.Type() != ClusterEventTypeSchemaChangeAggregate {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeSchemaChangeAggregate)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("SchemaChangeAggregateEvent.String() = %s", str)
+}
+
+func TestEventInterface(t *testing.T) {
+	events := []Event{
+		&TopologyChangeEvent{Change: "NEW_NODE", Host: net.ParseIP("127.0.0.1"), Port: 9042},
+		&StatusChangeEvent{Change: "UP", Host: net.ParseIP("127.0.0.2"), Port: 9042},
+		&SchemaChangeKeyspaceEvent{Change: "CREATED", Keyspace: "ks"},
+		&SchemaChangeTableEvent{Change: "UPDATED", Keyspace: "ks", Table: "tbl"},
+		&SchemaChangeTypeEvent{Change: "DROPPED", Keyspace: "ks", TypeName: "typ"},
+		&SchemaChangeFunctionEvent{Change: "CREATED", Keyspace: "ks", Function: "fn", Arguments: []string{}},
+		&SchemaChangeAggregateEvent{Change: "UPDATED", Keyspace: "ks", Aggregate: "agg", Arguments: []string{}},
+	}
+
+	for _, event := range events {
+		if event.Type() < ClusterEventTypeTopologyChange || event.Type() > ClusterEventTypeSchemaChangeAggregate {
+			t.Errorf("Invalid event type: %v", event.Type())
+		}
+		if event.String() == "" {
+			t.Errorf("Event.String() returned empty string for %T", event)
+		}
+	}
+}

--- a/internal/eventbus/README.md
+++ b/internal/eventbus/README.md
@@ -1,0 +1,241 @@
+# EventBus
+
+A generic, thread-safe event processing package for Go based on channels. EventBus allows multiple subscribers to receive events from a single input channel, with optional event filtering and configurable buffer sizes.
+
+## Features
+
+- **Generic Type Support**: Works with any type using Go generics
+- **Thread-Safe**: Safe for concurrent use by multiple goroutines
+- **Event Filtering**: Subscribers can filter events using custom filter functions
+- **Configurable Buffers**: Each subscriber can have its own channel buffer size
+- **Non-Blocking Distribution**: Slow subscribers don't block event distribution
+- **Context Support**: Automatic unsubscription when context is cancelled
+- **Zero External Dependencies**: Pure Go implementation
+
+## Installation
+
+```bash
+go get github.com/gocql/gocql/eventbus
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/gocql/gocql/internal/eventbus"
+)
+
+func main() {
+	// Create a new EventBus for integer events
+	eb := eventbus.New[int](10) // input buffer size of 10
+
+	// Start processing events
+	eb.Start()
+	defer eb.Stop()
+
+	// Subscribe to all events
+	allSub, _ := eb.Subscribe("subscriber1", 10, nil)
+
+	// Subscribe with a filter (only even numbers)
+	evenFilter := func(n int) bool { return n%2 == 0 }
+	evenSub, _ := eb.Subscribe("subscriber2", 10, evenFilter)
+
+	// Send events
+	go func() {
+		for i := 1; i <= 5; i++ {
+			eb.PublishEvent(i)
+		}
+	}()
+
+	// Receive events
+	for event := range allSub.Events() {
+		fmt.Println("All:", event)
+		// Process event...
+		if event == 5 {
+			break
+		}
+	}
+
+	// Clean up
+	allSub.Stop()
+	evenSub.Stop()
+}
+```
+
+## API Overview
+
+### Creating an EventBus
+
+```go
+eb := eventbus.New[T](inputChanSize int) *EventBus[T]
+```
+
+Creates a new EventBus for type `T` with specified input channel buffer size.
+
+### Starting and Stopping
+
+```go
+err := eb.Start()  // Start processing events
+err := eb.Stop()   // Stop processing and close all subscriber channels
+```
+
+### Subscribing
+
+```go
+// Subscribe without filter
+sub, err := eb.Subscribe("subscriber-name", chanSize, nil)
+
+// Subscribe with filter
+filter := func(event T) bool { return /* condition */ }
+sub, err := eb.Subscribe("subscriber-name", chanSize, filter)
+
+// Subscribe with context (auto-unsubscribes when context is cancelled)
+sub, err := eb.SubscribeWithContext(ctx, "subscriber-name", chanSize, filter)
+
+// Access events from subscriber
+events := sub.Events()  // Returns <-chan T
+```
+
+### Unsubscribing
+
+```go
+// Using the Subscriber instance (recommended)
+err := sub.Stop()
+
+// Or using the EventBus directly
+err := eb.Unsubscribe("subscriber-name")
+```
+
+### Sending Events
+
+```go
+eb.PublishEvent(event)
+```
+
+### Getting Information
+
+```go
+count := eb.SubscriberCount()
+str := eb.String() // Debug string representation
+```
+
+## Examples
+
+### Basic Usage
+
+```go
+eb := eventbus.New[string](10)
+eb.Start()
+defer eb.Stop()
+
+sub, _ := eb.Subscribe("logger", 10, nil)
+defer sub.Stop()
+
+go func() {
+    eb.PublishEvent("Hello")
+    eb.PublishEvent("World")
+}()
+
+for msg := range sub.Events() {
+    fmt.Println(msg)
+}
+```
+
+### With Event Filtering
+
+```go
+type LogEvent struct {
+    Level   string
+    Message string
+}
+
+eb := eventbus.New[LogEvent](10)
+eb.Start()
+defer eb.Stop()
+
+// Subscribe to errors only
+errorFilter := func(e LogEvent) bool { return e.Level == "ERROR" }
+errorSub, _ := eb.Subscribe("error-handler", 10, errorFilter)
+defer errorSub.Stop()
+
+// Subscribe to all events
+allSub, _ := eb.Subscribe("all-handler", 10, nil)
+defer allSub.Stop()
+
+// Access events
+for event := range errorSub.Events() {
+    // Handle error events only
+}
+```
+
+### With Context
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+
+eb := eventbus.New[int](10)
+eb.Start()
+defer eb.Stop()
+
+// Automatically unsubscribes after 5 seconds
+sub, _ := eb.SubscribeWithContext(ctx, "temp", 10, nil)
+
+for {
+    select {
+    case event := <-sub.Events():
+        // Process event
+    case <-ctx.Done():
+        return
+    }
+}
+```
+
+## Design Decisions
+
+### Non-Blocking Distribution
+
+EventBus uses non-blocking sends to subscriber channels. If a subscriber's channel is full, the event is dropped for that subscriber only, ensuring that slow subscribers don't block the event bus or other subscribers.
+
+### Channel Closure
+
+- Subscriber channels are closed when `Subscriber.Stop()` or `EventBus.Unsubscribe()` is called
+- All subscriber channels are closed when `EventBus.Stop()` is called
+- When using `SubscribeWithContext()`, channels are closed when the context is cancelled
+
+### Subscriber API
+
+The `Subscribe()` and `SubscribeWithContext()` methods return a `Subscriber` instance that provides:
+- `Events()` - Returns the receive-only channel for events
+- `Stop()` - Unsubscribes and closes the channel
+
+### Thread Safety
+
+All public methods are thread-safe and can be called concurrently from multiple goroutines. The EventBus uses read-write mutexes to minimize contention during event distribution.
+
+## Performance Considerations
+
+- **Buffer Sizes**: Choose appropriate buffer sizes based on your event rate and processing speed
+- **Filter Functions**: Keep filter functions fast; they're called for every event-subscriber pair
+- **Slow Subscribers**: Slow subscribers with small buffers will drop events; increase buffer size or process events asynchronously
+
+## Testing
+
+Run unit tests:
+
+```bash
+go test -tags unit -v ./eventbus
+```
+
+Run benchmarks:
+
+```bash
+go test -tags unit -bench=. ./eventbus
+```
+
+## License
+
+Licensed under the Apache License, Version 2.0. See LICENSE file for details.

--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package eventbus provides a generic event processing system based on channels.
+// It allows multiple subscribers to receive events from a single input channel,
+// with optional filtering and configurable buffer sizes.
+package eventbus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	// ErrAlreadyStarted is returned when Start is called on an already running EventBus
+	ErrAlreadyStarted = errors.New("eventbus: already started")
+	// ErrNotStarted is returned when operations are attempted on a non-started EventBus
+	ErrNotStarted = errors.New("eventbus: not started")
+	// ErrAlreadyStopped is returned when Stop is called on an already stopped EventBus
+	ErrAlreadyStopped = errors.New("eventbus: already stopped")
+	// ErrSubscriberNotFound is returned when unsubscribing a non-existent subscriber
+	ErrSubscriberNotFound = errors.New("eventbus: subscriber not found")
+)
+
+// FilterFunc is a function type that filters events.
+// It returns true if the event should be sent to the subscriber, false otherwise.
+type FilterFunc[T any] func(T) bool
+
+// subscriber represents a single subscriber to the event bus
+type subscriber[T any] struct {
+	ch     chan T
+	filter FilterFunc[T]
+	name   string
+	id     int
+}
+
+// Subscriber provides access to events and control over the subscription
+type Subscriber[T any] struct {
+	ch   <-chan T
+	eb   *EventBus[T]
+	name string
+	id   int
+}
+
+// Events returns the channel to receive events from
+func (s *Subscriber[T]) Events() <-chan T {
+	return s.ch
+}
+
+// Stop unsubscribes and closes the subscriber's channel
+func (s *Subscriber[T]) Stop() error {
+	return s.eb.remove(s)
+}
+
+type status uint8
+
+const (
+	statusInitialized status = iota
+	statusStarted
+	statusStopped
+)
+
+// EventBus manages event distribution to multiple subscribers
+type EventBus[T any] struct {
+	logger       StdLogger
+	input        chan T
+	closedSignal chan struct{}
+	subscribers  []*subscriber[T]
+	wg           sync.WaitGroup
+	cfg          EventBusConfig
+	mu           sync.RWMutex
+	status       status
+}
+
+type StdLogger interface {
+	Print(v ...interface{})
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}
+
+type EventBusConfig struct {
+	// Size of the event queue, when queue gets more events than queue events are getting dropped.
+	InputEventsQueueSize int
+}
+
+// New creates a new EventBus with the specified input channel buffer size.
+// The EventBus must be status with Start() before it begins processing events.
+func New[T any](cfg EventBusConfig, logger StdLogger) *EventBus[T] {
+	return &EventBus[T]{
+		cfg:          cfg,
+		logger:       logger,
+		input:        make(chan T, cfg.InputEventsQueueSize),
+		closedSignal: make(chan struct{}, 1),
+		status:       statusInitialized,
+	}
+}
+
+// Start begins processing events from the input channel and distributing them to subscribers.
+// Returns ErrAlreadyStarted if the EventBus is already running.
+func (eb *EventBus[T]) Start() error {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+
+	switch eb.status {
+	case statusStarted:
+		return ErrAlreadyStarted
+	case statusStopped:
+		return ErrAlreadyStopped
+	default:
+	}
+
+	eb.status = statusStarted
+	eb.wg.Add(1)
+
+	go eb.run()
+
+	return nil
+}
+
+// Stop halts event processing and closes all subscriber channels.
+// It waits for the processing goroutine to finish.
+// Returns ErrNotStarted if the EventBus was never started, or ErrAlreadyStopped if already stopped.
+func (eb *EventBus[T]) Stop() error {
+	eb.mu.Lock()
+
+	defer eb.mu.Unlock()
+	switch eb.status {
+	case statusStopped:
+		return ErrAlreadyStopped
+	case statusInitialized:
+		return ErrNotStarted
+	default:
+		eb.status = statusStopped
+	}
+	close(eb.closedSignal)
+	// Wait for the run goroutine to finish
+	eb.mu.Unlock()
+	eb.wg.Wait()
+	eb.mu.Lock()
+
+	for _, sub := range eb.subscribers {
+		close(sub.ch)
+	}
+
+	return nil
+}
+
+// PublishEvent sends an event onto the bus. If the input buffer is full the
+// event is dropped to avoid blocking publishers.
+func (eb *EventBus[T]) PublishEvent(e T) bool {
+	select {
+	case eb.input <- e:
+		return true
+	default:
+		return false
+	}
+}
+
+// PublishEventBlocking sends an event onto the bus. If the input buffer is full is blocks, until event is published
+func (eb *EventBus[T]) PublishEventBlocking(e T) {
+	select {
+	case eb.input <- e:
+	}
+}
+
+// Subscribe adds a new subscriber to the event bus.
+// name: unique identifier for the subscriber
+// queueSize: buffer size for the subscriber's channel (must be >= 0)
+// filter: optional filter function (can be nil to receive all events)
+//
+// Returns a Subscriber instance that provides access to events and a Stop method.
+func (eb *EventBus[T]) Subscribe(name string, queueSize int, filter FilterFunc[T]) *Subscriber[T] {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+
+	sub := &subscriber[T]{
+		name:   name,
+		ch:     make(chan T, queueSize),
+		filter: filter,
+	}
+	eb.subscribers = append(eb.subscribers, sub)
+
+	return &Subscriber[T]{
+		ch:   sub.ch,
+		name: name,
+		eb:   eb,
+	}
+}
+
+// Unsubscribe removes a subscriber from the event bus and closes its channel.
+// Returns ErrSubscriberNotFound if the subscriber doesn't exist.
+func (eb *EventBus[T]) remove(s *Subscriber[T]) error {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+
+	subID := -1
+
+	for id, sub := range eb.subscribers {
+		if s.ch == sub.ch {
+			subID = id
+			close(sub.ch)
+		}
+	}
+
+	if subID == -1 {
+		return ErrSubscriberNotFound
+	}
+
+	eb.subscribers = append(eb.subscribers[0:subID], eb.subscribers[subID+1:]...)
+	return nil
+}
+
+// SubscriberCount returns the current number of active subscribers
+func (eb *EventBus[T]) SubscriberCount() int {
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	return len(eb.subscribers)
+}
+
+// run is the main event processing loop
+func (eb *EventBus[T]) run() {
+	defer eb.wg.Done()
+
+	for {
+		select {
+		case <-eb.closedSignal:
+			return
+		case event, ok := <-eb.input:
+			if !ok {
+				if eb.logger == nil {
+					eb.logger.Printf("eventbus channel has been closed, it should not have happened, report the bug please.")
+				}
+				return
+			}
+			eb.distribute(event)
+		}
+	}
+}
+
+// distribute sends an event to all matching subscribers
+func (eb *EventBus[T]) distribute(event T) {
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+
+	for _, sub := range eb.subscribers {
+		if sub.filter != nil && !sub.filter(event) {
+			continue
+		}
+
+		// Non-blocking send to avoid slow subscribers blocking the bus
+		select {
+		case sub.ch <- event:
+		default:
+			if eb.logger != nil {
+				eb.logger.Printf("eventbus: dropped event for subscriber %s, make sure it is running and update it's channel size\n", sub.name)
+			}
+		}
+	}
+}
+
+// SubscribeWithContext subscribes with a context that can cancel the subscription.
+// The subscriber will be automatically unsubscribed when the context is cancelled.
+// Returns a Subscriber instance and an error if subscription fails.
+func (eb *EventBus[T]) SubscribeWithContext(ctx context.Context, name string, chanSize int, filter FilterFunc[T]) *Subscriber[T] {
+	sub := eb.Subscribe(name, chanSize, filter)
+
+	// Start a goroutine to handle context cancellation
+	go func() {
+		<-ctx.Done()
+		_ = eb.remove(sub) // Ignore error if already unsubscribed
+	}()
+
+	return sub
+}
+
+// String returns a string representation of the EventBus for debugging
+func (eb *EventBus[T]) String() string {
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+
+	return fmt.Sprintf("EventBus{subscribers: %d, status: %v}", len(eb.subscribers), eb.status)
+}

--- a/internal/eventbus/eventbus_test.go
+++ b/internal/eventbus/eventbus_test.go
@@ -1,0 +1,507 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventbus
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	if eb == nil {
+		t.Fatal("New returned nil")
+	}
+	if eb.input == nil {
+		t.Error("input channel is nil")
+	}
+	if len(eb.subscribers) != 0 {
+		t.Error("subscribers list is not empty")
+	}
+	if eb.status != statusInitialized {
+		t.Error("EventBus should not be status initially")
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+
+	// Test starting
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Test double start
+	err = eb.Start()
+	if err != ErrAlreadyStarted {
+		t.Errorf("Expected ErrAlreadyStarted, got: %v", err)
+	}
+
+	// Test stopping
+	err = eb.Stop()
+	if err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+
+	// Test double stop
+	err = eb.Stop()
+	if err != ErrAlreadyStopped {
+		t.Errorf("Expected ErrAlreadyStopped, got: %v", err)
+	}
+}
+
+func TestStopWithoutStart(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Stop()
+	if err != ErrNotStarted {
+		t.Errorf("Expected ErrNotStarted, got: %v", err)
+	}
+}
+
+func TestEventDistribution(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer eb.Stop()
+
+	sub1 := eb.Subscribe("sub1", 10, nil)
+	sub2 := eb.Subscribe("sub2", 10, nil)
+
+	// Send events
+	eb.PublishEvent(1)
+	eb.PublishEvent(2)
+	eb.PublishEvent(3)
+
+	// Verify both subscribers receive all events
+	for i := 1; i <= 3; i++ {
+		select {
+		case val := <-sub1.Events():
+			if val != i {
+				t.Errorf("sub1: expected %d, got %d", i, val)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("sub1: timeout waiting for event")
+		}
+
+		select {
+		case val := <-sub2.Events():
+			if val != i {
+				t.Errorf("sub2: expected %d, got %d", i, val)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("sub2: timeout waiting for event")
+		}
+	}
+}
+
+func TestEventFiltering(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer eb.Stop()
+
+	// Subscriber 1: no filter (receives all)
+	sub1 := eb.Subscribe("all", 10, nil)
+
+	// Subscriber 2: only even numbers
+	evenFilter := func(n int) bool { return n%2 == 0 }
+	sub2 := eb.Subscribe("even", 10, evenFilter)
+
+	// Subscriber 3: only odd numbers
+	oddFilter := func(n int) bool { return n%2 != 0 }
+	sub3 := eb.Subscribe("odd", 10, oddFilter)
+
+	// Send events
+	for i := 1; i <= 6; i++ {
+		eb.PublishEvent(i)
+	}
+
+	// Verify subscriber 1 gets all events
+	received1 := make([]int, 0, 6)
+	for i := 0; i < 6; i++ {
+		select {
+		case val := <-sub1.Events():
+			received1 = append(received1, val)
+		case <-time.After(1 * time.Second):
+			t.Fatal("timeout waiting for event on ch1")
+		}
+	}
+	if len(received1) != 6 {
+		t.Errorf("ch1: expected 6 events, got %d", len(received1))
+	}
+
+	// Verify subscriber 2 gets only even numbers
+	received2 := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		select {
+		case val := <-sub2.Events():
+			if val%2 != 0 {
+				t.Errorf("ch2: received odd number %d", val)
+			}
+			received2 = append(received2, val)
+		case <-time.After(1 * time.Second):
+			t.Fatal("timeout waiting for event on ch2")
+		}
+	}
+
+	// Verify subscriber 3 gets only odd numbers
+	received3 := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		select {
+		case val := <-sub3.Events():
+			if val%2 == 0 {
+				t.Errorf("ch3: received even number %d", val)
+			}
+			received3 = append(received3, val)
+		case <-time.After(1 * time.Second):
+			t.Fatal("timeout waiting for event on ch3")
+		}
+	}
+}
+
+func TestSubscriberCount(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+
+	if eb.SubscriberCount() != 0 {
+		t.Errorf("Expected 0 subscribers, got %d", eb.SubscriberCount())
+	}
+
+	sub1 := eb.Subscribe("sub1", 5, nil)
+	if eb.SubscriberCount() != 1 {
+		t.Errorf("Expected 1 subscriber, got %d", eb.SubscriberCount())
+	}
+
+	eb.Subscribe("sub2", 5, nil)
+	if eb.SubscriberCount() != 2 {
+		t.Errorf("Expected 2 subscribers, got %d", eb.SubscriberCount())
+	}
+
+	err := sub1.Stop()
+	if err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+	if eb.SubscriberCount() != 1 {
+		t.Errorf("Expected 1 subscriber, got %d", eb.SubscriberCount())
+	}
+}
+
+func TestConcurrentSubscribers(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer eb.Stop()
+
+	numSubscribers := 10
+	eventsPerSubscriber := 100
+
+	var wg sync.WaitGroup
+	wg.Add(numSubscribers)
+
+	// Create multiple subscribers
+	for i := 0; i < numSubscribers; i++ {
+		sub := eb.Subscribe(string(rune('A'+i)), 100, nil)
+
+		go func(sub *Subscriber[int], subName string) {
+			defer wg.Done()
+			count := 0
+			for range sub.Events() {
+				count++
+				if count == eventsPerSubscriber {
+					return
+				}
+			}
+		}(sub, string(rune('A'+i)))
+	}
+
+	// Send events
+	go func() {
+		for i := 0; i < eventsPerSubscriber; i++ {
+			eb.PublishEventBlocking(i)
+		}
+	}()
+
+	// Wait for all subscribers to receive their events
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All subscribers received events
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for subscribers")
+	}
+}
+
+func TestSubscribeWithContext(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer eb.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sub := eb.SubscribeWithContext(ctx, "test", 10, nil)
+	if err != nil {
+		t.Fatalf("SubscribeWithContext failed: %v", err)
+	}
+
+	// Send an event
+	eb.PublishEvent(42)
+
+	// Verify event is received
+	select {
+	case val := <-sub.Events():
+		if val != 42 {
+			t.Errorf("Expected 42, got %d", val)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+
+	// Cancel context
+	cancel()
+
+	// Give it time to be removed
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify subscriber was removed
+	if eb.SubscriberCount() != 0 {
+		t.Errorf("Expected 0 subscribers after context cancel, got %d", eb.SubscriberCount())
+	}
+}
+
+func TestChannelClosedOnStop(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	sub := eb.Subscribe("test", 10, nil)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	err = eb.Stop()
+	if err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+
+	// Verify channel is closed
+	select {
+	case _, ok := <-sub.Events():
+		if ok {
+			t.Error("Channel should be closed")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for channel close")
+	}
+}
+
+func TestChannelClosedOnUnsubscribe(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+
+	sub := eb.Subscribe("test", 10, nil)
+
+	err := sub.Stop()
+	if err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+
+	// Verify channel is closed
+	select {
+	case _, ok := <-sub.Events():
+		if ok {
+			t.Error("Channel should be closed")
+		}
+	default:
+		// Channel might not be immediately readable, try with timeout
+		time.Sleep(10 * time.Millisecond)
+		select {
+		case _, ok := <-sub.Events():
+			if ok {
+				t.Error("Channel should be closed")
+			}
+		default:
+			t.Error("Channel should be closed but is not readable")
+		}
+	}
+}
+
+func TestString(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	str := eb.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+
+	eb.Subscribe("test", 5, nil)
+	str = eb.String()
+	if str == "" {
+		t.Error("String() returned empty string after subscription")
+	}
+}
+
+func TestSlowSubscriberDoesNotBlockBus(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer eb.Stop()
+
+	// Fast subscriber with buffer
+	fastSub := eb.Subscribe("fast", 100, nil)
+
+	// Slow subscriber with small buffer
+	slowSub := eb.Subscribe("slow", 1, nil)
+
+	// Send many events quickly
+	for i := 0; i < 50; i++ {
+		eb.PublishEventBlocking(i)
+	}
+
+	// Fast subscriber should receive most/all events
+	fastCount := 0
+	timeout := time.After(1 * time.Second)
+drainFast:
+	for {
+		select {
+		case <-fastSub.Events():
+			fastCount++
+			if fastCount == 50 {
+				break drainFast
+			}
+		case <-timeout:
+			break drainFast
+		}
+	}
+
+	if fastCount < 50 { // Should receive most events
+		t.Errorf("Fast subscriber only received %d events, expected 50", fastCount)
+	}
+
+	// Slow subscriber may have dropped events (buffer overflow)
+	slowCount := 0
+drainSlow:
+	for {
+		select {
+		case <-slowSub.Events():
+			slowCount++
+		default:
+			break drainSlow
+		}
+	}
+
+	// Slow subscriber should have received some events but likely not all
+	t.Logf("Slow subscriber received %d events (some may have been dropped)", slowCount)
+}
+
+func BenchmarkEventDistribution(b *testing.B) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 1000,
+		}, nil)
+	eb.Start()
+	defer eb.Stop()
+
+	// Create 10 subscribers
+	for i := 0; i < 10; i++ {
+		eb.Subscribe(string(rune('A'+i)), 1000, nil)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		eb.PublishEvent(i)
+	}
+}
+
+func BenchmarkEventDistributionWithFilter(b *testing.B) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 1000,
+		}, nil)
+	eb.Start()
+	defer eb.Stop()
+
+	filter := func(n int) bool { return n%2 == 0 }
+
+	// Create 10 subscribers with filters
+	for i := 0; i < 10; i++ {
+		eb.Subscribe(string(rune('A'+i)), 1000, filter)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		eb.PublishEvent(i)
+	}
+}

--- a/internal/eventbus/example_test.go
+++ b/internal/eventbus/example_test.go
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eventbus_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gocql/gocql/internal/eventbus"
+)
+
+// Example demonstrates basic usage of EventBus
+func Example() {
+	// Create a new EventBus for integer events with input buffer of 10
+	eb := eventbus.New[int](eventbus.EventBusConfig{
+		InputEventsQueueSize: 10,
+	}, nil)
+
+	// Start the event bus
+	if err := eb.Start(); err != nil {
+		panic(err)
+	}
+	defer eb.Stop()
+
+	// Subscribe to all events
+	allSub := eb.Subscribe("all-subscriber", 10, nil)
+
+	// Subscribe to even numbers only
+	evenFilter := func(n int) bool { return n%2 == 0 }
+	evenSub := eb.Subscribe("even-subscriber", 10, evenFilter)
+
+	// Send some events
+	go func() {
+		for i := 1; i <= 5; i++ {
+			eb.PublishEvent(i)
+		}
+	}()
+
+	// Receive events
+	time.Sleep(100 * time.Millisecond) // Give time for events to be distributed
+
+	// Drain all events from allEvents
+	for {
+		select {
+		case val := <-allSub.Events():
+			fmt.Printf("All subscriber received: %d\n", val)
+		default:
+			goto evenLoop
+		}
+	}
+
+evenLoop:
+	// Drain even events
+	for {
+		select {
+		case val := <-evenSub.Events():
+			fmt.Printf("Even subscriber received: %d\n", val)
+		default:
+			return
+		}
+	}
+
+	// Output:
+	// All subscriber received: 1
+	// All subscriber received: 2
+	// All subscriber received: 3
+	// All subscriber received: 4
+	// All subscriber received: 5
+	// Even subscriber received: 2
+	// Even subscriber received: 4
+}
+
+// Example_withContext demonstrates using context-based subscriptions
+func Example_withContext() {
+	eb := eventbus.New[string](
+		eventbus.EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	eb.Start()
+	defer eb.Stop()
+
+	// Create a context that will be cancelled
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Subscribe with context - will auto-remove when context is cancelled
+	sub := eb.SubscribeWithContext(ctx, "temp-subscriber", 10, nil)
+
+	// Send some events
+	go func() {
+		for i := 0; i < 3; i++ {
+			eb.PublishEvent(fmt.Sprintf("event-%d", i))
+			time.Sleep(30 * time.Millisecond)
+		}
+	}()
+
+	// Receive events until context is cancelled
+	for {
+		select {
+		case event := <-sub.Events():
+			fmt.Println("Received:", event)
+		case <-ctx.Done():
+			fmt.Println("Context cancelled, subscription ended")
+			return
+		}
+	}
+
+	// Output:
+	// Received: event-0
+	// Received: event-1
+	// Received: event-2
+	// Context cancelled, subscription ended
+}
+
+// Example_multipleSubscribers demonstrates multiple subscribers with different filters
+func Example_multipleSubscribers() {
+	type LogEvent struct {
+		Level   string
+		Message string
+	}
+
+	eb := eventbus.New[LogEvent](eventbus.EventBusConfig{
+		InputEventsQueueSize: 10,
+	}, nil)
+	eb.Start()
+	defer eb.Stop()
+
+	// Subscribe to error logs only
+	errorFilter := func(e LogEvent) bool { return e.Level == "ERROR" }
+	errorSub := eb.Subscribe("error-logger", 5, errorFilter)
+
+	// Subscribe to all logs
+	allSub := eb.Subscribe("all-logger", 10, nil)
+
+	// Send various log events
+	go func() {
+		logs := []LogEvent{
+			{Level: "INFO", Message: "Application status"},
+			{Level: "ERROR", Message: "Connection failed"},
+			{Level: "INFO", Message: "Retrying connection"},
+			{Level: "ERROR", Message: "Max retries exceeded"},
+		}
+		for _, log := range logs {
+			eb.PublishEvent(log)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	fmt.Println("Error logger received:")
+	for {
+		select {
+		case event := <-errorSub.Events():
+			fmt.Printf("  [%s] %s\n", event.Level, event.Message)
+		default:
+			goto allLogs
+		}
+	}
+
+allLogs:
+	fmt.Println("All logger received:")
+	for {
+		select {
+		case event := <-allSub.Events():
+			fmt.Printf("  [%s] %s\n", event.Level, event.Message)
+		default:
+			return
+		}
+	}
+
+	// Output:
+	// Error logger received:
+	//   [ERROR] Connection failed
+	//   [ERROR] Max retries exceeded
+	// All logger received:
+	//   [INFO] Application status
+	//   [ERROR] Connection failed
+	//   [INFO] Retrying connection
+	//   [ERROR] Max retries exceeded
+}
+
+// Example_unsubscribe demonstrates dynamic subscription management
+func Example_unsubscribe() {
+	eb := eventbus.New[int](eventbus.EventBusConfig{
+		InputEventsQueueSize: 10,
+	}, nil)
+
+	eb.Start()
+	defer eb.Stop()
+
+	// Subscribe
+	sub := eb.Subscribe("temporary", 10, nil)
+
+	// Send first batch of events
+	eb.PublishEvent(1)
+	eb.PublishEvent(2)
+
+	// Receive first batch
+	fmt.Println("Before remove:")
+	for i := 0; i < 2; i++ {
+		fmt.Println("Received:", <-sub.Events())
+	}
+
+	// Unsubscribe using Stop method
+	err := sub.Stop()
+	if err != nil {
+		panic(err)
+	}
+
+	// Send more events (won't be received)
+	eb.PublishEvent(3)
+	eb.PublishEvent(4)
+
+	// Channel is now closed
+	if _, ok := <-sub.Events(); !ok {
+		fmt.Println("Channel closed after remove")
+	}
+
+	// Output:
+	// Before remove:
+	// Received: 1
+	// Received: 2
+	// Channel closed after remove
+}

--- a/session_event_bus_integration_test.go
+++ b/session_event_bus_integration_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+// +build integration
+
+package gocql
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql/events"
+)
+
+func TestSessionEventBusReceivesSchemaChangeEvent(t *testing.T) {
+	cluster := createCluster()
+	cluster.Events.DisableSchemaEvents = false
+
+	sess, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("unable to create session: %v", err)
+	}
+	defer sess.Close()
+
+	sub := sess.SubscribeToEvents("schema-event", 10, func(ev events.Event) bool {
+		return ev.Type() == events.ClusterEventTypeSchemaChangeKeyspace
+	})
+	defer sub.Stop()
+
+	keyspace := fmt.Sprintf("eventbus_schema_%d", time.Now().UnixNano())
+	createStmt := fmt.Sprintf(`CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}`, keyspace)
+	if err := sess.Query(createStmt).Exec(); err != nil {
+		t.Fatalf("create keyspace: %v", err)
+	}
+	defer sess.Query("DROP KEYSPACE " + keyspace).Exec()
+
+	select {
+	case ev := <-sub.Events():
+		if _, ok := ev.(*events.SchemaChangeKeyspaceEvent); !ok {
+			t.Fatalf("unexpected event type: %T", ev)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for schema change event")
+	}
+}
+
+func TestSessionEventBusReceivesControlReconnectEvent(t *testing.T) {
+	cluster := createCluster()
+	cluster.Events.DisableTopologyEvents = true
+	cluster.Events.DisableNodeStatusEvents = true
+
+	sess, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("unable to create session: %v", err)
+	}
+	defer sess.Close()
+
+	sub := sess.SubscribeToEvents("control-reconnect", 10, func(ev events.Event) bool {
+		return ev.Type() == events.SessionEventTypeControlConnectionRecreated
+	})
+	defer sub.Stop()
+
+	if err := sess.control.reconnect(); err != nil {
+		t.Fatalf("control reconnect: %v", err)
+	}
+
+	select {
+	case ev := <-sub.Events():
+		if _, ok := ev.(*events.ControlConnectionRecreatedEvent); !ok {
+			t.Fatalf("unexpected event type: %T", ev)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for control reconnect event")
+	}
+}

--- a/session_event_bus_test.go
+++ b/session_event_bus_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+// +build unit
+
+package gocql
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql/events"
+	"github.com/gocql/gocql/internal/eventbus"
+)
+
+func TestSessionEventBusPublishesEvents(t *testing.T) {
+	s := &Session{
+		eventBus: eventbus.New[events.Event](eventbus.EventBusConfig{
+			InputEventsQueueSize: 1,
+		}, nil),
+		logger: &nopLogger{},
+	}
+
+	if err := s.eventBus.Start(); err != nil {
+		t.Fatalf("starting event bus: %v", err)
+	}
+	defer s.eventBus.Stop()
+
+	sub := s.SubscribeToEvents("test", 1, nil)
+	defer sub.Stop()
+
+	ev := &events.StatusChangeEvent{
+		Change: "UP",
+		Host:   net.ParseIP("127.0.0.1"),
+		Port:   9042,
+	}
+
+	s.publishEvent(ev)
+
+	select {
+	case received := <-sub.Events():
+		if received != ev {
+			t.Fatalf("unexpected event pointer: got %p want %p", received, ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+}


### PR DESCRIPTION
Create a bus that will allow consume different events from the Session. Targeted event types:
1. Cluster events that comes from Control connection, like: alter schema, topology change, node status change
2. Session events: Control Connection being recreated

Session API allows to subscribe to events and unsubscribe:
```
	// Subscribe
	sub := sess.SubscribeToEvents("my-subs", 10, nil)
	// Unsubscribe
	defer sub.Stop()
```

It also should allow filtering:
```
	sub := sess.SubscribeToEvents("schema-event", 10, func(ev events.Event) bool {
		return ev.Type() == events.ClusterEventTypeSchemaChangeKeyspace
	})
```

Fixes: https://github.com/scylladb/gocql/issues/617
