### PR TITLE
Add PrivateLink support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ It also provides support for shard aware ports, a faster way to connect to all s
 - [4. Data Types](#4-data-types)
 - [5. Configuration](#5-configuration)
   - [5.1 Shard-aware port](#51-shard-aware-port)
-  - [5.2 Iterator](#52-iterator)
+  - [5.2 Client routes (PrivateLink)](#52-client-routes-privatelink)
+  - [5.3 Iterator](#53-iterator)
 - [6. Contributing](#6-contributing)
 
 ## 1. Sunsetting Model
@@ -210,7 +211,27 @@ Issues with shard-aware port not being reachable are not reported in non-debug m
 
 If you suspect that this feature is causing you problems, you can completely disable it by setting the `ClusterConfig.DisableShardAwarePort` flag to true.
 
-### 5.2 Iterator
+### 5.2 Client routes (PrivateLink)
+
+Scylla Cloud exposes a `system.client_routes` table that maps hosts to PrivateLink endpoints.
+When configured, the driver can resolve and connect to the per-host PrivateLink address instead of using the public host IP.
+
+Use `WithClientRoutes` to enable it and pass the connection IDs you receive from Scylla Cloud:
+
+```go
+cluster := gocql.NewCluster("private-link.dns.name")
+cluster.WithOptions(
+	gocql.WithClientRoutes(
+		gocql.WithEndpoints(
+			gocql.ClientRoutesEndpoint{ConnectionID: "your-connection-id"},
+		),
+	),
+)
+```
+
+If you also want to seed the cluster with PrivateLink hostnames, provide `ConnectionAddr` values in the endpoints list.
+
+### 5.3 Iterator
 
 Paging is a way to parse large result sets in smaller chunks.
 The driver provides an iterator to simplify this process.

--- a/client_routes.go
+++ b/client_routes.go
@@ -1,0 +1,741 @@
+package gocql
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gocql/gocql/events"
+	"github.com/gocql/gocql/internal/debug"
+	"github.com/gocql/gocql/internal/eventbus"
+)
+
+type ClientRoutesEndpoint struct {
+	// Scylla Cloud ConnectionID to read from `system.client_routes`
+	ConnectionID string
+
+	// Ip Address or DNS name of the AWS endpoint
+	// Could stay empty, in this case driver will pick it up from system.client_routes table
+	ConnectionAddr string
+}
+
+func (e ClientRoutesEndpoint) Validate() error {
+	if e.ConnectionID == "" {
+		return errors.New("missing ConnectionID")
+	}
+	return nil
+}
+
+type ClientRoutesEndpointList []ClientRoutesEndpoint
+
+func (l *ClientRoutesEndpointList) GetAllConnectionIDs() []string {
+	var ids []string
+	for _, endpoint := range *l {
+		ids = append(ids, endpoint.ConnectionID)
+	}
+	return ids
+}
+
+func (l *ClientRoutesEndpointList) GetConnectionAddr(connectionID string) string {
+	for _, endpoint := range *l {
+		if endpoint.ConnectionID == connectionID {
+			return endpoint.ConnectionAddr
+		}
+	}
+	return ""
+}
+
+func (l *ClientRoutesEndpointList) Validate() error {
+	for id, endpoint := range *l {
+		if err := endpoint.Validate(); err != nil {
+			return fmt.Errorf("endpoint #%d is invalid: %w", id, err)
+		}
+	}
+	return nil
+}
+
+type ClientRoutesConfig struct {
+	TableName                    string
+	Endpoints                    ClientRoutesEndpointList
+	MaxResolverConcurrency       int
+	ResolveHealthyEndpointPeriod time.Duration
+	BlockUnknownEndpoints        bool
+	ResolverCacheDuration        time.Duration
+}
+
+func (cfg *ClientRoutesConfig) Validate() error {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.Endpoints) == 0 {
+		return errors.New("no endpoints specified")
+	}
+
+	if err := cfg.Endpoints.Validate(); err != nil {
+		return fmt.Errorf("failed to validate endpoints: %w", err)
+	}
+	if cfg.ResolveHealthyEndpointPeriod < 0 {
+		return errors.New("resolve healthy endpoint period must be >= 0")
+	}
+	if cfg.MaxResolverConcurrency <= 0 {
+		return errors.New("max resolver concurrency must be > 0")
+	}
+	return nil
+}
+
+type UnresolvedClientRoute struct {
+	ConnectionID  string
+	HostID        string
+	Address       string
+	CQLPort       uint16
+	SecureCQLPort uint16
+}
+
+// Similar returns true if both records targets same host and connection id
+func (r UnresolvedClientRoute) Similar(o UnresolvedClientRoute) bool {
+	return r.ConnectionID == o.ConnectionID && r.HostID == o.HostID
+}
+
+// Equal returns true if both records are exactly the same
+func (r UnresolvedClientRoute) Equal(o UnresolvedClientRoute) bool {
+	return r == o
+}
+
+func (r UnresolvedClientRoute) String() string {
+	return fmt.Sprintf(
+		"UnresolvedClientRoute{ConnectionID=%s, HostID=%s, Address=%s, CQLPort=%d, SecureCQLPort=%d}",
+		r.ConnectionID,
+		r.HostID,
+		r.Address,
+		r.CQLPort,
+		r.SecureCQLPort,
+	)
+}
+
+type UnresolvedClientRouteList []UnresolvedClientRoute
+
+func (l *UnresolvedClientRouteList) Len() int {
+	return len(*l)
+}
+
+type ResolvedClientRoute struct {
+	updateTime time.Time
+	UnresolvedClientRoute
+	allKnownIPs   []net.IP
+	currentIP     net.IP
+	forcedResolve bool
+}
+
+func (r ResolvedClientRoute) String() string {
+	var ip string
+	if r.currentIP == nil {
+		ip = "<nil>"
+	} else {
+		ip = r.currentIP.String()
+	}
+
+	return fmt.Sprintf(
+		"ResolvedClientRoute{ConnectionID=%s, HostID=%s, Address=%s, CQLPort=%d, SecureCQLPort=%d, CurrentIP=%s}",
+		r.ConnectionID,
+		r.HostID,
+		r.Address,
+		r.CQLPort,
+		r.SecureCQLPort,
+		ip,
+	)
+}
+
+func (r ResolvedClientRoute) Clone() ResolvedClientRoute {
+	res := r
+	if res.allKnownIPs != nil {
+		res.allKnownIPs = make([]net.IP, 0, len(r.allKnownIPs))
+		for _, ip := range r.allKnownIPs {
+			res.allKnownIPs = append(res.allKnownIPs, slices.Clone(ip))
+		}
+	}
+	if len(res.currentIP) != 0 {
+		copy(res.currentIP, r.currentIP)
+		res.currentIP = slices.Clone(res.currentIP)
+	}
+	return res
+}
+
+// Newer returns true if o is newer than r
+func (r ResolvedClientRoute) Newer(o ResolvedClientRoute) bool {
+	if len(r.currentIP) == 0 && len(o.currentIP) != 0 {
+		return true
+	}
+	if len(r.allKnownIPs) == 0 && len(o.allKnownIPs) != 0 {
+		return true
+	}
+	return r.updateTime.Compare(o.updateTime) == -1
+}
+
+// Similar returns true if both records targets same host and connection id
+func (r ResolvedClientRoute) Similar(o ResolvedClientRoute) bool {
+	return r.ConnectionID == o.ConnectionID && r.HostID == o.HostID
+}
+
+func (r ResolvedClientRoute) NeedsUpdate() bool {
+	return r.currentIP == nil || len(r.allKnownIPs) == 0 || r.forcedResolve
+}
+
+func (r ResolvedClientRoute) GetCQLPort() uint16 {
+	if r.SecureCQLPort != 0 {
+		return r.SecureCQLPort
+	}
+	return r.CQLPort
+}
+
+type ResolvedClientRouteList []ResolvedClientRoute
+
+func (l *ResolvedClientRouteList) Len() int {
+	return len(*l)
+}
+
+func (l *ResolvedClientRouteList) MergeWithUnresolved(unresolved UnresolvedClientRouteList) {
+	for _, unres := range unresolved {
+		found := false
+		for id, res := range *l {
+			if res.UnresolvedClientRoute.Similar(unres) {
+				found = true
+				if res.Equal(unres) {
+					// Records are the same, no information has changed
+					break
+				}
+				// Records are not the same, add unresolved record
+				// It will be picked up by resolver on very next iteration
+				(*l)[id] = ResolvedClientRoute{
+					UnresolvedClientRoute: unres,
+					forcedResolve:         true,
+				}
+				break
+			}
+		}
+		if !found {
+			*l = append(*l, ResolvedClientRoute{
+				UnresolvedClientRoute: unres,
+				forcedResolve:         true,
+			})
+		}
+	}
+}
+
+func (l *ResolvedClientRouteList) MergeWithResolved(o *ResolvedClientRouteList) {
+	for id, rec := range *l {
+		for _, otherRec := range *o {
+			if rec.Similar(otherRec) {
+				if rec.Newer(otherRec) {
+					(*l)[id] = otherRec
+				}
+				break
+			}
+		}
+	}
+
+	for _, otherRec := range *o {
+		if !slices.ContainsFunc(*l, otherRec.Similar) {
+			*l = append(*l, otherRec)
+		}
+	}
+}
+
+func (l *ResolvedClientRouteList) UpdateIfNewer(route ResolvedClientRoute) bool {
+	for id, r := range *l {
+		if r.Similar(route) {
+			if !r.Newer(route) {
+				return false
+			}
+			(*l)[id] = route
+			return true
+		}
+	}
+	*l = append(*l, route)
+	return true
+}
+
+func (l *ResolvedClientRouteList) FindByHostID(hostID string) *ResolvedClientRoute {
+	for i := range *l {
+		if (*l)[i].HostID == hostID {
+			return &(*l)[i]
+		}
+	}
+	return nil
+}
+
+func (l *ResolvedClientRouteList) Clone() ResolvedClientRouteList {
+	if len(*l) == 0 {
+		return make(ResolvedClientRouteList, 0)
+	}
+	cpy := make(ResolvedClientRouteList, len(*l))
+	copy(cpy, *l)
+	return cpy
+}
+
+type ResolvedEndpoint struct {
+	updateTime    time.Time
+	connectionID  string
+	dc            string
+	rack          string
+	address       string
+	allKnown      []net.IP
+	currentIP     net.IP
+	forcedResolve bool
+}
+
+type ClientRoutesResolver interface {
+	Resolve(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error)
+}
+
+type resolvedCacheRecord struct {
+	lastTimeResolved time.Time
+	lastResult       []net.IP
+}
+
+func (r resolvedCacheRecord) WasResolvedLessThan(cachingTime time.Duration) bool {
+	return time.Now().UTC().Sub(r.lastTimeResolved) < cachingTime
+}
+
+// simpleClientRoutesResolver resolves endpoints using the provided lookup function while enforcing
+// a minimal period between successive resolutions of the same address.
+type simpleClientRoutesResolver struct {
+	resolver    DNSResolver
+	cache       map[string]resolvedCacheRecord
+	cachingTime time.Duration
+	mu          sync.RWMutex
+}
+
+func newSimpleClientRoutesResolver(cachingTime time.Duration, resolver DNSResolver) *simpleClientRoutesResolver {
+	if resolver == nil {
+		resolver = defaultDnsResolver
+	}
+	return &simpleClientRoutesResolver{
+		resolver:    resolver,
+		cachingTime: cachingTime,
+		cache:       make(map[string]resolvedCacheRecord),
+	}
+}
+
+func (r *simpleClientRoutesResolver) Resolve(endpoint ResolvedClientRoute) (allKnown []net.IP, current net.IP, err error) {
+	r.mu.RLock()
+	cache, ok := r.cache[endpoint.Address]
+	r.mu.RUnlock()
+	if ok && cache.WasResolvedLessThan(r.cachingTime) {
+		allKnown = cache.lastResult
+	}
+
+	if len(allKnown) == 0 {
+		allKnown, err = r.resolver.LookupIP(endpoint.Address)
+		if err != nil {
+			return endpoint.allKnownIPs, endpoint.currentIP, err
+		}
+		if len(allKnown) == 0 {
+			return endpoint.allKnownIPs, endpoint.currentIP, fmt.Errorf("no addresses returned for %s", endpoint.Address)
+		}
+	}
+
+	for _, addr := range allKnown {
+		if endpoint.currentIP != nil && endpoint.currentIP.Equal(addr) {
+			current = addr
+			break
+		}
+	}
+	if current == nil {
+		current = allKnown[0]
+	}
+
+	r.mu.Lock()
+	r.cache[endpoint.Address] = resolvedCacheRecord{
+		lastTimeResolved: time.Now().UTC(),
+		lastResult:       allKnown,
+	}
+	r.mu.Unlock()
+	return allKnown, current, nil
+}
+
+type ClientRoutesHandler struct {
+	log               StdLogger
+	c                 controlConnection
+	resolver          ClientRoutesResolver
+	sub               *eventbus.Subscriber[events.Event]
+	resolvedEndpoints atomic.Pointer[ResolvedClientRouteList]
+	updateTasks       chan updateTask
+	closeChan         chan struct{}
+	cfg               ClientRoutesConfig
+	pickTLSPorts      bool
+	initialized       bool
+}
+
+var _ AddressTranslatorV2 = (*ClientRoutesHandler)(nil)
+
+// Translate implements old AddressTranslator interface
+// should not be uses since driver prefer AddressTranslatorV2 API if it is implemented
+func (p *ClientRoutesHandler) Translate(addr net.IP, port int) (net.IP, int) {
+	panic("should never be called")
+}
+
+func pickProperPort(pickTLSPorts bool, rec *ResolvedClientRoute) uint16 {
+	if pickTLSPorts {
+		return rec.SecureCQLPort
+	}
+	return rec.CQLPort
+}
+
+// TranslateWithHost implements AddressTranslatorV2 interface
+func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) (AddressPort, error) {
+	hostID := host.HostID()
+	if hostID == "" {
+		return addr, nil
+	}
+
+	current := p.resolvedEndpoints.Load()
+	rec := current.FindByHostID(hostID)
+	if rec == nil {
+		return addr, fmt.Errorf("no address found for host %s", hostID)
+	}
+
+	if rec.currentIP != nil {
+		port := pickProperPort(p.pickTLSPorts, rec)
+		if port == 0 {
+			return addr, fmt.Errorf("record %s/%s has target port empty", rec.HostID, rec.ConnectionID)
+		}
+		return AddressPort{
+			Address: rec.currentIP,
+			Port:    port,
+		}, nil
+	}
+
+	all, currentIP, err := p.resolver.Resolve(*rec)
+	if err != nil {
+		return addr, fmt.Errorf("failed to resolve DNS resolver for host %s: %v", hostID, err)
+	}
+	rec.allKnownIPs = all
+	rec.currentIP = currentIP
+
+	for {
+		updated := current.Clone()
+		if updated.UpdateIfNewer(*rec) {
+			if p.resolvedEndpoints.CompareAndSwap(current, &updated) {
+				port := pickProperPort(p.pickTLSPorts, rec)
+				if port == 0 {
+					return addr, fmt.Errorf("record %s/%s has target port empty", rec.HostID, rec.ConnectionID)
+				}
+				return AddressPort{
+					Address: rec.currentIP,
+					Port:    port,
+				}, nil
+			}
+			continue
+		}
+
+		rec = current.FindByHostID(hostID)
+		if rec == nil {
+			return addr, fmt.Errorf("no address found for host %s", hostID)
+		}
+		port := pickProperPort(p.pickTLSPorts, rec)
+		if port == 0 {
+			return addr, fmt.Errorf("record %s/%s has target port empty", rec.HostID, rec.ConnectionID)
+		}
+		return AddressPort{
+			Address: rec.currentIP,
+			Port:    port,
+		}, nil
+	}
+}
+
+var never = time.Unix(1<<63-1, 0)
+
+type updateTask struct {
+	result        chan error
+	connectionIDs []string
+	hostIDs       []string
+}
+
+func (p *ClientRoutesHandler) Initialize(s *Session) error {
+	if p.initialized {
+		return errors.New("already initialized")
+	}
+	connectionIDs := make([]string, 0, len(p.cfg.Endpoints))
+	for _, ep := range p.cfg.Endpoints {
+		if ep.ConnectionID != "" {
+			connectionIDs = append(connectionIDs, ep.ConnectionID)
+		}
+	}
+	p.c = s.control
+	p.sub = s.eventBus.Subscribe("port-mux", 1024, func(event events.Event) bool {
+		switch event.Type() {
+		case events.SessionEventTypeControlConnectionRecreated, events.ClusterEventTypeClientRoutesChanged:
+			return true
+		default:
+			return false
+		}
+	})
+	p.startUpdateWorker()
+	p.startReadingEvents()
+	err := p.updateHostPortMappingSync(connectionIDs, nil)
+	if err != nil {
+		p.log.Printf("error updating host ports: %v\n", err)
+	}
+	return nil
+}
+
+func (p *ClientRoutesHandler) Stop() {
+	if p.updateTasks != nil {
+		close(p.updateTasks)
+	}
+	if p.closeChan != nil {
+		close(p.closeChan)
+	}
+	if p.sub != nil {
+		p.sub.Stop()
+	}
+}
+
+// resolveAndUpdateInPlace updates provided list of resolved endpoint in place
+// If it can't resolve it keeps old record as is.
+// Logic to pick a single address from all available addresses is delegated to ClientRoutesResolver at p.endpointResolver
+// It does not resolve everything, it picks endpoints that are:
+// 1. Marked via forcedResolve=true,
+// 2. Have not resolved previously and have no ip address information
+// 3. Was resolved more than cfg.ResolveHealthyEndpointPeriod ago.
+func (p *ClientRoutesHandler) resolveAndUpdateInPlace(records ResolvedClientRouteList) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	errs := make([]error, len(records))
+	tasks := make(chan int, len(records))
+
+	var cutoffTimeForHealthy time.Time
+	if p.cfg.ResolveHealthyEndpointPeriod == 0 {
+		cutoffTimeForHealthy = never
+	} else {
+		cutoffTimeForHealthy = time.Now().UTC().Add(-p.cfg.ResolveHealthyEndpointPeriod)
+	}
+
+	scheduled := false
+	for id, endpoint := range records {
+		if endpoint.currentIP == nil || len(endpoint.allKnownIPs) == 0 || endpoint.forcedResolve {
+			scheduled = true
+			tasks <- id
+		} else if endpoint.updateTime.Before(cutoffTimeForHealthy) {
+			scheduled = true
+			tasks <- id
+		}
+	}
+
+	if !scheduled {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < p.cfg.MaxResolverConcurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for id := range tasks {
+				all, currentIP, err := p.resolver.Resolve(records[id])
+				records[id].updateTime = time.Now().UTC()
+				if err != nil {
+					errs[id] = fmt.Errorf("resolve %s failed: %w", records[id].currentIP, err)
+					continue
+				} else if len(all) == 0 {
+					errs[id] = fmt.Errorf("resolve %s: no addresses returned", records[id].currentIP)
+				} else if currentIP == nil {
+					errs[id] = fmt.Errorf("resolve %s: no current addres has been set, should not happen, please report a bug", records[id].currentIP)
+				} else {
+					// Reset forcedResolve is it was resolved successfully
+					records[id].forcedResolve = false
+				}
+				records[id].allKnownIPs = all
+				records[id].currentIP = currentIP
+			}
+		}()
+	}
+
+	close(tasks)
+	wg.Wait()
+
+	return errors.Join(errs...)
+}
+
+func (p *ClientRoutesHandler) updateHostPortMappingAsync(connectionIDs []string, hostIDs []string) {
+	p.updateTasks <- updateTask{
+		connectionIDs: connectionIDs,
+		hostIDs:       hostIDs,
+	}
+}
+
+func (p *ClientRoutesHandler) updateHostPortMappingSync(connectionIDs []string, hostIDs []string) error {
+	result := make(chan error, 1)
+	p.updateTasks <- updateTask{
+		connectionIDs: connectionIDs,
+		hostIDs:       hostIDs,
+		result:        result,
+	}
+	return <-result
+}
+
+func (p *ClientRoutesHandler) startReadingEvents() {
+	var connectionIDs []string
+	if p.cfg.BlockUnknownEndpoints {
+		connectionIDs = p.cfg.Endpoints.GetAllConnectionIDs()
+	}
+
+	go func() {
+		for event := range p.sub.Events() {
+			switch evt := event.(type) {
+			case *events.ClientRoutesChangedEvent:
+				if debug.Enabled {
+					if len(evt.ConnectionIDs) == 0 {
+						p.log.Printf("got CLIENT_ROUTES_CHANGE event with no connection IDs")
+						continue
+					}
+					if len(evt.HostIDs) == 0 {
+						p.log.Printf("got CLIENT_ROUTES_CHANGE event with no host IDs")
+						continue
+					}
+				}
+				var newConnectionIDs []string
+				if p.cfg.BlockUnknownEndpoints {
+					for _, connectionID := range evt.ConnectionIDs {
+						if connectionID == "" {
+							continue
+						}
+						if slices.ContainsFunc(p.cfg.Endpoints, func(ep ClientRoutesEndpoint) bool {
+							return ep.ConnectionID == connectionID
+						}) {
+							newConnectionIDs = append(newConnectionIDs, connectionID)
+						}
+					}
+					if len(newConnectionIDs) != 0 {
+						p.updateHostPortMappingAsync(newConnectionIDs, evt.HostIDs)
+					}
+				} else {
+					p.updateHostPortMappingAsync(newConnectionIDs, evt.HostIDs)
+				}
+			case *events.ControlConnectionRecreatedEvent:
+				p.updateHostPortMappingAsync(connectionIDs, nil)
+			}
+		}
+	}()
+}
+
+func (p *ClientRoutesHandler) startUpdateWorker() {
+	go func() {
+		for task := range p.updateTasks {
+			err := p.updateHostPortMapping(task.connectionIDs, task.hostIDs)
+			if err != nil {
+				if debug.Enabled {
+					p.log.Printf("failed to update host port mapping: %v", err)
+				}
+			}
+			if task.result != nil {
+				task.result <- err
+				close(task.result)
+			}
+		}
+	}()
+}
+
+func (p *ClientRoutesHandler) updateHostPortMapping(connectionIDs []string, hostIDs []string) error {
+	unresolved, err := getHostPortMappingFromCluster(p.c, p.cfg.TableName, connectionIDs, hostIDs)
+	if err != nil {
+		return err
+	}
+	current := p.resolvedEndpoints.Load()
+	updated := slices.Clone(*current)
+	updated.MergeWithUnresolved(unresolved)
+	err = p.resolveAndUpdateInPlace(updated)
+	if err != nil {
+		p.log.Printf("failed to resolve endpoints: %v", err)
+		// Despite an error it is better to save results, it should not corrupt existing and resolved records
+	}
+
+	// Try to update until it successes
+	// 10 times is more than enough, if it fails
+	for range 10 {
+		if p.resolvedEndpoints.CompareAndSwap(current, &updated) {
+			return nil
+		}
+
+		current = p.resolvedEndpoints.Load()
+		updated.MergeWithResolved(current)
+	}
+	p.log.Printf("failed to update host port mapping due to collisions")
+
+	return nil
+}
+
+func NewClientRoutesAddressTranslator(
+	cfg ClientRoutesConfig,
+	resolver DNSResolver,
+	pickTLSPorts bool,
+	log StdLogger,
+) *ClientRoutesHandler {
+	res := &ClientRoutesHandler{
+		cfg:          cfg,
+		log:          log,
+		pickTLSPorts: pickTLSPorts,
+		closeChan:    make(chan struct{}),
+		updateTasks:  make(chan updateTask, 1024),
+		resolver:     newSimpleClientRoutesResolver(cfg.ResolverCacheDuration, resolver),
+	}
+	res.resolvedEndpoints.Store(&ResolvedClientRouteList{})
+	return res
+}
+
+var _ AddressTranslator = &ClientRoutesHandler{}
+
+func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string) (UnresolvedClientRouteList, error) {
+	var res UnresolvedClientRouteList
+
+	stmt := []string{fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s", table)}
+	var bounds []interface{}
+	if len(connectionIDs) != 0 {
+		var inClause []string
+		for _, connectionID := range connectionIDs {
+			bounds = append(bounds, connectionID)
+			inClause = append(inClause, "?")
+		}
+		if len(stmt) == 1 {
+			stmt = append(stmt, "where")
+		}
+		stmt = append(stmt, fmt.Sprintf("connection_id in (%s)", strings.Join(inClause, ",")))
+	}
+
+	if len(hostIDs) != 0 {
+		var inClause []string
+		for _, hostID := range hostIDs {
+			bounds = append(bounds, hostID)
+			inClause = append(inClause, "?")
+		}
+		if len(stmt) == 1 {
+			stmt = append(stmt, "where")
+		} else {
+			stmt = append(stmt, "and")
+		}
+		stmt = append(stmt, fmt.Sprintf("host_id in (%s)", strings.Join(inClause, ",")))
+	}
+
+	isFullScan := len(hostIDs) == 0 || len(connectionIDs) == 0
+	if isFullScan {
+		stmt = append(stmt, "allow filtering")
+	}
+
+	iter := c.query(strings.Join(stmt, " "), bounds...)
+	var rec UnresolvedClientRoute
+	for iter.Scan(&rec.ConnectionID, &rec.HostID, &rec.Address, &rec.CQLPort, &rec.SecureCQLPort) {
+		res = append(res, rec)
+	}
+	if err := iter.Close(); err != nil {
+		return nil, fmt.Errorf("error reading %s table: %v", table, err)
+	}
+	return res, nil
+}

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+// +build integration
+
+package gocql
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetHostPortMapping(t *testing.T) {
+	session := createSession(t)
+	createKeyspace(t, createCluster(), "gocql_test", true)
+	defer session.Close()
+
+	if err := createTable(session, `CREATE TABLE gocql_test.client_routes (
+    connection_id uuid,
+    host_id uuid,
+    Address text,
+    port int,
+    tls_port int,
+    alternator_port int,
+    alternator_https_port int,
+    Datacenter text,
+    Rack text,
+    PRIMARY KEY (connection_id, host_id))`); err != nil {
+		t.Fatal(err)
+	}
+
+	var hostIDs []string
+	for i := 0; i < 3; i++ {
+		hostIDs = append(hostIDs, MustRandomUUID().String())
+	}
+	var connectionIDs []string
+	for i := 0; i < 3; i++ {
+		connectionIDs = append(connectionIDs, MustRandomUUID().String())
+	}
+
+	racks := []string{"rack1", "rack2", "rack3"}
+	expected := []UnresolvedClientRoute{}
+	for id, hostID := range hostIDs {
+		rack := racks[id]
+		ip := net.ParseIP(fmt.Sprintf("127.0.0.%d", id+1))
+		for _, connectionID := range connectionIDs {
+			err := session.Query(
+				`INSERT INTO gocql_test.client_routes (
+                                            connection_id, host_id, Address, port, tls_port, alternator_port, alternator_https_port, Datacenter, Rack) 
+						VALUES (?, ?, ?, 9042, 9142, 0, 0, 'dc1', ?);`,
+				connectionID, hostID, ip.String(), rack,
+			).Exec()
+			if err != nil {
+				t.Fatalf("unable to insert connection metadata: %s", err.Error())
+			}
+			expected = append(expected, UnresolvedClientRoute{
+				ConnectionID:  connectionID,
+				HostID:        hostID,
+				Address:       ip.String(),
+				CQLPort:       9042,
+				SecureCQLPort: 9142,
+			})
+		}
+	}
+
+	sortUnresolvedHostPorts(expected)
+
+	tcases := []struct {
+		name     string
+		method   func(controlConnection) ([]UnresolvedClientRoute, error)
+		expected []UnresolvedClientRoute
+	}{
+		{
+			name: "get-all",
+			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+				return getHostPortMappingFromCluster(session.control, "gocql_test.client_routes", nil, nil)
+			},
+			expected: expected,
+		},
+		{
+			name: "get-all-hosts",
+			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+				return getHostPortMappingFromCluster(session.control, "gocql_test.client_routes", connectionIDs, nil)
+			},
+			expected: expected,
+		},
+		{
+			name: "get-all-connections",
+			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+				return getHostPortMappingFromCluster(session.control, "gocql_test.client_routes", nil, hostIDs)
+			},
+			expected: expected,
+		},
+		{
+			name: "get-concrete",
+			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+				return getHostPortMappingFromCluster(session.control, "gocql_test.client_routes", connectionIDs, hostIDs)
+			},
+			expected: expected,
+		},
+		{
+			name: "get-concrete-host",
+			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+				return getHostPortMappingFromCluster(session.control, "gocql_test.client_routes", connectionIDs, hostIDs)
+			},
+			expected: expected,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.method(session.control)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sortUnresolvedHostPorts(got)
+
+			if diff := cmp.Diff(got, tc.expected); diff != "" {
+				t.Errorf("got unexpected result: %s", diff)
+			}
+		})
+	}
+}
+
+func sortUnresolvedHostPorts(xs []UnresolvedClientRoute) {
+	sort.Slice(xs, func(i, j int) bool {
+		a, b := xs[i], xs[j]
+
+		if a.ConnectionID != b.ConnectionID {
+			return a.ConnectionID < b.ConnectionID // or bytes.Compare if raw [16]byte
+		}
+		return a.HostID < b.HostID
+	})
+}

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -1,0 +1,527 @@
+//go:build unit
+// +build unit
+
+package gocql
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type dnsResolverFunc func(string) ([]net.IP, error)
+
+// LookupIP implements DNSResolver for dnsResolverFunc.
+func (f dnsResolverFunc) LookupIP(host string) ([]net.IP, error) { return f(host) }
+
+type clientRoutesResolverFunc func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error)
+
+func (f clientRoutesResolverFunc) Resolve(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
+	return f(endpoint)
+}
+
+type fakeControlConn struct {
+	statement string
+	values    []interface{}
+}
+
+func (f *fakeControlConn) getConn() *connHost          { return nil }
+func (f *fakeControlConn) awaitSchemaAgreement() error { return nil }
+func (f *fakeControlConn) query(statement string, values ...interface{}) *Iter {
+	f.statement = statement
+	f.values = values
+	return &Iter{}
+}
+func (f *fakeControlConn) querySystem(statement string, values ...interface{}) *Iter {
+	return &Iter{}
+}
+func (f *fakeControlConn) discoverProtocol(hosts []*HostInfo) (int, error) { return 0, nil }
+func (f *fakeControlConn) connect(hosts []*HostInfo) error                 { return nil }
+func (f *fakeControlConn) close()                                          {}
+func (f *fakeControlConn) getSession() *Session                            { return nil }
+func (f *fakeControlConn) reconnect() error                                { return nil }
+
+type testHostInfo struct {
+	hostID string
+}
+
+func (t testHostInfo) HostID() string                     { return t.hostID }
+func (t testHostInfo) Rack() string                       { return "" }
+func (t testHostInfo) DataCenter() string                 { return "" }
+func (t testHostInfo) BroadcastAddress() net.IP           { return nil }
+func (t testHostInfo) ListenAddress() net.IP              { return nil }
+func (t testHostInfo) RPCAddress() net.IP                 { return nil }
+func (t testHostInfo) PreferredIP() net.IP                { return nil }
+func (t testHostInfo) Peer() net.IP                       { return nil }
+func (t testHostInfo) UntranslatedConnectAddress() net.IP { return nil }
+func (t testHostInfo) Port() int                          { return 0 }
+func (t testHostInfo) Partitioner() string                { return "" }
+func (t testHostInfo) ClusterName() string                { return "" }
+func (t testHostInfo) ScyllaShardAwarePort() uint16       { return 0 }
+func (t testHostInfo) ScyllaShardAwarePortTLS() uint16    { return 0 }
+func (t testHostInfo) ScyllaShardCount() int              { return 0 }
+
+func TestResolvedClientRouteCloneNewerNeedsUpdate(t *testing.T) {
+	ip1 := net.ParseIP("127.0.0.1")
+	ip2 := net.ParseIP("127.0.0.2")
+	base := ResolvedClientRoute{
+		UnresolvedClientRoute: UnresolvedClientRoute{
+			ConnectionID: "c1",
+			HostID:       "h1",
+			Address:      "host",
+			CQLPort:      9042,
+		},
+		allKnownIPs: []net.IP{ip1},
+		currentIP:   ip1,
+		updateTime:  time.Unix(10, 0),
+	}
+
+	clone := base.Clone()
+	clone.allKnownIPs[0][0] = 8
+	clone.currentIP[0] = 9
+
+	if base.allKnownIPs[0][0] == 8 {
+		t.Fatalf("Clone should not share allKnownIPs slices")
+	}
+	if base.currentIP[0] == 9 {
+		t.Fatalf("Clone should not share currentIP slices")
+	}
+
+	newerIP := ResolvedClientRoute{currentIP: ip2}
+	if !(ResolvedClientRoute{}).Newer(newerIP) {
+		t.Fatalf("expected Newer to prefer non-nil currentIP")
+	}
+
+	newerTime := ResolvedClientRoute{updateTime: time.Unix(20, 0)}
+	if !base.Newer(newerTime) {
+		t.Fatalf("expected Newer to prefer newer updateTime")
+	}
+
+	if !(ResolvedClientRoute{currentIP: nil}).NeedsUpdate() {
+		t.Fatalf("expected NeedsUpdate for missing currentIP")
+	}
+	if !(ResolvedClientRoute{currentIP: ip1}).NeedsUpdate() {
+		t.Fatalf("expected NeedsUpdate for missing allKnownIPs")
+	}
+	if !(ResolvedClientRoute{currentIP: ip1, allKnownIPs: []net.IP{ip1}, forcedResolve: true}).NeedsUpdate() {
+		t.Fatalf("expected NeedsUpdate when forcedResolve is set")
+	}
+	if (ResolvedClientRoute{currentIP: ip1, allKnownIPs: []net.IP{ip1}}).NeedsUpdate() {
+		t.Fatalf("did not expect NeedsUpdate for fully resolved route")
+	}
+}
+
+func TestResolvedClientRouteListMergeWithUnresolved(t *testing.T) {
+	list := ResolvedClientRouteList{
+		{
+			UnresolvedClientRoute: UnresolvedClientRoute{
+				ConnectionID: "c1",
+				HostID:       "h1",
+				Address:      "a1",
+				CQLPort:      9042,
+			},
+			forcedResolve: false,
+		},
+	}
+
+	list.MergeWithUnresolved(UnresolvedClientRouteList{
+		{
+			ConnectionID: "c1",
+			HostID:       "h1",
+			Address:      "a1",
+			CQLPort:      9042,
+		},
+	})
+	if len(list) != 1 || list[0].forcedResolve {
+		t.Fatalf("expected unchanged record when unresolved is equal")
+	}
+
+	list.MergeWithUnresolved(UnresolvedClientRouteList{
+		{
+			ConnectionID: "c1",
+			HostID:       "h1",
+			Address:      "a2",
+			CQLPort:      9043,
+		},
+	})
+	if list[0].Address != "a2" || list[0].CQLPort != 9043 || !list[0].forcedResolve {
+		t.Fatalf("expected record to update and force resolve")
+	}
+
+	list = ResolvedClientRouteList{}
+	list.MergeWithUnresolved(UnresolvedClientRouteList{
+		{
+			ConnectionID: "c2",
+			HostID:       "h2",
+			Address:      "a3",
+			CQLPort:      9044,
+		},
+	})
+	if len(list) != 1 || !list[0].forcedResolve {
+		t.Fatalf("expected new record to be appended with forcedResolve")
+	}
+}
+
+func TestResolvedClientRouteListMergeWithResolved(t *testing.T) {
+	older := ResolvedClientRoute{
+		UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"},
+		updateTime:            time.Unix(10, 0),
+	}
+	newer := ResolvedClientRoute{
+		UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"},
+		updateTime:            time.Unix(20, 0),
+		currentIP:             net.ParseIP("10.0.0.1"),
+	}
+
+	list := ResolvedClientRouteList{older}
+	other := ResolvedClientRouteList{newer, {UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c2", HostID: "h2"}}}
+	list.MergeWithResolved(&other)
+
+	if list[0].updateTime != newer.updateTime || list[0].currentIP == nil {
+		t.Fatalf("expected newer record to replace older one")
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected new record to be appended")
+	}
+
+	list = ResolvedClientRouteList{newer}
+	stale := ResolvedClientRouteList{older}
+	list.MergeWithResolved(&stale)
+	if list[0].updateTime != newer.updateTime {
+		t.Fatalf("expected newer record to be preserved when other is stale")
+	}
+}
+
+func TestResolvedClientRouteListUpdateIfNewerAndFindByHostID(t *testing.T) {
+	list := ResolvedClientRouteList{{
+		UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"},
+		updateTime:            time.Unix(10, 0),
+	}}
+
+	older := ResolvedClientRoute{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"}, updateTime: time.Unix(5, 0)}
+	if list.UpdateIfNewer(older) {
+		t.Fatalf("expected UpdateIfNewer to ignore older record")
+	}
+
+	newer := ResolvedClientRoute{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"}, updateTime: time.Unix(15, 0)}
+	if !list.UpdateIfNewer(newer) {
+		t.Fatalf("expected UpdateIfNewer to accept newer record")
+	}
+
+	rec := list.FindByHostID("h1")
+	if rec == nil {
+		t.Fatalf("expected FindByHostID to locate record")
+	}
+	rec.ConnectionID = "updated"
+	if list[0].ConnectionID != "updated" {
+		t.Fatalf("expected FindByHostID to return pointer to list element")
+	}
+}
+
+func TestSimpleClientRoutesResolverResolve(t *testing.T) {
+	calls := 0
+	resolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
+		calls++
+		return []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2")}, nil
+	})
+
+	res := newSimpleClientRoutesResolver(time.Hour, resolver)
+	endpoint := ResolvedClientRoute{
+		UnresolvedClientRoute: UnresolvedClientRoute{Address: "example"},
+		currentIP:             net.ParseIP("10.0.0.2"),
+	}
+
+	all, current, err := res.Resolve(endpoint)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected resolver to be called once, got %d", calls)
+	}
+	if current == nil || !current.Equal(endpoint.currentIP) {
+		t.Fatalf("expected currentIP to be preserved when present")
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected allKnownIPs to be returned")
+	}
+
+	_, _, err = res.Resolve(endpoint)
+	if err != nil {
+		t.Fatalf("unexpected error from cached resolve: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected cached resolve to avoid LookupIP, got %d", calls)
+	}
+
+	resolveErr := errors.New("resolve failed")
+	errorResolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
+		return nil, resolveErr
+	})
+	errorRes := newSimpleClientRoutesResolver(0, errorResolver)
+	endpoint.allKnownIPs = []net.IP{net.ParseIP("10.0.0.9")}
+	all, current, err = errorRes.Resolve(endpoint)
+	if !errors.Is(err, resolveErr) {
+		t.Fatalf("expected resolver error to propagate")
+	}
+	if len(all) != 1 || current == nil || !current.Equal(endpoint.currentIP) {
+		t.Fatalf("expected existing values to be returned on error")
+	}
+
+	emptyResolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
+		return []net.IP{}, nil
+	})
+	emptyRes := newSimpleClientRoutesResolver(0, emptyResolver)
+	_, _, err = emptyRes.Resolve(ResolvedClientRoute{UnresolvedClientRoute: UnresolvedClientRoute{Address: "example"}})
+	if err == nil {
+		t.Fatalf("expected error when resolver returns empty list")
+	}
+}
+
+func TestClientRoutesHandlerTranslateHost(t *testing.T) {
+	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
+	noHost := testHostInfo{hostID: ""}
+	missingHost := testHostInfo{hostID: "missing"}
+
+	handler := &ClientRoutesHandler{}
+	handler.resolvedEndpoints.Store(&ResolvedClientRouteList{})
+
+	res, err := handler.TranslateHost(noHost, addr)
+	if err != nil {
+		t.Fatalf("unexpected error for empty hostID: %v", err)
+	}
+	if !res.Equal(addr) {
+		t.Fatalf("expected address to pass through when hostID is empty")
+	}
+
+	_, err = handler.TranslateHost(missingHost, addr)
+	if err == nil {
+		t.Fatalf("expected error for missing host entry")
+	}
+
+	resolvedList := ResolvedClientRouteList{
+		{
+			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1", CQLPort: 9042, SecureCQLPort: 9142},
+			currentIP:             net.ParseIP("10.0.0.1"),
+		},
+	}
+
+	handler.pickTLSPorts = false
+	handler.resolvedEndpoints.Store(&resolvedList)
+	res, err = handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Port != 9042 {
+		t.Fatalf("expected non-TLS port, got %d", res.Port)
+	}
+
+	handler.pickTLSPorts = true
+	res, err = handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Port != 9142 {
+		t.Fatalf("expected TLS port, got %d", res.Port)
+	}
+
+	errorHandler := &ClientRoutesHandler{
+		resolver: clientRoutesResolverFunc(func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
+			return nil, nil, errors.New("lookup failed")
+		}),
+	}
+	errorList := ResolvedClientRouteList{{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c2", HostID: "h2", Address: "host"}}}
+	errorHandler.resolvedEndpoints.Store(&errorList)
+	_, err = errorHandler.TranslateHost(testHostInfo{hostID: "h2"}, addr)
+	if err == nil {
+		t.Fatalf("expected resolver error to bubble up")
+	}
+}
+
+func TestClientRoutesHandlerTranslateHost_CASCollision(t *testing.T) {
+	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
+	resolverStarted := make(chan struct{})
+	releaseResolver := make(chan struct{})
+	resolver := clientRoutesResolverFunc(func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
+		close(resolverStarted)
+		<-releaseResolver
+		ip := net.ParseIP("10.0.0.1")
+		return []net.IP{ip}, ip, nil
+	})
+
+	handler := &ClientRoutesHandler{resolver: resolver, pickTLSPorts: false}
+	origList := ResolvedClientRouteList{{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1", Address: "host", CQLPort: 9042}}}
+	handler.resolvedEndpoints.Store(&origList)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+		done <- err
+	}()
+
+	<-resolverStarted
+	altList := ResolvedClientRouteList{}
+	handler.resolvedEndpoints.Store(&altList)
+	close(releaseResolver)
+	time.Sleep(10 * time.Millisecond)
+	handler.resolvedEndpoints.Store(&origList)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error after CAS collision: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("TranslateHost timed out after CAS collision")
+	}
+}
+
+func TestClientRoutesHandlerResolveAndUpdateInPlace(t *testing.T) {
+	var inFlight int32
+	var maxInFlight int32
+	called := make(chan string, 4)
+	resolveErr := errors.New("resolve error")
+
+	resolver := clientRoutesResolverFunc(func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
+		curr := atomic.AddInt32(&inFlight, 1)
+		for {
+			prev := atomic.LoadInt32(&maxInFlight)
+			if curr > prev && atomic.CompareAndSwapInt32(&maxInFlight, prev, curr) {
+				break
+			}
+			if curr <= prev {
+				break
+			}
+		}
+		defer atomic.AddInt32(&inFlight, -1)
+
+		called <- endpoint.Address
+		time.Sleep(10 * time.Millisecond)
+		if endpoint.Address == "err" {
+			return nil, nil, resolveErr
+		}
+		ip := net.ParseIP("10.0.0.1")
+		return []net.IP{ip}, ip, nil
+	})
+
+	handler := &ClientRoutesHandler{
+		resolver: resolver,
+		cfg: ClientRoutesConfig{
+			MaxResolverConcurrency:       2,
+			ResolveHealthyEndpointPeriod: time.Hour,
+		},
+	}
+
+	now := time.Now().UTC()
+	ip := net.ParseIP("10.0.0.2")
+	records := ResolvedClientRouteList{
+		{
+			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1", Address: "healthy"},
+			currentIP:             ip,
+			allKnownIPs:           []net.IP{ip},
+			updateTime:            now,
+		},
+		{
+			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c2", HostID: "h2", Address: "forced"},
+			forcedResolve:         true,
+		},
+		{
+			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c3", HostID: "h3", Address: "empty"},
+		},
+		{
+			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c4", HostID: "h4", Address: "stale"},
+			currentIP:             ip,
+			allKnownIPs:           []net.IP{ip},
+			updateTime:            now.Add(-2 * time.Hour),
+		},
+		{
+			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c5", HostID: "h5", Address: "err"},
+		},
+	}
+
+	err := handler.resolveAndUpdateInPlace(records)
+	if err == nil || !errors.Is(err, resolveErr) {
+		t.Fatalf("expected aggregated error to include resolver error")
+	}
+	close(called)
+
+	calledMap := map[string]bool{}
+	for addr := range called {
+		calledMap[addr] = true
+	}
+
+	if calledMap["healthy"] {
+		t.Fatalf("did not expect healthy endpoint to be resolved")
+	}
+	for _, addr := range []string{"forced", "empty", "stale", "err"} {
+		if !calledMap[addr] {
+			t.Fatalf("expected resolver to be called for %s", addr)
+		}
+	}
+
+	if atomic.LoadInt32(&maxInFlight) > int32(handler.cfg.MaxResolverConcurrency) {
+		t.Fatalf("expected max concurrency <= %d, got %d", handler.cfg.MaxResolverConcurrency, maxInFlight)
+	}
+
+	if records[1].currentIP == nil || len(records[1].allKnownIPs) == 0 || records[1].forcedResolve {
+		t.Fatalf("expected forced endpoint to be resolved and forcedResolve cleared")
+	}
+}
+
+func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
+	tcases := []struct {
+		name          string
+		connectionIDs []string
+		hostIDs       []string
+		expectedStmt  string
+		expectedVals  []interface{}
+	}{
+		{
+			name:         "all",
+			expectedStmt: "select connection_id, host_id, address, port, tls_port from system.client_routes allow filtering",
+		},
+		{
+			name:          "connections-only",
+			connectionIDs: []string{"c1", "c2"},
+			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in (?,?) allow filtering",
+			expectedVals:  []interface{}{"c1", "c2"},
+		},
+		{
+			name:         "hosts-only",
+			hostIDs:      []string{"h1"},
+			expectedStmt: "select connection_id, host_id, address, port, tls_port from system.client_routes where host_id in (?) allow filtering",
+			expectedVals: []interface{}{"h1"},
+		},
+		{
+			name:          "connections-and-hosts",
+			connectionIDs: []string{"c1"},
+			hostIDs:       []string{"h1", "h2"},
+			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in (?) and host_id in (?,?)",
+			expectedVals:  []interface{}{"c1", "h1", "h2"},
+		},
+		{
+			name:          "empty-slices",
+			connectionIDs: []string{},
+			hostIDs:       []string{},
+			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes allow filtering",
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := &fakeControlConn{}
+			_, err := getHostPortMappingFromCluster(ctrl, "system.client_routes", tc.connectionIDs, tc.hostIDs)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ctrl.statement != tc.expectedStmt {
+				t.Fatalf("statement mismatch: got %q want %q", ctrl.statement, tc.expectedStmt)
+			}
+			if fmt.Sprint(ctrl.values) != fmt.Sprint(tc.expectedVals) {
+				t.Fatalf("values mismatch: got %v want %v", ctrl.values, tc.expectedVals)
+			}
+		})
+	}
+}

