### PR TITLE
Translate address for non-shard-aware connection

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -71,6 +71,11 @@ func (hd *defaultHostDialer) DialHost(ctx context.Context, host *HostInfo) (*Dia
 	}
 
 	addr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
+	translatedInfo := host.getTranslatedConnectionInfo()
+	if translatedInfo != nil {
+		addr = translatedInfo.CQL.ToNetAddr()
+	}
+
 	conn, err := hd.dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err

--- a/scylla.go
+++ b/scylla.go
@@ -783,6 +783,11 @@ func (sd *scyllaDialer) DialHost(ctx context.Context, host *HostInfo) (*DialedHo
 	}
 
 	addr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
+	translatedInfo := host.getTranslatedConnectionInfo()
+	if translatedInfo != nil {
+		addr = translatedInfo.CQL.ToNetAddr()
+	}
+
 	conn, err := sd.dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Regression was introduced in https://github.com/scylladb/gocql/pull/671 Address translation was implemented only for DialShard. This change adds it for DialHost