### PR TITLE
Expose scylla features at host level

### DIFF
--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -282,9 +282,11 @@ func (*mockConnection) querySystem(ctx context.Context, query string, values ...
 	return nil
 }
 
-func (*mockConnection) getIsSchemaV2() bool                 { return false }
-func (*mockConnection) setSchemaV2(s bool)                  {}
-func (*mockConnection) getScyllaSupported() scyllaSupported { return scyllaSupported{} }
+func (*mockConnection) getIsSchemaV2() bool { return false }
+func (*mockConnection) setSchemaV2(s bool)  {}
+func (*mockConnection) getScyllaSupported() ScyllaConnectionFeatures {
+	return ScyllaConnectionFeatures{}
+}
 
 type mockControlConn struct{}
 

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -443,12 +443,14 @@ func TestScyllaConnPickerHandleShardCountChange(t *testing.T) {
 func mockConn(shard int) *Conn {
 	return &Conn{
 		streams: streams.New(),
-		scyllaSupported: scyllaSupported{
-			shard:             shard,
-			nrShards:          4,
-			msbIgnore:         12,
-			partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
-			shardingAlgorithm: "biased-token-round-robin",
+		scyllaSupported: ScyllaConnectionFeatures{
+			shard: shard,
+			ScyllaHostFeatures: ScyllaHostFeatures{
+				nrShards:          4,
+				msbIgnore:         12,
+				partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
+				shardingAlgorithm: "biased-token-round-robin",
+			},
 		},
 	}
 }
@@ -460,10 +462,12 @@ func mockConnForPicker(shard, nrShards int) *Conn {
 	_ = conn2.Close()
 
 	return &Conn{
-		scyllaSupported: scyllaSupported{
-			shard:     shard,
-			nrShards:  nrShards,
-			msbIgnore: 12,
+		scyllaSupported: ScyllaConnectionFeatures{
+			shard: shard,
+			ScyllaHostFeatures: ScyllaHostFeatures{
+				nrShards:  nrShards,
+				msbIgnore: 12,
+			},
 		},
 		conn:    conn1,
 		addr:    fmt.Sprintf("192.168.1.%d:9042", shard+1),


### PR DESCRIPTION
1. Populate LWT flag, rate limiter, MetadataID features information
3. Make ScyllaHostFeatures atomic on host level
4. Make ScyllaHostFeatures exportable
5. Make use of new API in driver code