### PR TITLE
Add error to AddressTranslatorV2.TranslateHost API

### DIFF
--- a/address_translators.go
+++ b/address_translators.go
@@ -72,7 +72,7 @@ type AddressTranslatorHostInfo interface {
 // for instance, to translate public IPs to private IPs.
 type AddressTranslatorV2 interface {
 	AddressTranslator
-	TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) AddressPort
+	TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) (AddressPort, error)
 }
 
 type AddressTranslatorFuncV2 func(hostID string, addr AddressPort) AddressPort
@@ -85,8 +85,8 @@ func (fn AddressTranslatorFuncV2) Translate(addr net.IP, port int) (net.IP, int)
 	return res.Address, int(res.Port)
 }
 
-func (fn AddressTranslatorFuncV2) TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) AddressPort {
-	return fn(host.HostID(), addr)
+func (fn AddressTranslatorFuncV2) TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) (AddressPort, error) {
+	return fn(host.HostID(), addr), nil
 }
 
 var _ AddressTranslatorV2 = AddressTranslatorFuncV2(nil)

--- a/address_translators_test.go
+++ b/address_translators_test.go
@@ -77,8 +77,9 @@ func TestTranslateHostAddresses_NoScyllaPorts(t *testing.T) {
 		Port:           9042,
 	}.Build()
 
-	translated := translateHostAddresses(translator, &host, nil)
+	translated, err := translateHostAddresses(translator, &host, nil)
 
+	tests.AssertNil(t, "should return no error", err)
 	tests.AssertTrue(t, "translated CQL address", net.ParseIP("10.10.10.10").Equal(translated.CQL.Address))
 	tests.AssertEqual(t, "translated CQL port", uint16(9142), translated.CQL.Port)
 	tests.AssertTrue(t, "shard aware empty address", len(translated.ShardAware.Address) == 0)
@@ -110,8 +111,9 @@ func TestTranslateHostAddresses_WithScyllaPorts(t *testing.T) {
 		shardAwarePortTLS: 19043,
 	})
 
-	translated := translateHostAddresses(translator, &host, nil)
+	translated, err := translateHostAddresses(translator, &host, nil)
 
+	tests.AssertNil(t, "should return no error", err)
 	tests.AssertTrue(t, "translated CQL address", translatedIP.Equal(translated.CQL.Address))
 	tests.AssertEqual(t, "translated CQL port", uint16(9043), translated.CQL.Port)
 	tests.AssertTrue(t, "translated shard aware address", translatedIP.Equal(translated.ShardAware.Address))

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -68,17 +68,15 @@ func TestNewCluster_WithHosts(t *testing.T) {
 
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 	t.Parallel()
-
-	cfg := NewCluster()
-	tests.AssertNil(t, "cluster config address translator", cfg.AddressTranslator)
 	hh := HostInfoBuilder{
 		ConnectAddress: net.ParseIP("10.0.0.1"),
 		Port:           1234,
 	}.Build()
-	newAddr := translateAddressPort(cfg.AddressTranslator, &hh, AddressPort{
+	newAddr, err := translateAddressPort(nil, &hh, AddressPort{
 		Address: hh.UntranslatedConnectAddress(),
 		Port:    uint16(hh.Port()),
 	}, nil)
+	tests.AssertNil(t, "should return no error", err)
 	tests.AssertTrue(t, "same address as provided", net.ParseIP("10.0.0.1").Equal(newAddr.Address))
 	tests.AssertEqual(t, "translated host and port", uint16(1234), newAddr.Port)
 }
@@ -91,10 +89,11 @@ func TestClusterConfig_translateAddressAndPort_EmptyAddr(t *testing.T) {
 		ConnectAddress: []byte{},
 		Port:           0,
 	}.Build()
-	newAddr := translateAddressPort(translator, &hh, AddressPort{
+	newAddr, err := translateAddressPort(translator, &hh, AddressPort{
 		Address: hh.UntranslatedConnectAddress(),
 		Port:    uint16(hh.Port()),
 	}, nil)
+	tests.AssertNil(t, "should return no error", err)
 	tests.AssertTrue(t, "translated address is still empty", len(newAddr.Address) == 0)
 	tests.AssertEqual(t, "translated port", uint16(0), newAddr.Port)
 }
@@ -107,10 +106,11 @@ func TestClusterConfig_translateAddressAndPort_Success(t *testing.T) {
 		ConnectAddress: net.ParseIP("10.0.0.1"),
 		Port:           2345,
 	}.Build()
-	newAddr := translateAddressPort(translator, &hh, AddressPort{
+	newAddr, err := translateAddressPort(translator, &hh, AddressPort{
 		Address: hh.UntranslatedConnectAddress(),
 		Port:    uint16(hh.Port()),
 	}, nil)
+	tests.AssertNil(t, "should return no error", err)
 	tests.AssertTrue(t, "translated address", net.ParseIP("10.10.10.10").Equal(newAddr.Address))
 	tests.AssertEqual(t, "translated port", uint16(5432), newAddr.Port)
 }


### PR DESCRIPTION
This will allow `AddressTranslatorV2` to report when translation data is broken and it is better not to establish connection to the host yet.

Very handy to address some of the cases in PrivateLink.