### PR TITLE
Fix refresh all schema

### DIFF
--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -557,7 +557,7 @@ func (s *metadataDescriber) refreshAllSchema() error {
 		}
 
 		for tableName, tableMetadata := range metadata.Tables {
-			if updatedTableMetadata, ok := updatedMetadata.Tables[tableName]; !ok || tableMetadata.Equals(updatedTableMetadata) {
+			if updatedTableMetadata, ok := updatedMetadata.Tables[tableName]; !ok || !tableMetadata.Equals(updatedTableMetadata) {
 				s.RemoveTabletsWithTable(keyspaceName, tableName)
 			}
 		}


### PR DESCRIPTION
This PR fixes inverted table comparison logic in `refreshAllSchema`. Now it correctly removes tablets when tables are different, not when they're equal.