### PR TITLE
Decouple shard aware flag from connection address

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -210,6 +210,7 @@ type Conn struct {
 	mu                   sync.Mutex
 	tabletsRoutingV1     int32
 	headerBuf            [headSize]byte
+	isShardAware         bool
 	// true if connection close process for the connection started.
 	// closed is protected by mu.
 	closed     bool
@@ -305,7 +306,10 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		dialedHost *DialedHost
 		err        error
 	)
+
+	isShardAware := false
 	if ok && nrShards > 0 {
+		isShardAware = true
 		dialedHost, err = shardDialer.DialShard(ctx, host, shardID, nrShards)
 	} else {
 		dialedHost, err = cfg.HostDialer.DialHost(ctx, host)
@@ -322,6 +326,7 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		cfg:           cfg,
 		calls:         make(map[int]*callReq),
 		version:       uint8(cfg.ProtoVersion),
+		isShardAware:  isShardAware,
 		addr:          dialedHost.Conn.RemoteAddr().String(),
 		errorHandler:  errorHandler,
 		compressor:    cfg.Compressor,

--- a/scylla_shard_aware_port_common_test.go
+++ b/scylla_shard_aware_port_common_test.go
@@ -226,27 +226,11 @@ func testShardAwarePortUnusedIfNotEnabled(t *testing.T, makeCluster makeClusterT
 	}
 }
 
-func checkIfShardAwarePortIsExposed(pool *hostConnPool, useTLS bool) bool {
-	return getShardAwareAddress(pool, useTLS) != ""
-}
-
 func getShardAwarePort(pool *hostConnPool, useTLS bool) uint16 {
-	addr := getShardAwareAddress(pool, useTLS)
-	if addr == "" {
-		return 0
+	if useTLS {
+		return pool.Host().ScyllaShardAwarePortTLS()
 	}
-
-	_, portS, _ := net.SplitHostPort(addr)
-	port, _ := strconv.Atoi(portS)
-	return uint16(port)
-}
-
-func getShardAwareAddress(pool *hostConnPool, useTLS bool) string {
-	picker, ok := pool.connPicker.(*scyllaConnPicker)
-	if !ok {
-		return ""
-	}
-	return picker.shardAwareAddress
+	return pool.Host().ScyllaShardAwarePort()
 }
 
 func triggerPoolsRefill(sess *Session) {

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -373,8 +373,7 @@ func TestScyllaConnPickerHandleShardCountChange(t *testing.T) {
 				logger:                     logger,
 				disableShardAwarePortUntil: new(atomic.Value),
 				hostId:                     "test-host-id",
-				shardAwareAddress:          "192.168.1.1:19042", // Shard-aware port
-				address:                    "192.168.1.1:9042",  // Regular port
+				address:                    "192.168.1.1:9042", // Regular port
 				conns:                      make([]*Conn, tt.initialShards),
 				excessConns:                make([]*Conn, 0),
 				nrShards:                   tt.initialShards,


### PR DESCRIPTION
The goal is to remove `cfg.translateAddressPort` call from `newScyllaConnPicker` which creates problem for private link 

Removes shardAwareAddress that is used only to check if connection is shardaware and replaces it with direct Conn.isShardAware flag.

Fixes: https://github.com/scylladb/gocql/issues/656