### PR TITLE
.github/workflows/docs-pr.yml: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -14,6 +14,9 @@ on:
       - ".github/workflows/docs-pr.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/gocql/security/code-scanning/4](https://github.com/scylladb/gocql/security/code-scanning/4)

In general, fix this by explicitly setting a `permissions` block to limit the GITHUB_TOKEN to the minimal scopes required. You can set it at the workflow root so it applies to all jobs by default, or per job if different jobs need different permissions.

For this specific workflow, the `build` job checks out code, uses cache, sets up Python, and builds docs; none of these require write access to repository contents or admin scopes. The minimal safe configuration is to restrict `contents` to `read` at the workflow level. To implement this, add a `permissions:` section right after the `on:` block (before `jobs:`) in `.github/workflows/docs-pr.yml`:

- File: `.github/workflows/docs-pr.yml`
- Insert:

```yaml
permissions:
  contents: read
```

This change does not alter existing functionality: `actions/checkout` and the other used actions work with read-only repo contents for a build job. No new imports or methods are needed, only this YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