--- a/control.go
+++ b/control.go
@@ -373,6 +373,9 @@ func (c *controlConn) registerEvents(conn *Conn) error {
 	if !c.session.cfg.Events.DisableSchemaEvents {
 		events = append(events, "SCHEMA_CHANGE")
 	}
+	if c.session.cfg.ClientRoutesConfig != nil {
+		events = append(events, "CLIENT_ROUTES_CHANGE")
+	}
 
 	if len(events) == 0 {
 		return nil

--- a/events.go
+++ b/events.go
@@ -140,6 +140,8 @@ func (s *Session) handleEvent(framer *framer) {
 		s.schemaEvents.debounce(frame)
 	case *frm.TopologyChangeEventFrame, *frm.StatusChangeEventFrame:
 		s.nodeEvents.debounce(frame)
+	case *frm.ClientRoutesChanged:
+		break
 	default:
 		s.logger.Printf("gocql: invalid event frame (%T): %v\n", f, f)
 	}

--- a/events/event_converter.go
+++ b/events/event_converter.go
@@ -81,7 +81,12 @@ func FrameToEvent(f interface{}) Event {
 			Aggregate: frame.Name,
 			Arguments: frame.Args,
 		}
-
+	case *frm.ClientRoutesChanged:
+		return &ClientRoutesChangedEvent{
+			ChangeType:    frame.ChangeType,
+			ConnectionIDs: frame.ConnectionIDs,
+			HostIDs:       frame.HostIDs,
+		}
 	default:
 		return nil
 	}

--- a/events/event_converter_test.go
+++ b/events/event_converter_test.go
@@ -265,3 +265,34 @@ func TestFrameToEvent_NonEventFrame(t *testing.T) {
 		t.Errorf("FrameToEvent(non-event) = %v, want nil", event)
 	}
 }
