### PR TITLE
perf: use explicit column lists in system.local/peers queries

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -171,6 +171,7 @@ type ConnInterface interface {
 	querySystem(ctx context.Context, query string, values ...any) *Iter
 	getIsSchemaV2() bool
 	setSchemaV2(s bool)
+	isScyllaConn() bool
 	getScyllaSupported() ScyllaConnectionFeatures
 }
 
@@ -1990,10 +1991,11 @@ func (c *Conn) querySystem(ctx context.Context, query string, values ...any) *It
 	return c.executeQuery(ctx, q)
 }
 
-const qrySystemPeers = "SELECT * FROM system.peers"
-const qrySystemPeersV2 = "SELECT * FROM system.peers_v2"
+const qrySystemPeers = "SELECT peer, data_center, host_id, rack, release_version, rpc_address, schema_version, tokens FROM system.peers"
+const qrySystemPeersCassandra = "SELECT peer, data_center, host_id, preferred_ip, rack, release_version, rpc_address, schema_version, tokens FROM system.peers"
+const qrySystemPeersV2 = "SELECT peer, data_center, host_id, native_address, native_port, preferred_ip, rack, release_version, schema_version, tokens FROM system.peers_v2"
 
-const qrySystemLocal = "SELECT * FROM system.local WHERE key='local'"
+const qrySystemLocal = "SELECT broadcast_address, cluster_name, data_center, host_id, listen_address, partitioner, rack, release_version, rpc_address, schema_version, tokens FROM system.local WHERE key='local'"
 
 func getSchemaAgreement(queryLocalSchemasRows []string, querySystemPeersRows []schemaAgreementHost, logger StdLogger) (err error) {
 	versions := make(map[string]struct{})
@@ -2058,7 +2060,7 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 		} else {
 			iter = c.querySystem(ctx, "SELECT host_id, data_center, rack, schema_version, rpc_address FROM system.peers")
 		}
-		// data_center, rack, host_id, schema_version, rpc_address
+		// Scan order: host_id, data_center, rack, schema_version, rpc_address/preferred_ip
 		var hosts []schemaAgreementHost
 		var tmp schemaAgreementHost
 		for iter.Scan(&tmp.HostID, &tmp.DataCenter, &tmp.Rack, &tmp.SchemaVersion, &tmp.RPCAddress) {

--- a/host_source.go
+++ b/host_source.go
@@ -412,18 +412,24 @@ func (h *HostInfo) hostUUID() UUID {
 	return h.hostId
 }
 
+// Deprecated: WorkLoad is a DSE-specific field that is no longer queried
+// from system tables. It will always return "" for hosts discovered via
+// the driver. Only populated if set explicitly via HostInfoBuilder.
 func (h *HostInfo) WorkLoad() string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.workload
 }
 
+// Deprecated: Graph is a DSE-specific field that is no longer queried
+// from system tables. It always returns false.
 func (h *HostInfo) Graph() bool {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return h.graph
+	return false
 }
 
+// Deprecated: DSEVersion is a DSE-specific field that is no longer queried
+// from system tables. It will always return "" for hosts discovered via
+// the driver. Only populated if set explicitly via HostInfoBuilder.
 func (h *HostInfo) DSEVersion() string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -721,25 +727,10 @@ func hostInfoFromMap(row map[string]any, defaultPort int) (*HostInfo, error) {
 				return nil, fmt.Errorf(assertErrorMsg, "native_port")
 			}
 			host.port = native_port
-		case "workload":
-			host.workload, ok = value.(string)
-			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "workload")
-			}
-		case "graph":
-			host.graph, ok = value.(bool)
-			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "graph")
-			}
 		case "tokens":
 			host.tokens, ok = value.([]string)
 			if !ok {
 				return nil, fmt.Errorf(assertErrorMsg, "tokens")
-			}
-		case "dse_version":
-			host.dseVersion, ok = value.(string)
-			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "dse_version")
 			}
 		case "schema_version":
 			schemaVersion, ok := value.(UUID)

--- a/host_source.go
+++ b/host_source.go
@@ -412,21 +412,24 @@ func (h *HostInfo) hostUUID() UUID {
 	return h.hostId
 }
 
