### PR TITLE
fix(host_source): use RLock instead of Lock for ConnectAddressAndPort

### DIFF
--- a/host_source.go
+++ b/host_source.go
@@ -469,8 +469,9 @@ func (h *HostInfo) IsBusy(s *Session) bool {
 }
 
 func (h *HostInfo) ConnectAddressAndPort() string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
 	addr, _ := h.connectAddressLocked()
 	return net.JoinHostPort(addr.String(), strconv.Itoa(h.port))
 }

--- a/tests/bench/go.mod
+++ b/tests/bench/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/klauspost/compress v1.18.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 )
 

--- a/tests/bench/go.sum
+++ b/tests/bench/go.sum
@@ -8,6 +8,7 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
 github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
+github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
All other methods are using RLock for accessing the `h.connectAddressLocked()`, while `ConnectAddressAndPort` is using a Lock, which when accessed from `QueryObserver` leads to heavy lock contention on high loads. Chaning it to `RLock` makes also the read semantics correct.

This was first seen in Gemini

https://github.com/scylladb/gemini/blob/2f590b2c5d17789528ad3e3a8c56882740dbad27/pkg/store/observers.go#L132

Which lead to heavy lock contention since every query had to LOCK the address before printing storing it for logging (There is no way to cache it, since we don't know the node which executed Query before this method is called, so calling it is the only way).

Current way to circumvent this issue (at least in QueryObserver):

```go

func ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
   addr := net.JoinHostPort(query.Host.ConnectAddress().String(), strconv.Itoa(query.Host.Port()))
   // ...
}
```
as `ConnectAddress` correctly uses `RLock` instead of `Lock`