### PR TITLE
Stop translating initial endpoints

### DIFF
--- a/control_test.go
+++ b/control_test.go
@@ -48,7 +48,7 @@ func TestHostInfo_Lookup(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		hosts, err := translateAndResolveInitialEndpoint(resolver, nil, test.addr, 1)
+		hosts, err := resolveInitialEndpoint(resolver, test.addr, 1)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 			continue

--- a/exec.go
+++ b/exec.go
@@ -69,7 +69,7 @@ func NewSingleHostQueryExecutor(cfg *ClusterConfig) (e SingleHostQueryExecutor, 
 	}
 
 	var hosts []*HostInfo
-	if hosts, err = translateAndResolveInitialEndpoints(c.DNSResolver, c.translateAddressPort, c.Hosts, c.Port, c.Logger); err != nil {
+	if hosts, err = resolveInitialEndpoints(c.DNSResolver, c.Hosts, c.Port, c.Logger); err != nil {
 		err = fmt.Errorf("addrs to hosts: %w", err)
 		return
 	}

--- a/filters.go
+++ b/filters.go
@@ -70,7 +70,7 @@ func DataCentreHostFilter(dataCenter string) HostFilter {
 // WhiteListHostFilter filters incoming hosts by checking that their address is
 // in the initial hosts whitelist.
 func WhiteListHostFilter(hosts ...string) HostFilter {
-	hostInfos, err := translateAndResolveInitialEndpoints(defaultDnsResolver, nil, hosts, 9042, nopLogger{})
+	hostInfos, err := resolveInitialEndpoints(defaultDnsResolver, hosts, 9042, nopLogger{})
 	if err != nil {
 		// dont want to panic here, but rather not break the API
 		panic(fmt.Errorf("unable to lookup host info from address: %v", err))

--- a/host_source.go
+++ b/host_source.go
@@ -162,7 +162,7 @@ func (a *AddressPort) Equal(o AddressPort) bool {
 }
 
 func (a *AddressPort) IsValid() bool {
-	return a.Address != nil && !a.Address.IsUnspecified() && a.Port != 0
+	return len(a.Address) != 0 && !a.Address.IsUnspecified() && a.Port != 0
 }
 
 func (a *AddressPort) String() string {

--- a/scylla.go
+++ b/scylla.go
@@ -730,8 +730,10 @@ func (sd *scyllaDialer) DialShard(ctx context.Context, host *HostInfo, shardID, 
 	translatedInfo := host.getTranslatedConnectionInfo()
 	if translatedInfo != nil {
 		addr = translatedInfo.CQL.ToNetAddr()
-		if sd.tlsConfig != nil && translatedInfo.ShardAwareTLS.IsValid() {
-			shardAwareAddr = translatedInfo.ShardAwareTLS.ToNetAddr()
+		if sd.tlsConfig != nil {
+			if translatedInfo.ShardAwareTLS.IsValid() {
+				shardAwareAddr = translatedInfo.ShardAwareTLS.ToNetAddr()
+			}
 		} else if translatedInfo.ShardAware.IsValid() {
 			shardAwareAddr = translatedInfo.ShardAware.ToNetAddr()
 		}

--- a/scylla_shard_aware_port_common_test.go
+++ b/scylla_shard_aware_port_common_test.go
@@ -62,7 +62,7 @@ func testShardAwarePortNoReconnections(t *testing.T, makeCluster makeClusterTest
 
 			hosts := sess.hostSource.getHostsList()
 			for _, host := range hosts {
-				t.Logf("checking host %q hostID: %q", host.hostname, host.hostId)
+				t.Logf("checking host %s:%d hostID: %q", host.ConnectAddress(), host.Port(), host.hostId)
 				hostPool, ok := sess.pool.getPool(host)
 				if !ok {
 					pushErr(fmt.Errorf("host %q hostID not found", host.hostname))

--- a/session.go
+++ b/session.go
@@ -100,23 +100,21 @@ var queryPool = &sync.Pool{
 	},
 }
 
-func translateAndResolveInitialEndpoints(resolver DNSResolver, translateAddressPort addressTranslateFn, addrs []string, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
+func resolveInitialEndpoints(resolver DNSResolver, addrs []string, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
 	var hosts []*HostInfo
+	var errs []error
 	for _, hostaddr := range addrs {
-		resolvedHosts, err := translateAndResolveInitialEndpoint(resolver, translateAddressPort, hostaddr, defaultPort)
+		resolvedHosts, err := resolveInitialEndpoint(resolver, hostaddr, defaultPort)
 		if err != nil {
-			// Try other hosts if unable to resolve DNS name
-			if _, ok := err.(*net.DNSError); ok {
-				logger.Printf("gocql: dns error: %v\n", err)
-				continue
-			}
-			return nil, err
+			err = fmt.Errorf("failed to resolve endpoint %q: %w", hostaddr, err)
+			errs = append(errs, err)
+			logger.Println(err.Error())
+			continue
 		}
-
 		hosts = append(hosts, resolvedHosts...)
 	}
 	if len(hosts) == 0 {
-		return nil, errors.New("failed to resolve any of the provided hostnames")
+		return nil, fmt.Errorf("failed to resolve any of the provided hostnames: %w", errors.Join(errs...))
 	}
 	return hosts, nil
 }
@@ -258,7 +256,7 @@ func (s *Session) init() error {
 		return nil
 	}
 
-	hosts, err := translateAndResolveInitialEndpoints(s.cfg.DNSResolver, s.cfg.translateAddressPort, s.cfg.Hosts, s.cfg.Port, s.logger)
+	hosts, err := resolveInitialEndpoints(s.cfg.DNSResolver, s.cfg.Hosts, s.cfg.Port, s.logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There is no need to translate them anymore since after #669 translation is done when driver creates new connection, 