### PR TITLE
Fix Makefile: correct `download-cassandra` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ scylla-start: .prepare-pki .prepare-scylla-ccm .prepare-environment-update-aio-m
 	ccm node1 nodetool status
 	sudo chmod 0777 ${CCM_CONFIG_DIR}/${CCM_SCYLLA_CLUSTER_NAME}/*/cql.m || true
 
-download-cassandra: .prepare-scylla-ccm resolve-cassandra-version
+download-cassandra: .prepare-cassandra-ccm resolve-cassandra-version
 	@if [[ -z "$${CASSANDRA_VERSION_RESOLVED}" ]]; then
 		CASSANDRA_VERSION_RESOLVED=$$(cat '${CASSANDRA_VERSION_FILE}')
 	fi


### PR DESCRIPTION
## Summary

This patch fixes the `download-cassandra` target in the `Makefile` so it depends on the Cassandra CCM preparation target instead of the Scylla CCM target.

## Problem

The `download-cassandra` make target incorrectly depended on `.prepare-scylla-ccm`, which runs Scylla CCM preparation. This causes the wrong CCM installer/configuration step to run when attempting to download or prepare Cassandra.

## Change

- Updated `Makefile` to use the correct dependency:

- `download-cassandra: .prepare-scylla-ccm resolve-cassandra-version`
+ `download-cassandra: .prepare-cassandra-ccm resolve-cassandra-version`

No other functional changes were made.

## Testing

Run the target locally to verify it resolves and prepares the Cassandra CCM environment:

```bash
make download-cassandra
# or run the higher-level flow:
make cassandra-start
```

## Risk

Minimal — this is a small Makefile dependency fix only affecting developer tooling (CCM preparation and test cluster setup). No runtime code or API changes.
