### PR TITLE
fix: unsafe.Pointer use-after-free in double and float unmarshal

### DIFF
--- a/serialization/double/unmarshal_utils.go
+++ b/serialization/double/unmarshal_utils.go
@@ -53,7 +53,7 @@ func DecReflect(p []byte, v reflect.Value) error {
 
 	switch v = v.Elem(); v.Kind() {
 	case reflect.Float64:
-		return decReflectFloat32(p, v)
+		return decReflectFloat64(p, v)
 	default:
 		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v), supported types: ~float64", v.Interface())
 	}
@@ -66,13 +66,13 @@ func DecReflectR(p []byte, v reflect.Value) error {
 
 	switch v.Type().Elem().Elem().Kind() {
 	case reflect.Float64:
-		return decReflectFloat32R(p, v)
+		return decReflectFloat64R(p, v)
 	default:
 		return fmt.Errorf("failed to unmarshal double: unsupported value type (%T)(%[1]v), supported types: ~float64", v.Interface())
 	}
 }
 
-func decReflectFloat32(p []byte, v reflect.Value) error {
+func decReflectFloat64(p []byte, v reflect.Value) error {
 	switch len(p) {
 	case 0:
 		v.SetFloat(0)
@@ -84,7 +84,7 @@ func decReflectFloat32(p []byte, v reflect.Value) error {
 	return nil
 }
 
-func decReflectFloat32R(p []byte, v reflect.Value) error {
+func decReflectFloat64R(p []byte, v reflect.Value) error {
 	switch len(p) {
 	case 0:
 		v.Elem().Set(decReflectNullableR(p, v))
@@ -118,7 +118,8 @@ func uint64ToFloat(v uint64) float64 {
 }
 
 func uint64ToFloatR(v uint64) *float64 {
-	return (*float64)(unsafe.Pointer(&v))
+	f := *(*float64)(unsafe.Pointer(&v))
+	return &f
 }
 
 func decUint64(p []byte) uint64 {

--- a/serialization/float/unmarshal_utils.go
+++ b/serialization/float/unmarshal_utils.go
@@ -118,7 +118,8 @@ func uint32ToFloat(v uint32) float32 {
 }
 
 func uint32ToFloatR(v uint32) *float32 {
-	return (*float32)(unsafe.Pointer(&v))
+	f := *(*float32)(unsafe.Pointer(&v))
+	return &f
 }
 
 func decUint32(p []byte) uint32 {


### PR DESCRIPTION
Fixes https://github.com/scylladb/gocql/issues/757

## 💪 What

- Fixes use-after-free in `uint64ToFloatR` (`serialization/double`) and `uint32ToFloatR` (`serialization/float`) where a pointer to a stack-local function parameter was returned as the result
- Renames copy-paste-misnamed `decReflectFloat32` / `decReflectFloat32R` in the `double` package to `decReflectFloat64` / `decReflectFloat64R`

## 🤔 Why

- Both `uint64ToFloatR` and `uint32ToFloatR` return an `unsafe.Pointer` to a function parameter `v`. Once the function returns, `v` goes out of scope, leaving a dangling pointer. This affects the `**float64` / `**float32` unmarshal paths (`DecFloat64R` / `DecFloat32R`)
- The misleading `decReflectFloat32` names in the `double` package were a copy-paste artifact from the `float` package — the functions correctly operate on `float64`, but the names suggest `float32`

## 👩‍🔬 How to validate

1. Review `uint64ToFloatR` and `uint32ToFloatR` — the value is now dereferenced into a local variable before returning its address, avoiding the dangling pointer
2. Verify `decReflectFloat64` / `decReflectFloat64R` names match usage in `DecReflect` / `DecReflectR` call sites