+
+func TestFrameToEvent_ClientRoutesChanged(t *testing.T) {
+	frame := &frm.ClientRoutesChanged{
+		ChangeType:    "UPDATED",
+		ConnectionIDs: []string{"c1", ""},
+		HostIDs:       []string{},
+	}
+
+	event := events.FrameToEvent(frame)
+	if event == nil {
+		t.Fatal("FrameToEvent returned nil")
+	}
+
+	clientEvent, ok := event.(*events.ClientRoutesChangedEvent)
+	if !ok {
+		t.Fatalf("Expected *ClientRoutesChangedEvent, got %T", event)
+	}
+
+	if clientEvent.ChangeType != "UPDATED" {
+		t.Errorf("ChangeType = %v, want UPDATED", clientEvent.ChangeType)
+	}
+	if len(clientEvent.ConnectionIDs) != 2 || clientEvent.ConnectionIDs[1] != "" {
+		t.Errorf("ConnectionIDs = %v, want [c1 \"\"]", clientEvent.ConnectionIDs)
+	}
+	if len(clientEvent.HostIDs) != 0 {
+		t.Errorf("HostIDs = %v, want empty", clientEvent.HostIDs)
+	}
+	if clientEvent.Type() != events.ClusterEventTypeClientRoutesChanged {
+		t.Errorf("Type() = %v, want ClusterEventTypeClientRoutesChanged", clientEvent.Type())
+	}
+}

