### PR TITLE
(improvement) select only needed columns from system_schema.columns

### DIFF
--- a/events_unit_test.go
+++ b/events_unit_test.go
@@ -271,7 +271,7 @@ func (m *schemaDataMock) querySystem(statement string, values ...interface{}) *I
 		return &Iter{}
 	}
 
-	if strings.HasPrefix(statement, "SELECT * FROM system_schema.columns WHERE keyspace_name = ?") &&
+	if strings.HasPrefix(statement, "SELECT "+columnMetadataColumns+" FROM system_schema.columns WHERE keyspace_name = ?") &&
 		!strings.Contains(statement, "AND table_name") {
 		ksName, _ := values[0].(string)
 		tables, ok := m.knownKeyspaces[ksName]
@@ -296,7 +296,7 @@ func (m *schemaDataMock) querySystem(statement string, values ...interface{}) *I
 		}
 	}
 
-	if strings.HasPrefix(statement, "SELECT * FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?") {
+	if strings.HasPrefix(statement, "SELECT "+columnMetadataColumns+" FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?") {
 		ksName, _ := values[0].(string)
 		tblName, _ := values[1].(string)
 		tables, ok := m.knownKeyspaces[ksName]
@@ -713,7 +713,7 @@ func TestHandleSchemaEvent(t *testing.T) {
 		return map[string]int{
 			"SELECT durable_writes, replication FROM system_schema.keyspaces WHERE keyspace_name = ?": 1,
 			"SELECT * FROM system_schema.tables WHERE keyspace_name = ?":                              1,
-			"SELECT * FROM system_schema.columns WHERE keyspace_name = ?":                             1,
+			"SELECT " + columnMetadataColumns + " FROM system_schema.columns WHERE keyspace_name = ?": 1,
 			"SELECT * FROM system_schema.types WHERE keyspace_name = ?":                               1,
 			"SELECT * FROM system_schema.indexes WHERE keyspace_name = ?":                             1,
 			"SELECT * FROM system_schema.views WHERE keyspace_name = ?":                               1,
@@ -721,10 +721,10 @@ func TestHandleSchemaEvent(t *testing.T) {
 		}
 	}
 	tableRefresh := map[string]int{
-		"SELECT * FROM system_schema.tables WHERE keyspace_name = ? AND table_name = ?":                     1,
-		"SELECT * FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?":                    1,
-		"SELECT * FROM system_schema.indexes WHERE keyspace_name = ? AND table_name = ?":                    1,
-		"SELECT * FROM system_schema.views WHERE keyspace_name = ? AND base_table_name = ? ALLOW FILTERING": 1,
+		"SELECT * FROM system_schema.tables WHERE keyspace_name = ? AND table_name = ?":                              1,
+		"SELECT " + columnMetadataColumns + " FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?": 1,
+		"SELECT * FROM system_schema.indexes WHERE keyspace_name = ? AND table_name = ?":                             1,
+		"SELECT * FROM system_schema.views WHERE keyspace_name = ? AND base_table_name = ? ALLOW FILTERING":          1,
 	}
 	noQueries := map[string]int{}
 

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -1222,8 +1222,15 @@ func getTableMetadataByName(session *Session, keyspaceName, tableName string) ([
 	return tables, nil
 }
 
+// columnMetadataColumns lists the columns consumed by getColumnMetadata and
+// getColumnMetadataByTable. Selecting only these columns (instead of SELECT *)
+// avoids deserializing unused fields such as keyspace_name (already known from
+// the WHERE clause) and column_name_bytes (ScyllaDB-specific), which can add
+// over 50 KB of wasted payload per keyspace with 80+ tables.
+const columnMetadataColumns = `table_name, column_name, clustering_order, type, kind, position`
+
 func getColumnMetadataByTable(session *Session, keyspaceName, tableName string) ([]ColumnMetadata, error) {
-	const stmt = `SELECT * FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?`
+	const stmt = `SELECT ` + columnMetadataColumns + ` FROM system_schema.columns WHERE keyspace_name = ? AND table_name = ?`
 
 	var columns []ColumnMetadata
 
@@ -1327,7 +1334,7 @@ func getViewMetadataByTable(session *Session, keyspaceName, tableName string) ([
 
 // query for column metadata in the system_schema.columns
 func getColumnMetadata(session *Session, keyspaceName string) ([]ColumnMetadata, error) {
-	const stmt = `SELECT * FROM system_schema.columns WHERE keyspace_name = ?`
+	const stmt = `SELECT ` + columnMetadataColumns + ` FROM system_schema.columns WHERE keyspace_name = ?`
 
 	var columns []ColumnMetadata
 


### PR DESCRIPTION
The metadata refresh queries for system_schema.columns used SELECT *, which fetches all columns even though the driver only consumes 6 of the ~8 available (table_name, column_name, clustering_order, type, kind, position). The unused columns (keyspace_name, column_name_bytes) were deserialized and silently discarded by MapScan on every row.

Because system_schema.columns has one row per column per table, its size is the cartesian product of tables x columns-per-table in a keyspace. In a setup with >80 tables, this produced response payloads exceeding 50KB per metadata refresh — with a significant portion being redundant data (e.g. keyspace_name repeated identically in every row, despite already being known from the query's WHERE clause).

Replace SELECT * with an explicit column list in both getColumnMetadata (keyspace-wide refresh) and getColumnMetadataByTable (single-table refresh) to reduce network transfer, server-side serialization, and client-side deserialization overhead.