### PR TITLE
feat: Table-level schema cache invalidation and refresh

### DIFF
--- a/events.go
+++ b/events.go
@@ -152,17 +152,17 @@ func (s *Session) handleSchemaEvent(frames []frame) {
 	for _, frame := range frames {
 		switch f := frame.(type) {
 		case *frm.SchemaChangeKeyspace:
-			s.metadataDescriber.clearSchema(f.Keyspace)
+			s.metadataDescriber.invalidateKeyspaceSchema(f.Keyspace)
 			s.handleKeyspaceChange(f.Keyspace, f.Change)
 		case *frm.SchemaChangeTable:
-			s.metadataDescriber.clearSchema(f.Keyspace)
+			s.metadataDescriber.invalidateTableSchema(f.Keyspace, f.Object)
 			s.handleTableChange(f.Keyspace, f.Object, f.Change)
 		case *frm.SchemaChangeAggregate:
-			s.metadataDescriber.clearSchema(f.Keyspace)
+			s.metadataDescriber.invalidateKeyspaceSchema(f.Keyspace)
 		case *frm.SchemaChangeFunction:
-			s.metadataDescriber.clearSchema(f.Keyspace)
+			s.metadataDescriber.invalidateKeyspaceSchema(f.Keyspace)
 		case *frm.SchemaChangeType:
-			s.metadataDescriber.clearSchema(f.Keyspace)
+			s.metadataDescriber.invalidateKeyspaceSchema(f.Keyspace)
 		}
 	}
 }

