### PR TITLE
(improvement) perf: Vector float fast paths (subset of https://github.com/scylladb/gocql/pull/770 !)

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -26,6 +26,7 @@ package gocql
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -861,6 +862,33 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 		return nil, nil
 	}
 
+	// Fast paths for []float64/[]float32 — skip reflect/per-element dispatch.
+	// dim=0 falls through to the generic path (CQL null semantics).
+	if info.Dimensions > 0 {
+		switch info.SubType.Type() {
+		case TypeDouble:
+			if v, ok := value.([]float64); ok {
+				if v == nil {
+					return nil, nil
+				}
+				if len(v) != info.Dimensions {
+					return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, len(v))
+				}
+				return marshalVectorFloat64(info.Dimensions, v)
+			}
+		case TypeFloat:
+			if v, ok := value.([]float32); ok {
+				if v == nil {
+					return nil, nil
+				}
+				if len(v) != info.Dimensions {
+					return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, len(v))
+				}
+				return marshalVectorFloat32(info.Dimensions, v)
+			}
+		}
+	}
+
 	rv := reflect.ValueOf(value)
 	t := rv.Type()
 	k := t.Kind()
@@ -899,7 +927,81 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 	return nil, marshalErrorf("can not marshal %T into %s. Accepted types: slice, array.", value, info)
 }
 
