### PR TITLE
Fix eventbus panic when subscriber stops after EventBus is stopped

### DIFF
--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -158,7 +158,7 @@ func (eb *EventBus[T]) Stop() error {
 	for _, sub := range eb.subscribers {
 		close(sub.ch)
 	}
-
+	eb.subscribers = nil
 	return nil
 }
 


### PR DESCRIPTION
Eventbus do not remove subscribers when it stops, but closes their channels.
When Subscriber stops it go over list of subscribers, removes it and closes the channel, which leads to the panic since channel is already closed.
A proper fix, is to clean subscriber list when event bus is stopped.

Fix: https://github.com/scylladb/gocql/issues/688