### PR TITLE
Remove unnecessary arguments from getSchemaAgreement

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1821,7 +1821,7 @@ const qrySystemPeersV2 = "SELECT * FROM system.peers_v2"
 
 const qrySystemLocal = "SELECT * FROM system.local WHERE key='local'"
 
-func getSchemaAgreement(queryLocalSchemasRows []string, querySystemPeersRows []schemaAgreementHost, connectAddress net.IP, port int, translateAddressPort func(addr net.IP, port int) (net.IP, int), logger StdLogger) (err error) {
+func getSchemaAgreement(queryLocalSchemasRows []string, querySystemPeersRows []schemaAgreementHost, logger StdLogger) (err error) {
 	versions := make(map[string]struct{})
 
 	for _, row := range querySystemPeersRows {
@@ -1912,12 +1912,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 			return err
 		}
 
-		var addr net.IP
-		if addr, err = c.host.ConnectAddressWithError(); err != nil {
-			return err
-		}
-
-		err = getSchemaAgreement(schemaVersions, hosts, addr, c.session.cfg.Port, c.session.cfg.translateAddressPort, c.logger)
+		err = getSchemaAgreement(schemaVersions, hosts, c.logger)
 
 		if err == ErrConnectionClosed || err == nil {
 			return err

--- a/conn_test.go
+++ b/conn_test.go
@@ -1581,19 +1581,12 @@ func TestGetSchemaAgreement(t *testing.T) {
 		},
 	}
 
-	translateAddressPort := func(addr net.IP, port int) (net.IP, int) {
-		return addr, port
-	}
-
 	var logger StdLogger
 
 	t.Run("SchemaNotConsistent", func(t *testing.T) {
 		err := getSchemaAgreement(
 			[]string{"875a938a-a695-11ef-4314-85c8ef0ebaa2"},
 			peersRows,
-			net.ParseIP("127.0.0.1"),
-			9042,
-			translateAddressPort,
 			logger,
 		)
 
@@ -1604,9 +1597,6 @@ func TestGetSchemaAgreement(t *testing.T) {
 		err := getSchemaAgreement(
 			[]string{"af810386-a694-11ef-81fa-3aea73156247"},
 			peersRows,
-			net.ParseIP("127.0.0.1"),
-			9042,
-			translateAddressPort,
 			logger,
 		)
 
@@ -1618,9 +1608,6 @@ func TestGetSchemaAgreement(t *testing.T) {
 		err := getSchemaAgreement(
 			[]string{"af810386-a694-11ef-81fa-3aea73156247"},
 			peersRows,
-			net.ParseIP("127.0.0.1"),
-			9042,
-			translateAddressPort,
 			logger,
 		)
 


### PR DESCRIPTION
Fixes: https://github.com/scylladb/gocql/issues/630