+// vectorSliceReuse reuses *dst's backing array when cap is sufficient.
+func vectorSliceReuse[T any](dst *[]T, dim int) []T {
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]T, dim)
+	}
+	return vec
+}
+
+// marshalVectorFloat64 encodes []float64 as contiguous big-endian IEEE 754 doubles.
+func marshalVectorFloat64(dim int, vec []float64) ([]byte, error) {
+	buf := make([]byte, dim*8)
+	for i, v := range vec {
+		binary.BigEndian.PutUint64(buf[i*8:], math.Float64bits(v))
+	}
+	return buf, nil
+}
+
+// marshalVectorFloat32 encodes []float32 as contiguous big-endian IEEE 754 floats.
+func marshalVectorFloat32(dim int, vec []float32) ([]byte, error) {
+	buf := make([]byte, dim*4)
+	for i, v := range vec {
+		binary.BigEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	return buf, nil
+}
+
+// unmarshalVectorFloat64 decodes contiguous big-endian IEEE 754 doubles into vec.
+// The caller is responsible for ensuring data is dim*8 bytes and vec has length dim.
+func unmarshalVectorFloat64(data []byte, vec []float64) {
+	for i := range vec {
+		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[i*8:]))
+	}
+}
+
+// unmarshalVectorFloat32 decodes contiguous big-endian IEEE 754 floats into vec.
+// The caller is responsible for ensuring data is dim*4 bytes and vec has length dim.
+func unmarshalVectorFloat32(data []byte, vec []float32) {
+	for i := range vec {
+		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[i*4:]))
+	}
+}
+
 func unmarshalVector(info VectorType, data []byte, value any) error {
+	// Fast paths for *[]float64/*[]float32 — skip reflect/per-element dispatch.
+	// nil/empty and dim=0 fall through to the generic path.
+	if info.Dimensions > 0 && data != nil {
+		switch info.SubType.Type() {
+		case TypeDouble:
+			if dst, ok := value.(*[]float64); ok {
+				expected := info.Dimensions * 8
+				if len(data) != expected {
+					return unmarshalErrorf("unmarshal vector<double>: expected %d bytes, got %d", expected, len(data))
+				}
+				vec := vectorSliceReuse(dst, info.Dimensions)
+				unmarshalVectorFloat64(data, vec)
+				*dst = vec
+				return nil
+			}
+		case TypeFloat:
+			if dst, ok := value.(*[]float32); ok {
+				expected := info.Dimensions * 4
+				if len(data) != expected {
+					return unmarshalErrorf("unmarshal vector<float>: expected %d bytes, got %d", expected, len(data))
+				}
+				vec := vectorSliceReuse(dst, info.Dimensions)
+				unmarshalVectorFloat32(data, vec)
+				*dst = vec
+				return nil
+			}
+		}
+	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -1,0 +1,551 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"encoding/binary"
+	"math"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// makeDoubleVectorType creates a VectorType for vector<double> with the given dimension.
+func makeDoubleVectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "DoubleType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeDouble},
+		Dimensions: dim,
+	}
+}
+
+// makeFloat32VectorType creates a VectorType for vector<float> with the given dimension.
+func makeFloat32VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "FloatType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+		Dimensions: dim,
+	}
+}
+
+func TestMarshalVectorFloat64_RoundTrip(t *testing.T) {
+	dim := 5
+	info := makeDoubleVectorType(dim)
+	vec := []float64{1.1, 2.2, 3.3, 4.4, 5.5}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshalVector: %v", err)
+	}
+	if len(data) != dim*8 {
+		t.Fatalf("expected %d bytes, got %d", dim*8, len(data))
+	}
+
+	var result []float64
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshalVector: %v", err)
+	}
+	if !reflect.DeepEqual(vec, result) {
+		t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+	}
+}
+
+func TestMarshalVectorFloat32_RoundTrip(t *testing.T) {
+	dim := 5
+	info := makeFloat32VectorType(dim)
+	vec := []float32{1.1, 2.2, 3.3, 4.4, 5.5}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshalVector: %v", err)
+	}
+	if len(data) != dim*4 {
+		t.Fatalf("expected %d bytes, got %d", dim*4, len(data))
+	}
+
+	var result []float32
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshalVector: %v", err)
+	}
+	if !reflect.DeepEqual(vec, result) {
+		t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+	}
+}
+
+// TestVectorFloat_ByteCompatibility verifies that the fast path produces
+// identical bytes to what the generic reflect-based path would produce.
+func TestVectorFloat_ByteCompatibility(t *testing.T) {
+	t.Run("float64", func(t *testing.T) {
+		dim := 3
+		vec := []float64{-1.5, 0, 42.125}
+		// Build expected bytes manually using the same encoding the generic path uses.
+		expected := make([]byte, dim*8)
+		for i, v := range vec {
+			binary.BigEndian.PutUint64(expected[i*8:], math.Float64bits(v))
+		}
+
+		info := makeDoubleVectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+	t.Run("float32", func(t *testing.T) {
+		dim := 3
+		vec := []float32{-1.5, 0, 42.125}
+		expected := make([]byte, dim*4)
+		for i, v := range vec {
+			binary.BigEndian.PutUint32(expected[i*4:], math.Float32bits(v))
+		}
+
+		info := makeFloat32VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+}
+
+func TestVectorFloat_SliceReuse(t *testing.T) {
+	t.Run("float64", func(t *testing.T) {
+		dim := 4
+		info := makeDoubleVectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)))
+		}
+
+		// First unmarshal allocates.
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+
+		// Save the underlying array pointer.
+		ptr := &result[0]
+
+		// Second unmarshal should reuse the same backing array.
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+	t.Run("float32", func(t *testing.T) {
+		dim := 4
+		info := makeFloat32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i)))
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+	t.Run("float64_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeDoubleVectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)+0.5))
+		}
+
+		// Pre-allocate with excess capacity.
+		result := make([]float64, 0, dim+10)
+		ptr := &result[:1][0] // get pointer to backing array
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+	t.Run("float32_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeFloat32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i)+0.5))
+		}
+
+		result := make([]float32, 0, dim+10)
+		ptr := &result[:1][0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+}
+
+func TestVectorFloat_NilData(t *testing.T) {
+	t.Run("float64_nil_data_nil_dst", func(t *testing.T) {
+		info := makeDoubleVectorType(3)
+		var result []float64
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+	t.Run("float64_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeDoubleVectorType(3)
+		result := []float64{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+	t.Run("float32_nil_data_nil_dst", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var result []float32
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+	t.Run("float32_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		result := []float32{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+}
+
+func TestVectorFloat_NilSliceMarshal(t *testing.T) {
+	t.Run("float64_nil_slice", func(t *testing.T) {
+		info := makeDoubleVectorType(3)
+		var vec []float64
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+	t.Run("float32_nil_slice", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var vec []float32
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+	t.Run("float64_nil_ptr", func(t *testing.T) {
+		info := makeDoubleVectorType(3)
+		var ptr *[]float64
+		// Nil pointer handling is Marshal()'s responsibility, not marshalVector's.
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+	t.Run("float32_nil_ptr", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var ptr *[]float32
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+	t.Run("float64_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeDoubleVectorType(3)
+		var s []float64 // nil slice
+		// Non-nil pointer to nil slice — Marshal() dereferences, marshalVector sees nil slice.
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+	t.Run("float32_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var s []float32 // nil slice
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+}
+
+func TestVectorFloat_DimensionMismatch(t *testing.T) {
+	t.Run("float64_marshal", func(t *testing.T) {
+		info := makeDoubleVectorType(3)
+		vec := []float64{1, 2} // wrong dimension
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+	t.Run("float32_marshal", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		vec := []float32{1, 2} // wrong dimension
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+	t.Run("float64_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeDoubleVectorType(3)
+		data := make([]byte, 10) // not divisible by 8*3=24
+		var result []float64
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+	t.Run("float32_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		data := make([]byte, 10) // not 4*3=12
+		var result []float32
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+}
+
+func TestVectorFloat_EmptyVector(t *testing.T) {
+	t.Run("float64_dim0", func(t *testing.T) {
+		info := makeDoubleVectorType(0)
+		vec := []float64{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		// A 0-dimension vector must marshal to CQL null (nil), matching the
+		// generic reflect path; the float fast path must not produce a non-nil
+		// zero-length slice here.
+		if data != nil {
+			t.Errorf("expected nil data for 0-dim vector, got %d bytes (% x)", len(data), data)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+	t.Run("float32_dim0", func(t *testing.T) {
+		info := makeFloat32VectorType(0)
+		vec := []float32{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for 0-dim vector, got %d bytes (% x)", len(data), data)
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+}
+
+func TestVectorFloat_PointerToSlice(t *testing.T) {
+	t.Run("float64_ptr_marshal", func(t *testing.T) {
+		info := makeDoubleVectorType(2)
+		vec := []float64{1.5, 2.5}
+		// Marshal() dereferences the pointer, then marshalVector hits the []float64 fast path.
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]float64: %v", err)
+		}
+
+		// Verify the data is correct by unmarshaling.
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+	t.Run("float32_ptr_marshal", func(t *testing.T) {
+		info := makeFloat32VectorType(2)
+		vec := []float32{1.5, 2.5}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]float32: %v", err)
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+}
+
+func TestVectorFloat_SpecialValues(t *testing.T) {
+	t.Run("float64", func(t *testing.T) {
+		negZero := math.Float64frombits(0x8000000000000000) // -0.0
+		info := makeDoubleVectorType(5)
+		vec := []float64{math.Inf(1), math.Inf(-1), math.MaxFloat64, math.SmallestNonzeroFloat64, negZero}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		// Compare bit patterns: reflect.DeepEqual uses == for floats, where
+		// -0.0 == 0.0, so it would not catch a flipped sign bit on negative
+		// zero. Float64bits makes the negZero element actually verifiable.
+		if len(result) != len(vec) {
+			t.Fatalf("special values length mismatch: got %d, want %d", len(result), len(vec))
+		}
+		for i := range vec {
+			if math.Float64bits(result[i]) != math.Float64bits(vec[i]) {
+				t.Errorf("special values mismatch at %d: got %x, want %x",
+					i, math.Float64bits(result[i]), math.Float64bits(vec[i]))
+			}
+		}
+	})
+	t.Run("float64_nan", func(t *testing.T) {
+		info := makeDoubleVectorType(1)
+		vec := []float64{math.NaN()}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 1 || !math.IsNaN(result[0]) {
+			t.Errorf("expected NaN, got %v", result)
+		}
+	})
+	t.Run("float32", func(t *testing.T) {
+		negZero := math.Float32frombits(0x80000000) // -0.0
+		info := makeFloat32VectorType(5)
+		vec := []float32{float32(math.Inf(1)), float32(math.Inf(-1)), math.MaxFloat32, math.SmallestNonzeroFloat32, negZero}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		// Bitwise compare so the negative-zero element is actually verified
+		// (reflect.DeepEqual treats -0.0 and 0.0 as equal for floats).
+		if len(result) != len(vec) {
+			t.Fatalf("special values length mismatch: got %d, want %d", len(result), len(vec))
+		}
+		for i := range vec {
+			if math.Float32bits(result[i]) != math.Float32bits(vec[i]) {
+				t.Errorf("special values mismatch at %d: got %x, want %x",
+					i, math.Float32bits(result[i]), math.Float32bits(vec[i]))
+			}
+		}
+	})
+	t.Run("float32_nan", func(t *testing.T) {
+		info := makeFloat32VectorType(1)
+		vec := []float32{float32(math.NaN())}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 1 || !math.IsNaN(float64(result[0])) {
+			t.Errorf("expected NaN, got %v", result)
+		}
+	})
+}


### PR DESCRIPTION
Optimizes the float-type marshal/unmarshal code paths used for vector arrays in the driver.

The first commit adds unit tests; the following commit adds type-specialized fast paths for common vector element types.

Additional, smaller performance changes to the marshal/unmarshal paths of this and other types will be submitted separately.

Perf numbers (768-dim float32, benchstat, n=5):
  Marshal:   30.3µs → 1.4µs   (-95.3%, 1544 → 2 allocs)
  Unmarshal: 25.1µs → 631ns   (-97.5%, 2 → 0 allocs)

Measured throughput: ~1.5 GB/s marshal, ~4.5 GB/s unmarshal for float32 vectors (the generic reflect path is roughly 15–35x slower on this benchmark).

---
> **Maintenance note (rebased onto `master`):** This branch was rebased onto the latest `master` (tip `bed2bb09`) and all unit tests pass (only the known SSL/cloud cert env failures, unrelated to this change). The rebase surfaced and fixed a zero-dimension handling case in `unmarshalVector` (empty/zero-dim and nil inputs now defer to the generic path, matching current `master` semantics).
> The benchmark figures above were measured **pre-rebase** against the branch's original merge-base; a re-benchmark against current `master` is pending and numbers will be refreshed.
