### PR TITLE
fix: use correct make target for Cassandra CCM integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,5 +185,5 @@ jobs:
 
       - name: Run CCM integration suite with Cassandra ${{ matrix.cassandra-version }}(${{ steps.cassandra-version.outputs.value }})
         if: steps.cassandra-version.outputs.value != 'NOT-FOUND'
-        run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla
+        run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-cassandra
 


### PR DESCRIPTION
## Summary
- The Cassandra CCM integration step in `main.yml:188` was running `make test-integration-scylla` instead of `make test-integration-cassandra`
- This meant CCM integration tests were never actually executed against Cassandra
- Fixed by changing the make target to `test-integration-cassandra`

## Test plan
- [x] Verify the Cassandra CCM integration job runs the correct target by inspecting CI logs after merge