### PR TITLE
(fix): (benign) remove duplicate iter.Close() call in awaitSchemaAgreement

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1915,9 +1915,6 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err = iter.Close(); err != nil {
-			return err
-		}
 
 		schemaVersions := []string{}
 


### PR DESCRIPTION
The peers iterator was closed twice in succession — the second call is a no-op (returns the cached error) but is clearly a copy-paste mistake.