### PR TITLE
fix: GetTable should fetch unknown tables from the server

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -2523,6 +2523,62 @@ func TestSessionMetadataAPIs(t *testing.T) {
 				t.Errorf("expected ErrNoKeyspace, got: %v", err)
 			}
 		})
+
+		t.Run("fetches_unknown_table_from_server", func(t *testing.T) {
+			// Verifies that GetTable fetches a table from the server even
+			// when the table was never in the local metadata cache and was
+			// never added to tablesInvalidated. This happens for tables
+			// created as side effects (e.g. CDC log tables) where no
+			// dedicated schema event is sent.
+
+			// Ensure keyspace metadata is cached first.
+			if _, err := session.KeyspaceMetadata(ks); err != nil {
+				t.Fatalf("pre-cache KeyspaceMetadata: %v", err)
+			}
+
+			table := "tbl_tm_unknown"
+			if err := createTable(session, fmt.Sprintf(
+				"CREATE TABLE IF NOT EXISTS %s.%s (pk int PRIMARY KEY, v int)", ks, table)); err != nil {
+				t.Fatalf("create table: %v", err)
+			}
+			defer session.Query(fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", ks, table)).Exec()
+
+			waitForSchemaRefresh()
+
+			// Simulate a table that the cache doesn't know about by
+			// looking up a table name that was never invalidated.
+			// The schema event for CREATE TABLE will invalidate the
+			// base table, but we query a different name to replicate
+			// the CDC log table scenario.
+			altTable := "tbl_tm_unknown_alt"
+			if err := createTable(session, fmt.Sprintf(
+				"CREATE TABLE IF NOT EXISTS %s.%s (pk int PRIMARY KEY, v2 text)", ks, altTable)); err != nil {
+				t.Fatalf("create alt table: %v", err)
+			}
+			defer session.Query(fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", ks, altTable)).Exec()
+
+			waitForSchemaRefresh()
+
+			// Clear the invalidation entry so GetTable has to decide
+			// what to do with a table it has never seen.
+			session.metadataDescriber.metadata.keyspaceMetadata.updateKeyspace(ks, func(ksMeta *KeyspaceMetadata) {
+				delete(ksMeta.Tables, altTable)
+				if ksMeta.tablesInvalidated != nil {
+					delete(ksMeta.tablesInvalidated, altTable)
+				}
+			})
+
+			tm, err := session.TableMetadata(ks, altTable)
+			if err != nil {
+				t.Fatalf("TableMetadata for unknown-to-cache table failed: %v", err)
+			}
+			if tm.Name != altTable {
+				t.Errorf("expected table name %q, got %q", altTable, tm.Name)
+			}
+			if _, ok := tm.Columns["v2"]; !ok {
+				t.Errorf("expected column 'v2', got columns: %v", columnNames(tm.Columns))
+			}
+		})
 	})
 
 	t.Run("KeyspaceMetadata", func(t *testing.T) {

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -590,10 +590,10 @@ func (s *metadataDescriber) GetTable(keyspaceName, tableName string) (*TableMeta
 		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
 	}
 
-	if _, ok := keyspaceMetadata.tablesInvalidated[tableName]; !ok {
-		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
-	}
-
+	// Try to refresh the table from the server even if it's not in
+	// tablesInvalidated. The table may exist on the server but be unknown
+	// to the local cache — e.g. CDC log tables created as a side effect
+	// of CREATE TABLE don't trigger a dedicated schema event.
 	err = s.deduplicatedRefreshTable(keyspaceName, tableName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- `GetTable` previously returned `ErrNotFound` immediately when a table was not in the local metadata cache and not in `tablesInvalidated`
- This caused failures for tables created as side effects (e.g. **CDC log tables** created by Scylla when a base table has `cdc = {'enabled': true}`), since no dedicated schema event is sent for the side-effect table and it never appears in `tablesInvalidated`
- Now `GetTable` always attempts to refresh the table from the server when it's not found locally, via the existing `deduplicatedRefreshTable` (singleflight-protected), regardless of whether it was previously invalidated

The change is minimal: removing the 3-line `tablesInvalidated` gate in `GetTable` (lines 593-595 of `metadata_scylla.go`).

## Test plan

- [x] New integration test `TestSessionMetadataAPIs/TableMetadata/fetches_unknown_table_from_server` — simulates the CDC log table scenario by removing a table from both the cache and `tablesInvalidated`, then verifying `TableMetadata` still succeeds
- [x] Existing `TestSessionMetadataAPIs` subtests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)