### PR TITLE
cicd: skip test if image not found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,26 +95,29 @@ jobs:
 
       - name: Pull CCM image from the cache
         uses: actions/cache/restore@v5
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
         id: ccm-cache
         with:
           path: ~/.ccm/repository
           key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
 
       - name: Download ScyllaDB (${{ steps.scylla-version.outputs.value }}) image
-        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
         run: make download-scylla
 
       - name: Save CCM ScyllaDB image into the cache
-        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
         uses: actions/cache/save@v5
         with:
           path: ~/.ccm/repository
           key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
 
       - name: Run integration suite with ScyllaDB ${{ matrix.scylla-version }}(${{ steps.scylla-version.outputs.value }})
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
         run: make test-integration-scylla
 
       - name: Run CCM integration suite with ScyllaDB ${{ matrix.scylla-version }}(${{ steps.scylla-version.outputs.value }})
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
         run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla
 
   test-integration-cassandra:
@@ -159,25 +162,28 @@ jobs:
 
       - name: Pull CCM image from the cache
         uses: actions/cache/restore@v5
+        if: steps.cassandra-version.outputs.value != 'NOT-FOUND'
         id: ccm-cache
         with:
           path: ~/.ccm/repository
           key: ccm-cassandra-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}
 
       - name: Download Cassandra (${{ steps.cassandra-version.outputs.value }}) image
-        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.cassandra-version.outputs.value != 'NOT-FOUND'
         run: make download-cassandra
 
       - name: Save CCM Cassandra image into the cache
-        if: steps.ccm-cache.outputs.cache-hit != 'true'
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.cassandra-version.outputs.value != 'NOT-FOUND'
         uses: actions/cache/save@v5
         with:
           path: ~/.ccm/repository
           key: ccm-cassandra-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}
 
       - name: Run integration suite with Cassandra ${{ matrix.cassandra-version }}(${{ steps.cassandra-version.outputs.value }})
+        if: steps.cassandra-version.outputs.value != 'NOT-FOUND'
         run: make test-integration-cassandra
 
       - name: Run CCM integration suite with Cassandra ${{ matrix.cassandra-version }}(${{ steps.cassandra-version.outputs.value }})
+        if: steps.cassandra-version.outputs.value != 'NOT-FOUND'
         run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla
 

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,13 @@ resolve-cassandra-version: .prepare-get-version
 	fi
 
 	if [[ -z "$${CASSANDRA_VERSION_RESOLVED}" ]]; then
-		echo "Failed to resolve Cassandra ${CASSANDRA_VERSION}"
-		exit 1
+		echo "There is no ${CASSANDRA_VERSION} Cassandra version"
+		if [[ -n "$${GITHUB_ENV}" ]]; then
+			echo "value=NOT-FOUND" >>$${GITHUB_OUTPUT}
+			echo "CASSANDRA_VERSION_RESOLVED=NOT-FOUND" >>$${GITHUB_ENV}
+			exit 0
+		fi
+		exit 2
 	fi
 
 	echo "Resolved Cassandra ${CASSANDRA_VERSION} to $${CASSANDRA_VERSION_RESOLVED}"
@@ -164,8 +169,13 @@ resolve-scylla-version: .prepare-get-version
 	fi
 
 	if [[ -z "$${SCYLLA_VERSION_RESOLVED}" ]]; then
-		echo "Failed to resolve ScyllaDB '${SCYLLA_VERSION}'"
-		exit 1
+		echo "There is no ${SCYLLA_VERSION} ScyllaDB version"
+		if [[ -n "$${GITHUB_ENV}" ]]; then
+			echo "value=NOT-FOUND" >>$${GITHUB_OUTPUT}
+			echo "SCYLLA_VERSION_RESOLVED=NOT-FOUND" >>$${GITHUB_ENV}
+			exit 0
+		fi
+		exit 2
 	fi
 
 	echo "Resolved ScyllaDB ${SCYLLA_VERSION} to $${SCYLLA_VERSION_RESOLVED}"


### PR DESCRIPTION
Sometimes there is no PRIOR image, because current version looks like this `2025.4.0`.
Currently it fails to find an image, we need to make it skip the test in such case.

Fixes: https://github.com/scylladb/gocql/issues/657
