### PR TITLE
(improvement) remove deprecated COMPACT STORAGE

### DIFF
--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -336,12 +336,6 @@ const (
 	IndexKindCustom = "CUSTOM"
 )
 
-const (
-	TableFlagDense    = "dense"
-	TableFlagSuper    = "super"
-	TableFlagCompound = "compound"
-)
-
 // the ordering of the column with regard to its comparator
 type ColumnOrder bool
 

--- a/recreate.go
+++ b/recreate.go
@@ -95,7 +95,7 @@ var tableCQLTemplate = template.Must(template.New("table").
 	Parse(`
 CREATE TABLE {{ .KeyspaceName }}.{{ .Tm.Name }} (
     {{ tableColumnToCQL .Tm }}
-) WITH {{ tablePropertiesToCQL .Tm.ClusteringColumns .Tm.Options .Tm.Flags .Tm.Extensions }};
+) WITH {{ tablePropertiesToCQL .Tm.ClusteringColumns .Tm.Options .Tm.Extensions }};
 `))
 
 func (km *KeyspaceMetadata) tableToCQL(w io.Writer, kn string, tm *TableMetadata) error {
@@ -154,13 +154,12 @@ CREATE MATERIALIZED VIEW {{ .vm.KeyspaceName }}.{{ .vm.ViewName }} AS
     FROM {{ .vm.KeyspaceName }}.{{ .vm.BaseTableName }}
     WHERE {{ .vm.WhereClause }}
     PRIMARY KEY ({{ partitionKeyString .vm.PartitionKey .vm.ClusteringColumns }})
-    WITH {{ tablePropertiesToCQL .vm.ClusteringColumns .vm.Options .flags .vm.Extensions }};
+    WITH {{ tablePropertiesToCQL .vm.ClusteringColumns .vm.Options .vm.Extensions }};
 `))
 
 func (km *KeyspaceMetadata) viewToCQL(w io.Writer, vm *ViewMetadata) error {
 	if err := viewTemplate.Execute(w, map[string]interface{}{
-		"vm":    vm,
-		"flags": []string{},
+		"vm": vm,
 	}); err != nil {
 		return err
 	}
@@ -396,18 +395,10 @@ func (h toCQLHelpers) tableExtensionsToCQL(extensions map[string]interface{}) ([
 }
 
 func (h toCQLHelpers) tablePropertiesToCQL(cks []*ColumnMetadata, opts TableMetadataOptions,
-	flags []string, extensions map[string]interface{}) (string, error) {
+	extensions map[string]interface{}) (string, error) {
 	var sb strings.Builder
 
 	var properties []string
-
-	compactStorage := len(flags) > 0 && (contains(flags, TableFlagDense) ||
-		contains(flags, TableFlagSuper) ||
-		!contains(flags, TableFlagCompound))
-
-	if compactStorage {
-		properties = append(properties, "COMPACT STORAGE")
-	}
 
 	if len(cks) > 0 {
 		var inner []string


### PR DESCRIPTION
Scylla is deprecating it and will remove it entirely in 2026.1.

Code change was done by AI, so here's what it did (based on my request and review): I have removed all support for COMPACT STORAGE from recreate.go and removed the associated unused flag definitions from metadata_scylla.go.

Here is a summary of the changes:

recreate.go:

Removed the logic in tablePropertiesToCQL that checked for TableFlagDense, TableFlagSuper, and TableFlagCompound to append COMPACT STORAGE. Removed the flags parameter from tablePropertiesToCQL as it became unused. Updated tableCQLTemplate and viewTemplate to reflect the signature change of tablePropertiesToCQL. Updated viewToCQL to stop passing the unused flags to the template. metadata_scylla.go:

Removed the constants TableFlagDense, `Table
FlagSuper, and TableFlagCompound`.

I verified the changes by running go build [github](http://_vscodecontentref_/4). and go vet [github](http://_vscodecontentref_/5)., and confirmed that there are no remaining usages of the removed flags or the "COMPACT STORAGE" string in the codebase (excluding potential golden files which grep didn't find).