### PR TITLE
(Improvement) receive path performance improvements - NOT for MERGE

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -816,15 +816,17 @@ func (c *Conn) recv(ctx context.Context) error {
 		c.conn.SetReadDeadline(time.Time{})
 	}
 
-	headStartTime := time.Now()
-	// were just reading headers over and over and copy bodies
+	var headStartTime time.Time
+	if c.frameObserver != nil {
+		headStartTime = time.Now()
+	}
 	head, err := readHeader(c.r, c.headerBuf[:])
-	headEndTime := time.Now()
 	if err != nil {
 		return err
 	}
 
 	if c.frameObserver != nil {
+		headEndTime := time.Now()
 		c.frameObserver.ObserveFrameHeader(context.Background(), ObservedFrameHeader{
 			Version: head.Version,
 			Flags:   head.Flags,
@@ -839,24 +841,21 @@ func (c *Conn) recv(ctx context.Context) error {
 
 	if head.Stream > c.streams.NumStreams {
 		return fmt.Errorf("gocql: frame header stream is beyond call expected bounds: %d", head.Stream)
-	} else if head.Stream == -1 {
-		// TODO: handle cassandra event frames, we shouldnt get any currently
-		framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts, c.logger)
-		c.setTabletSupported(framer.tabletsRoutingV1)
-		if err := framer.readFrame(c, &head); err != nil {
-			return err
-		}
-		go c.session.handleEvent(framer)
-		return nil
 	} else if head.Stream <= 0 {
-		// reserved stream that we dont use, probably due to a protocol error
-		// or a bug in Cassandra, this should be an error, parse it and return.
 		framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts, c.logger)
 		c.setTabletSupported(framer.tabletsRoutingV1)
 		if err := framer.readFrame(c, &head); err != nil {
 			return err
 		}
 
+		if head.Stream == -1 {
+			// TODO: handle cassandra event frames, we shouldnt get any currently
+			go c.session.handleEvent(framer)
+			return nil
+		}
+
+		// reserved stream that we dont use, probably due to a protocol error
+		// or a bug in Cassandra, this should be an error, parse it and return.
 		frame, err := framer.parseFrame()
 		if err != nil {
 			return err

--- a/frame.go
+++ b/frame.go
@@ -189,7 +189,7 @@ func readInt(p []byte) int32 {
 	return int32(binary.BigEndian.Uint32(p[:4]))
 }
 
-const defaultBufSize = 128
+const defaultBufSize = 4096
 
 type ObservedFrameHeader struct {
 	// StartHeader is the time we started reading the frame header off the network connection.

--- a/frame.go
+++ b/frame.go
@@ -318,11 +318,7 @@ type frame interface {
 func readHeader(r io.Reader, p []byte) (head frm.FrameHeader, err error) {
 	_, err = io.ReadFull(r, p[:headSize])
 	if err != nil {
-		if len(p) < headSize {
-			return frm.FrameHeader{}, fmt.Errorf("not enough bytes to read header require 9 got: %d", len(p))
-		} else {
-			return frm.FrameHeader{}, err
-		}
+		return frm.FrameHeader{}, err
 	}
 
 	head.Version = frm.ProtoVersion(p[0])

--- a/helpers.go
+++ b/helpers.go
@@ -482,9 +482,13 @@ func (iter *Iter) RowData() (RowData, error) {
 		return RowData{}, iter.err
 	}
 
-	columns := make([]string, 0, len(iter.Columns()))
-	values := make([]interface{}, 0, len(iter.Columns()))
+	// Pre-size slices to actual column count including tuple expansion
+	// and use direct indexing instead of append for better performance
+	actualSize := iter.meta.actualColCount
+	columns := make([]string, actualSize)
+	values := make([]interface{}, actualSize)
 
+	idx := 0
 	for _, column := range iter.Columns() {
 		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
 			val, err := column.TypeInfo.NewWithError()
@@ -492,17 +496,19 @@ func (iter *Iter) RowData() (RowData, error) {
 				iter.err = err
 				return RowData{}, err
 			}
-			columns = append(columns, column.Name)
-			values = append(values, val)
+			columns[idx] = column.Name
+			values[idx] = val
+			idx++
 		} else {
 			for i, elem := range c.Elems {
-				columns = append(columns, TupleColumnName(column.Name, i))
+				columns[idx] = TupleColumnName(column.Name, i)
 				val, err := elem.NewWithError()
 				if err != nil {
 					iter.err = err
 					return RowData{}, err
 				}
-				values = append(values, val)
+				values[idx] = val
+				idx++
 			}
 		}
 	}

--- a/helpers_bench_test.go
+++ b/helpers_bench_test.go
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"fmt"
+	"testing"
+)
+
+// createMockIter creates a mock iterator with the specified number of simple columns
+func createMockIter(numColumns int) *Iter {
+	columns := make([]ColumnInfo, numColumns)
+	for i := 0; i < numColumns; i++ {
+		columns[i] = ColumnInfo{
+			Keyspace: "test_keyspace",
+			Table:    "test_table",
+			Name:     fmt.Sprintf("column_%d", i),
+			TypeInfo: NativeType{typ: TypeInt, proto: protoVersion4},
+		}
+	}
+
+	return &Iter{
+		meta: resultMetadata{
+			columns:        columns,
+			colCount:       numColumns,
+			actualColCount: numColumns,
+		},
+		numRows: 1,
+	}
+}
+
+// createMockIterWithTypes creates a mock iterator with varied column types
+func createMockIterWithTypes() *Iter {
+	columns := []ColumnInfo{
+		{Name: "id", TypeInfo: NativeType{typ: TypeInt, proto: protoVersion4}},
+		{Name: "name", TypeInfo: NativeType{typ: TypeVarchar, proto: protoVersion4}},
+		{Name: "created", TypeInfo: NativeType{typ: TypeTimestamp, proto: protoVersion4}},
+		{Name: "score", TypeInfo: NativeType{typ: TypeBigInt, proto: protoVersion4}},
+		{Name: "active", TypeInfo: NativeType{typ: TypeBoolean, proto: protoVersion4}},
+		{Name: "data", TypeInfo: NativeType{typ: TypeBlob, proto: protoVersion4}},
+		{Name: "uuid", TypeInfo: NativeType{typ: TypeUUID, proto: protoVersion4}},
+		{Name: "value", TypeInfo: NativeType{typ: TypeDouble, proto: protoVersion4}},
+		{Name: "count", TypeInfo: NativeType{typ: TypeCounter, proto: protoVersion4}},
+		{Name: "text", TypeInfo: NativeType{typ: TypeText, proto: protoVersion4}},
+	}
+
+	return &Iter{
+		meta: resultMetadata{
+			columns:        columns,
+			colCount:       len(columns),
+			actualColCount: len(columns),
+		},
+		numRows: 1,
+	}
+}
+
+// createMockIterWithTuples creates a mock iterator with tuple columns
+func createMockIterWithTuples() *Iter {
+	// Create a tuple with 3 elements
+	tupleElems := []TypeInfo{
+		NativeType{typ: TypeInt, proto: protoVersion4},
+		NativeType{typ: TypeVarchar, proto: protoVersion4},
+		NativeType{typ: TypeTimestamp, proto: protoVersion4},
+	}
+
+	columns := []ColumnInfo{
+		{Name: "id", TypeInfo: NativeType{typ: TypeInt, proto: protoVersion4}},
+		{Name: "coords", TypeInfo: TupleTypeInfo{
+			NativeType: NativeType{typ: TypeTuple, proto: protoVersion4},
+			Elems:      tupleElems,
+		}},
+		{Name: "name", TypeInfo: NativeType{typ: TypeVarchar, proto: protoVersion4}},
+	}
+
+	// actualColCount accounts for tuple expansion: 1 (id) + 3 (tuple elements) + 1 (name) = 5
+	actualColCount := 1 + len(tupleElems) + 1
+
+	return &Iter{
+		meta: resultMetadata{
+			columns:        columns,
+			colCount:       len(columns),
+			actualColCount: actualColCount,
+		},
+		numRows: 1,
+	}
+}
+
+// BenchmarkRowData measures the performance of RowData() with simple columns
+func BenchmarkRowData(b *testing.B) {
+	iter := createMockIter(10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd, err := iter.RowData()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = rd
+	}
+}
+
+// BenchmarkRowDataSmall measures performance with few columns (typical for narrow tables)
+func BenchmarkRowDataSmall(b *testing.B) {
+	iter := createMockIter(3)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd, err := iter.RowData()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = rd
+	}
+}
+
+// BenchmarkRowDataLarge measures performance with many columns (wide tables)
+func BenchmarkRowDataLarge(b *testing.B) {
+	iter := createMockIter(50)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd, err := iter.RowData()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = rd
+	}
+}
+
+// BenchmarkRowDataWithTypes measures performance with varied column types
+func BenchmarkRowDataWithTypes(b *testing.B) {
+	iter := createMockIterWithTypes()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd, err := iter.RowData()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = rd
+	}
+}
+
+// BenchmarkRowDataWithTuples measures performance with tuple columns
+func BenchmarkRowDataWithTuples(b *testing.B) {
+	iter := createMockIterWithTuples()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd, err := iter.RowData()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = rd
+	}
+}
+
+// BenchmarkRowDataRepeated simulates MapScan calling RowData repeatedly
+func BenchmarkRowDataRepeated(b *testing.B) {
+	iter := createMockIter(10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Simulate 100 rows being scanned with MapScan
+		for j := 0; j < 100; j++ {
+			rd, err := iter.RowData()
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = rd
+		}
+	}
+}
+
+// BenchmarkRowDataAllocation focuses on allocation patterns
+func BenchmarkRowDataAllocation(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		iter *Iter
+	}{
+		{"10cols", createMockIter(10)},
+		{"100cols", createMockIter(100)},
+		{"1000cols", createMockIter(1000)},
+		{"WithTuples", createMockIterWithTuples()},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				rd, err := bm.iter.RowData()
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = rd
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a collection of partially independent and partially dependant (I can, if needed, extract specific ones to their own PRs) optimizations focused on the receive and parsing results path.

They are mostly straightforward and each has its own somewhat lengthy commit message explaining the change.

On the simple benchmark that was added as well (I always ran it o my laptop with `go test -bench=BenchmarkRowData -benchmem -run=^$ -cpu=1 .` ), it shows a very nice performance improvement.
Of course, in real life, latency and other stuff may dominate, but it's a good series, I think.

Pay attention to https://github.com/scylladb/gocql/commit/ca6c1ea8206401f98dde2baa355157e5baa52e34 where I cheat and violate the protocol. If approved, I think we should do the same for other drivers as well.
