### PR TITLE
perf: pool write-side framers to eliminate per-request allocations

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1184,9 +1184,11 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 		return nil, &QueryError{err: ErrNoStreams, potentiallyExecuted: false}
 	}
 
-	// resp is basically a waiting semaphore protecting the framer
-	framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts, c.logger)
-	c.setTabletSupported(framer.tabletsRoutingV1)
+	// Get a write-side framer from the pool. This framer is only used to
+	// serialize and write the request frame; the response comes back on a
+	// separate read-side framer created in recv().
+	writeFramer := getWriteFramer(c.compressor, c.version, c.cqlProtoExts, c.logger)
+	c.setTabletSupported(writeFramer.tabletsRoutingV1)
 
 	call := &callReq{
 		timeout:  make(chan struct{}),
@@ -1199,6 +1201,7 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 	}
 
 	if err := c.addCall(call); err != nil {
+		putWriteFramer(writeFramer)
 		return nil, &QueryError{err: err, potentiallyExecuted: false}
 	}
 
@@ -1207,7 +1210,7 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 	// If we don't close(call.timeout) or read from call.resp, closeWithError can deadlock.
 
 	if tracer != nil {
-		framer.trace()
+		writeFramer.trace()
 	}
 
 	if call.streamObserverContext != nil {
@@ -1216,8 +1219,9 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 		})
 	}
 
-	err := req.buildFrame(framer, stream)
+	err := req.buildFrame(writeFramer, stream)
 	if err != nil {
+		putWriteFramer(writeFramer)
 		// closeWithError will block waiting for this stream to either receive a response
 		// or for us to timeout.
 		close(call.timeout)
@@ -1234,7 +1238,12 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 		return nil, &QueryError{err: err, potentiallyExecuted: false}
 	}
 
-	n, err := c.w.writeContext(ctx, framer.buf)
+	n, err := c.w.writeContext(ctx, writeFramer.buf)
+	// Safety: writeContext always blocks until the buffer is fully consumed by
+	// the underlying writer. Both deadlineContextWriter.writeContext (synchronous
+	// Write) and writeCoalescer.writeContext (blocks on resultChan until flush
+	// completes) guarantee this. The framer's buffer is therefore safe to recycle.
+	putWriteFramer(writeFramer)
 	if err != nil {
 		// closeWithError will block waiting for this stream to either receive a response
 		// or for us to timeout, close the timeout chan here. Im not entirely sure

--- a/frame.go
+++ b/frame.go
@@ -34,6 +34,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	frm "github.com/gocql/gocql/internal/frame"
@@ -250,6 +251,13 @@ func newFramer(compressor Compressor, version byte) *framer {
 		buf:        buf[:0],
 		readBuffer: buf,
 	}
+	initFramer(f, compressor, version)
+	return f
+}
+
+// initFramer sets the compressor, protocol version, and flags on a framer.
+// Shared by newFramer (fresh allocation) and getWriteFramer (pool path).
+func initFramer(f *framer, compressor Compressor, version byte) {
 	var flags byte
 	if compressor != nil {
 		flags |= frm.FlagCompress
@@ -258,29 +266,22 @@ func newFramer(compressor Compressor, version byte) *framer {
 		flags |= frm.FlagBetaProtocol
 	}
 
-	version &= protoVersionMask
 	f.compres = compressor
-	f.proto = version
+	f.proto = version & protoVersionMask
 	f.flags = flags
-	f.header = nil
-	f.traceID = nil
-
-	f.tabletsRoutingV1 = false
-
-	return f
 }
 
-func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension, logger StdLogger) *framer {
-
-	f := newFramer(compressor, version)
-
+// applyFramerExtensions applies CQL protocol extensions to a framer.
+// Shared by newFramerWithExts (fresh allocation) and getWriteFramer (pool path)
+// to prevent the extension-handling logic from diverging.
+func applyFramerExtensions(f *framer, cqlProtoExts []cqlProtocolExtension, logger StdLogger) {
 	if lwtExt := findCQLProtoExtByName(cqlProtoExts, lwtAddMetadataMarkKey); lwtExt != nil {
 		castedExt, ok := lwtExt.(*lwtAddMetadataMarkExt)
 		if !ok {
 			logger.Println(
 				fmt.Errorf("failed to cast CQL protocol extension identified by name %s to type %T",
 					lwtAddMetadataMarkKey, lwtAddMetadataMarkExt{}))
-			return f
+			return
 		}
 		f.flagLWT = castedExt.lwtOptMetaBitMask
 	}
@@ -291,7 +292,7 @@ func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlPr
 			logger.Println(
 				fmt.Errorf("failed to cast CQL protocol extension identified by name %s to type %T",
 					rateLimitError, rateLimitExt{}))
-			return f
+			return
 		}
 		f.rateLimitingErrorCode = castedExt.rateLimitErrorCode
 	}
