### PR TITLE
Drop go minor version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,4 +48,4 @@ retract (
 	v1.8.0 // tag from kiwicom/gocql added by mistake to scylladb/gocql
 )
 
-go 1.25.0
+go 1.25

--- a/lz4/go.mod
+++ b/lz4/go.mod
@@ -17,7 +17,7 @@
 //
 module github.com/gocql/gocql/lz4
 
-go 1.25.0
+go 1.25
 
 require (
 	github.com/pierrec/lz4/v4 v4.1.25

--- a/tests/bench/go.mod
+++ b/tests/bench/go.mod
@@ -1,6 +1,6 @@
 module github.com/gocql/gocql/bench_test
 
-go 1.25.0
+go 1.25
 
 require (
 	github.com/brianvoe/gofakeit/v6 v6.28.0


### PR DESCRIPTION
It does not make sense to target particular minor.

Closes: https://github.com/scylladb/gocql/issues/696