### PR TITLE
Fix for Unused import

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
 import sys
 import warnings
 from datetime import date


### PR DESCRIPTION
To fix the problem, simply remove the line `import os` from the file `docs/source/conf.py`. This change will not affect any functionality as the `os` module is not used in the provided snippet. Remove only line 2 (or the line containing `import os`), making sure not to disturb the other imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._