### PR TITLE
.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml: Potential fix for code scanning alert no. 9: Improper Access Control

### DIFF
--- a/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
+++ b/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
@@ -2,7 +2,7 @@ name: Build scylla-bench docker image with gocql PR
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
 
 jobs:
   trigger-longevity-large-partitions-with-network-nemesis-1h-test:
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: gocql
 
       - name: Build and push Scylla-bench Docker Image with gocql from PR


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/gocql/security/code-scanning/9](https://github.com/scylladb/gocql/security/code-scanning/9)

To fix the issue, the workflow must ensure that privileged actions only ever run on the exact code version that was reviewed and explicitly labeled as safe, and that no later PR updates can re-use that approval. In GitHub Actions, this means limiting the trigger to the `labeled` activity (so adding new commits does not re-trigger the workflow under the previous label) and checking out the PR code by immutable SHA, not by a branch name or other mutable ref.

The concrete, minimal fix here is:
1. Change the `on.pull_request_target.types` list so it only includes `labeled`. This prevents `opened`, `synchronize`, and `reopened` events from running the workflow based solely on the presence of the label.
2. Change the GoCQL PR checkout step to use `ref: ${{ github.event.pull_request.head.sha }}` instead of `head.ref`. That guarantees the workflow uses the exact commit that existed at labeling time.
3. Leave the rest of the behavior (building Docker images, tagging with SHA, and triggering Jenkins) unchanged, since they already rely on `head.sha`.

All required values (`github.event.pull_request.head.sha`) are already available in the workflow context, so no new methods, imports, or additional steps are needed; only the YAML keys on the shown lines must be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
