### PR TITLE
(fix) benign fix to a query NOT to contain \t\n

### DIFF
--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -775,10 +775,7 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 	}
 	keyspace := &KeyspaceMetadata{Name: keyspaceName}
 
-	const stmt = `
-		SELECT durable_writes, replication
-		FROM system_schema.keyspaces
-		WHERE keyspace_name = ?`
+	const stmt = `SELECT durable_writes, replication FROM system_schema.keyspaces WHERE keyspace_name = ?`
 
 	var replication map[string]string
 


### PR DESCRIPTION
Found when looking at the Wireshark capture.
This query contains tabs and new lines, since this is how the const was defined. It still seem to work, but was plain confusing and inconsistent (and might break in the future). Fixed by ensuring it's a single line.

We stil have some in test code. Example:
	err = createTable(session, fmt.Sprintf(`CREATE KEYSPACE %s
	WITH replication = {
		'class' : 'NetworkTopologyStrategy',
		'replication_factor' : 1
	}`, keyspace))

I don't think it's important to fix them, so left them as such.