@@ -302,12 +303,78 @@ func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlPr
 			logger.Println(
 				fmt.Errorf("failed to cast CQL protocol extension identified by name %s to type %T",
 					tabletsRoutingV1, tabletsRoutingV1Ext{}))
-			return f
+			return
 		}
 		f.tabletsRoutingV1 = true
 	}
+}
 
+func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension, logger StdLogger) *framer {
+	f := newFramer(compressor, version)
+	applyFramerExtensions(f, cqlProtoExts, logger)
 	return f
+}
+
+// writeFramerPool pools write-side framers to reduce allocations in the
+// request hot path. Write-side framers have a short, self-contained lifecycle:
+// they are used to serialize a request frame and then immediately returned
+// to the pool. The backing buffer is preserved across reuses to avoid
+// repeated grow/allocate cycles from append().
+var writeFramerPool = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, defaultBufSize)
+		return &framer{
+			buf:        buf[:0],
+			readBuffer: buf,
+		}
+	},
+}
+
+// reset clears all mutable state on the framer so it can be returned to the
+// pool. The backing buffer (readBuffer) is intentionally preserved so that
+// subsequent users benefit from an already-grown buffer, avoiding append
+// reallocation. A cap check prevents oversized buffers from lingering in
+// the pool.
+const maxPooledBufSize = 64 * 1024 // 64 KiB
+
+func (f *framer) reset() {
+	// If buf grew beyond readBuffer during writes (via append), adopt the
+	// larger backing array so subsequent pool users benefit from the already-
+	// grown buffer. Discard if it exceeds the maximum pooled size.
+	if cap(f.buf) > cap(f.readBuffer) {
+		f.readBuffer = f.buf[:cap(f.buf)]
+	}
+	if cap(f.readBuffer) > maxPooledBufSize {
+		buf := make([]byte, defaultBufSize)
+		f.readBuffer = buf
+	}
+	f.buf = f.readBuffer[:0]
+	f.compres = nil
+	f.header = nil
+	f.customPayload = nil
+	f.traceID = nil
+	f.flagLWT = 0
+	f.rateLimitingErrorCode = 0
+	f.proto = 0
+	f.flags = 0
+	f.tabletsRoutingV1 = false
+}
+
+// getWriteFramer retrieves a framer from the pool and initializes it for
+// writing with the given compressor and protocol version, including any
+// CQL protocol extensions. This mirrors what newFramerWithExts does but
+// reuses allocations.
+func getWriteFramer(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension, logger StdLogger) *framer {
+	f := writeFramerPool.Get().(*framer)
+	initFramer(f, compressor, version)
+	applyFramerExtensions(f, cqlProtoExts, logger)
+	return f
+}
+
+// putWriteFramer returns a write-side framer to the pool after resetting it.
+func putWriteFramer(f *framer) {
+	f.reset()
+	writeFramerPool.Put(f)
 }
 
 type frame interface {

--- a/frame_test.go
+++ b/frame_test.go
@@ -29,11 +29,17 @@ package gocql
 
 import (
 	"bytes"
+	"io"
+	"log"
 	"os"
+	"sync"
 	"testing"
 
 	frm "github.com/gocql/gocql/internal/frame"
 )
+
+// benchLogger discards output to avoid skewing benchmark results.
+var benchLogger = log.New(io.Discard, "", 0)
 
 func TestFuzzBugs(t *testing.T) {
 	t.Parallel()
@@ -161,4 +167,265 @@ func TestParseEventFrame_ClientRoutesChanged(t *testing.T) {
 	if len(evt.HostIDs) != 0 {
 		t.Fatalf("HostIDs = %v, want empty", evt.HostIDs)
 	}
+}
+
+func TestFramerResetClearsAllFields(t *testing.T) {
+	t.Parallel()
+
+	f := newFramer(nil, protoVersion4)
+	// Populate every mutable field
+	f.header = &frm.FrameHeader{Version: protoVersion4}
+	f.customPayload = map[string][]byte{"key": {1, 2, 3}}
+	f.traceID = make([]byte, 16)
+	f.flagLWT = 42
+	f.rateLimitingErrorCode = 7
+	f.tabletsRoutingV1 = true
+	f.proto = protoVersion4
+	f.flags = frm.FlagTracing | frm.FlagCompress
+
+	// Grow buf beyond readBuffer to simulate a serialized frame
+	f.writeHeader(f.flags, frm.OpQuery, 1)
+	f.writeBytes(make([]byte, 512))
+
+	f.reset()
+
+	if f.compres != nil {
+		t.Error("compres should be nil after reset")
+	}
+	if f.header != nil {
+		t.Error("header should be nil after reset")
+	}
+	if f.customPayload != nil {
+		t.Error("customPayload should be nil after reset")
+	}
+	if f.traceID != nil {
+		t.Error("traceID should be nil after reset")
+	}
+	if f.flagLWT != 0 {
+		t.Errorf("flagLWT should be 0 after reset, got %d", f.flagLWT)
+	}
+	if f.rateLimitingErrorCode != 0 {
+		t.Errorf("rateLimitingErrorCode should be 0 after reset, got %d", f.rateLimitingErrorCode)
+	}
+	if f.proto != 0 {
+		t.Errorf("proto should be 0 after reset, got %d", f.proto)
+	}
+	if f.flags != 0 {
+		t.Errorf("flags should be 0 after reset, got %x", f.flags)
+	}
+	if f.tabletsRoutingV1 {
+		t.Error("tabletsRoutingV1 should be false after reset")
+	}
+	if len(f.buf) != 0 {
+		t.Errorf("buf should have length 0 after reset, got %d", len(f.buf))
+	}
+	if f.readBuffer == nil {
+		t.Error("readBuffer should not be nil after reset")
+	}
+}
+
+func TestFramerResetPreservesNormalBuffer(t *testing.T) {
+	t.Parallel()
+
+	f := newFramer(nil, protoVersion4)
+	// Grow the buffer to something larger than default but under the cap
+	f.writeHeader(0, frm.OpQuery, 1)
+	f.writeBytes(make([]byte, 4096))
+
+	grownCap := cap(f.buf)
+	if grownCap <= defaultBufSize {
+		t.Fatalf("expected buf to have grown beyond %d, got cap=%d", defaultBufSize, grownCap)
+	}
+
+	f.reset()
+
+	// readBuffer should retain the grown capacity
+	if cap(f.readBuffer) != grownCap {
+		t.Errorf("expected readBuffer cap to be preserved at %d, got %d", grownCap, cap(f.readBuffer))
+	}
+	// buf should point to readBuffer
+	if cap(f.buf) != cap(f.readBuffer) {
+		t.Errorf("buf and readBuffer should share backing array after reset")
+	}
+}
+
+func TestFramerResetDiscardsOversizedBuffer(t *testing.T) {
+	t.Parallel()
+
+	f := newFramer(nil, protoVersion4)
+	// Replace readBuffer with an oversized one
+	oversized := make([]byte, maxPooledBufSize+1)
+	f.readBuffer = oversized
+	f.buf = oversized[:0]
+
+	f.reset()
+
+	if cap(f.readBuffer) > maxPooledBufSize {
+		t.Errorf("expected readBuffer to be replaced (cap=%d), got cap=%d", defaultBufSize, cap(f.readBuffer))
+	}
+	if cap(f.readBuffer) != defaultBufSize {
+		t.Errorf("expected readBuffer cap=%d after discard, got %d", defaultBufSize, cap(f.readBuffer))
+	}
+}
+
+func TestGetPutWriteFramerRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+
+	f := getWriteFramer(nil, protoVersion4, nil, logger)
+	if f == nil {
+		t.Fatal("getWriteFramer returned nil")
+	}
+	if f.proto != protoVersion4&protoVersionMask {
+		t.Errorf("expected proto=%d, got %d", protoVersion4&protoVersionMask, f.proto)
+	}
+
+	// Use it: write a header and some data
+	f.writeHeader(f.flags, frm.OpQuery, 1)
+	f.writeBytes(make([]byte, 256))
+
+	grownCap := cap(f.buf)
+
+	// Return to pool
+	putWriteFramer(f)
+
+	// Get another framer — should reuse the pooled one (or get a new one; either is valid)
+	f2 := getWriteFramer(nil, protoVersion3, nil, logger)
+	if f2 == nil {
+		t.Fatal("second getWriteFramer returned nil")
+	}
+	if f2.proto != protoVersion3&protoVersionMask {
+		t.Errorf("expected proto=%d, got %d", protoVersion3&protoVersionMask, f2.proto)
+	}
+	if len(f2.buf) != 0 {
+		t.Errorf("expected buf to be empty, got len=%d", len(f2.buf))
+	}
+
+	// If we got the same framer back, the buffer should retain its capacity
+	if f == f2 && cap(f2.readBuffer) != grownCap {
+		t.Errorf("expected reused framer to retain buffer capacity %d, got %d", grownCap, cap(f2.readBuffer))
+	}
+
+	putWriteFramer(f2)
+}
+
+func TestWriteFramerPoolConcurrency(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+
+	const goroutines = 100
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				f := getWriteFramer(nil, protoVersion4, nil, logger)
+
+				// Simulate building a frame
+				f.writeHeader(f.flags, frm.OpQuery, 1)
+				f.writeBytes(make([]byte, 64))
+
+				// Verify basic invariants before returning
+				if f.proto != protoVersion4&protoVersionMask {
+					t.Errorf("unexpected proto version: %d", f.proto)
+				}
+				if len(f.buf) == 0 {
+					t.Error("buf should not be empty after writing")
+				}
+
+				putWriteFramer(f)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestWriteFramerBuiltFrameIntegrity(t *testing.T) {
+	t.Parallel()
+
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+
+	// Get a framer, build a real frame, verify bytes match what newFramerWithExts produces
+	pooled := getWriteFramer(nil, protoVersion4, nil, logger)
+	pooled.writeHeader(pooled.flags, frm.OpQuery, 5)
+	pooled.writeString("SELECT 1")
+	if err := pooled.finish(); err != nil {
+		t.Fatal(err)
+	}
+	pooledBuf := make([]byte, len(pooled.buf))
+	copy(pooledBuf, pooled.buf)
+	putWriteFramer(pooled)
+
+	fresh := newFramerWithExts(nil, protoVersion4, nil, logger)
+	fresh.writeHeader(fresh.flags, frm.OpQuery, 5)
+	fresh.writeString("SELECT 1")
+	if err := fresh.finish(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(pooledBuf, fresh.buf) {
+		t.Errorf("pooled framer produced different bytes than fresh framer:\npooled: %x\nfresh:  %x", pooledBuf, fresh.buf)
+	}
+}
+
+// buildTypicalFrame simulates building a typical CQL query frame.
+func buildTypicalFrame(f *framer) {
+	f.writeHeader(f.flags, frm.OpQuery, 1)
+	f.writeString("SELECT key, value FROM my_keyspace.my_table WHERE key = ?")
+	// Simulate query parameters (consistency + values)
+	f.writeShort(0x0001) // ONE consistency
+	f.writeByte(0x01)    // flags: values present
+	f.writeShort(1)      // 1 value
+	f.writeBytes([]byte("some-partition-key-value-here"))
+	_ = f.finish()
+}
+
+// BenchmarkFramerNewAlloc benchmarks the old path: allocate a new framer per frame.
+func BenchmarkFramerNewAlloc(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		f := newFramerWithExts(nil, protoVersion4, nil, benchLogger)
+		buildTypicalFrame(f)
+		// Frame is written to wire; framer becomes garbage
+	}
+}
+
+// BenchmarkFramerPooled benchmarks the new path: get from pool, use, return.
+func BenchmarkFramerPooled(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		f := getWriteFramer(nil, protoVersion4, nil, benchLogger)
+		buildTypicalFrame(f)
+		putWriteFramer(f)
+	}
+}
+
+// BenchmarkFramerNewAllocParallel benchmarks concurrent new-alloc framers.
+func BenchmarkFramerNewAllocParallel(b *testing.B) {
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			f := newFramerWithExts(nil, protoVersion4, nil, benchLogger)
+			buildTypicalFrame(f)
+		}
+	})
+}
+
+// BenchmarkFramerPooledParallel benchmarks concurrent pooled framers.
+func BenchmarkFramerPooledParallel(b *testing.B) {
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			f := getWriteFramer(nil, protoVersion4, nil, benchLogger)
+			buildTypicalFrame(f)
+			putWriteFramer(f)
+		}
+	})
 }


### PR DESCRIPTION
Add a sync.Pool for write-side framers in exec(), reducing allocations on the request hot path. Each CQL request previously allocated a new framer (struct + 128-byte buffer) that was discarded after serializing the frame. Pooled framers preserve their grown backing buffers across reuses, avoiding repeated append-triggered reallocations.

Key changes:
- frame.go: Add writeFramerPool, reset(), getWriteFramer(), putWriteFramer() with a 64 KiB cap to prevent oversized buffers from lingering in the pool. reset() adopts buf's grown backing array when append() has outgrown readBuffer.
- conn.go: exec() uses getWriteFramer/putWriteFramer on all exit paths (addCall failure, buildFrame failure, after writeContext).
- frame_test.go: 6 unit tests covering reset field clearing, buffer preservation/discard, pool round-trip, concurrent safety, and byte-level integrity vs newFramerWithExts. 4 benchmarks (sequential + parallel).

Benchmark results (12th Gen i7-1270P, 16 threads):
  Sequential: 111 ns/op -> 25 ns/op  (~4.4x faster, 2 -> 0 allocs)
  Parallel:   146 ns/op -> 6.7 ns/op (~22x faster, 2 -> 0 allocs)

Refs: https://github.com/scylladb/gocql/issues/613