### PR TITLE
Fix for Unused import

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
 import warnings
 from datetime import date
 


### PR DESCRIPTION
To fix the issue, simply remove the unused import of the `sys` module from line 2 of `docs/source/conf.py`. No replacement is required for this import, and functionality will not be affected, as the code snippet does not utilize anything from the `sys` module. No new imports, methods, or definitions are required elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._