--- a/events_unit_test.go
+++ b/events_unit_test.go
@@ -1,0 +1,1075 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql/internal/tests/mock"
+	"github.com/gocql/gocql/tablets"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+var (
+	typeVarchar = NativeType{proto: 4, typ: TypeVarchar}
+	typeBoolean = NativeType{proto: 4, typ: TypeBoolean}
+	typeDouble  = NativeType{proto: 4, typ: TypeDouble}
+	typeInt     = NativeType{proto: 4, typ: TypeInt}
+	typeMapSS   = CollectionType{
+		NativeType: NativeType{proto: 4, typ: TypeMap},
+		Key:        NativeType{proto: 4, typ: TypeVarchar},
+		Elem:       NativeType{proto: 4, typ: TypeVarchar},
+	}
+	typeMapSB = CollectionType{
+		NativeType: NativeType{proto: 4, typ: TypeMap},
+		Key:        NativeType{proto: 4, typ: TypeVarchar},
+		Elem:       NativeType{proto: 4, typ: TypeBlob},
+	}
+	typeSetS = CollectionType{
+		NativeType: NativeType{proto: 4, typ: TypeSet},
+		Elem:       NativeType{proto: 4, typ: TypeVarchar},
+	}
+)
+
+var keyspaceMeta = resultMetadata{
+	columns: []ColumnInfo{
+		{Name: "durable_writes", TypeInfo: typeBoolean},
+		{Name: "replication", TypeInfo: typeMapSS},
+	},
+	actualColCount: 2,
+	colCount:       2,
+}
+
+var tableMeta = resultMetadata{
+	columns: []ColumnInfo{
+		{Name: "table_name", TypeInfo: typeVarchar},
+		{Name: "bloom_filter_fp_chance", TypeInfo: typeDouble},
+		{Name: "caching", TypeInfo: typeMapSS},
+		{Name: "comment", TypeInfo: typeVarchar},
+		{Name: "compaction", TypeInfo: typeMapSS},
+		{Name: "compression", TypeInfo: typeMapSS},
+		{Name: "crc_check_chance", TypeInfo: typeDouble},
+		{Name: "default_time_to_live", TypeInfo: typeInt},
+		{Name: "gc_grace_seconds", TypeInfo: typeInt},
+		{Name: "max_index_interval", TypeInfo: typeInt},
+		{Name: "memtable_flush_period_in_ms", TypeInfo: typeInt},
+		{Name: "min_index_interval", TypeInfo: typeInt},
+		{Name: "speculative_retry", TypeInfo: typeVarchar},
+		{Name: "flags", TypeInfo: typeSetS},
+		{Name: "extensions", TypeInfo: typeMapSB},
+	},
+	actualColCount: 15,
+	colCount:       15,
+}
+
+var columnMeta = resultMetadata{
+	columns: []ColumnInfo{
+		{Name: "table_name", TypeInfo: typeVarchar},
+		{Name: "column_name", TypeInfo: typeVarchar},
+		{Name: "clustering_order", TypeInfo: typeVarchar},
+		{Name: "type", TypeInfo: typeVarchar},
+		{Name: "kind", TypeInfo: typeVarchar},
+		{Name: "position", TypeInfo: typeInt},
+	},
+	actualColCount: 6,
+	colCount:       6,
+}
+
+func mustMarshal(info TypeInfo, value interface{}) []byte {
+	b, err := Marshal(info, value)
+	if err != nil {
+		panic(fmt.Sprintf("mustMarshal(%v, %v): %v", info, value, err))
+	}
+	return b
+}
+
+func marshalRow(meta resultMetadata, values []interface{}) [][]byte {
+	if len(meta.columns) != len(values) {
+		panic(fmt.Sprintf("marshalRow: column count %d != value count %d", len(meta.columns), len(values)))
+	}
+	row := make([][]byte, len(values))
+	for i, col := range meta.columns {
+		row[i] = mustMarshal(col.TypeInfo, values[i])
+	}
+	return row
+}
+
+func makeKeyspaceRow(durableWrites bool) [][]byte {
+	replication := map[string]string{
+		"class":              "org.apache.cassandra.locator.SimpleStrategy",
+		"replication_factor": "1",
+	}
+	return marshalRow(keyspaceMeta, []interface{}{durableWrites, replication})
+}
+
+func makeTableRow(tableName string) [][]byte {
+	return marshalRow(tableMeta, []interface{}{
+		tableName,              // table_name
+		float64(0.01),          // bloom_filter_fp_chance
+		map[string]string(nil), // caching
+		"",                     // comment
+		map[string]string(nil), // compaction
+		map[string]string(nil), // compression
+		float64(0),             // crc_check_chance
+		0,                      // default_time_to_live
+		0,                      // gc_grace_seconds
+		0,                      // max_index_interval
+		0,                      // memtable_flush_period_in_ms
+		0,                      // min_index_interval
+		"",                     // speculative_retry
+		[]string(nil),          // flags
+		map[string][]byte(nil), // extensions
+	})
+}
+
+func makeColumnRow(tableName, colName, kind string, position int) [][]byte {
+	return marshalRow(columnMeta, []interface{}{
+		tableName, // table_name
+		colName,   // column_name
+		"none",    // clustering_order
+		"int",     // type
+		kind,      // kind
+		position,  // position
+	})
+}
+
+func makeIter(meta resultMetadata, rows ...[][]byte) *Iter {
+	if len(rows) == 0 {
+		return &Iter{}
+	}
+	var allData [][]byte
+	for _, row := range rows {
+		allData = append(allData, row...)
+	}
+	return &Iter{
+		meta:    meta,
+		framer:  &mock.MockFramer{Data: allData},
+		numRows: len(rows),
+	}
+}
+
+type tableInfo struct {
+	name    string
+	columns []columnInfo
+}
+
+type columnInfo struct {
+	name     string
+	kind     string // "partition_key", "clustering", "regular"
+	position int
+}
+
+type schemaDataMock struct {
+	fakeControlConn
+
+	mu                        sync.Mutex
+	awaitSchemaAgreementCalls int
+	queries                   []queryRecord
+
+	knownKeyspaces map[string][]tableInfo
+	queryDelay     time.Duration
+}
+
+func (m *schemaDataMock) awaitSchemaAgreement() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.awaitSchemaAgreementCalls++
+	return nil
+}
+
+func (m *schemaDataMock) query(statement string, values ...interface{}) *Iter {
+	m.mu.Lock()
+	m.queries = append(m.queries, queryRecord{method: "query", stmt: statement})
+	delay := m.queryDelay
+	m.mu.Unlock()
+
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	return &Iter{}
+}
+
+func (m *schemaDataMock) querySystem(statement string, values ...interface{}) *Iter {
+	m.mu.Lock()
+	m.queries = append(m.queries, queryRecord{method: "querySystem", stmt: statement})
+	delay := m.queryDelay
+	m.mu.Unlock()
+
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	if strings.HasPrefix(statement, "SELECT durable_writes, replication FROM system_schema.keyspaces") {
+		ksName, _ := values[0].(string)
+		if _, ok := m.knownKeyspaces[ksName]; ok {
+			return makeIter(keyspaceMeta, makeKeyspaceRow(true))
+		}
+		return &Iter{}
+	}
+
+	if strings.HasPrefix(statement, "SELECT * FROM system_schema.tables WHERE keyspace_name = ?") &&
+		!strings.Contains(statement, "AND table_name") {
+		ksName, _ := values[0].(string)
+		tables, ok := m.knownKeyspaces[ksName]
+		if !ok || len(tables) == 0 {
+			return &Iter{}
+		}
+		var rows [][]byte
+		for _, t := range tables {
+			rows = append(rows, makeTableRow(t.name)...)
+		}
+		return &Iter{
+			meta:    tableMeta,
+			framer:  &mock.MockFramer{Data: rows},
+			numRows: len(tables),
+		}
+	}
+
+	if strings.HasPrefix(statement, "SELECT * FROM system_schema.tables WHERE keyspace_name = ? AND table_name = ?") {
+		ksName, _ := values[0].(string)
+		tblName, _ := values[1].(string)
+		tables, ok := m.knownKeyspaces[ksName]
+		if ok {
+			for _, t := range tables {
+				if t.name == tblName {
+					return makeIter(tableMeta, makeTableRow(t.name))
+				}
+			}
+		}
+		return &Iter{}
+	}
+
+	if strings.HasPrefix(statement, "SELECT * FROM system_schema.columns WHERE keyspace_name = ?") &&
+		!strings.Contains(statement, "AND table_name") {
+		ksName, _ := values[0].(string)
+		tables, ok := m.knownKeyspaces[ksName]
+		if !ok {
+			return &Iter{}
+		}
+		var rows [][]byte
+		count := 0
+		for _, t := range tables {
+			for _, c := range t.columns {
+				rows = append(rows, makeColumnRow(t.name, c.name, c.kind, c.position)...)
+				count++
+			}
+		}
+		if count == 0 {
+			return &Iter{}
+		}
+		return &Iter{
+			meta:    columnMeta,
+			framer:  &mock.MockFramer{Data: rows},
+			numRows: count,
+		}
+	}
+
+	if strings.HasPrefix(statement, "SELECT * FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?") {
+		ksName, _ := values[0].(string)
+		tblName, _ := values[1].(string)
+		tables, ok := m.knownKeyspaces[ksName]
+		if !ok {
+			return &Iter{}
+		}
+		var rows [][]byte
+		count := 0
+		for _, t := range tables {
+			if t.name != tblName {
+				continue
+			}
+			for _, c := range t.columns {
+				rows = append(rows, makeColumnRow(t.name, c.name, c.kind, c.position)...)
+				count++
+			}
+		}
+		if count == 0 {
+			return &Iter{}
+		}
+		return &Iter{
+			meta:    columnMeta,
+			framer:  &mock.MockFramer{Data: rows},
+			numRows: count,
+		}
+	}
+
+	return &Iter{}
+}
+
+func (m *schemaDataMock) resetQueries() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.queries = nil
+}
+
+func (m *schemaDataMock) getStatements() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	stmts := make([]string, len(m.queries))
+	for i, q := range m.queries {
+		stmts[i] = q.stmt
+	}
+	return stmts
+}
+
+func (m *schemaDataMock) getQueryCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.queries)
+}
+
+func (m *schemaDataMock) getAwaitSchemaAgreementCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.awaitSchemaAgreementCalls
+}
+
+func newSchemaEventTestSession(control controlConnection, policy HostSelectionPolicy, keyspace string) *Session {
+	s := &Session{
+		control: control,
+		policy:  policy,
+		logger:  log.Default(),
+		cfg:     ClusterConfig{Keyspace: keyspace},
+	}
+	s.hostSource = &ringDescriber{cfg: &s.cfg, logger: s.logger}
+	s.metadataDescriber = &metadataDescriber{
+		session: s,
+		metadata: &Metadata{
+			tabletsMetadata: tablets.NewCowTabletList(),
+		},
+	}
+	return s
+}
+
+func newSchemaEventTestSessionWithMock(mockCtrl *schemaDataMock) *Session {
+	s := newSchemaEventTestSession(mockCtrl, &trackingPolicy{}, "")
+	s.useSystemSchema = true
+	s.hasAggregatesAndFunctions = false
+	return s
+}
+
+func populateKeyspace(s *Session, ksName string, tableNames ...string) {
+	ks := &KeyspaceMetadata{
+		Name:          ksName,
+		DurableWrites: true,
+		Tables:        make(map[string]*TableMetadata),
+	}
+	for _, tbl := range tableNames {
+		ks.Tables[tbl] = &TableMetadata{
+			Keyspace: ksName,
+			Name:     tbl,
+			Columns: map[string]*ColumnMetadata{
+				"id": {Keyspace: ksName, Table: tbl, Name: "id", Kind: ColumnPartitionKey},
+			},
+		}
+	}
+	s.metadataDescriber.metadata.keyspaceMetadata.set(ksName, ks)
+}
+
+type trackingPolicy struct {
+	roundRobinHostPolicy
+	mu                   sync.Mutex
+	keyspaceChangedCalls []KeyspaceUpdateEvent
+}
+
+func (t *trackingPolicy) KeyspaceChanged(event KeyspaceUpdateEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.keyspaceChangedCalls = append(t.keyspaceChangedCalls, event)
+}
+
+func (t *trackingPolicy) getKeyspaceChangedCalls() []KeyspaceUpdateEvent {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	dst := make([]KeyspaceUpdateEvent, len(t.keyspaceChangedCalls))
+	copy(dst, t.keyspaceChangedCalls)
+	return dst
+}
+
+type queryRecord struct {
+	method string
+	stmt   string
+}
+
+func addTestTablets(t *testing.T, session *Session, ksName, tblName string) {
+	t.Helper()
+	t1, err := tablets.TabletInfoBuilder{
+		KeyspaceName: ksName,
+		TableName:    tblName,
+		FirstToken:   0,
+		LastToken:    100,
+	}.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t2, err := tablets.TabletInfoBuilder{
+		KeyspaceName: ksName,
+		TableName:    tblName,
+		FirstToken:   101,
+		LastToken:    200,
+	}.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.metadataDescriber.AddTablet(t1)
+	session.metadataDescriber.AddTablet(t2)
+}
+
+func TestHandleSchemaEvent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cache_state", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name           string
+			keyspaces      map[string][]string // ks → tables to pre-populate
+			tablets        [][2]string         // (ks, table) pairs to add tablets for
+			event          frame
+			wantKsGone     []string    // keyspaces removed from cache
+			wantKsPresent  []string    // keyspaces still in cache
+			wantTblGone    [][2]string // (ks, table) removed from Tables map
+			wantTblPresent [][2]string // (ks, table) still in Tables map
+			wantTblInvalid [][2]string // (ks, table) in tablesInvalidated
+			wantTablets    int         // expected tablet count; -1 to skip check
+		}{
+			{
+				name:        "keyspace/CREATED clears cache",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				event:       &frm.SchemaChangeKeyspace{Change: "CREATED", Keyspace: "test_ks"},
+				wantKsGone:  []string{"test_ks"},
+				wantTablets: -1,
+			},
+			{
+				name:        "keyspace/UPDATED clears cache and removes tablets",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
+				tablets:     [][2]string{{"test_ks", "tbl_a"}},
+				event:       &frm.SchemaChangeKeyspace{Change: "UPDATED", Keyspace: "test_ks"},
+				wantKsGone:  []string{"test_ks"},
+				wantTablets: 0,
+			},
+			{
+				name:        "keyspace/DROPPED clears cache and removes tablets",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
+				tablets:     [][2]string{{"test_ks", "tbl_a"}},
+				event:       &frm.SchemaChangeKeyspace{Change: "DROPPED", Keyspace: "test_ks"},
+				wantKsGone:  []string{"test_ks"},
+				wantTablets: 0,
+			},
+			{
+				name:        "keyspace/CREATED does not remove tablets",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
+				tablets:     [][2]string{{"test_ks", "tbl_a"}},
+				event:       &frm.SchemaChangeKeyspace{Change: "CREATED", Keyspace: "test_ks"},
+				wantKsGone:  []string{"test_ks"},
+				wantTablets: 2,
+			},
+			{
+				name:           "table/CREATED invalidates table only",
+				keyspaces:      map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				event:          &frm.SchemaChangeTable{Change: "CREATED", Keyspace: "test_ks", Object: "tbl_a"},
+				wantKsPresent:  []string{"test_ks"},
+				wantTblGone:    [][2]string{{"test_ks", "tbl_a"}},
+				wantTblPresent: [][2]string{{"test_ks", "tbl_b"}},
+				wantTblInvalid: [][2]string{{"test_ks", "tbl_a"}},
+				wantTablets:    -1,
+			},
+			{
+				name:           "table/UPDATED invalidates table and removes tablets",
+				keyspaces:      map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				tablets:        [][2]string{{"test_ks", "tbl_a"}},
+				event:          &frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_a"},
+				wantKsPresent:  []string{"test_ks"},
+				wantTblGone:    [][2]string{{"test_ks", "tbl_a"}},
+				wantTblPresent: [][2]string{{"test_ks", "tbl_b"}},
+				wantTablets:    0,
+			},
+			{
+				name:        "table/DROPPED removes tablets",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
+				tablets:     [][2]string{{"test_ks", "tbl_a"}},
+				event:       &frm.SchemaChangeTable{Change: "DROPPED", Keyspace: "test_ks", Object: "tbl_a"},
+				wantTablets: 0,
+			},
+			{
+				name:        "table/CREATED does not remove tablets",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
+				tablets:     [][2]string{{"test_ks", "tbl_a"}},
+				event:       &frm.SchemaChangeTable{Change: "CREATED", Keyspace: "test_ks", Object: "tbl_a"},
+				wantTablets: 2,
+			},
+			{
+				name:        "type/CREATED clears entire keyspace",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				event:       &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				wantKsGone:  []string{"test_ks"},
+				wantTablets: -1,
+			},
+			{
+				name:        "function/CREATED clears entire keyspace",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
+				event:       &frm.SchemaChangeFunction{Change: "CREATED", Keyspace: "test_ks", Name: "fn", Args: []string{"int"}},
+				wantKsGone:  []string{"test_ks"},
+				wantTablets: -1,
+			},
+			{
+				name:        "aggregate/CREATED clears entire keyspace",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
+				event:       &frm.SchemaChangeAggregate{Change: "CREATED", Keyspace: "test_ks", Name: "agg", Args: []string{"int"}},
+				wantKsGone:  []string{"test_ks"},
+				wantTablets: -1,
+			},
+			// Cross-isolation
+			{
+				name:           "keyspace/DROPPED does not affect other keyspace",
+				keyspaces:      map[string][]string{"ks_a": {"tbl_a"}, "ks_b": {"tbl_b"}},
+				event:          &frm.SchemaChangeKeyspace{Change: "DROPPED", Keyspace: "ks_a"},
+				wantKsGone:     []string{"ks_a"},
+				wantKsPresent:  []string{"ks_b"},
+				wantTblPresent: [][2]string{{"ks_b", "tbl_b"}},
+				wantTablets:    -1,
+			},
+			{
+				name:           "table/UPDATED does not affect other tables",
+				keyspaces:      map[string][]string{"test_ks": {"tbl_a", "tbl_b", "tbl_c"}},
+				event:          &frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_a"},
+				wantKsPresent:  []string{"test_ks"},
+				wantTblGone:    [][2]string{{"test_ks", "tbl_a"}},
+				wantTblPresent: [][2]string{{"test_ks", "tbl_b"}, {"test_ks", "tbl_c"}},
+				wantTablets:    -1,
+			},
+			// Tablet cross-isolation
+			{
+				name:        "table/DROPPED for different table keeps tablets",
+				keyspaces:   map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				tablets:     [][2]string{{"test_ks", "tbl_a"}},
+				event:       &frm.SchemaChangeTable{Change: "DROPPED", Keyspace: "test_ks", Object: "tbl_b"},
+				wantTablets: 2,
+			},
+			{
+				name:        "keyspace/DROPPED for different keyspace keeps tablets",
+				keyspaces:   map[string][]string{"ks_a": {"tbl_a"}, "ks_b": {"tbl_b"}},
+				tablets:     [][2]string{{"ks_a", "tbl_a"}},
+				event:       &frm.SchemaChangeKeyspace{Change: "DROPPED", Keyspace: "ks_b"},
+				wantTablets: 2,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ctrl := &schemaDataMock{knownKeyspaces: map[string][]tableInfo{}}
+				s := newSchemaEventTestSessionWithMock(ctrl)
+				for ks, tables := range tt.keyspaces {
+					populateKeyspace(s, ks, tables...)
+				}
+				for _, tb := range tt.tablets {
+					addTestTablets(t, s, tb[0], tb[1])
+				}
+
+				s.handleSchemaEvent([]frame{tt.event})
+
+				for _, ks := range tt.wantKsGone {
+					if _, found := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace(ks); found {
+						t.Errorf("keyspace %q should have been removed from cache", ks)
+					}
+				}
+				for _, ks := range tt.wantKsPresent {
+					if _, found := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace(ks); !found {
+						t.Errorf("keyspace %q should still be in cache", ks)
+					}
+				}
+				for _, pair := range tt.wantTblGone {
+					ks, _ := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace(pair[0])
+					if ks != nil {
+						if _, ok := ks.Tables[pair[1]]; ok {
+							t.Errorf("table %s.%s should have been removed from Tables map", pair[0], pair[1])
+						}
+					}
+				}
+				for _, pair := range tt.wantTblPresent {
+					ks, _ := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace(pair[0])
+					if ks == nil {
+						t.Errorf("keyspace %q not found when checking table %s", pair[0], pair[1])
+					} else if _, ok := ks.Tables[pair[1]]; !ok {
+						t.Errorf("table %s.%s should still be in Tables map", pair[0], pair[1])
+					}
+				}
+				for _, pair := range tt.wantTblInvalid {
+					ks, _ := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace(pair[0])
+					if ks == nil {
+						t.Errorf("keyspace %q not found when checking tablesInvalidated %s", pair[0], pair[1])
+					} else if _, ok := ks.tablesInvalidated[pair[1]]; !ok {
+						t.Errorf("table %s.%s should be in tablesInvalidated", pair[0], pair[1])
+					}
+				}
+				if tt.wantTablets >= 0 {
+					if n := len(s.metadataDescriber.getTablets()); n != tt.wantTablets {
+						t.Errorf("expected %d tablets, got %d", tt.wantTablets, n)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("callbacks", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name                string
+			populateTables      []string
+			event               frame
+			wantSchemaAgreement int
+			wantKsChanged       []KeyspaceUpdateEvent
+		}{
+			{
+				name:                "keyspace event calls schema agreement and policy",
+				event:               &frm.SchemaChangeKeyspace{Change: "UPDATED", Keyspace: "test_ks"},
+				wantSchemaAgreement: 1,
+				wantKsChanged:       []KeyspaceUpdateEvent{{Keyspace: "test_ks", Change: "UPDATED"}},
+			},
+			{
+				name:                "table event: no schema agreement, no policy callback",
+				populateTables:      []string{"tbl_a"},
+				event:               &frm.SchemaChangeTable{Change: "CREATED", Keyspace: "test_ks", Object: "tbl_a"},
+				wantSchemaAgreement: 0,
+			},
+			{
+				name:                "type event: no schema agreement, no policy callback",
+				event:               &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				wantSchemaAgreement: 0,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				ctrl := &schemaDataMock{knownKeyspaces: map[string][]tableInfo{}}
+				policy := &trackingPolicy{}
+				s := newSchemaEventTestSession(ctrl, policy, "")
+				s.useSystemSchema = true
+				populateKeyspace(s, "test_ks", tt.populateTables...)
+
+				s.handleSchemaEvent([]frame{tt.event})
+
+				if got := ctrl.getAwaitSchemaAgreementCalls(); got != tt.wantSchemaAgreement {
+					t.Fatalf("awaitSchemaAgreement: got %d, want %d", got, tt.wantSchemaAgreement)
+				}
+				kc := policy.getKeyspaceChangedCalls()
+				if len(tt.wantKsChanged) == 0 {
+					if len(kc) != 0 {
+						t.Fatalf("KeyspaceChanged should not be called, got %+v", kc)
+					}
+				} else {
+					if len(kc) != len(tt.wantKsChanged) {
+						t.Fatalf("KeyspaceChanged: got %d calls, want %d", len(kc), len(tt.wantKsChanged))
+					}
+					for i, want := range tt.wantKsChanged {
+						if kc[i] != want {
+							t.Errorf("KeyspaceChanged[%d]: got %+v, want %+v", i, kc[i], want)
+						}
+					}
+				}
+			})
+		}
+	})
+
+	fullRefresh := func(ksName string) map[string]int {
+		return map[string]int{
+			"SELECT durable_writes, replication FROM system_schema.keyspaces WHERE keyspace_name = ?": 1,
+			"SELECT * FROM system_schema.tables WHERE keyspace_name = ?":                              1,
+			"SELECT * FROM system_schema.columns WHERE keyspace_name = ?":                             1,
+			"SELECT * FROM system_schema.types WHERE keyspace_name = ?":                               1,
+			"SELECT * FROM system_schema.indexes WHERE keyspace_name = ?":                             1,
+			"SELECT * FROM system_schema.views WHERE keyspace_name = ?":                               1,
+			fmt.Sprintf("DESCRIBE KEYSPACE %s WITH INTERNALS", ksName):                                1,
+		}
+	}
+	tableRefresh := map[string]int{
+		"SELECT * FROM system_schema.tables WHERE keyspace_name = ? AND table_name = ?":     1,
+		"SELECT * FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?":    1,
+		"SELECT * FROM system_schema.indexes WHERE keyspace_name = ? AND table_name = ?":    1,
+		"SELECT * FROM system_schema.views WHERE keyspace_name = ? AND base_table_name = ?": 1,
+	}
+	noQueries := map[string]int{}
+
+	assertExpectedQueries := func(t *testing.T, ctrl *schemaDataMock, expected map[string]int) {
+		t.Helper()
+		stmts := ctrl.getStatements()
+		if len(expected) == 0 {
+			if len(stmts) != 0 {
+				t.Errorf("expected 0 queries, got %d:\n%s", len(stmts), strings.Join(stmts, "\n"))
+			}
+			return
+		}
+		wantTotal := 0
+		for stmt, wantCount := range expected {
+			wantTotal += wantCount
+			gotCount := 0
+			for _, s := range stmts {
+				if s == stmt {
+					gotCount++
+				}
+			}
+			if gotCount != wantCount {
+				t.Errorf("query %q: got %d, want %d", stmt, gotCount, wantCount)
+			}
+		}
+		if len(stmts) != wantTotal {
+			t.Errorf("total queries: got %d, want %d\nqueries:\n%s",
+				len(stmts), wantTotal, strings.Join(stmts, "\n"))
+		}
+	}
+
+	t.Run("GetKeyspace", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name                string
+			knownKeyspaces      map[string][]tableInfo
+			populateKs          map[string][]string
+			disableSystemSchema bool
+			event               frame // nil = no event
+			getKeyspace         string
+			wantError           bool
+			expectedQueries     map[string]int // nil = skip check; empty = expect 0 queries
+			wantNoRequery       bool           // second identical call fires 0 queries
+		}{
+			{
+				name: "after keyspace event: refreshes and caches",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
+				event:           &frm.SchemaChangeKeyspace{Change: "UPDATED", Keyspace: "test_ks"},
+				getKeyspace:     "test_ks",
+				expectedQueries: fullRefresh("test_ks"),
+				wantNoRequery:   true,
+			},
+			{
+				name:            "after table event: returns cached, no queries",
+				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
+				event:           &frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_a"},
+				getKeyspace:     "test_ks",
+				expectedQueries: noQueries,
+			},
+			{
+				name: "after type event: refreshes and caches",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
+				event:           &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				getKeyspace:     "test_ks",
+				expectedQueries: fullRefresh("test_ks"),
+				wantNoRequery:   true,
+			},
+			{
+				name:            "uncached keyspace: refreshes and caches",
+				knownKeyspaces:  map[string][]tableInfo{"new_ks": {}},
+				getKeyspace:     "new_ks",
+				expectedQueries: fullRefresh("new_ks"),
+				wantNoRequery:   true,
+			},
+			{
+				name:        "unknown keyspace: returns error",
+				getKeyspace: "nonexistent",
+				wantError:   true,
+			},
+			{
+				name:                "useSystemSchema=false: returns error",
+				disableSystemSchema: true,
+				getKeyspace:         "test_ks",
+				wantError:           true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				knownKs := tt.knownKeyspaces
+				if knownKs == nil {
+					knownKs = map[string][]tableInfo{}
+				}
+				ctrl := &schemaDataMock{knownKeyspaces: knownKs}
+				s := newSchemaEventTestSessionWithMock(ctrl)
+				if tt.disableSystemSchema {
+					s.useSystemSchema = false
+				}
+				for ks, tables := range tt.populateKs {
+					populateKeyspace(s, ks, tables...)
+				}
+				if tt.event != nil {
+					s.handleSchemaEvent([]frame{tt.event})
+				}
+
+				ctrl.resetQueries()
+
+				ks, err := s.metadataDescriber.GetKeyspace(tt.getKeyspace)
+				if tt.wantError {
+					if err == nil {
+						t.Fatal("expected error")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("GetKeyspace failed: %v", err)
+				}
+				if ks.Name != tt.getKeyspace {
+					t.Fatalf("expected keyspace %s, got %s", tt.getKeyspace, ks.Name)
+				}
+				if tt.expectedQueries != nil {
+					assertExpectedQueries(t, ctrl, tt.expectedQueries)
+				}
+				if tt.wantNoRequery {
+					ctrl.resetQueries()
+					_, err = s.metadataDescriber.GetKeyspace(tt.getKeyspace)
+					if err != nil {
+						t.Fatalf("second GetKeyspace failed: %v", err)
+					}
+					assertExpectedQueries(t, ctrl, noQueries)
+				}
+			})
+		}
+	})
+
+	t.Run("GetTable", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name            string
+			knownKeyspaces  map[string][]tableInfo
+			populateKs      map[string][]string
+			event           frame
+			getTable        [2]string // [ks, table]
+			wantError       bool
+			expectedQueries map[string]int // nil = skip check; empty = expect 0 queries
+			expectNoRequery bool
+		}{
+			{
+				name: "after table event: refreshes only that table",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {
+						{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}},
+						{name: "tbl_b", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}},
+					},
+				},
+				populateKs:      map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				event:           &frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_a"},
+				getTable:        [2]string{"test_ks", "tbl_a"},
+				expectedQueries: tableRefresh,
+				expectNoRequery: true,
+			},
+			{
+				name:            "after table event: other table returns cached directly",
+				populateKs:      map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				event:           &frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_a"},
+				getTable:        [2]string{"test_ks", "tbl_b"},
+				expectedQueries: noQueries,
+			},
+			{
+				name: "after keyspace event: refreshes full keyspace",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
+				event:           &frm.SchemaChangeKeyspace{Change: "UPDATED", Keyspace: "test_ks"},
+				getTable:        [2]string{"test_ks", "tbl_a"},
+				expectedQueries: fullRefresh("test_ks"),
+				expectNoRequery: true,
+			},
+			{
+				name: "after type event: refreshes full keyspace",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
+				event:           &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				getTable:        [2]string{"test_ks", "tbl_a"},
+				expectedQueries: fullRefresh("test_ks"),
+			},
+			{
+				name: "unknown table: returns error",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs: map[string][]string{"test_ks": {"tbl_a"}},
+				getTable:   [2]string{"test_ks", "nonexistent"},
+				wantError:  true,
+			},
+			{
+				name:      "unknown keyspace: returns error",
+				getTable:  [2]string{"nonexistent", "tbl_a"},
+				wantError: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				knownKs := tt.knownKeyspaces
+				if knownKs == nil {
+					knownKs = map[string][]tableInfo{}
+				}
+				ctrl := &schemaDataMock{knownKeyspaces: knownKs}
+				s := newSchemaEventTestSessionWithMock(ctrl)
+				for ks, tables := range tt.populateKs {
+					populateKeyspace(s, ks, tables...)
+				}
+				if tt.event != nil {
+					s.handleSchemaEvent([]frame{tt.event})
+				}
+
+				ctrl.resetQueries()
+
+				tbl, err := s.metadataDescriber.GetTable(tt.getTable[0], tt.getTable[1])
+				if tt.wantError {
+					if err == nil {
+						t.Fatal("expected error")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("GetTable failed: %v", err)
+				}
+				if tbl.Name != tt.getTable[1] {
+					t.Fatalf("expected table %s, got %s", tt.getTable[1], tbl.Name)
+				}
+				if tt.expectedQueries != nil {
+					assertExpectedQueries(t, ctrl, tt.expectedQueries)
+				}
+				if tt.expectNoRequery {
+					ctrl.resetQueries()
+					_, err = s.metadataDescriber.GetTable(tt.getTable[0], tt.getTable[1])
+					if err != nil {
+						t.Fatalf("second GetTable failed: %v", err)
+					}
+					assertExpectedQueries(t, ctrl, noQueries)
+				}
+			})
+		}
+	})
+
+	t.Run("batch/multiple_table_events", func(t *testing.T) {
+		t.Parallel()
+		ctrl := &schemaDataMock{
+			knownKeyspaces: map[string][]tableInfo{
+				"test_ks": {
+					{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}},
+					{name: "tbl_b", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}},
+					{name: "tbl_c", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}},
+				},
+			},
+		}
+		s := newSchemaEventTestSessionWithMock(ctrl)
+		populateKeyspace(s, "test_ks", "tbl_a", "tbl_b", "tbl_c")
+
+		s.handleSchemaEvent([]frame{
+			&frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_a"},
+			&frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_b"},
+		})
+
+		ks, _ := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace("test_ks")
+		if _, ok := ks.Tables["tbl_a"]; ok {
+			t.Fatal("tbl_a should be invalidated")
+		}
+		if _, ok := ks.Tables["tbl_b"]; ok {
+			t.Fatal("tbl_b should be invalidated")
+		}
+		if _, ok := ks.Tables["tbl_c"]; !ok {
+			t.Fatal("tbl_c should still be cached")
+		}
+
+		ctrl.resetQueries()
+
+		_, err := s.metadataDescriber.GetTable("test_ks", "tbl_a")
+		if err != nil {
+			t.Fatalf("GetTable(tbl_a) failed: %v", err)
+		}
+		if ctrl.getQueryCount() == 0 {
+			t.Fatal("expected queries for tbl_a")
+		}
+
+		ctrl.resetQueries()
+
+		_, err = s.metadataDescriber.GetTable("test_ks", "tbl_b")
+		if err != nil {
+			t.Fatalf("GetTable(tbl_b) failed: %v", err)
+		}
+		if ctrl.getQueryCount() == 0 {
+			t.Fatal("expected queries for tbl_b")
+		}
+
+		ctrl.resetQueries()
+
+		_, err = s.metadataDescriber.GetTable("test_ks", "tbl_c")
+		if err != nil {
+			t.Fatalf("GetTable(tbl_c) failed: %v", err)
+		}
+		if got := ctrl.getQueryCount(); got != 0 {
+			t.Fatalf("tbl_c not invalidated, expected 0 queries, got %d", got)
+		}
+	})
+
+	t.Run("batch/mixed_keyspace_and_table_events", func(t *testing.T) {
+		t.Parallel()
+		ctrl := &schemaDataMock{
+			knownKeyspaces: map[string][]tableInfo{
+				"test_ks": {
+					{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}},
+				},
+			},
+		}
+		policy := &trackingPolicy{}
+		s := newSchemaEventTestSession(ctrl, policy, "")
+		s.useSystemSchema = true
+		s.hasAggregatesAndFunctions = false
+		populateKeyspace(s, "test_ks", "tbl_a")
+
+		s.handleSchemaEvent([]frame{
+			&frm.SchemaChangeTable{Change: "CREATED", Keyspace: "test_ks", Object: "tbl_a"},
+			&frm.SchemaChangeKeyspace{Change: "UPDATED", Keyspace: "test_ks"},
+		})
+
+		if got := ctrl.getAwaitSchemaAgreementCalls(); got != 1 {
+			t.Fatalf("awaitSchemaAgreement: got %d, want 1", got)
+		}
+		if _, found := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace("test_ks"); found {
+			t.Fatal("keyspace should have been removed from cache by keyspace event")
+		}
+
+		ctrl.resetQueries()
+
+		ks, err := s.metadataDescriber.GetKeyspace("test_ks")
+		if err != nil {
+			t.Fatalf("GetKeyspace failed: %v", err)
+		}
+		if ks.Name != "test_ks" {
+			t.Fatalf("expected test_ks, got %s", ks.Name)
+		}
+		if got := ctrl.getQueryCount(); got == 0 {
+			t.Fatal("expected queries after keyspace was cleared")
+		}
+	})
+}

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -7,6 +7,7 @@ package gocql
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 	"sync"
@@ -18,17 +19,72 @@ import (
 
 // schema metadata for a keyspace
 type KeyspaceMetadata struct {
-	StrategyOptions map[string]interface{}
-	Tables          map[string]*TableMetadata
-	Functions       map[string]*FunctionMetadata
-	Aggregates      map[string]*AggregateMetadata
-	Types           map[string]*TypeMetadata
-	Indexes         map[string]*IndexMetadata
-	Views           map[string]*ViewMetadata
-	Name            string
-	StrategyClass   string
-	CreateStmts     string
-	DurableWrites   bool
+	StrategyOptions   map[string]interface{}
+	Tables            map[string]*TableMetadata
+	Functions         map[string]*FunctionMetadata
+	Aggregates        map[string]*AggregateMetadata
+	Types             map[string]*TypeMetadata
+	Indexes           map[string]*IndexMetadata
+	Views             map[string]*ViewMetadata
+	tablesInvalidated map[string]struct{}
+	Name              string
+	StrategyClass     string
+	CreateStmts       string
+	DurableWrites     bool
+}
+
+// Clone returns a shallow copy of the keyspace metadata with
+// cloned Tables, Indexes, Views, and tablesInvalidated maps so that mutations
+// do not race with concurrent readers of the original.
+func (ks *KeyspaceMetadata) Clone() *KeyspaceMetadata {
+	cloned := &KeyspaceMetadata{
+		Name:            ks.Name,
+		DurableWrites:   ks.DurableWrites,
+		StrategyClass:   ks.StrategyClass,
+		StrategyOptions: maps.Clone(ks.StrategyOptions),
+		Tables:          maps.Clone(ks.Tables),
+		Functions:       maps.Clone(ks.Functions),
+		Aggregates:      maps.Clone(ks.Aggregates),
+		Types:           maps.Clone(ks.Types),
+		Indexes:         maps.Clone(ks.Indexes),
+		Views:           maps.Clone(ks.Views),
+		CreateStmts:     ks.CreateStmts,
+	}
+	if ks.tablesInvalidated != nil {
+		cloned.tablesInvalidated = maps.Clone(ks.tablesInvalidated)
+	}
+	return cloned
+}
+
+func (ks *KeyspaceMetadata) removeTableData(tableName string) {
+	if ks.Tables != nil {
+		delete(ks.Tables, tableName)
+	}
+	for name, idx := range ks.Indexes {
+		if idx != nil && idx.TableName == tableName {
+			delete(ks.Indexes, name)
+		}
+	}
+	for name, view := range ks.Views {
+		if view != nil && view.BaseTableName == tableName {
+			delete(ks.Views, name)
+		}
+	}
+}
+
+func (ks *KeyspaceMetadata) invalidateTable(tableName string) {
+	ks.removeTableData(tableName)
+	if ks.tablesInvalidated == nil {
+		ks.tablesInvalidated = make(map[string]struct{})
+	}
+	ks.tablesInvalidated[tableName] = struct{}{}
+}
+
+func (ks *KeyspaceMetadata) removeTable(tableName string) {
+	ks.removeTableData(tableName)
+	if ks.tablesInvalidated != nil {
+		delete(ks.tablesInvalidated, tableName)
+	}
 }
 
 // schema metadata for a table (a.k.a. column family)
@@ -320,16 +376,30 @@ func (c *cowKeyspaceMetadataMap) set(keyspaceName string, keyspaceMetadata *Keys
 	return true
 }
 
-func (c *cowKeyspaceMetadataMap) remove(keyspaceName string) {
+func (c *cowKeyspaceMetadataMap) invalidateTable(keyspaceName, tableName string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	m := c.get()
+	ks, ok := m[keyspaceName]
+	if !ok || ks == nil {
+		return
+	}
+
+	cloned := ks.Clone()
+	cloned.invalidateTable(tableName)
+
+	newM := maps.Clone(m)
+	newM[keyspaceName] = cloned
+	c.keyspaceMap.Store(newM)
+}
+
+func (c *cowKeyspaceMetadataMap) removeKeyspace(keyspaceName string) {
 	c.mu.Lock()
 	m := c.get()
 
-	newM := map[string]*KeyspaceMetadata{}
-	for name, meta := range m {
-		if name != keyspaceName {
-			newM[name] = meta
-		}
-	}
+	newM := maps.Clone(m)
+	delete(newM, keyspaceName)
 
 	c.keyspaceMap.Store(newM)
 	c.mu.Unlock()
@@ -458,24 +528,65 @@ func newMetadataDescriber(session *Session) *metadataDescriber {
 	}
 }
 
-// getSchema returns the KeyspaceMetadata for the keyspace, if it is not present, loads it from `system_schema`
-// does not require holding a lock
-func (s *metadataDescriber) getSchema(keyspaceName string) (*KeyspaceMetadata, error) {
-	metadata, found := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+func (s *metadataDescriber) getKeyspaceInternal(keyspaceName string) (metadata *KeyspaceMetadata, wasReloaded bool, err error) {
+	var found bool
+	metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
 	if !found {
-		// refresh the cache for this keyspace
-		err := s.refreshSchema(keyspaceName)
+		wasReloaded = true
+		err = s.refreshKeyspaceSchema(keyspaceName)
 		if err != nil {
-			return nil, err
+			return metadata, wasReloaded, err
 		}
 
 		metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
 		if !found {
-			return nil, fmt.Errorf("Metadata not found for keyspace: %s", keyspaceName)
+			return nil, true, fmt.Errorf("keyspace %s: %w", keyspaceName, ErrNotFound)
 		}
 	}
 
-	return metadata, nil
+	return metadata, wasReloaded, nil
+}
+
+func (s *metadataDescriber) GetKeyspace(keyspaceName string) (*KeyspaceMetadata, error) {
+	metadata, _, err := s.getKeyspaceInternal(keyspaceName)
+	return metadata, err
+}
+
+func (s *metadataDescriber) GetTable(keyspaceName, tableName string) (*TableMetadata, error) {
+	keyspaceMetadata, wasReloaded, err := s.getKeyspaceInternal(keyspaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	tableMetadata, found := keyspaceMetadata.Tables[tableName]
+	if found {
+		return tableMetadata, nil
+	}
+
+	if wasReloaded {
+		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
+	}
+
+	if _, ok := keyspaceMetadata.tablesInvalidated[tableName]; !ok {
+		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
+	}
+
+	err = s.refreshTableSchema(keyspaceName, tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	keyspaceMetadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+	if !found {
+		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
+	}
+
+	tableMetadata, found = keyspaceMetadata.Tables[tableName]
+	if !found {
+		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
+	}
+
+	return tableMetadata, nil
 }
 
 func (s *metadataDescriber) getTablets() tablets.TabletInfoList {
@@ -504,9 +615,13 @@ func (s *metadataDescriber) RemoveTabletsWithTable(keyspace string, table string
 	s.metadata.tabletsMetadata.RemoveTabletsWithTableFromTabletsList(keyspace, table)
 }
 
-// clearSchema clears the cached keyspace metadata
-func (s *metadataDescriber) clearSchema(keyspaceName string) {
-	s.metadata.keyspaceMetadata.remove(keyspaceName)
+// invalidateKeyspaceSchema clears the cached keyspace metadata
+func (s *metadataDescriber) invalidateKeyspaceSchema(keyspaceName string) {
+	s.metadata.keyspaceMetadata.removeKeyspace(keyspaceName)
+}
+
+func (s *metadataDescriber) invalidateTableSchema(keyspaceName, tableName string) {
+	s.metadata.keyspaceMetadata.invalidateTable(keyspaceName, tableName)
 }
 
 func (s *metadataDescriber) refreshAllSchema() error {
@@ -537,16 +652,16 @@ func (s *metadataDescriber) refreshAllSchema() error {
 
 	for keyspaceName, metadata := range copiedMap {
 		// refresh the cache for this keyspace
-		err := s.refreshSchema(keyspaceName)
+		err := s.refreshKeyspaceSchema(keyspaceName)
 		if errors.Is(err, ErrKeyspaceDoesNotExist) {
-			s.clearSchema(keyspaceName)
+			s.invalidateKeyspaceSchema(keyspaceName)
 			s.RemoveTabletsWithKeyspace(keyspaceName)
 			continue
 		} else if err != nil {
 			return err
 		}
 
-		updatedMetadata, err := s.getSchema(keyspaceName)
+		updatedMetadata, err := s.GetKeyspace(keyspaceName)
 		if err != nil {
 			return err
 		}
@@ -567,7 +682,7 @@ func (s *metadataDescriber) refreshAllSchema() error {
 
 // forcibly updates the current KeyspaceMetadata held by the schema describer
 // for a given named keyspace.
-func (s *metadataDescriber) refreshSchema(keyspaceName string) error {
+func (s *metadataDescriber) refreshKeyspaceSchema(keyspaceName string) error {
 	var err error
 
 	// query the system keyspace for schema data
@@ -610,12 +725,68 @@ func (s *metadataDescriber) refreshSchema(keyspaceName string) error {
 		return err
 	}
 
-	// organize the schema data
 	compileMetadata(keyspace, tables, columns, functions, aggregates, types, indexes, views, createStmts)
 
-	// update the cache
 	s.metadata.keyspaceMetadata.set(keyspaceName, keyspace)
 
+	return nil
+}
+
+func (s *metadataDescriber) refreshTableSchema(keyspaceName, tableName string) error {
+	keyspace, found := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+	if !found {
+		return s.refreshKeyspaceSchema(keyspaceName)
+	}
+
+	// Perform network queries outside the lock.
+	tables, err := getTableMetadataByName(s.session, keyspaceName, tableName)
+	if err != nil {
+		return err
+	}
+
+	columns, err := getColumnMetadataByTable(s.session, keyspaceName, tableName)
+	if err != nil {
+		return err
+	}
+
+	indexes, err := getIndexMetadataByTable(s.session, keyspaceName, tableName)
+	if err != nil {
+		return err
+	}
+
+	views, err := getViewMetadataByTable(s.session, keyspaceName, tableName)
+	if err != nil {
+		return err
+	}
+
+	// Hold the lock for the read-clone-mutate-write to prevent concurrent
+	// refreshes for different tables from overwriting each other's results.
+	s.mu.Lock()
+
+	keyspace, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+	if !found {
+		// Keyspace was removed between the two lookups; release the lock
+		// and fall back to a full keyspace refresh.
+		s.mu.Unlock()
+		return s.refreshKeyspaceSchema(keyspaceName)
+	}
+
+	keyspace = keyspace.Clone()
+
+	if len(tables) == 0 {
+		keyspace.removeTable(tableName)
+		s.metadata.keyspaceMetadata.set(keyspaceName, keyspace)
+		s.mu.Unlock()
+		return nil
+	}
+
+	compileTableMetadata(keyspace, tables, columns, indexes, views)
+	if keyspace.tablesInvalidated != nil {
+		delete(keyspace.tablesInvalidated, tableName)
+	}
+
+	s.metadata.keyspaceMetadata.set(keyspaceName, keyspace)
+	s.mu.Unlock()
 	return nil
 }
 
@@ -724,6 +895,101 @@ func compileMetadata(
 	}
 
 	keyspace.CreateStmts = string(createStmts)
+}
+
+func compileTableMetadata(
+	keyspace *KeyspaceMetadata,
+	tables []TableMetadata,
+	columns []ColumnMetadata,
+	indexes []IndexMetadata,
+	views []ViewMetadata,
+) {
+	if keyspace.Tables == nil {
+		keyspace.Tables = make(map[string]*TableMetadata)
+	}
+	for i := range tables {
+		tables[i].Columns = make(map[string]*ColumnMetadata)
+		keyspace.Tables[tables[i].Name] = &tables[i]
+	}
+
+	if keyspace.Indexes == nil {
+		keyspace.Indexes = make(map[string]*IndexMetadata)
+	}
+	for name, ix := range keyspace.Indexes {
+		for i := range tables {
+			if ix.TableName == tables[i].Name {
+				delete(keyspace.Indexes, name)
+			}
+		}
+	}
+	for i := range indexes {
+		indexes[i].Columns = make(map[string]*ColumnMetadata)
+		keyspace.Indexes[indexes[i].Name] = &indexes[i]
+	}
+
+	if keyspace.Views == nil {
+		keyspace.Views = make(map[string]*ViewMetadata)
+	}
+	for name, v := range keyspace.Views {
+		for i := range tables {
+			if v.BaseTableName == tables[i].Name {
+				delete(keyspace.Views, name)
+			}
+		}
+	}
+	for i := range views {
+		v := &views[i]
+		if _, ok := keyspace.Indexes[strings.TrimSuffix(v.ViewName, "_index")]; ok {
+			continue
+		}
+		v.Columns = make(map[string]*ColumnMetadata)
+		keyspace.Views[v.ViewName] = v
+	}
+
+	for i := range columns {
+		col := &columns[i]
+		col.Order = ASC
+		if col.ClusteringOrder == "desc" {
+			col.Order = DESC
+		}
+
+		table, ok := keyspace.Tables[col.Table]
+		if !ok {
+			if indexName, found := strings.CutSuffix(col.Table, "_index"); found {
+				ix, ok := keyspace.Indexes[indexName]
+				if ok {
+					ix.Columns[col.Name] = col
+					ix.OrderedColumns = append(ix.OrderedColumns, col.Name)
+					continue
+				}
+			}
+
+			view, ok := keyspace.Views[col.Table]
+			if !ok {
+				continue
+			}
+
+			view.Columns[col.Name] = col
+			view.OrderedColumns = append(view.OrderedColumns, col.Name)
+			continue
+		}
+
+		table.Columns[col.Name] = col
+		table.OrderedColumns = append(table.OrderedColumns, col.Name)
+	}
+
+	for i := range tables {
+		t := &tables[i]
+		t.PartitionKey, t.ClusteringColumns, t.OrderedColumns = compileColumns(t.Columns, t.OrderedColumns)
+	}
+	for i := range views {
+		v := &views[i]
+		v.PartitionKey, v.ClusteringColumns, v.OrderedColumns = compileColumns(v.Columns, v.OrderedColumns)
+	}
+	for i := range indexes {
+		ix := &indexes[i]
+		ix.PartitionKey, ix.ClusteringColumns, ix.OrderedColumns = compileColumns(ix.Columns, ix.OrderedColumns)
+	}
 }
 
 func compileColumns(columns map[string]*ColumnMetadata, orderedColumns []string) (
@@ -867,6 +1133,173 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 	}
 
 	return tables, nil
+}
+
+func getTableMetadataByName(session *Session, keyspaceName, tableName string) ([]TableMetadata, error) {
+	if !session.useSystemSchema {
+		return nil, nil
+	}
+
+	stmt := `SELECT * FROM system_schema.tables WHERE keyspace_name = ? AND table_name = ?`
+	iter := session.control.querySystem(stmt, keyspaceName, tableName)
+
+	var tables []TableMetadata
+	table := TableMetadata{Keyspace: keyspaceName}
+	for iter.MapScan(map[string]interface{}{
+		"table_name":                  &table.Name,
+		"bloom_filter_fp_chance":      &table.Options.BloomFilterFpChance,
+		"caching":                     &table.Options.Caching,
+		"comment":                     &table.Options.Comment,
+		"compaction":                  &table.Options.Compaction,
+		"compression":                 &table.Options.Compression,
+		"crc_check_chance":            &table.Options.CrcCheckChance,
+		"default_time_to_live":        &table.Options.DefaultTimeToLive,
+		"gc_grace_seconds":            &table.Options.GcGraceSeconds,
+		"max_index_interval":          &table.Options.MaxIndexInterval,
+		"memtable_flush_period_in_ms": &table.Options.MemtableFlushPeriodInMs,
+		"min_index_interval":          &table.Options.MinIndexInterval,
+		"speculative_retry":           &table.Options.SpeculativeRetry,
+		"flags":                       &table.Flags,
+		"extensions":                  &table.Extensions,
+	}) {
+		tables = append(tables, table)
+		table = TableMetadata{Keyspace: keyspaceName}
+	}
+
+	err := iter.Close()
+	if err != nil && err != ErrNotFound {
+		return nil, fmt.Errorf("error querying table schema: %w", err)
+	}
+
+	if conn := session.getConn(); conn == nil || !conn.isScyllaConn() {
+		return tables, nil
+	}
+
+	stmt = `SELECT * FROM system_schema.scylla_tables WHERE keyspace_name = ? AND table_name = ?`
+	for i, t := range tables {
+		iter := session.control.querySystem(stmt, keyspaceName, t.Name)
+
+		table := TableMetadata{}
+		if iter.MapScan(map[string]interface{}{
+			"cdc":         &table.Options.CDC,
+			"in_memory":   &table.Options.InMemory,
+			"partitioner": &table.Options.Partitioner,
+			"version":     &table.Options.Version,
+		}) {
+			tables[i].Options.CDC = table.Options.CDC
+			tables[i].Options.Version = table.Options.Version
+			tables[i].Options.Partitioner = table.Options.Partitioner
+			tables[i].Options.InMemory = table.Options.InMemory
+		}
+		if err := iter.Close(); err != nil && err != ErrNotFound {
+			return nil, fmt.Errorf("error querying scylla table schema: %w", err)
+		}
+	}
+
+	return tables, nil
+}
+
+func getColumnMetadataByTable(session *Session, keyspaceName, tableName string) ([]ColumnMetadata, error) {
+	const stmt = `SELECT * FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?`
+
+	var columns []ColumnMetadata
+
+	iter := session.control.querySystem(stmt, keyspaceName, tableName)
+	column := ColumnMetadata{Keyspace: keyspaceName}
+
+	for iter.MapScan(map[string]interface{}{
+		"table_name":       &column.Table,
+		"column_name":      &column.Name,
+		"clustering_order": &column.ClusteringOrder,
+		"type":             &column.Type,
+		"kind":             &column.Kind,
+		"position":         &column.ComponentIndex,
+	}) {
+		columns = append(columns, column)
+		column = ColumnMetadata{Keyspace: keyspaceName}
+	}
+
+	if err := iter.Close(); err != nil && err != ErrNotFound {
+		return nil, fmt.Errorf("error querying column schema: %w", err)
+	}
+
+	return columns, nil
+}
+
+func getIndexMetadataByTable(session *Session, keyspaceName, tableName string) ([]IndexMetadata, error) {
+	if !session.useSystemSchema {
+		return nil, nil
+	}
+
+	const stmt = `SELECT * FROM system_schema.indexes WHERE keyspace_name = ? AND table_name = ?`
+
+	var indexes []IndexMetadata
+	index := IndexMetadata{}
+
+	iter := session.control.querySystem(stmt, keyspaceName, tableName)
+	for iter.MapScan(map[string]interface{}{
+		"index_name":    &index.Name,
+		"keyspace_name": &index.KeyspaceName,
+		"table_name":    &index.TableName,
+		"kind":          &index.Kind,
+		"options":       &index.Options,
+	}) {
+		indexes = append(indexes, index)
+		index = IndexMetadata{}
+	}
+
+	if err := iter.Close(); err != nil {
+		return nil, err
+	}
+
+	return indexes, nil
+}
+
+func getViewMetadataByTable(session *Session, keyspaceName, tableName string) ([]ViewMetadata, error) {
+	if !session.useSystemSchema {
+		return nil, nil
+	}
+
+	stmt := `SELECT * FROM system_schema.views WHERE keyspace_name = ? AND base_table_name = ?`
+
+	iter := session.control.querySystem(stmt, keyspaceName, tableName)
+
+	var views []ViewMetadata
+	view := ViewMetadata{KeyspaceName: keyspaceName}
+
+	for iter.MapScan(map[string]interface{}{
+		"id":                          &view.ID,
+		"view_name":                   &view.ViewName,
+		"base_table_id":               &view.BaseTableID,
+		"base_table_name":             &view.BaseTableName,
+		"include_all_columns":         &view.IncludeAllColumns,
+		"where_clause":                &view.WhereClause,
+		"bloom_filter_fp_chance":      &view.Options.BloomFilterFpChance,
+		"caching":                     &view.Options.Caching,
+		"comment":                     &view.Options.Comment,
+		"compaction":                  &view.Options.Compaction,
+		"compression":                 &view.Options.Compression,
+		"crc_check_chance":            &view.Options.CrcCheckChance,
+		"default_time_to_live":        &view.Options.DefaultTimeToLive,
+		"gc_grace_seconds":            &view.Options.GcGraceSeconds,
+		"max_index_interval":          &view.Options.MaxIndexInterval,
+		"memtable_flush_period_in_ms": &view.Options.MemtableFlushPeriodInMs,
+		"min_index_interval":          &view.Options.MinIndexInterval,
+		"speculative_retry":           &view.Options.SpeculativeRetry,
+		"extensions":                  &view.Extensions,
+		"dclocal_read_repair_chance":  &view.DcLocalReadRepairChance,
+		"read_repair_chance":          &view.ReadRepairChance,
+	}) {
+		views = append(views, view)
+		view = ViewMetadata{KeyspaceName: keyspaceName}
+	}
+
+	err := iter.Close()
+	if err != nil && err != ErrNotFound {
+		return nil, fmt.Errorf("error querying view schema: %w", err)
+	}
+
+	return views, nil
 }
 
 // query for column metadata in the system_schema.columns

--- a/policies.go
+++ b/policies.go
@@ -550,7 +550,7 @@ func (t *tokenAwareHostPolicy) Init(s *Session) {
 		if keyspace == "" {
 			return nil, ErrNoKeyspace
 		}
-		return s.metadataDescriber.getSchema(keyspace)
+		return s.metadataDescriber.GetKeyspace(keyspace)
 	}
 	t.getKeyspaceName = func() string { return s.cfg.Keyspace }
 	t.logger = s.logger

--- a/recreate.go
+++ b/recreate.go
@@ -16,63 +16,63 @@ import (
 // ToCQL returns a CQL query that ca be used to recreate keyspace with all
 // user defined types, tables, indexes, functions, aggregates and views associated
 // with this keyspace.
-func (km *KeyspaceMetadata) ToCQL() (string, error) {
+func (ks *KeyspaceMetadata) ToCQL() (string, error) {
 	// Be aware that `CreateStmts` is not only a cache for ToCQL,
 	// but it also can be populated from response to `DESCRIBE KEYSPACE %s WITH INTERNALS`
-	if len(km.CreateStmts) != 0 {
-		return km.CreateStmts, nil
+	if len(ks.CreateStmts) != 0 {
+		return ks.CreateStmts, nil
 	}
 
 	var sb strings.Builder
 
-	if err := km.keyspaceToCQL(&sb); err != nil {
+	if err := ks.keyspaceToCQL(&sb); err != nil {
 		return "", err
 	}
 
-	sortedTypes := km.typesSortedTopologically()
+	sortedTypes := ks.typesSortedTopologically()
 	for _, tm := range sortedTypes {
-		if err := km.userTypeToCQL(&sb, tm); err != nil {
+		if err := ks.userTypeToCQL(&sb, tm); err != nil {
 			return "", err
 		}
 	}
 
-	for _, tm := range km.Tables {
-		if err := km.tableToCQL(&sb, km.Name, tm); err != nil {
+	for _, tm := range ks.Tables {
+		if err := ks.tableToCQL(&sb, ks.Name, tm); err != nil {
 			return "", err
 		}
 	}
 
-	for _, im := range km.Indexes {
-		if err := km.indexToCQL(&sb, im); err != nil {
+	for _, im := range ks.Indexes {
+		if err := ks.indexToCQL(&sb, im); err != nil {
 			return "", err
 		}
 	}
 
-	for _, fm := range km.Functions {
-		if err := km.functionToCQL(&sb, km.Name, fm); err != nil {
+	for _, fm := range ks.Functions {
+		if err := ks.functionToCQL(&sb, ks.Name, fm); err != nil {
 			return "", err
 		}
 	}
 
-	for _, am := range km.Aggregates {
-		if err := km.aggregateToCQL(&sb, am); err != nil {
+	for _, am := range ks.Aggregates {
+		if err := ks.aggregateToCQL(&sb, am); err != nil {
 			return "", err
 		}
 	}
 
-	for _, vm := range km.Views {
-		if err := km.viewToCQL(&sb, vm); err != nil {
+	for _, vm := range ks.Views {
+		if err := ks.viewToCQL(&sb, vm); err != nil {
 			return "", err
 		}
 	}
 
-	km.CreateStmts = sb.String()
-	return km.CreateStmts, nil
+	ks.CreateStmts = sb.String()
+	return ks.CreateStmts, nil
 }
 
-func (km *KeyspaceMetadata) typesSortedTopologically() []*TypeMetadata {
-	sortedTypes := make([]*TypeMetadata, 0, len(km.Types))
-	for _, tm := range km.Types {
+func (ks *KeyspaceMetadata) typesSortedTopologically() []*TypeMetadata {
+	sortedTypes := make([]*TypeMetadata, 0, len(ks.Types))
+	for _, tm := range ks.Types {
 		sortedTypes = append(sortedTypes, tm)
 	}
 	sort.Slice(sortedTypes, func(i, j int) bool {
@@ -98,7 +98,7 @@ CREATE TABLE {{ .KeyspaceName }}.{{ .Tm.Name }} (
 ) WITH {{ tablePropertiesToCQL .Tm.ClusteringColumns .Tm.Options .Tm.Extensions }};
 `))
 
-func (km *KeyspaceMetadata) tableToCQL(w io.Writer, kn string, tm *TableMetadata) error {
+func (ks *KeyspaceMetadata) tableToCQL(w io.Writer, kn string, tm *TableMetadata) error {
 	if err := tableCQLTemplate.Execute(w, map[string]interface{}{
 		"Tm":           tm,
 		"KeyspaceName": kn,
@@ -127,7 +127,7 @@ CREATE FUNCTION {{ .keyspaceName }}.{{ .fm.Name }} (
     AS $${{ .fm.Body }}$$;
 `))
 
-func (km *KeyspaceMetadata) functionToCQL(w io.Writer, keyspaceName string, fm *FunctionMetadata) error {
+func (ks *KeyspaceMetadata) functionToCQL(w io.Writer, keyspaceName string, fm *FunctionMetadata) error {
 	if err := functionTemplate.Execute(w, map[string]interface{}{
 		"fm":           fm,
 		"keyspaceName": keyspaceName,
@@ -157,7 +157,7 @@ CREATE MATERIALIZED VIEW {{ .vm.KeyspaceName }}.{{ .vm.ViewName }} AS
     WITH {{ tablePropertiesToCQL .vm.ClusteringColumns .vm.Options .vm.Extensions }};
 `))
 
-func (km *KeyspaceMetadata) viewToCQL(w io.Writer, vm *ViewMetadata) error {
+func (ks *KeyspaceMetadata) viewToCQL(w io.Writer, vm *ViewMetadata) error {
 	if err := viewTemplate.Execute(w, map[string]interface{}{
 		"vm": vm,
 	}); err != nil {
@@ -187,7 +187,7 @@ CREATE AGGREGATE {{ .Keyspace }}.{{ .Name }}(
 ;
 `))
 
-func (km *KeyspaceMetadata) aggregateToCQL(w io.Writer, am *AggregateMetadata) error {
+func (ks *KeyspaceMetadata) aggregateToCQL(w io.Writer, am *AggregateMetadata) error {
 	if err := aggregatesTemplate.Execute(w, am); err != nil {
 		return err
 	}
@@ -206,14 +206,14 @@ CREATE TYPE {{ .Keyspace }}.{{ .Name }} (
 );
 `))
 
-func (km *KeyspaceMetadata) userTypeToCQL(w io.Writer, tm *TypeMetadata) error {
+func (ks *KeyspaceMetadata) userTypeToCQL(w io.Writer, tm *TypeMetadata) error {
 	if err := typeCQLTemplate.Execute(w, tm); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (km *KeyspaceMetadata) indexToCQL(w io.Writer, im *IndexMetadata) error {
+func (ks *KeyspaceMetadata) indexToCQL(w io.Writer, im *IndexMetadata) error {
 	// Scylla doesn't support any custom indexes
 	if im.Kind == IndexKindCustom {
 		return nil
@@ -261,8 +261,8 @@ var keyspaceCQLTemplate = template.Must(template.New("keyspace").
 }{{ if not .DurableWrites }} AND durable_writes = 'false'{{ end }};
 `))
 
-func (km *KeyspaceMetadata) keyspaceToCQL(w io.Writer) error {
-	if err := keyspaceCQLTemplate.Execute(w, km); err != nil {
+func (ks *KeyspaceMetadata) keyspaceToCQL(w io.Writer) error {
+	if err := keyspaceCQLTemplate.Execute(w, ks); err != nil {
 		return err
 	}
 	return nil

--- a/recreate_test.go
+++ b/recreate_test.go
@@ -116,7 +116,7 @@ func TestRecreateSchema(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to await for schema agreement", err)
 			}
-			err = session.metadataDescriber.refreshSchema(test.Keyspace)
+			err = session.metadataDescriber.refreshKeyspaceSchema(test.Keyspace)
 			if err != nil {
 				t.Fatal("failed to read schema for keyspace", err)
 			}
@@ -181,7 +181,7 @@ func TestRecreateSchema(t *testing.T) {
 
 			// Exec dumped queries to check if they are CQL-correct
 			cleanup(t, session, test.Keyspace)
-			session.metadataDescriber.clearSchema(test.Keyspace)
+			session.metadataDescriber.invalidateKeyspaceSchema(test.Keyspace)
 
 			for _, q := range trimQueries(strings.Split(dump, ";")) {
 				qr := session.Query(q, nil)
@@ -196,7 +196,7 @@ func TestRecreateSchema(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to await for schema agreement", err)
 			}
-			err = session.metadataDescriber.refreshSchema(test.Keyspace)
+			err = session.metadataDescriber.refreshKeyspaceSchema(test.Keyspace)
 			if err != nil {
 				t.Fatal("failed to read schema for keyspace", err)
 			}

--- a/schema_queries_test.go
+++ b/schema_queries_test.go
@@ -18,7 +18,7 @@ func TestSchemaQueries(t *testing.T) {
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
 
-	keyspaceMetadata, err := session.metadataDescriber.getSchema("gocql_test")
+	keyspaceMetadata, err := session.metadataDescriber.GetKeyspace("gocql_test")
 	if err != nil {
 		t.Fatal("unable to get keyspace metadata for keyspace: ", err)
 	}

--- a/session.go
+++ b/session.go
@@ -700,7 +700,23 @@ func (s *Session) KeyspaceMetadata(keyspace string) (*KeyspaceMetadata, error) {
 		return nil, ErrNoKeyspace
 	}
 
-	return s.metadataDescriber.getSchema(keyspace)
+	return s.metadataDescriber.GetKeyspace(keyspace)
+}
+
+// TableMetadata returns the schema metadata for the specified table. Returns an error if the keyspace or table does not exist.
+func (s *Session) TableMetadata(keyspace, table string) (*TableMetadata, error) {
+	// fail fast
+	if s.Closed() {
+		return nil, ErrSessionClosed
+	} else if err := s.Ready(); err != nil {
+		return nil, err
+	} else if keyspace == "" {
+		return nil, ErrNoKeyspace
+	} else if table == "" {
+		return nil, fmt.Errorf("no table name provided: %w", ErrNotFound)
+	}
+
+	return s.metadataDescriber.GetTable(keyspace, table)
 }
 
 // TabletsMetadata returns the metadata about tablets


### PR DESCRIPTION
## Summary
- Table-level schema events now only invalidate the specific table instead of clearing the entire keyspace from the metadata cache
- `GetTable` refreshes only that table's metadata (4 queries: tables, columns, indexes, views filtered by table name) instead of a full keyspace refresh (7 queries)
- Adds `GetKeyspace` / `GetTable` public API on `metadataDescriber` and `TableMetadata(keyspace, table)` public API on `Session`
- Adds `refreshTableSchema` for single-table refresh with mutex-protected clone-mutate-swap to prevent concurrent table refreshes from overwriting each other
- Adds `cowKeyspaceMetadataMap.invalidateTable` for table-level COW invalidation with `tablesInvalidated` tracking on `KeyspaceMetadata`
- Adds `KeyspaceMetadata.Clone()` for safe copy-on-write mutations
- Renames `clearSchema` → `invalidateKeyspaceSchema`, `refreshSchema` → `refreshKeyspaceSchema`, `getSchema` → `GetKeyspace`, `cowKeyspaceMetadataMap.remove` → `removeKeyspace` for clarity
- Comprehensive unit tests (1075 lines) with mock infrastructure covering cache state, callbacks, query behavior, and batch events

Fixes: https://github.com/scylladb/gocql/issues/727
Fixes: https://github.com/scylladb/gocql/issues/728

## Known issues to address in follow-ups

1. **No concurrent deduplication (wasted queries)**: Multiple parallel `GetKeyspace` calls on an uncached keyspace fire N×7 queries instead of 7. Same for `GetTable` — N×4 instead of 4. Adding `sync.singleflight` to `getKeyspaceInternal` and `refreshTableSchema` would collapse concurrent callers into a single refresh.

2. **Type/function/aggregate events clear the entire keyspace**: A type change triggers `invalidateKeyspaceSchema` which removes all cached tables, forcing a full 7-query refresh on next access. A more targeted invalidation (refresh only types) would avoid re-fetching tables, columns, indexes, and views when they haven't changed.

3. **Full keyspace refresh on `GetTable` after keyspace invalidation**: When a keyspace event clears the cache and `GetTable("ks", "tbl")` is called, it does a full 7-query keyspace refresh even though only one table was requested. A lazy approach that fetches just keyspace metadata (1 query) + the requested table (4 queries) = 5 queries would be cheaper, deferring the rest until actually needed.

## Test plan
- [x] `make test-unit` — existing tests pass
- [x] `TestHandleSchemaEvent` — 37 sub-tests covering cache state (keyspace/table/type/function/aggregate events with tablet cross-isolation), callbacks (schema agreement, policy notifications), GetKeyspace and GetTable query behavior, and batch event processing
- [ ] `make test-integration-scylla` — run against ScyllaDB cluster
- [ ] `make test-integration-cassandra` — run against Cassandra cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)