### PR TITLE
Add HostInfo into AddressTranslatorV2 API

### DIFF
--- a/address_translators.go
+++ b/address_translators.go
@@ -49,12 +49,30 @@ func IdentityTranslator() AddressTranslator {
 	})
 }
 
+type AddressTranslatorHostInfo interface {
+	HostID() string
+	Rack() string
+	DataCenter() string
+	BroadcastAddress() net.IP
+	ListenAddress() net.IP
+	RPCAddress() net.IP
+	PreferredIP() net.IP
+	Peer() net.IP
+	UntranslatedConnectAddress() net.IP
+	Port() int
+	Partitioner() string
+	ClusterName() string
+	ScyllaShardAwarePort() uint16
+	ScyllaShardAwarePortTLS() uint16
+	ScyllaShardCount() int
+}
+
 // AddressTranslatorV2 provides a way to translate node addresses (and ports) that are
 // discovered or received as a node event. This can be useful in an ec2 environment,
 // for instance, to translate public IPs to private IPs.
 type AddressTranslatorV2 interface {
 	AddressTranslator
-	TranslateWithHostID(hostID string, addr AddressPort) AddressPort
+	TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) AddressPort
 }
 
 type AddressTranslatorFuncV2 func(hostID string, addr AddressPort) AddressPort
@@ -67,8 +85,8 @@ func (fn AddressTranslatorFuncV2) Translate(addr net.IP, port int) (net.IP, int)
 	return res.Address, int(res.Port)
 }
 
-func (fn AddressTranslatorFuncV2) TranslateWithHostID(hostID string, addr AddressPort) AddressPort {
-	return fn(hostID, addr)
+func (fn AddressTranslatorFuncV2) TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) AddressPort {
+	return fn(host.HostID(), addr)
 }
 
 var _ AddressTranslatorV2 = AddressTranslatorFuncV2(nil)

--- a/cluster.go
+++ b/cluster.go
@@ -423,13 +423,13 @@ func (cfg *ClusterConfig) CreateSessionNonBlocking() (*Session, error) {
 	return NewSessionNonBlocking(*cfg)
 }
 
-type addressTranslateFn func(hostID string, addr AddressPort) AddressPort
+type addressTranslateFn func(host *HostInfo, addr AddressPort) AddressPort
 
 // translateAddressPort is a helper method that will use the given AddressTranslator
 // if defined, to translate the given address and port into a possibly new address
 // and port, If no AddressTranslator or if an error occurs, the given address and
 // port will be returned.
-func (cfg *ClusterConfig) translateAddressPort(hostID string, addr AddressPort) AddressPort {
+func (cfg *ClusterConfig) translateAddressPort(host *HostInfo, addr AddressPort) AddressPort {
 	if cfg.AddressTranslator == nil || !addr.IsValid() {
 		return addr
 	}
@@ -444,7 +444,7 @@ func (cfg *ClusterConfig) translateAddressPort(hostID string, addr AddressPort) 
 			Port:    uint16(newPort),
 		}
 	}
-	newAddr := translatorV2.TranslateWithHostID(hostID, addr)
+	newAddr := translatorV2.TranslateHost(host, addr)
 	if debug.Enabled {
 		cfg.logger().Printf("gocql: translating address %q to %q", addr, newAddr)
 	}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -71,9 +71,13 @@ func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 
 	cfg := NewCluster()
 	tests.AssertNil(t, "cluster config address translator", cfg.AddressTranslator)
-	newAddr := cfg.translateAddressPort("", AddressPort{
-		Address: net.ParseIP("10.0.0.1"),
-		Port:    uint16(1234),
+	hh := HostInfoBuilder{
+		ConnectAddress: net.ParseIP("10.0.0.1"),
+		Port:           1234,
+	}.Build()
+	newAddr := cfg.translateAddressPort(&hh, AddressPort{
+		Address: hh.UntranslatedConnectAddress(),
+		Port:    uint16(hh.Port()),
 	})
 	tests.AssertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr.Address))
 	tests.AssertEqual(t, "translated host and port", uint16(1234), newAddr.Port)
