### PR TITLE
Fix: Prevent Policy Sharing in Test Helper Functions

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -242,6 +242,11 @@ func createKeyspace(tb testing.TB, cluster *ClusterConfig, keyspace string, disa
 	c := *cluster
 	c.Keyspace = "system"
 	c.Timeout = 30 * time.Second
+	// Create a fresh policy to avoid sharing the policy instance with the caller.
+	// Shallow copy of cluster config shares the HostSelectionPolicy pointer, which
+	// would cause "sharing token aware host selection policy between sessions" panic
+	// when both createKeyspace's session and the caller's session try to Init() it.
+	c.PoolConfig.HostSelectionPolicy = nil
 	session, err := c.CreateSession()
 	if err != nil {
 		tb.Fatalf("failed to create session: %v", err)


### PR DESCRIPTION
## Problem

Tests that set a custom `HostSelectionPolicy` on their cluster config were failing with the panic:
```
panic: sharing token aware host selection policy between sessions is not supported
```

This occurred when running tests locally, particularly `TestTablets` that configure a custom `TokenAwareHostPolicy`.

## Root Cause

The `createKeyspace()` test helper performs a shallow copy of the cluster config:

```go
c := *cluster  // Shallow copy
c.Keyspace = "system"
session, err := c.CreateSession()
```

In Go, shallow struct copies **share pointer fields**. This means:
- `c.PoolConfig.HostSelectionPolicy` points to the **same policy object** as `cluster.PoolConfig.HostSelectionPolicy`
- When `createKeyspace()` creates a session, it calls `policy.Init()` on the shared policy
- When the test later creates its own session with `createSessionFromCluster()`, it calls `policy.Init()` **again** on the same policy instance
- `TokenAwareHostPolicy.Init()` detects this and panics to prevent undefined behavior

```go
func (t *tokenAwareHostPolicy) Init(s *Session) {
    if t.getKeyspaceMetadata != nil {
        // Init was already called.
        panic("sharing token aware host selection policy between sessions is not supported")
    }
    // ...
}
```

## Solution

Set `c.PoolConfig.HostSelectionPolicy = nil` in `createKeyspace()` before creating the internal session:

```go
c := *cluster
c.Keyspace = "system"
c.Timeout = 30 * time.Second
// Create a fresh policy to avoid sharing the policy instance with the caller
c.PoolConfig.HostSelectionPolicy = nil
session, err := c.CreateSession()
```

This ensures:
1. The shallow-copied config no longer shares the policy pointer
2. The internal session gets its own default policy (created automatically when nil)
3. The test's original cluster config and its custom policy remain untouched
4. Each session has its own policy instance, preventing the panic

## Impact

- **Fixes**: Tests with custom policies that previously panicked on session creation
- **No behavior change**: The internal session created by `createKeyspace()` doesn't need the test's custom policy - it only performs simple DDL operations (DROP/CREATE KEYSPACE)
- **Safe**: Using the default policy for keyspace management operations is appropriate and matches the behavior when no custom policy is configured
- **Test integrity preserved**: The test's custom policy is **NOT** affected. Only the temporary internal session (used for DDL) gets a fresh policy. The actual test session still uses the original custom `TokenAwareHostPolicy` as intended.

## Important: Test Policy Remains Intact

A key concern might be: "Does resetting the policy in `createKeyspace()` affect the test's custom policy?"

**Answer: No, the test's custom policy is unaffected.**

Here's the actual flow:

1. Test sets custom `TokenAwareHostPolicy` on `cluster` config
2. `createSessionFromCluster(cluster, t)` is called
3. Inside it calls `createKeyspace(tb, cluster, ...)`
   - Creates `c := *cluster` (a **copy** of the config)
   - Sets `c.PoolConfig.HostSelectionPolicy = nil` on the **copy only**
   - Creates temporary session with the copy, runs DDL, closes it
   - The **original `cluster` config remains unchanged**
4. Then `cluster.CreateSession()` is called with the **original config**
   - This session uses the **original custom `TokenAwareHostPolicy`**
   - This is the session returned to the test

Therefore, tests like `TestTablets` that verify "TokenAwareHostPolicy works correctly when using tablets" are still testing the custom policy correctly. Only the short-lived internal DDL session uses a default policy.

## Testing

The fix allows tests like `TestTablets` to run successfully with custom `TokenAwareHostPolicy` configurations:

```go
cluster := createCluster()
fallback := RoundRobinHostPolicy()
cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(fallback)
session := createSessionFromCluster(cluster, t)  // No longer panics
```

## Follow Up Issue
#705 