### PR TITLE
Keep empty NodeID on fake HostInfo records for initial endpoints

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -461,6 +461,10 @@ func TestQueryMultinodeWithMetrics(t *testing.T) {
 			}
 		}
 
+		if host == nil {
+			t.Fatalf("failed to observe host info for address %v", ip)
+		}
+
 		queryMetric := qry.metrics.hostMetrics(host)
 		observedMetrics := observer.GetMetrics(host)
 

--- a/control.go
+++ b/control.go
@@ -161,7 +161,7 @@ func resolveInitialEndpoint(resolver DNSResolver, addr string, defaultPort int) 
 	if ip := net.ParseIP(host); ip != nil {
 		if validIpAddr(ip) {
 			hb := HostInfoBuilder{
-				HostId:         MustRandomUUID().String(),
+				// Fake hosts for initial endpoints do not need HostID
 				Hostname:       host,
 				ConnectAddress: ip,
 				Port:           port,
@@ -183,7 +183,7 @@ func resolveInitialEndpoint(resolver DNSResolver, addr string, defaultPort int) 
 	for _, ip := range ips {
 		if validIpAddr(ip) {
 			hb := HostInfoBuilder{
-				HostId:         MustRandomUUID().String(),
+				// Fake hosts for initial endpoints do not need HostID
 				Hostname:       host,
 				ConnectAddress: ip,
 				Port:           port,

--- a/session.go
+++ b/session.go
@@ -329,6 +329,13 @@ func (s *Session) init() error {
 		newer, _ := checkSystemSchema(s.control)
 		s.useSystemSchema = newer
 		defer conn.finalizeConnection()
+	} else {
+		// For testing purposes we populate host ids
+		for _, host := range hosts {
+			if len(host.hostId) == 0 {
+				host.hostId = MustRandomUUID().String()
+			}
+		}
 	}
 
 	if partitioner != "" {


### PR DESCRIPTION
Make it possible to distinct fake HostInfo records for initial endpoints and regular HostInfo records.
Will be needed for PrivateLink AddressTranslator.
These records should no leak to metadata.