@@ -84,9 +88,13 @@ func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
-	newAddr := cfg.translateAddressPort("", AddressPort{
-		Address: []byte{},
-		Port:    0,
+	hh := HostInfoBuilder{
+		ConnectAddress: []byte{},
+		Port:           0,
+	}.Build()
+	newAddr := cfg.translateAddressPort(&hh, AddressPort{
+		Address: hh.UntranslatedConnectAddress(),
+		Port:    uint16(hh.Port()),
 	})
 	tests.AssertTrue(t, "translated address is still empty", len(newAddr.Address) == 0)
 	tests.AssertEqual(t, "translated port", uint16(0), newAddr.Port)
@@ -97,9 +105,13 @@ func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 
 	cfg := NewCluster()
 	cfg.AddressTranslator = staticAddressTranslator(net.ParseIP("10.10.10.10"), 5432)
-	newAddr := cfg.translateAddressPort("", AddressPort{
-		Address: net.ParseIP("10.0.0.1"),
-		Port:    2345,
+	hh := HostInfoBuilder{
+		ConnectAddress: net.ParseIP("10.0.0.1"),
+		Port:           2345,
+	}.Build()
+	newAddr := cfg.translateAddressPort(&hh, AddressPort{
+		Address: hh.UntranslatedConnectAddress(),
+		Port:    uint16(hh.Port()),
 	})
 	tests.AssertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr.Address))
 	tests.AssertEqual(t, "translated port", uint16(5432), newAddr.Port)

--- a/conn.go
+++ b/conn.go
@@ -272,26 +272,23 @@ func (s *Session) dial(ctx context.Context, host *HostInfo, connConfig *ConnConf
 }
 
 func (s *Session) translateHostAddresses(host *HostInfo) translatedAddresses {
-	addr := host.UntranslatedConnectAddress()
 	resultedInfo := translatedAddresses{
-		CQL: s.cfg.translateAddressPort(host.HostID(), AddressPort{
-			Address: addr,
+		CQL: s.cfg.translateAddressPort(host, AddressPort{
+			Address: host.UntranslatedConnectAddress(),
 			Port:    uint16(host.Port()),
 		}),
 	}
 	if port := host.ScyllaShardAwarePort(); port != 0 {
-		resultedInfo.ShardAware = s.cfg.translateAddressPort(host.HostID(),
-			AddressPort{
-				Address: addr,
-				Port:    port,
-			})
+		resultedInfo.ShardAware = s.cfg.translateAddressPort(host, AddressPort{
+			Address: host.UntranslatedConnectAddress(),
+			Port:    port,
+		})
 	}
 	if port := host.ScyllaShardAwarePortTLS(); port != 0 {
-		resultedInfo.ShardAwareTLS = s.cfg.translateAddressPort(host.HostID(),
-			AddressPort{
-				Address: addr,
-				Port:    port,
-			})
+		resultedInfo.ShardAwareTLS = s.cfg.translateAddressPort(host, AddressPort{
+			Address: host.UntranslatedConnectAddress(),
+			Port:    port,
+		})
 	}
 	return resultedInfo
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -189,7 +189,7 @@ var _ DNSResolver = brokenDNSResolver{}
 func TestDNSLookupConnected(t *testing.T) {
 	log := &testLogger{}
 
-	// Override the defaul DNS resolver and restore at the end
+	// Override the default DNS resolver and restore at the end
 
 	srv := NewTestServer(t, defaultProto, context.Background())
 	defer srv.Stop()
@@ -207,20 +207,15 @@ func TestDNSLookupConnected(t *testing.T) {
 		t.Fatal("CreateSession() should have connected")
 	}
 
-<<<<<<< HEAD
 	if !strings.Contains(log.String(), "failed to resolve endpoint") {
 		t.Fatalf("Expected to receive 'failed to resolve endpoint' log message  - got '%s' instead", log.String())
-=======
-	if !strings.Contains(log.String(), "failed to resolve and translate endpoint") {
-		t.Fatalf("Expected to receive 'failed to resolve and translate endpoint' log message  - got '%s' instead", log.String())
->>>>>>> 5831973 (Stop translating initial endpoints)
 	}
 }
 
 func TestDNSLookupError(t *testing.T) {
 	log := &testLogger{}
 
-	// Override the defaul DNS resolver and restore at the end
+	// Override the default DNS resolver and restore at the end
 	hosts := []string{"cassandra1.invalid", "cassandra2.invalid"}
 
 	cluster := NewCluster(hosts...)


### PR DESCRIPTION
It will help to address future cases for Private Link when certain connection could be used to route only certain nodes, say nodes from certain rack or datacenter. 

Fixes: https://github.com/scylladb/gocql/issues/670