### PR TITLE
(improvement): Skip DDL prepare and optimize shouldPrepare

### DIFF
--- a/session.go
+++ b/session.go
@@ -36,6 +36,7 @@ import (
 	"sync/atomic"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/gocql/gocql/debounce"
 	"github.com/gocql/gocql/events"
@@ -1223,6 +1224,12 @@ type Query struct {
 	skipPrepare           bool
 	disableSkipMetadata   bool
 	defaultTimestamp      bool
+	// prepareCache caches whether shouldPrepare has been computed.
+	// Since q.stmt is immutable after construction, the result never
+	// changes. Accessed atomically because speculative execution may
+	// call shouldPrepare from multiple goroutines concurrently.
+	// Values: 0 = unknown, 1 = should prepare (DML), 2 = should not prepare.
+	prepareCache uint32
 }
 
 type queryRoutingInfo struct {
@@ -1506,23 +1513,79 @@ func (q *Query) GetRoutingKey() ([]byte, error) {
 }
 
 func (q *Query) shouldPrepare() bool {
-
-	stmt := strings.TrimLeftFunc(strings.TrimRightFunc(q.stmt, func(r rune) bool {
-		return unicode.IsSpace(r) || r == ';'
-	}), unicode.IsSpace)
-
-	var stmtType string
-	if n := strings.IndexFunc(stmt, unicode.IsSpace); n >= 0 {
-		stmtType = strings.ToLower(stmt[:n])
+	if v := atomic.LoadUint32(&q.prepareCache); v != 0 {
+		return v == 1
 	}
-	if stmtType == "begin" {
-		if n := strings.LastIndexFunc(stmt, unicode.IsSpace); n >= 0 {
-			stmtType = strings.ToLower(stmt[n+1:])
+	result := stmtIsDML(q.stmt)
+	if result {
+		atomic.StoreUint32(&q.prepareCache, 1)
+	} else {
+		atomic.StoreUint32(&q.prepareCache, 2)
+	}
+	return result
+}
+
+// stmtKeyword returns the first whitespace-delimited keyword of a CQL
+// statement, skipping leading whitespace. For "BEGIN …" statements it
+// returns the last word instead (e.g. "BATCH"). The returned substring
+// shares the backing array of stmt (zero allocations). The result is
+// not lowercased; callers should use strings.EqualFold for comparison.
+func stmtKeyword(stmt string) string {
+	// Skip leading whitespace using unicode-aware scanning (no allocation).
+	i := 0
+	for i < len(stmt) {
+		r, size := utf8.DecodeRuneInString(stmt[i:])
+		if !unicode.IsSpace(r) {
+			break
 		}
+		i += size
 	}
-	switch stmtType {
-	case "select", "insert", "update", "delete", "batch":
-		return true
+
+	// Find the end of the first word.
+	j := i
+	for j < len(stmt) {
+		r, size := utf8.DecodeRuneInString(stmt[j:])
+		if unicode.IsSpace(r) {
+			break
+		}
+		j += size
+	}
+
+	word := stmt[i:j]
+	if strings.EqualFold(word, "begin") {
+		// Handle "BEGIN BATCH ... APPLY BATCH" — extract the last word.
+		end := len(stmt)
+		for end > j {
+			r, size := utf8.DecodeLastRuneInString(stmt[:end])
+			if !unicode.IsSpace(r) && r != ';' {
+				break
+			}
+			end -= size
+		}
+		start := end
+		for start > j {
+			r, size := utf8.DecodeLastRuneInString(stmt[:start])
+			if unicode.IsSpace(r) {
+				break
+			}
+			start -= size
+		}
+		word = stmt[start:end]
+	}
+	return word
+}
+
+// stmtIsDML reports whether stmt is a DML statement that should be prepared.
+func stmtIsDML(stmt string) bool {
+	kw := stmtKeyword(stmt)
+	switch len(kw) {
+	case 5: // "batch"
+		return strings.EqualFold(kw, "batch")
+	case 6: // "select", "insert", "update", "delete"
+		return strings.EqualFold(kw, "select") ||
+			strings.EqualFold(kw, "insert") ||
+			strings.EqualFold(kw, "update") ||
+			strings.EqualFold(kw, "delete")
 	}
 	return false
 }

--- a/session.go
+++ b/session.go
@@ -1481,6 +1481,13 @@ func (q *Query) GetRoutingKey() ([]byte, error) {
 		return nil, nil
 	}
 
+	// Non-DML statements (DDL, USE, GRANT, etc.) do not need preparation
+	// and have no routing key. Skip the routingKeyInfo call which would
+	// otherwise send a wasteful PREPARE frame to the server.
+	if !q.shouldPrepare() {
+		return nil, nil
+	}
+
 	// try to determine the routing key
 	routingKeyInfo, err := q.session.routingKeyInfo(q.Context(), q.stmt, q.requestTimeout)
 	if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -207,17 +207,16 @@ func TestQueryShouldPrepare(t *testing.T) {
 
 	toPrepare := []string{"select * ", "INSERT INTO", "update table", "delete from", "begin batch"}
 	cantPrepare := []string{"create table", "USE table", "LIST keyspaces", "alter table", "drop table", "grant user", "revoke user"}
-	q := &Query{routingInfo: &queryRoutingInfo{}}
 
 	for i := 0; i < len(toPrepare); i++ {
-		q.stmt = toPrepare[i]
+		q := &Query{stmt: toPrepare[i], routingInfo: &queryRoutingInfo{}}
 		if !q.shouldPrepare() {
 			t.Fatalf("expected Query.shouldPrepare to return true, got false for statement '%v'", toPrepare[i])
 		}
 	}
 
 	for i := 0; i < len(cantPrepare); i++ {
-		q.stmt = cantPrepare[i]
+		q := &Query{stmt: cantPrepare[i], routingInfo: &queryRoutingInfo{}}
 		if q.shouldPrepare() {
 			t.Fatalf("expected Query.shouldPrepare to return false, got true for statement '%v'", cantPrepare[i])
 		}

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -36,10 +36,10 @@ import (
 	"github.com/gocql/gocql/tablets"
 )
 
-func TestGetRoutingKeySkipsDDL(t *testing.T) {
+func TestShouldPrepareNonDML(t *testing.T) {
 	t.Parallel()
 
-	ddlStatements := []string{
+	nonDMLStatements := []string{
 		"CREATE TABLE ks.tbl (id int PRIMARY KEY)",
 		"ALTER TABLE ks.tbl ADD col text",
 		"DROP TABLE ks.tbl",
@@ -50,50 +50,39 @@ func TestGetRoutingKeySkipsDDL(t *testing.T) {
 		"USE ks",
 	}
 
-	for _, stmt := range ddlStatements {
-		// session is intentionally nil — if GetRoutingKey tries to call
-		// routingKeyInfo it will panic, proving the guard works.
-		q := &Query{
-			stmt:        stmt,
-			routingInfo: &queryRoutingInfo{},
-		}
-		key, err := q.GetRoutingKey()
-		if err != nil {
-			t.Errorf("GetRoutingKey(%q) returned error: %v", stmt, err)
-		}
-		if key != nil {
-			t.Errorf("GetRoutingKey(%q) returned non-nil key: %v", stmt, key)
-		}
+	for _, stmt := range nonDMLStatements {
+		t.Run(stmt, func(t *testing.T) {
+			q := &Query{stmt: stmt, routingInfo: &queryRoutingInfo{}}
+			if q.shouldPrepare() {
+				t.Errorf("shouldPrepare(%q) = true, want false", stmt)
+			}
+		})
 	}
 }
 
-func TestGetRoutingKeyDMLNeedsSession(t *testing.T) {
+func TestShouldPrepareDML(t *testing.T) {
 	t.Parallel()
 
-	// DML statements should NOT be short-circuited — they need to go through
-	// routingKeyInfo to compute a routing key. With a nil session this will
-	// panic, confirming that the guard does not block DML.
 	dmlStatements := []string{
 		"SELECT * FROM ks.tbl",
 		"INSERT INTO ks.tbl (id) VALUES (?)",
 		"UPDATE ks.tbl SET col = ? WHERE id = ?",
 		"DELETE FROM ks.tbl WHERE id = ?",
+		"BEGIN BATCH INSERT INTO ks.tbl (id) VALUES (1) APPLY BATCH",
+		"BEGIN BATCH INSERT INTO ks.tbl (id) VALUES (1) APPLY BATCH;",
+		"BEGIN UNLOGGED BATCH INSERT INTO ks.tbl (id) VALUES (1) APPLY BATCH",
+		"  SELECT * FROM ks.tbl",
+		"\t INSERT INTO ks.tbl (id) VALUES (?)",
+		"\u00a0SELECT * FROM ks.tbl",
 	}
 
 	for _, stmt := range dmlStatements {
-		q := &Query{
-			stmt:        stmt,
-			routingInfo: &queryRoutingInfo{},
-		}
-
-		func() {
-			defer func() {
-				if r := recover(); r == nil {
-					t.Errorf("GetRoutingKey(%q) did not panic with nil session — shouldPrepare guard may be blocking DML", stmt)
-				}
-			}()
-			q.GetRoutingKey()
-		}()
+		t.Run(stmt, func(t *testing.T) {
+			q := &Query{stmt: stmt, routingInfo: &queryRoutingInfo{}}
+			if !q.shouldPrepare() {
+				t.Errorf("shouldPrepare(%q) = false, want true", stmt)
+			}
+		})
 	}
 }
 

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -36,6 +36,67 @@ import (
 	"github.com/gocql/gocql/tablets"
 )
 
+func TestGetRoutingKeySkipsDDL(t *testing.T) {
+	t.Parallel()
+
+	ddlStatements := []string{
+		"CREATE TABLE ks.tbl (id int PRIMARY KEY)",
+		"ALTER TABLE ks.tbl ADD col text",
+		"DROP TABLE ks.tbl",
+		"TRUNCATE ks.tbl",
+		"CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy'}",
+		"DROP KEYSPACE ks",
+		"GRANT SELECT ON ks.tbl TO user1",
+		"USE ks",
+	}
+
+	for _, stmt := range ddlStatements {
+		// session is intentionally nil — if GetRoutingKey tries to call
+		// routingKeyInfo it will panic, proving the guard works.
+		q := &Query{
+			stmt:        stmt,
+			routingInfo: &queryRoutingInfo{},
+		}
+		key, err := q.GetRoutingKey()
+		if err != nil {
+			t.Errorf("GetRoutingKey(%q) returned error: %v", stmt, err)
+		}
+		if key != nil {
+			t.Errorf("GetRoutingKey(%q) returned non-nil key: %v", stmt, key)
+		}
+	}
+}
+
+func TestGetRoutingKeyDMLNeedsSession(t *testing.T) {
+	t.Parallel()
+
+	// DML statements should NOT be short-circuited — they need to go through
+	// routingKeyInfo to compute a routing key. With a nil session this will
+	// panic, confirming that the guard does not block DML.
+	dmlStatements := []string{
+		"SELECT * FROM ks.tbl",
+		"INSERT INTO ks.tbl (id) VALUES (?)",
+		"UPDATE ks.tbl SET col = ? WHERE id = ?",
+		"DELETE FROM ks.tbl WHERE id = ?",
+	}
+
+	for _, stmt := range dmlStatements {
+		q := &Query{
+			stmt:        stmt,
+			routingInfo: &queryRoutingInfo{},
+		}
+
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("GetRoutingKey(%q) did not panic with nil session — shouldPrepare guard may be blocking DML", stmt)
+				}
+			}()
+			q.GetRoutingKey()
+		}()
+	}
+}
+
 func TestAsyncSessionInit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
While testing Temporal.IO and capturing some CQL queries, I've noticed for some reason it was preparing some DDL queries, such as 'CREATE TABLE ...' which made no sense at all.

## Changes

### Commit 1 — Skip wasteful PREPARE for non-DML statements

When `TokenAwareHostPolicy` is active, every query goes through
`GetRoutingKey()` → `routingKeyInfo()` → `prepareStatement()` to compute a
routing key for token-aware host selection. This path has no guard on
the statement type, so non-DML statements (CREATE TABLE, ALTER, DROP,
USE, GRANT, etc.) trigger a PREPARE frame that the server rejects.
The error is silently swallowed by the policy which falls back to
round-robin, and execution proceeds normally via a simple QUERY frame.

While the final behavior is correct, each non-DML statement incurs a
wasteful PREPARE round-trip. The failed result is also not cached
(`routingKeyInfoCache.Remove` is called on error), so the same DDL
statement will trigger the wasteful PREPARE on every execution.

Adds a `shouldPrepare()` guard in `GetRoutingKey()` that returns `(nil, nil)`
for non-DML statements, short-circuiting before the PREPARE is sent.

### Commit 2 — Eliminate heap allocations in `shouldPrepare()`

`shouldPrepare()` is called on every query execution (both from
`Conn.executeQuery` and now from `GetRoutingKey`). The previous
implementation allocated 1–2 strings per call via `TrimRightFunc`,
`TrimLeftFunc`, and `ToLower`.

Replaces with:
- Zero-allocation rune-level index walking via `utf8.DecodeRuneInString`
- `strings.EqualFold` for case-insensitive comparison (no lowered copy)
- Length pre-check in `stmtIsDML()` to skip `EqualFold` calls for non-matching keyword lengths
- Extracted `stmtKeyword()` / `stmtIsDML()` standalone functions for readability and testability
- Cached result on the `Query` struct (`prepareCache uint32` with `atomic` load/store) so repeated calls (from `GetRoutingKey` + `Conn.executeQuery`) pay zero cost after the first, and are safe under concurrent speculative execution

## Benchmark results (benchstat, 10 samples, `taskset -c 0`)

```
goos: linux
goarch: amd64
cpu: 12th Gen Intel(R) Core(TM) i7-1270P
```

### Time/op

| Benchmark | Before | After | Delta |
|---|---|---|---|
| `SELECT` | 80.42 ns/op | 66.36 ns/op | **-17.48%** (p=0.000) |
| `INSERT` | 74.28 ns/op | 66.64 ns/op | **-10.28%** (p=0.000) |
| `BEGIN BATCH` | 158.45 ns/op | 73.98 ns/op | **-53.31%** (p=0.000) |
| `CREATE TABLE` | 79.67 ns/op | 70.49 ns/op | **-11.52%** (p=0.000) |
| `USE` | 62.71 ns/op | 25.41 ns/op | **-59.48%** (p=0.000) |
| **geomean** | **86.09 ns** | **56.70 ns** | **-34.14%** |

### Allocations

| Benchmark | Before (B/op) | After (B/op) | Before (allocs/op) | After (allocs/op) |
|---|---|---|---|---|
| `SELECT` | 8 | 0 | 1 | 0 |
| `INSERT` | 8 | 0 | 1 | 0 |
| `BEGIN BATCH` | 16 | 0 | 2 | 0 |
| `CREATE TABLE` | 8 | 0 | 1 | 0 |
| `USE` | 8 | 0 | 1 | 0 |

All allocations eliminated (p=0.000 for every case).

> Note: benchmarks defeat the per-Query cache (`prepareCache = 0` each iteration) to measure the raw parsing cost. In production, repeated calls to `shouldPrepare()` on the same Query are free after the first.

---

### v2 — Fix `TestQueryShouldPrepare` CI failure

The pre-existing `TestQueryShouldPrepare` (integration-tagged, `session_test.go`) reused a single `Query` object across all test cases by mutating `q.stmt` between iterations. With the new per-Query `shouldPrepare()` cache, the first call cached the result and all subsequent calls returned the stale cached value regardless of `stmt` changes.

Fixed by creating a fresh `Query` per test case, consistent with the new `TestShouldPrepareNonDML` / `TestShouldPrepareDML` unit tests.

### v3 — Fix data race in `shouldPrepare()`

CI runs with `-race` and caught a data race: speculative execution calls `shouldPrepare()` from multiple goroutines concurrently on the same `Query`. The two plain `bool` fields (`prepareKnown`/`prepareResult`) were read and written without synchronization.

Fixed by replacing the two bools with a single `uint32` field (`prepareCache`) using `atomic.LoadUint32`/`atomic.StoreUint32`. Values: 0 = unknown, 1 = should prepare (DML), 2 = should not prepare. All unit tests pass with `-race`. Benchmarks re-run and updated above.