### PR TITLE
Remove unused code - JoinHostPort() helper

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -34,7 +34,6 @@ import (
 	"io/ioutil"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -58,16 +57,6 @@ func approve(authenticator string, approvedAuthenticators []string) bool {
 		}
 	}
 	return false
-}
-
-// JoinHostPort is a utility to return an address string that can be used
-// by `gocql.Conn` to form a connection with a host.
-func JoinHostPort(addr string, port int) string {
-	addr = strings.TrimSpace(addr)
-	if _, _, err := net.SplitHostPort(addr); err != nil {
-		addr = net.JoinHostPort(addr, strconv.Itoa(port))
-	}
-	return addr
 }
 
 type Authenticator interface {

--- a/conn_test.go
+++ b/conn_test.go
@@ -90,20 +90,6 @@ func TestApprove(t *testing.T) {
 	}
 }
 
-func TestJoinHostPort(t *testing.T) {
-	tests := map[string]string{
-		"127.0.0.1:0": JoinHostPort("127.0.0.1", 0),
-		"127.0.0.1:1": JoinHostPort("127.0.0.1:1", 9142),
-		"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:0": JoinHostPort("2001:0db8:85a3:0000:0000:8a2e:0370:7334", 0),
-		"[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1": JoinHostPort("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1", 9142),
-	}
-	for k, v := range tests {
-		if k != v {
-			t.Fatalf("expected '%v', got '%v'", k, v)
-		}
-	}
-}
-
 func testCluster(proto frm.ProtoVersion, addresses ...string) *ClusterConfig {
 	cluster := NewCluster(addresses...)
 	cluster.ProtoVersion = int(proto)


### PR DESCRIPTION
The code uses net.JoinHostPort() where needed, this helper is not used.