+// Deprecated: WorkLoad is a DSE-specific field that is no longer queried
+// from system tables. It will always return "" for hosts discovered via
+// the driver. Only populated if set explicitly via HostInfoBuilder.
 func (h *HostInfo) WorkLoad() string {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
 	return h.workload
 }
 
+// Deprecated: Graph is a DSE-specific field that is no longer queried
+// from system tables. It will always return false for hosts discovered via
+// the driver.
 func (h *HostInfo) Graph() bool {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return h.graph
+	return false
 }
 
+// Deprecated: DSEVersion is a DSE-specific field that is no longer queried
+// from system tables. It will always return "" for hosts discovered via
+// the driver. Only populated if set explicitly via HostInfoBuilder.
 func (h *HostInfo) DSEVersion() string {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
 	return h.dseVersion
 }
 
@@ -721,25 +724,10 @@ func hostInfoFromMap(row map[string]any, defaultPort int) (*HostInfo, error) {
 				return nil, fmt.Errorf(assertErrorMsg, "native_port")
 			}
 			host.port = native_port
-		case "workload":
-			host.workload, ok = value.(string)
-			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "workload")
-			}
-		case "graph":
-			host.graph, ok = value.(bool)
-			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "graph")
-			}
 		case "tokens":
 			host.tokens, ok = value.([]string)
 			if !ok {
 				return nil, fmt.Errorf(assertErrorMsg, "tokens")
-			}
-		case "dse_version":
-			host.dseVersion, ok = value.(string)
-			if !ok {
-				return nil, fmt.Errorf(assertErrorMsg, "dse_version")
 			}
 		case "schema_version":
 			schemaVersion, ok := value.(UUID)

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -205,25 +205,20 @@ func TestCheckSystemSchemaClosesIter(t *testing.T) {
 func TestHostInfoFromIterClosesIter(t *testing.T) {
 	t.Parallel()
 
+	// Column order matches systemLocalResultMetadata:
+	// broadcast_address, cluster_name, data_center, host_id, listen_address, partitioner, rack, release_version, rpc_address, schema_version, tokens
 	row := []any{
-		"local",
-		"COMPLETED",
 		net.IPv4(192, 168, 100, 12),
 		"cluster",
-		"3.3.1",
 		"datacenter1",
-		1733834239,
 		ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"),
 		net.IPv4(192, 168, 100, 12),
-		"4",
 		"org.apache.cassandra.dht.Murmur3Partitioner",
 		"rack1",
 		"3.0.8",
 		net.IPv4(192, 168, 100, 12),
 		ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"),
-		"",
 		[]string{"1"},
-		map[UUID]byte{},
 	}
 	framer := &trackingMockFramer{
 		MockFramer: mock.MockFramer{Data: marshalMetadataMust(systemLocalResultMetadata, row)},

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -206,24 +206,17 @@ func TestHostInfoFromIterClosesIter(t *testing.T) {
 	t.Parallel()
 
 	row := []any{
-		"local",
-		"COMPLETED",
 		net.IPv4(192, 168, 100, 12),
 		"cluster",
-		"3.3.1",
 		"datacenter1",
-		1733834239,
 		ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"),
 		net.IPv4(192, 168, 100, 12),
-		"4",
 		"org.apache.cassandra.dht.Murmur3Partitioner",
 		"rack1",
 		"3.0.8",
 		net.IPv4(192, 168, 100, 12),
 		ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"),
-		"",
 		[]string{"1"},
-		map[UUID]byte{},
 	}
 	framer := &trackingMockFramer{
 		MockFramer: mock.MockFramer{Data: marshalMetadataMust(systemLocalResultMetadata, row)},

--- a/ring_describer.go
+++ b/ring_describer.go
@@ -48,8 +48,10 @@ func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo, c ConnInterface)
 	var iter *Iter
 	if c.getIsSchemaV2() {
 		iter = c.querySystem(context.TODO(), qrySystemPeersV2)
-	} else {
+	} else if c.isScyllaConn() {
 		iter = c.querySystem(context.TODO(), qrySystemPeers)
+	} else {
+		iter = c.querySystem(context.TODO(), qrySystemPeersCassandra)
 	}
 
 	if iter == nil {

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -97,18 +97,8 @@ func (*mockConnection) executeQuery(ctx context.Context, qry *Query) *Iter { ret
 var systemLocalResultMetadata = resultMetadata{
 	flags:          0,
 	pagingState:    []byte{},
-	actualColCount: 18,
+	actualColCount: 11,
 	columns: []ColumnInfo{{
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "key",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "bootstrapped",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
 		Keyspace: "system",
 		Table:    "local",
 		Name:     "broadcast_address",
@@ -121,18 +111,8 @@ var systemLocalResultMetadata = resultMetadata{
 	}, {
 		Keyspace: "system",
 		Table:    "local",
-		Name:     "cql_version",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
 		Name:     "data_center",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "gossip_generation",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInt},
 	}, {
 		Keyspace: "system",
 		Table:    "local",
@@ -143,11 +123,6 @@ var systemLocalResultMetadata = resultMetadata{
 		Table:    "local",
 		Name:     "listen_address",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "native_protocol_version",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
 		Table:    "local",
@@ -176,25 +151,10 @@ var systemLocalResultMetadata = resultMetadata{
 	}, {
 		Keyspace: "system",
 		Table:    "local",
-		Name:     "supported_features",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
 		Name:     "tokens",
 		TypeInfo: CollectionType{
 			NativeType: NativeType{proto: protoVersion4, typ: TypeSet},
 			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
-		},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "truncated_at",
-		TypeInfo: CollectionType{
-			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
-
-			Key:  NativeType{proto: protoVersion4, typ: TypeUUID},
-			Elem: NativeType{proto: protoVersion4, typ: TypeBlob},
 		},
 	}},
 }
@@ -202,55 +162,50 @@ var systemLocalResultMetadata = resultMetadata{
 var systemPeersResultMetadata = resultMetadata{
 	flags:          0,
 	pagingState:    []byte{},
-	actualColCount: 10,
+	actualColCount: 9,
 	columns: []ColumnInfo{{
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "peer",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "data_center",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "host_id",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeUUID},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "preferred_ip",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "rack",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "release_version",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "rpc_address",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "schema_version",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeUUID},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
-		Name:     "supported_features",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "tokens",
 		TypeInfo: CollectionType{
 			NativeType: NativeType{proto: protoVersion4, typ: TypeSet},
@@ -260,18 +215,22 @@ var systemPeersResultMetadata = resultMetadata{
 }
 
 func (*mockConnection) querySystem(ctx context.Context, query string, values ...any) *Iter {
-	localData := []any{"local", "COMPLETED", net.IPv4(192, 168, 100, 12), "", "3.3.1", "datacenter1", 1733834239, ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"), net.IPv4(192, 168, 100, 12), "4", "org.apache.cassandra.dht.Murmur3Partitioner", "rack1", "3.0.8", net.IPv4(192, 168, 100, 12), ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"), "", []string{}, map[UUID]byte{}}
-	peerData1 := []any{net.IPv4(192, 168, 100, 13), "datacenter1", ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 13), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{"-1032311531684407545", "-1112089412567859825"}}
-	peerData2 := []any{net.IPv4(192, 168, 100, 14), "datacenter1", ParseUUIDMust("8269e111-ea38-44bd-a73f-9d3d12cfaf78"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 14), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{}}
+	// Column order matches the explicit SELECT in qrySystemLocal:
+	// broadcast_address, cluster_name, data_center, host_id, listen_address, partitioner, rack, release_version, rpc_address, schema_version, tokens
+	localData := []any{net.IPv4(192, 168, 100, 12), "", "datacenter1", ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"), net.IPv4(192, 168, 100, 12), "org.apache.cassandra.dht.Murmur3Partitioner", "rack1", "3.0.8", net.IPv4(192, 168, 100, 12), ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"), []string{}}
+	// Column order matches the explicit SELECT in qrySystemPeersCassandra:
+	// peer, data_center, host_id, preferred_ip, rack, release_version, rpc_address, schema_version, tokens
+	peerData1 := []any{net.IPv4(192, 168, 100, 13), "datacenter1", ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 13), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), []string{"-1032311531684407545", "-1112089412567859825"}}
+	peerData2 := []any{net.IPv4(192, 168, 100, 14), "datacenter1", ParseUUIDMust("8269e111-ea38-44bd-a73f-9d3d12cfaf78"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 14), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), []string{}}
 
-	if query == "SELECT * FROM system.local WHERE key='local'" {
+	if query == qrySystemLocal {
 		return &Iter{
 			meta:    systemLocalResultMetadata,
 			framer:  &mock.MockFramer{Data: marshalMetadataMust(systemLocalResultMetadata, localData)},
 			numRows: 1,
 			next:    nil,
 		}
-	} else if query == "SELECT * FROM system.peers" {
+	} else if query == qrySystemPeersCassandra {
 		return &Iter{
 			meta:    systemPeersResultMetadata,
 			framer:  &mock.MockFramer{Data: append(marshalMetadataMust(systemPeersResultMetadata, peerData1), marshalMetadataMust(systemPeersResultMetadata, peerData2)...)},
@@ -284,6 +243,7 @@ func (*mockConnection) querySystem(ctx context.Context, query string, values ...
 
 func (*mockConnection) getIsSchemaV2() bool { return false }
 func (*mockConnection) setSchemaV2(s bool)  {}
+func (*mockConnection) isScyllaConn() bool  { return false }
 func (*mockConnection) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }
@@ -344,6 +304,7 @@ func (c *trackingRingConnection) querySystem(context.Context, string, ...any) *I
 }
 func (c *trackingRingConnection) getIsSchemaV2() bool { return c.schemaV2 }
 func (*trackingRingConnection) setSchemaV2(bool)      {}
+func (*trackingRingConnection) isScyllaConn() bool    { return false }
 func (*trackingRingConnection) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }
@@ -375,7 +336,6 @@ func TestRingDescriberGetClusterPeerInfoClosesIter(t *testing.T) {
 		"3.0.8",
 		net.IPv4(192, 168, 100, 13),
 		ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"),
-		"",
 		[]string{"-1032311531684407545"},
 	}
 	framer := &trackingMockFramer{

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -97,18 +97,8 @@ func (*mockConnection) executeQuery(ctx context.Context, qry *Query) *Iter { ret
 var systemLocalResultMetadata = resultMetadata{
 	flags:          0,
 	pagingState:    []byte{},
-	actualColCount: 18,
+	actualColCount: 11,
 	columns: []ColumnInfo{{
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "key",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "bootstrapped",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
 		Keyspace: "system",
 		Table:    "local",
 		Name:     "broadcast_address",
@@ -121,18 +111,8 @@ var systemLocalResultMetadata = resultMetadata{
 	}, {
 		Keyspace: "system",
 		Table:    "local",
-		Name:     "cql_version",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
 		Name:     "data_center",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "gossip_generation",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInt},
 	}, {
 		Keyspace: "system",
 		Table:    "local",
@@ -143,11 +123,6 @@ var systemLocalResultMetadata = resultMetadata{
 		Table:    "local",
 		Name:     "listen_address",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "native_protocol_version",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
 		Table:    "local",
@@ -176,25 +151,10 @@ var systemLocalResultMetadata = resultMetadata{
 	}, {
 		Keyspace: "system",
 		Table:    "local",
-		Name:     "supported_features",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
 		Name:     "tokens",
 		TypeInfo: CollectionType{
 			NativeType: NativeType{proto: protoVersion4, typ: TypeSet},
 			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
-		},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
-		Name:     "truncated_at",
-		TypeInfo: CollectionType{
-			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
-
-			Key:  NativeType{proto: protoVersion4, typ: TypeUUID},
-			Elem: NativeType{proto: protoVersion4, typ: TypeBlob},
 		},
 	}},
 }
@@ -202,55 +162,50 @@ var systemLocalResultMetadata = resultMetadata{
 var systemPeersResultMetadata = resultMetadata{
 	flags:          0,
 	pagingState:    []byte{},
-	actualColCount: 10,
+	actualColCount: 9,
 	columns: []ColumnInfo{{
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "peer",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "data_center",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "host_id",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeUUID},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "preferred_ip",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "rack",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "release_version",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "rpc_address",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeInet},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "schema_version",
 		TypeInfo: NativeType{proto: protoVersion4, typ: TypeUUID},
 	}, {
 		Keyspace: "system",
-		Table:    "local",
-		Name:     "supported_features",
-		TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar},
-	}, {
-		Keyspace: "system",
-		Table:    "local",
+		Table:    "peers",
 		Name:     "tokens",
 		TypeInfo: CollectionType{
 			NativeType: NativeType{proto: protoVersion4, typ: TypeSet},
@@ -260,18 +215,22 @@ var systemPeersResultMetadata = resultMetadata{
 }
 
 func (*mockConnection) querySystem(ctx context.Context, query string, values ...any) *Iter {
-	localData := []any{"local", "COMPLETED", net.IPv4(192, 168, 100, 12), "", "3.3.1", "datacenter1", 1733834239, ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"), net.IPv4(192, 168, 100, 12), "4", "org.apache.cassandra.dht.Murmur3Partitioner", "rack1", "3.0.8", net.IPv4(192, 168, 100, 12), ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"), "", []string{}, map[UUID]byte{}}
-	peerData1 := []any{net.IPv4(192, 168, 100, 13), "datacenter1", ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 13), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{"-1032311531684407545", "-1112089412567859825"}}
-	peerData2 := []any{net.IPv4(192, 168, 100, 14), "datacenter1", ParseUUIDMust("8269e111-ea38-44bd-a73f-9d3d12cfaf78"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 14), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{}}
+	// Column order matches the explicit SELECT in qrySystemLocal:
+	// broadcast_address, cluster_name, data_center, host_id, listen_address, partitioner, rack, release_version, rpc_address, schema_version, tokens
+	localData := []any{net.IPv4(192, 168, 100, 12), "", "datacenter1", ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"), net.IPv4(192, 168, 100, 12), "org.apache.cassandra.dht.Murmur3Partitioner", "rack1", "3.0.8", net.IPv4(192, 168, 100, 12), ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"), []string{}}
+	// Column order matches the explicit SELECT in qrySystemPeersCassandra:
+	// peer, data_center, host_id, preferred_ip, rack, release_version, rpc_address, schema_version, tokens
+	peerData1 := []any{net.IPv4(192, 168, 100, 13), "datacenter1", ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 13), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), []string{"-1032311531684407545", "-1112089412567859825"}}
+	peerData2 := []any{net.IPv4(192, 168, 100, 14), "datacenter1", ParseUUIDMust("8269e111-ea38-44bd-a73f-9d3d12cfaf78"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 14), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), []string{}}
 
-	if query == "SELECT * FROM system.local WHERE key='local'" {
+	if query == qrySystemLocal {
 		return &Iter{
 			meta:    systemLocalResultMetadata,
 			framer:  &mock.MockFramer{Data: marshalMetadataMust(systemLocalResultMetadata, localData)},
 			numRows: 1,
 			next:    nil,
 		}
-	} else if query == "SELECT * FROM system.peers" {
+	} else if query == qrySystemPeersCassandra {
 		return &Iter{
 			meta:    systemPeersResultMetadata,
 			framer:  &mock.MockFramer{Data: append(marshalMetadataMust(systemPeersResultMetadata, peerData1), marshalMetadataMust(systemPeersResultMetadata, peerData2)...)},
@@ -284,6 +243,7 @@ func (*mockConnection) querySystem(ctx context.Context, query string, values ...
 
 func (*mockConnection) getIsSchemaV2() bool { return false }
 func (*mockConnection) setSchemaV2(s bool)  {}
+func (*mockConnection) isScyllaConn() bool  { return false }
 func (*mockConnection) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }
@@ -347,6 +307,7 @@ func (*trackingRingConnection) setSchemaV2(bool)      {}
 func (*trackingRingConnection) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }
+func (*trackingRingConnection) isScyllaConn() bool { return false }
 
 func TestMockGetHostsFromSystem(t *testing.T) {
 	t.Parallel()
@@ -375,7 +336,6 @@ func TestRingDescriberGetClusterPeerInfoClosesIter(t *testing.T) {
 		"3.0.8",
 		net.IPv4(192, 168, 100, 13),
 		ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"),
-		"",
 		[]string{"-1032311531684407545"},
 	}
 	framer := &trackingMockFramer{

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -289,8 +289,10 @@ func marshalMetadataMust(metadata resultMetadata, data []any) [][]byte {
 }
 
 type trackingRingConnection struct {
-	iter     *Iter
-	schemaV2 bool
+	iter      *Iter
+	schemaV2  bool
+	scylla    bool
+	lastQuery string
 }
 
 func (*trackingRingConnection) Close() {}
@@ -299,12 +301,13 @@ func (*trackingRingConnection) exec(context.Context, frameBuilder, Tracer, time.
 }
 func (*trackingRingConnection) awaitSchemaAgreement(context.Context) error { return nil }
 func (*trackingRingConnection) executeQuery(context.Context, *Query) *Iter { return nil }
-func (c *trackingRingConnection) querySystem(context.Context, string, ...any) *Iter {
+func (c *trackingRingConnection) querySystem(_ context.Context, q string, _ ...any) *Iter {
+	c.lastQuery = q
 	return c.iter
 }
 func (c *trackingRingConnection) getIsSchemaV2() bool { return c.schemaV2 }
 func (*trackingRingConnection) setSchemaV2(bool)      {}
-func (*trackingRingConnection) isScyllaConn() bool    { return false }
+func (c *trackingRingConnection) isScyllaConn() bool  { return c.scylla }
 func (*trackingRingConnection) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }
@@ -358,6 +361,36 @@ func TestRingDescriberGetClusterPeerInfoClosesIter(t *testing.T) {
 	}
 	if !framer.released {
 		t.Fatal("expected iterator framer to be released")
+	}
+}
+
+func TestGetClusterPeerInfoQueryRouting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		schemaV2  bool
+		scylla    bool
+		wantQuery string
+	}{
+		{"schema_v2", true, false, qrySystemPeersV2},
+		{"scylla_peers", false, true, qrySystemPeers},
+		{"cassandra_peers", false, false, qrySystemPeersCassandra},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &trackingRingConnection{
+				schemaV2: tt.schemaV2,
+				scylla:   tt.scylla,
+			}
+			r := &ringDescriber{cfg: &ClusterConfig{}}
+			// iter is nil so getClusterPeerInfo returns errNoControl, but the query is still recorded
+			_, _ = r.getClusterPeerInfo(&HostInfo{}, conn)
+			if conn.lastQuery != tt.wantQuery {
+				t.Errorf("got query %q, want %q", conn.lastQuery, tt.wantQuery)
+			}
+		})
 	}
 }
 

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -530,6 +530,7 @@ func (c *pagingTestConn) executeQuery(ctx context.Context, qry *Query) *Iter {
 func (*pagingTestConn) querySystem(context.Context, string, ...any) *Iter { return nil }
 func (*pagingTestConn) getIsSchemaV2() bool                               { return false }
 func (*pagingTestConn) setSchemaV2(bool)                                  {}
+func (*pagingTestConn) isScyllaConn() bool                                { return false }
 func (*pagingTestConn) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -532,6 +532,7 @@ func (*pagingTestConn) setSchemaV2(bool)                                  {}
 func (*pagingTestConn) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }
+func (*pagingTestConn) isScyllaConn() bool { return false }
 
 type fixedRetryPolicy struct {
 	maxRetries int


### PR DESCRIPTION
Replace SELECT * with explicit column lists in qrySystemLocal, qrySystemPeers, and qrySystemPeersV2 to reduce the amount of data transferred from the server during topology discovery and control connection setup. Only columns actually consumed by hostInfoFromMap are now fetched.

This mirrors the same optimization done in the Python driver (scylladb/python-driver#528).

Fixes: https://scylladb.atlassian.net/browse/DRIVER-366