--- a/events/events.go
+++ b/events/events.go
@@ -44,6 +44,8 @@ const (
 	ClusterEventTypeSchemaChangeFunction
 	// ClusterEventTypeSchemaChangeAggregate represents an aggregate schema change
 	ClusterEventTypeSchemaChangeAggregate
+	// ClusterEventTypeClientRoutesChanged represents an event of update of `system.client_routes` table
+	ClusterEventTypeClientRoutesChanged
 	// SessionEventTypeControlConnectionRecreated is fired when the session loses it's control connection to the cluster and has just been re-established it.
 	SessionEventTypeControlConnectionRecreated
 )
@@ -63,6 +65,8 @@ func (t EventType) IsClusterEvent() bool {
 	case ClusterEventTypeSchemaChangeFunction:
 		return true
 	case ClusterEventTypeSchemaChangeAggregate:
+		return true
+	case ClusterEventTypeClientRoutesChanged:
 		return true
 	default:
 		return false
@@ -85,6 +89,8 @@ func (t EventType) String() string {
 		return "CLUSTER<SCHEMA_CHANGE_FUNCTION>"
 	case ClusterEventTypeSchemaChangeAggregate:
 		return "CLUSTER<SCHEMA_CHANGE_AGGREGATE>"
+	case ClusterEventTypeClientRoutesChanged:
+		return "CLUSTER<CLIENT_ROUTES_CHANGE>"
 	case SessionEventTypeControlConnectionRecreated:
 		return "SESSION<CONTROL_CONNECTION_RECREATED>"
 	default:
@@ -242,6 +248,27 @@ func (e *SchemaChangeAggregateEvent) Type() EventType {
 func (e *SchemaChangeAggregateEvent) String() string {
 	return fmt.Sprintf("SchemaChangeAggregate{change=%s, keyspace=%s, aggregate=%s, args=%v}",
 		e.Change, e.Keyspace, e.Aggregate, e.Arguments)
+}
+
+// ClientRoutesChangedEvent represents an aggregate schema change
+type ClientRoutesChangedEvent struct {
+	// Change is the type of change (UPDATED)
+	ChangeType string
+	// List of connection ids involved into update
+	ConnectionIDs []string
+	// List of host ids involved into update
+	HostIDs []string
+}
+
+// Type returns ClusterEventTypeClientRoutesChanged
+func (e *ClientRoutesChangedEvent) Type() EventType {
+	return ClusterEventTypeClientRoutesChanged
+}
+
+// String returns a string representation of the event
+func (e *ClientRoutesChangedEvent) String() string {
+	return fmt.Sprintf("ConnectionMetadataChanged{changeType=%s, ConnectionIDs=%s, HostIDs=%s}",
+		e.ChangeType, e.ConnectionIDs, e.HostIDs)
 }
 
 type HostInfo struct {

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -153,6 +153,24 @@ func TestSchemaChangeAggregateEvent(t *testing.T) {
 	t.Logf("SchemaChangeAggregateEvent.String() = %s", str)
 }
 
+func TestClientRoutesChangedEvent(t *testing.T) {
+	event := &ClientRoutesChangedEvent{
+		ChangeType:    "UPDATED",
+		ConnectionIDs: []string{"c1"},
+		HostIDs:       []string{},
+	}
+
+	if event.Type() != ClusterEventTypeClientRoutesChanged {
+		t.Errorf("Type() = %v, want %v", event.Type(), ClusterEventTypeClientRoutesChanged)
+	}
+
+	str := event.String()
+	if str == "" {
+		t.Error("String() returned empty string")
+	}
+	t.Logf("ClientRoutesChangedEvent.String() = %s", str)
+}
+
 func TestEventInterface(t *testing.T) {
 	events := []Event{
 		&TopologyChangeEvent{Change: "NEW_NODE", Host: net.ParseIP("127.0.0.1"), Port: 9042},
@@ -162,10 +180,11 @@ func TestEventInterface(t *testing.T) {
 		&SchemaChangeTypeEvent{Change: "DROPPED", Keyspace: "ks", TypeName: "typ"},
 		&SchemaChangeFunctionEvent{Change: "CREATED", Keyspace: "ks", Function: "fn", Arguments: []string{}},
 		&SchemaChangeAggregateEvent{Change: "UPDATED", Keyspace: "ks", Aggregate: "agg", Arguments: []string{}},
+		&ClientRoutesChangedEvent{ChangeType: "UPDATED", ConnectionIDs: []string{"c1"}, HostIDs: []string{}},
 	}
 
 	for _, event := range events {
-		if event.Type() < ClusterEventTypeTopologyChange || event.Type() > ClusterEventTypeSchemaChangeAggregate {
+		if event.Type() < ClusterEventTypeTopologyChange || event.Type() > ClusterEventTypeClientRoutesChanged {
 			t.Errorf("Invalid event type: %v", event.Type())
 		}
 		if event.String() == "" {

--- a/frame.go
+++ b/frame.go
@@ -1126,6 +1126,13 @@ func (f *framer) parseEventFrame() frame {
 	case "SCHEMA_CHANGE":
 		// this should work for all versions
 		return f.parseResultSchemaChange()
+	case "CLIENT_ROUTES_CHANGE":
+		return &frm.ClientRoutesChanged{
+			FrameHeader:   *f.header,
+			ChangeType:    f.readString(),
+			ConnectionIDs: f.readStringList(),
+			HostIDs:       f.readStringList(),
+		}
 	default:
 		panic(fmt.Errorf("gocql: unknown event type: %q", eventType))
 	}

--- a/host_source.go
+++ b/host_source.go
@@ -157,19 +157,19 @@ type AddressPort struct {
 	Port    uint16
 }
 
-func (a *AddressPort) Equal(o AddressPort) bool {
+func (a AddressPort) Equal(o AddressPort) bool {
 	return a.Address.Equal(o.Address) && a.Port == o.Port
 }
 
-func (a *AddressPort) IsValid() bool {
+func (a AddressPort) IsValid() bool {
 	return len(a.Address) != 0 && !a.Address.IsUnspecified() && a.Port != 0
 }
 
-func (a *AddressPort) String() string {
+func (a AddressPort) String() string {
 	return fmt.Sprintf("%s:%d", a.Address, a.Port)
 }
 
-func (a *AddressPort) ToNetAddr() string {
+func (a AddressPort) ToNetAddr() string {
 	return net.JoinHostPort(a.Address.String(), strconv.Itoa(int(a.Port)))
 }
 

--- a/internal/eventbus/eventbus_test.go
+++ b/internal/eventbus/eventbus_test.go
@@ -358,6 +358,35 @@ func TestChannelClosedOnStop(t *testing.T) {
 	}
 }
 
+func TestSubscriberStopAfterEventBusStop(t *testing.T) {
+	eb := New[int](
+		EventBusConfig{
+			InputEventsQueueSize: 10,
+		}, nil)
+	err := eb.Start()
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	sub := eb.Subscribe("test", 10, nil)
+
+	err = eb.Stop()
+	if err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Stop should not panic after eventbus Stop: %v", r)
+		}
+	}()
+
+	err = sub.Stop()
+	if err != ErrSubscriberNotFound {
+		t.Fatalf("Expected ErrSubscriberNotFound, got: %v", err)
+	}
+}
+
 func TestChannelClosedOnUnsubscribe(t *testing.T) {
 	eb := New[int](
 		EventBusConfig{

--- a/internal/frame/frames.go
+++ b/internal/frame/frames.go
@@ -233,6 +233,13 @@ type SchemaChangeAggregate struct {
 	FrameHeader
 }
 
+type ClientRoutesChanged struct {
+	ChangeType    string
+	ConnectionIDs []string
+	HostIDs       []string
+	FrameHeader
+}
+
 type AuthenticateFrame struct {
 	Class string
 	FrameHeader


### PR DESCRIPTION
## Intro:
Implement scylla-specific ClientRoutes feature
    
This feature was implemented in https://github.com/scylladb/scylladb/pull/27323
Idea is to enable clients to dynamically learn address translation information from the system.client_routes table.
When this table is updated drivers get CLIENT_ROUTES_CHANGE event with scope of the change.
    
This PR adds ability to configure driver to read this table and events and maintain address translation mapping updated.

## Summary:
  - Introduce client routes address translation with DNS resolution/caching and async updates based on system.client_routes.
  - Add cluster config options for client routes and wire event handling, frames, and tests for CLIENT_ROUTES_CHANGE.
  - Add PrivateLink integration coverage and minor cleanups (value receivers, error wrapping, eventbus stop behavior, README update).

## How to use:
```go
cluster := gocql.NewCluster("private-link.dns.name")
cluster.WithOptions(
	gocql.WithClientRoutes(
		gocql.WithEndpoints(
			gocql.ClientRoutesEndpoint{ConnectionID: "your-connection-id"},
		),
	),
)
```

Fixes: https://github.com/scylladb/gocql/issues/616
Fixes: https://github.com/scylladb/gocql/issues/685
