### PR TITLE
perf: reuse queryRoutingInfo and queryMetrics in Query pool

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -1312,6 +1312,10 @@ type SpeculativeExecutionPolicy interface {
 
 type NonSpeculativeExecution struct{}
 
+// defaultNonSpecExec is a package-level singleton that avoids allocating a new
+// NonSpeculativeExecution every time a Query or Batch is initialised.
+var defaultNonSpecExec SpeculativeExecutionPolicy = &NonSpeculativeExecution{}
+
 func (sp NonSpeculativeExecution) Attempts() int        { return 0 } // No additional attempts
 func (sp NonSpeculativeExecution) Delay() time.Duration { return 1 } // The delay. Must be positive to be used in a ticker.
 

--- a/session.go
+++ b/session.go
@@ -1157,10 +1157,12 @@ func (qm *queryMetrics) latency() int64 {
 	return 0
 }
 
-// reset resets metrics, to forget about prior query executions
+// reset resets metrics, to forget about prior query executions.
+// Uses clear() instead of make() to preserve the map's backing array,
+// avoiding a heap allocation on each re-execution.
 func (qm *queryMetrics) reset() {
 	qm.l.Lock()
-	qm.m = make(map[string]*hostMetrics)
+	clear(qm.m)
 	qm.totalAttempts = 0
 	qm.l.Unlock()
 }
@@ -1869,7 +1871,6 @@ func (q *Query) reset() {
 	if m != nil {
 		clear(m.m)
 		m.totalAttempts = 0
-		m.l = sync.RWMutex{}
 	}
 
 	*q = Query{routingInfo: &queryRoutingInfo{}, metrics: m, refCount: 1}

--- a/session.go
+++ b/session.go
@@ -100,7 +100,11 @@ type Session struct {
 
 var queryPool = &sync.Pool{
 	New: func() interface{} {
-		return &Query{routingInfo: &queryRoutingInfo{}, refCount: 1}
+		return &Query{
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			refCount:    1,
+		}
 	},
 }
 
@@ -555,9 +559,7 @@ func (s *Session) Query(stmt string, values ...interface{}) *Query {
 	qry.session = s
 	qry.stmt = stmt
 	qry.values = values
-	qry.hostID = ""
 	qry.defaultsFromSession()
-	qry.routingInfo.lwt = false
 	qry.SetRequestTimeout(s.cfg.Timeout)
 	return qry
 }
@@ -581,7 +583,6 @@ func (s *Session) Bind(stmt string, b func(q *QueryInfo) ([]interface{}, error))
 	qry.stmt = stmt
 	qry.binding = b
 	qry.defaultsFromSession()
-	qry.routingInfo.lwt = false
 	qry.SetRequestTimeout(s.cfg.Timeout)
 	return qry
 }
@@ -1276,7 +1277,9 @@ func (q *Query) defaultsFromSession() {
 	q.serialCons = s.cfg.SerialConsistency
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
-	q.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
+	if q.metrics == nil {
+		q.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
+	}
 
 	q.spec = &NonSpeculativeExecution{}
 	s.mu.RUnlock()
@@ -1859,8 +1862,17 @@ func (q *Query) Release() {
 }
 
 // reset zeroes out all fields of a query so that it can be safely pooled.
+// It preserves the metrics allocation for reuse. routingInfo is always freshly
+// allocated because paging copies share the pointer (see conn.go executeQuery).
 func (q *Query) reset() {
-	*q = Query{routingInfo: &queryRoutingInfo{}, refCount: 1}
+	m := q.metrics
+	if m != nil {
+		clear(m.m)
+		m.totalAttempts = 0
+		m.l = sync.RWMutex{}
+	}
+
+	*q = Query{routingInfo: &queryRoutingInfo{}, metrics: m, refCount: 1}
 }
 
 func (q *Query) incRefCount() {

--- a/session.go
+++ b/session.go
@@ -1283,7 +1283,7 @@ func (q *Query) defaultsFromSession() {
 		q.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
 	}
 
-	q.spec = &NonSpeculativeExecution{}
+	q.spec = defaultNonSpecExec
 	s.mu.RUnlock()
 }
 
@@ -2536,7 +2536,7 @@ func (s *Session) Batch(typ BatchType) *Batch {
 		defaultTimestamp: s.cfg.DefaultTimestamp,
 		keyspace:         s.cfg.Keyspace,
 		metrics:          &queryMetrics{m: make(map[string]*hostMetrics)},
-		spec:             &NonSpeculativeExecution{},
+		spec:             defaultNonSpecExec,
 		routingInfo:      &queryRoutingInfo{},
 		requestTimeout:   s.cfg.Timeout,
 	}


### PR DESCRIPTION
## Summary

Pool `Query` objects using `sync.Pool` to reduce heap allocations on the hot path. Each query cycle (session.Query → execute → Release) previously allocated a fresh `Query`, `queryRoutingInfo`, `queryMetrics`, and its backing map. With pooling, the `Query` struct and its `queryMetrics` (including the map backing array) are reused across cycles.

### Changes

**Query pool & metrics reuse**
- **`Query.reset()`** zeroes all fields via struct assignment, preserves the `metrics` pointer for reuse (clears the map with `clear()` to keep bucket memory), and allocates a **fresh** `routingInfo` each time — because paging in `conn.go` does `*newQry = *qry` (shallow copy), sharing the `routingInfo` pointer with the original query.
- **`queryMetrics.reset()`** now uses `clear(qm.m)` instead of `make(map[string]*hostMetrics)` to preserve the map backing array, avoiding a heap allocation on each re-execution.
- **`Query.reset()` mutex**: Removed redundant `m.l = sync.RWMutex{}` — the `refCount` protocol guarantees the mutex is unlocked when `reset()` runs (only called when refCount hits 0).
- **`defaultsFromSession()`** skips metrics allocation if already present.
- **`queryPool.New`** creates metrics upfront to avoid first-use allocation.
- **Ref-counting** (`borrowForExecution`/`releaseAfterExecution`) ensures no goroutine accesses the `Query` after all refs are released. `decRefCount()` calls `reset()` only when `refCount` reaches 0.

**NonSpeculativeExecution singleton**
- `defaultsFromSession()` and `Batch()` previously allocated `&NonSpeculativeExecution{}` on every call. Because `NonSpeculativeExecution` is stored via the `SpeculativeExecutionPolicy` interface, each allocation escapes to the heap.
- Replaced with a package-level singleton `defaultNonSpecExec` — eliminates one heap allocation per query/batch init.

**Tests**: 4 unit tests + 4 benchmarks added in `query_pool_test.go`. All unit tests pass with `-race`.

### Benchmark Results

`benchstat` comparison — old pattern (fresh allocation each cycle) vs new pattern (pool reuse), count=5, 12th Gen i7-1270P:

| Benchmark | Baseline (alloc) | PR (pool) | Speedup |
|---|---|---|---|
| **QueryPool-16 sec/op** | 133.4n ± 34% | 82.3n ± 7% | **-38.3%** |
| **QueryPoolParallel-16 sec/op** | 119.1n ± 5% | 63.5n ± 9% | **-46.7%** |
| **QueryPool-16 B/op** | 320 | 96 | **-70.0%** |
| **QueryPoolParallel-16 B/op** | 320 | 96 | **-70.0%** |
| **QueryPool-16 allocs/op** | 4 | 2 | **-50.0%** |
| **QueryPoolParallel-16 allocs/op** | 4 | 2 | **-50.0%** |

The remaining 2 allocs/96B per op are: 1 fresh `queryRoutingInfo` (required for paging safety) + 1 `hostMetrics` struct from simulated query usage, not pool overhead.

Refs: https://github.com/scylladb/gocql/issues/613