### PR TITLE
perf: optimize vector marshal/unmarshal for float32/float64/int32/int64 (Throughput: 75 MiB/s → 1.9 GiB/s (marshal), 106 MiB/s → 4.6 GiB/s (unmarshal) )

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1687,6 +1687,29 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 			}
 		}
 
+		// Return pooled vector buffers after the framer has copied the
+		// marshalled bytes (which happens inside c.exec → buildFrame).
+		// Only install the defer when at least one column uses a poolable
+		// vector buffer to avoid ~50ns defer overhead on non-vector queries.
+		cols := info.request.columns
+		vals := params.values
+		hasPooledVec := false
+		for _, col := range cols {
+			if vt, ok := col.TypeInfo.(VectorType); ok && vectorBufPoolSubtype(vt) {
+				hasPooledVec = true
+				break
+			}
+		}
+		if hasPooledVec {
+			defer func() {
+				for i, col := range cols {
+					if vt, ok := col.TypeInfo.(VectorType); ok && vectorBufPoolSubtype(vt) {
+						putVectorBuf(vals[i].value)
+					}
+				}
+			}()
+		}
+
 		// if the metadata was not present in the response then we should not skip it
 		params.skipMeta = !(c.session.cfg.DisableSkipMetadata || qry.disableSkipMetadata) && len(info.response.columns) != 0
 
@@ -1866,6 +1889,10 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 
 	hasLwtEntries := false
 
+	// vectorBufs collects marshalled byte slices from vector fast paths
+	// so they can be returned to vectorBufPool after the framer copies them.
+	var vectorBufs [][]byte
+
 	for i := 0; i < n; i++ {
 		entry := &batch.Entries[i]
 		b := &req.statements[i]
@@ -1907,6 +1934,9 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 				if err := marshalQueryValue(typ, value, v); err != nil {
 					return &Iter{err: err}
 				}
+				if vt, ok := typ.(VectorType); ok && vectorBufPoolSubtype(vt) {
+					vectorBufs = append(vectorBufs, v.value)
+				}
 			}
 
 			if !hasLwtEntries && info.request.lwt {
@@ -1915,6 +1945,16 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 		} else {
 			b.statement = entry.Stmt
 		}
+	}
+
+	// Return pooled vector buffers after the framer has copied the
+	// marshalled bytes (which happens inside c.exec → buildFrame).
+	if len(vectorBufs) > 0 {
+		defer func() {
+			for _, buf := range vectorBufs {
+				putVectorBuf(buf)
+			}
+		}()
 	}
 
 	// The batch is considered to be conditional if even one of the

--- a/conn.go
+++ b/conn.go
@@ -2569,10 +2569,36 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 		}
 
 		params.values = getQueryValues(len(values))
+
+		// Install the pooled-vector-buffer cleanup BEFORE the marshalling loop:
+		// if marshalQueryValue fails mid-loop we still return already-marshalled
+		// vector buffers to the pool. The framer copies the bytes inside
+		// c.exec → buildFrame, so deferring the put until function exit is safe.
+		// Only install the defer when at least one column uses a poolable vector
+		// buffer, to avoid ~50ns defer overhead on non-vector queries.
+		// putVectorBuf(nil) is a no-op, so entries not yet marshalled are safe.
+		cols := info.request.columns
+		hasPooledVec := false
+		for i := 0; i < len(values) && i < len(cols); i++ {
+			if vt, ok := cols[i].TypeInfo.(VectorType); ok && vectorBufPoolSubtype(vt) {
+				hasPooledVec = true
+				break
+			}
+		}
+		if hasPooledVec {
+			defer func() {
+				for i := 0; i < len(params.values) && i < len(cols); i++ {
+					if vt, ok := cols[i].TypeInfo.(VectorType); ok && vectorBufPoolSubtype(vt) {
+						putVectorBuf(params.values[i].value)
+					}
+				}
+			}()
+		}
+
 		for i := 0; i < len(values); i++ {
 			v := &params.values[i]
 			value := values[i]
-			typ := info.request.columns[i].TypeInfo
+			typ := cols[i].TypeInfo
 			if err := marshalQueryValue(typ, value, v); err != nil {
 				putQueryValues(params.values)
 				return &Iter{err: err}
@@ -2879,6 +2905,20 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 
 	hasLwtEntries := false
 
+	// vectorBufs collects marshalled byte slices from vector fast paths
+	// so they can be returned to vectorBufPool after the framer copies them.
+	var vectorBufs [][]byte
+	// Install the cleanup defer up front (before the marshalling loop) so that
+	// buffers accumulated before an early return — e.g. a mid-loop
+	// marshalQueryValue failure — are still returned to the pool. The closure
+	// reads vectorBufs at function exit, so it sees whatever was appended. The
+	// framer copies the bytes inside c.exec → buildFrame, so deferring is safe.
+	defer func() {
+		for _, buf := range vectorBufs {
+			putVectorBuf(buf)
+		}
+	}()
+
 	for i := 0; i < n; i++ {
 		entry := &batch.Entries[i]
 		b := &req.statements[i]
@@ -2923,6 +2963,9 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 				if err := marshalQueryValue(typ, value, v); err != nil {
 					putBatchQueryValues(req.statements)
 					return &Iter{err: err}
+				}
+				if vt, ok := typ.(VectorType); ok && vectorBufPoolSubtype(vt) {
+					vectorBufs = append(vectorBufs, v.value)
 				}
 			}
 

--- a/helpers_bench_test.go
+++ b/helpers_bench_test.go
@@ -227,3 +227,40 @@ func BenchmarkRowDataAllocation(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkRowDataWithVector measures RowData() performance when the schema
+// includes a vector column (common in AI/ML embedding tables). This exercises
+// the VectorType.NewWithError() fast path added to avoid the expensive
+// goType() → asVectorType() re-parse on every call.
+func BenchmarkRowDataWithVector(b *testing.B) {
+	columns := []ColumnInfo{
+		{Name: "id", TypeInfo: NativeType{typ: TypeInt, proto: protoVersion4}},
+		{Name: "embedding", TypeInfo: VectorType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeCustom,
+				custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "FloatType, 1536)"},
+			SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+			Dimensions: 1536,
+		}},
+		{Name: "label", TypeInfo: NativeType{typ: TypeVarchar, proto: protoVersion4}},
+	}
+
+	iter := &Iter{
+		meta: resultMetadata{
+			columns:        columns,
+			colCount:       len(columns),
+			actualColCount: len(columns),
+		},
+		numRows: 1,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd, err := iter.RowData()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = rd
+	}
+}

--- a/helpers_bench_test.go
+++ b/helpers_bench_test.go
@@ -275,3 +275,40 @@ func BenchmarkRowDataRepeatedCached(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkRowDataWithVector measures RowData() performance when the schema
+// includes a vector column (common in AI/ML embedding tables). This exercises
+// the VectorType.NewWithError() fast path added to avoid the expensive
+// goType() → asVectorType() re-parse on every call.
+func BenchmarkRowDataWithVector(b *testing.B) {
+	columns := []ColumnInfo{
+		{Name: "id", TypeInfo: NativeType{typ: TypeInt, proto: protoVersion4}},
+		{Name: "embedding", TypeInfo: VectorType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeCustom,
+				custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "FloatType, 1536)"},
+			SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+			Dimensions: 1536,
+		}},
+		{Name: "label", TypeInfo: NativeType{typ: TypeVarchar, proto: protoVersion4}},
+	}
+
+	iter := &Iter{
+		meta: resultMetadata{
+			columns:        columns,
+			colCount:       len(columns),
+			actualColCount: len(columns),
+		},
+		numRows: 1,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd, err := iter.RowData()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = rd
+	}
+}

--- a/marshal.go
+++ b/marshal.go
@@ -26,12 +26,14 @@ package gocql
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
 	"math/big"
 	"math/bits"
 	"reflect"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -848,6 +850,26 @@ func marshalVector(info VectorType, value interface{}) ([]byte, error) {
 		return nil, nil
 	}
 
+	// Fast paths for common vector types — avoid reflect entirely.
+	switch info.SubType.Type() {
+	case TypeFloat:
+		if vec, ok := value.([]float32); ok {
+			return marshalVectorFloat32(info.Dimensions, vec)
+		}
+	case TypeDouble:
+		if vec, ok := value.([]float64); ok {
+			return marshalVectorFloat64(info.Dimensions, vec)
+		}
+	case TypeInt:
+		if vec, ok := value.([]int32); ok {
+			return marshalVectorInt32(info.Dimensions, vec)
+		}
+	case TypeBigInt:
+		if vec, ok := value.([]int64); ok {
+			return marshalVectorInt64(info.Dimensions, vec)
+		}
+	}
+
 	rv := reflect.ValueOf(value)
 	t := rv.Type()
 	k := t.Kind()
@@ -860,6 +882,11 @@ func marshalVector(info VectorType, value interface{}) ([]byte, error) {
 		n := rv.Len()
 		if n != info.Dimensions {
 			return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, n)
+		}
+		// Zero-dimension vectors encode as a non-nil empty value (not CQL NULL).
+		// bytes.Buffer{}.Bytes() returns nil, so we must special-case this.
+		if n == 0 {
+			return make([]byte, 0), nil
 		}
 
 		isLengthType := isVectorVariableLengthType(info.SubType)
@@ -887,6 +914,26 @@ func marshalVector(info VectorType, value interface{}) ([]byte, error) {
 }
 
 func unmarshalVector(info VectorType, data []byte, value interface{}) error {
+	// Fast paths for common vector types — avoid reflect entirely.
+	switch info.SubType.Type() {
+	case TypeFloat:
+		if dst, ok := value.(*[]float32); ok {
+			return unmarshalVectorFloat32(info.Dimensions, data, dst)
+		}
+	case TypeDouble:
+		if dst, ok := value.(*[]float64); ok {
+			return unmarshalVectorFloat64(info.Dimensions, data, dst)
+		}
+	case TypeInt:
+		if dst, ok := value.(*[]int32); ok {
+			return unmarshalVectorInt32(info.Dimensions, data, dst)
+		}
+	case TypeBigInt:
+		if dst, ok := value.(*[]int64); ok {
+			return unmarshalVectorInt64(info.Dimensions, data, dst)
+		}
+	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -931,6 +978,10 @@ func unmarshalVector(info VectorType, data []byte, value interface{}) error {
 				return unmarshalErrorf("unmarshal vector: array of size %d cannot store vector of %d dimensions", rv.Len(), info.Dimensions)
 			}
 		} else {
+			// TODO: reuse existing slice backing array when cap >= info.Dimensions
+			// instead of unconditionally allocating. This would bring the generic path
+			// closer to the fast-path zero-alloc behavior. Can be done independently
+			// since this code predates the fast-path implementation.
 			rv.Set(reflect.MakeSlice(t, info.Dimensions, info.Dimensions))
 			if rv.Kind() == reflect.Interface {
 				rv = rv.Elem()
@@ -969,6 +1020,316 @@ func unmarshalVector(info VectorType, data []byte, value interface{}) error {
 	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *slice, *array, *interface{}.", info, value)
 }
 
+// vectorBufPool pools []byte buffers used by vector marshal fast paths.
+// Buffers are returned to the pool by putVectorBuf after the framer copies them.
+//
+// NOTE: putVectorBuf is currently exercised only by benchmarks/tests.
+// Wiring it into the connection write path (so production callers return
+// buffers after the framer copies them) is planned for a follow-up change.
+var vectorBufPool = sync.Pool{}
+
+func getVectorBuf(size int) []byte {
+	if size < 0 {
+		return nil
+	}
+	if size == 0 {
+		return make([]byte, 0)
+	}
+	if v := vectorBufPool.Get(); v != nil {
+		if buf, ok := v.([]byte); ok {
+			if cap(buf) >= size {
+				return buf[:size]
+			}
+			// Undersized buffer: return it so smaller vectors can reuse it.
+			vectorBufPool.Put(buf) //nolint:staticcheck // SA6002: []byte is a value type; boxing cost is acceptable for pool reuse
+		}
+	}
+	return make([]byte, size)
+}
+
+func putVectorBuf(buf []byte) {
+	if buf == nil || cap(buf) > 65536 {
+		return
+	}
+	vectorBufPool.Put(buf) //nolint:staticcheck // SA6002: []byte is a value type; boxing cost is acceptable for pool reuse
+}
+
+// vectorByteSize computes dim * elemBytes and returns an error if the result
+// would overflow int. This guards against corrupt or adversarial schema metadata
+// on 32-bit platforms where int is 32 bits.
+func vectorByteSize(dim, elemBytes int) (int, error) {
+	n := int64(dim) * int64(elemBytes)
+	if n < 0 || n > int64(math.MaxInt) {
+		return 0, fmt.Errorf("vector byte size overflow: %d dimensions * %d bytes/elem", dim, elemBytes)
+	}
+	return int(n), nil
+}
+
+// marshalVectorFloat32 encodes a float32 slice as a contiguous big-endian
+// IEEE 754 vector. Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorFloat32(dim int, vec []float32) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint32(buf[off:off+4], math.Float32bits(v))
+		off += 4
+	}
+	return buf, nil
+}
+
+// marshalVectorFloat64 encodes a float64 slice as a contiguous big-endian
+// IEEE 754 vector. Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorFloat64(dim int, vec []float64) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint64(buf[off:off+8], math.Float64bits(v))
+		off += 8
+	}
+	return buf, nil
+}
+
+// unmarshalVectorFloat32 decodes contiguous big-endian IEEE 754 floats.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorFloat32(dim int, data []byte, dst *[]float32) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<float, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]float32, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]float32, dim)
+	}
+	for i := range vec {
+		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[:4]))
+		data = data[4:]
+	}
+	*dst = vec
+	return nil
+}
+
+// unmarshalVectorFloat64 decodes contiguous big-endian IEEE 754 doubles.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorFloat64(dim int, data []byte, dst *[]float64) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<double, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]float64, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]float64, dim)
+	}
+	for i := range vec {
+		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[:8]))
+		data = data[8:]
+	}
+	*dst = vec
+	return nil
+}
+
+// marshalVectorInt32 encodes an int32 slice as a contiguous big-endian
+// vector (CQL int = 4 bytes). Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorInt32(dim int, vec []int32) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint32(buf[off:off+4], uint32(v))
+		off += 4
+	}
+	return buf, nil
+}
+
+// marshalVectorInt64 encodes an int64 slice as a contiguous big-endian
+// vector (CQL bigint = 8 bytes). Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorInt64(dim int, vec []int64) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint64(buf[off:off+8], uint64(v))
+		off += 8
+	}
+	return buf, nil
+}
+
+// unmarshalVectorInt32 decodes contiguous big-endian CQL int (4-byte) values.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorInt32(dim int, data []byte, dst *[]int32) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<int, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]int32, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]int32, dim)
+	}
+	for i := range vec {
+		vec[i] = int32(binary.BigEndian.Uint32(data[:4]))
+		data = data[4:]
+	}
+	*dst = vec
+	return nil
+}
+
+// unmarshalVectorInt64 decodes contiguous big-endian CQL bigint (8-byte) values.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<bigint, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]int64, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]int64, dim)
+	}
+	for i := range vec {
+		vec[i] = int64(binary.BigEndian.Uint64(data[:8]))
+		data = data[8:]
+	}
+	*dst = vec
+	return nil
+}
+
+// vectorFixedElemSize returns the known wire-format byte size for fixed-length
+// CQL types used as vector elements, specifically the subset that
+// isVectorVariableLengthType classifies as fixed-length. Returns 0 for
+// variable-length or unknown types.
+//
+// NOTE: Some types that have a fixed wire size (TinyInt=1, SmallInt=2,
+// Date=4, Time=8, Counter=8) are classified as variable-length by
+// isVectorVariableLengthType due to discrepancies between Cassandra and
+// ScyllaDB implementations, and are deliberately excluded here.
 func vectorFixedElemSize(elemType TypeInfo) int {
 	switch elemType.Type() {
 	case TypeBoolean:
@@ -979,8 +1340,9 @@ func vectorFixedElemSize(elemType TypeInfo) int {
 		return 8
 	case TypeUUID, TypeTimeUUID:
 		return 16
+	default:
+		return 0
 	}
-	return 0
 }
 
 // isVectorVariableLengthType determines if a type requires explicit length serialization within a vector.

--- a/marshal.go
+++ b/marshal.go
@@ -868,6 +868,10 @@ func marshalVector(info VectorType, value interface{}) ([]byte, error) {
 		if vec, ok := value.([]int64); ok {
 			return marshalVectorInt64(info.Dimensions, vec)
 		}
+	case TypeUUID, TypeTimeUUID:
+		if vec, ok := value.([]UUID); ok {
+			return marshalVectorUUID(info.Dimensions, vec)
+		}
 	}
 
 	rv := reflect.ValueOf(value)
@@ -931,6 +935,10 @@ func unmarshalVector(info VectorType, data []byte, value interface{}) error {
 	case TypeBigInt:
 		if dst, ok := value.(*[]int64); ok {
 			return unmarshalVectorInt64(info.Dimensions, data, dst)
+		}
+	case TypeUUID, TypeTimeUUID:
+		if dst, ok := value.(*[]UUID); ok {
+			return unmarshalVectorUUID(info.Dimensions, data, dst)
 		}
 	}
 
@@ -1059,7 +1067,7 @@ func putVectorBuf(buf []byte) {
 // marshal fast path that allocates from vectorBufPool via getVectorBuf.
 func vectorBufPoolSubtype(vt VectorType) bool {
 	switch vt.SubType.Type() {
-	case TypeFloat, TypeDouble, TypeInt, TypeBigInt:
+	case TypeFloat, TypeDouble, TypeInt, TypeBigInt, TypeUUID, TypeTimeUUID:
 		return true
 	default:
 		return false
@@ -1336,6 +1344,73 @@ func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
 	_ = data[dim*8-1] // BCE hint: compiler can prove data[i*8:i*8+8] is in-bounds
 	for i := range vec {
 		vec[i] = int64(binary.BigEndian.Uint64(data[i*8 : i*8+8]))
+	}
+	*dst = vec
+	return nil
+}
+
+// marshalVectorUUID encodes a UUID slice as a contiguous vector
+// (CQL uuid/timeuuid = 16 bytes). Uses a pooled buffer for zero-alloc steady state.
+// UUID is [16]byte so no endian conversion is needed — just a flat copy.
+func marshalVectorUUID(dim int, vec []UUID) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*16-1] // BCE hint
+	for i, v := range vec {
+		copy(buf[i*16:i*16+16], v[:])
+	}
+	return buf, nil
+}
+
+// unmarshalVectorUUID decodes contiguous CQL uuid/timeuuid (16-byte) values.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorUUID(dim int, data []byte, dst *[]UUID) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<uuid, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]UUID, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]UUID, dim)
+	}
+	_ = data[dim*16-1] // BCE hint
+	for i := range vec {
+		copy(vec[i][:], data[i*16:i*16+16])
 	}
 	*dst = vec
 	return nil

--- a/marshal.go
+++ b/marshal.go
@@ -1023,9 +1023,10 @@ func unmarshalVector(info VectorType, data []byte, value interface{}) error {
 // vectorBufPool pools []byte buffers used by vector marshal fast paths.
 // Buffers are returned to the pool by putVectorBuf after the framer copies them.
 //
-// NOTE: putVectorBuf is currently exercised only by benchmarks/tests.
-// Wiring it into the connection write path (so production callers return
-// buffers after the framer copies them) is planned for a follow-up change.
+// vectorBufPool is used by the marshal fast paths (marshalVectorFloat32 etc.)
+// to allocate temporary byte buffers. After the framer copies the marshalled
+// bytes via writeBytes (append into framer.buf), the caller returns the buffer
+// to the pool via putVectorBuf.
 var vectorBufPool = sync.Pool{}
 
 func getVectorBuf(size int) []byte {
@@ -1052,6 +1053,17 @@ func putVectorBuf(buf []byte) {
 		return
 	}
 	vectorBufPool.Put(buf) //nolint:staticcheck // SA6002: []byte is a value type; boxing cost is acceptable for pool reuse
+}
+
+// vectorBufPoolSubtype returns true if the given VectorType's SubType uses a
+// marshal fast path that allocates from vectorBufPool via getVectorBuf.
+func vectorBufPoolSubtype(vt VectorType) bool {
+	switch vt.SubType.Type() {
+	case TypeFloat, TypeDouble, TypeInt, TypeBigInt:
+		return true
+	default:
+		return false
+	}
 }
 
 // vectorByteSize computes dim * elemBytes and returns an error if the result
@@ -1082,10 +1094,12 @@ func marshalVectorFloat32(dim int, vec []float32) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint32(buf[off:off+4], math.Float32bits(v))
-		off += 4
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*4-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint32(buf[i*4:i*4+4], math.Float32bits(v))
 	}
 	return buf, nil
 }
@@ -1107,10 +1121,12 @@ func marshalVectorFloat64(dim int, vec []float64) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint64(buf[off:off+8], math.Float64bits(v))
-		off += 8
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*8-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint64(buf[i*8:i*8+8], math.Float64bits(v))
 	}
 	return buf, nil
 }
@@ -1146,9 +1162,9 @@ func unmarshalVectorFloat32(dim int, data []byte, dst *[]float32) error {
 	} else {
 		vec = make([]float32, dim)
 	}
+	_ = data[dim*4-1] // BCE hint: compiler can prove data[i*4:i*4+4] is in-bounds
 	for i := range vec {
-		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[:4]))
-		data = data[4:]
+		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[i*4 : i*4+4]))
 	}
 	*dst = vec
 	return nil
@@ -1185,9 +1201,9 @@ func unmarshalVectorFloat64(dim int, data []byte, dst *[]float64) error {
 	} else {
 		vec = make([]float64, dim)
 	}
+	_ = data[dim*8-1] // BCE hint: compiler can prove data[i*8:i*8+8] is in-bounds
 	for i := range vec {
-		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[:8]))
-		data = data[8:]
+		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[i*8 : i*8+8]))
 	}
 	*dst = vec
 	return nil
@@ -1210,10 +1226,12 @@ func marshalVectorInt32(dim int, vec []int32) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint32(buf[off:off+4], uint32(v))
-		off += 4
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*4-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint32(buf[i*4:i*4+4], uint32(v))
 	}
 	return buf, nil
 }
@@ -1235,10 +1253,12 @@ func marshalVectorInt64(dim int, vec []int64) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint64(buf[off:off+8], uint64(v))
-		off += 8
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*8-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint64(buf[i*8:i*8+8], uint64(v))
 	}
 	return buf, nil
 }
@@ -1274,9 +1294,9 @@ func unmarshalVectorInt32(dim int, data []byte, dst *[]int32) error {
 	} else {
 		vec = make([]int32, dim)
 	}
+	_ = data[dim*4-1] // BCE hint: compiler can prove data[i*4:i*4+4] is in-bounds
 	for i := range vec {
-		vec[i] = int32(binary.BigEndian.Uint32(data[:4]))
-		data = data[4:]
+		vec[i] = int32(binary.BigEndian.Uint32(data[i*4 : i*4+4]))
 	}
 	*dst = vec
 	return nil
@@ -1313,9 +1333,9 @@ func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
 	} else {
 		vec = make([]int64, dim)
 	}
+	_ = data[dim*8-1] // BCE hint: compiler can prove data[i*8:i*8+8] is in-bounds
 	for i := range vec {
-		vec[i] = int64(binary.BigEndian.Uint64(data[:8]))
-		data = data[8:]
+		vec[i] = int64(binary.BigEndian.Uint64(data[i*8 : i*8+8]))
 	}
 	*dst = vec
 	return nil

--- a/marshal.go
+++ b/marshal.go
@@ -1149,20 +1149,23 @@ func unmarshalVectorFloat32(dim int, data []byte, dst *[]float32) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 4)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<float, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]float32, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<float, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1188,20 +1191,23 @@ func unmarshalVectorFloat64(dim int, data []byte, dst *[]float64) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 8)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<double, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]float64, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<double, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1281,20 +1287,23 @@ func unmarshalVectorInt32(dim int, data []byte, dst *[]int32) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 4)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<int, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]int32, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<int, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1320,20 +1329,23 @@ func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 8)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<bigint, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]int64, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<bigint, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1387,20 +1399,23 @@ func unmarshalVectorUUID(dim int, data []byte, dst *[]UUID) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 16)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<uuid, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]UUID, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<uuid, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -2314,6 +2329,63 @@ func (v VectorType) Zero() interface{} {
 		return nil
 	}
 	return reflect.Zero(reflect.SliceOf(reflect.TypeOf(t))).Interface()
+}
+
+// NewWithError creates a pointer to an empty slice of the appropriate Go type
+// for this vector's element type. Fast paths avoid reflection for the common
+// fixed-size element types (float, double, int, bigint, uuid/timeuuid).
+// Without this method, VectorType would inherit NativeType.NewWithError which
+// falls back to goType() → asVectorType(), re-parsing the full Java type
+// string (e.g. "org.apache.cassandra.db.marshal.VectorType(…)") on every call.
+func (v VectorType) NewWithError() (interface{}, error) {
+	// Fast path: return *[]T directly for common element types.
+	if nt, ok := v.SubType.(NativeType); ok {
+		switch nt.typ {
+		case TypeFloat:
+			return new([]float32), nil
+		case TypeDouble:
+			return new([]float64), nil
+		case TypeInt:
+			return new([]int), nil
+		case TypeBigInt, TypeCounter:
+			return new([]int64), nil
+		case TypeSmallInt:
+			return new([]int16), nil
+		case TypeTinyInt:
+			return new([]int8), nil
+		case TypeBoolean:
+			return new([]bool), nil
+		case TypeUUID, TypeTimeUUID:
+			return new([]UUID), nil
+		case TypeVarchar, TypeAscii, TypeText, TypeInet:
+			return new([]string), nil
+		case TypeBlob:
+			return new([][]byte), nil
+		case TypeTimestamp, TypeDate:
+			return new([]time.Time), nil
+		case TypeTime:
+			return new([]time.Duration), nil
+		case TypeDecimal:
+			return new([]*inf.Dec), nil
+		case TypeVarint:
+			return new([]*big.Int), nil
+		case TypeDuration:
+			return new([]Duration), nil
+		}
+	}
+
+	// Fallback: derive the slice type via SubType.NewWithError() + reflect.
+	// This still avoids the expensive asVectorType() re-parse since we
+	// already have the SubType available directly.
+	innerPtr, err := v.SubType.NewWithError()
+	if err != nil {
+		return nil, err
+	}
+	elemType := reflect.TypeOf(innerPtr)
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+	return reflect.New(reflect.SliceOf(elemType)).Interface(), nil
 }
 
 func (t CollectionType) NewWithError() (interface{}, error) {

--- a/marshal.go
+++ b/marshal.go
@@ -888,6 +888,10 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 		if vec, ok := value.([]int64); ok {
 			return marshalVectorInt64(info.Dimensions, vec)
 		}
+	case TypeUUID, TypeTimeUUID:
+		if vec, ok := value.([]UUID); ok {
+			return marshalVectorUUID(info.Dimensions, vec)
+		}
 	}
 
 	rv := reflect.ValueOf(value)
@@ -952,6 +956,10 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 	case TypeBigInt:
 		if dst, ok := value.(*[]int64); ok {
 			return unmarshalVectorInt64(info.Dimensions, data, dst)
+		}
+	case TypeUUID, TypeTimeUUID:
+		if dst, ok := value.(*[]UUID); ok {
+			return unmarshalVectorUUID(info.Dimensions, data, dst)
 		}
 	}
 
@@ -1080,7 +1088,7 @@ func putVectorBuf(buf []byte) {
 // marshal fast path that allocates from vectorBufPool via getVectorBuf.
 func vectorBufPoolSubtype(vt VectorType) bool {
 	switch vt.SubType.Type() {
-	case TypeFloat, TypeDouble, TypeInt, TypeBigInt:
+	case TypeFloat, TypeDouble, TypeInt, TypeBigInt, TypeUUID, TypeTimeUUID:
 		return true
 	default:
 		return false
@@ -1357,6 +1365,73 @@ func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
 	_ = data[dim*8-1] // BCE hint: compiler can prove data[i*8:i*8+8] is in-bounds
 	for i := range vec {
 		vec[i] = int64(binary.BigEndian.Uint64(data[i*8 : i*8+8]))
+	}
+	*dst = vec
+	return nil
+}
+
+// marshalVectorUUID encodes a UUID slice as a contiguous vector
+// (CQL uuid/timeuuid = 16 bytes). Uses a pooled buffer for zero-alloc steady state.
+// UUID is [16]byte so no endian conversion is needed — just a flat copy.
+func marshalVectorUUID(dim int, vec []UUID) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*16-1] // BCE hint
+	for i, v := range vec {
+		copy(buf[i*16:i*16+16], v[:])
+	}
+	return buf, nil
+}
+
+// unmarshalVectorUUID decodes contiguous CQL uuid/timeuuid (16-byte) values.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorUUID(dim int, data []byte, dst *[]UUID) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<uuid, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]UUID, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]UUID, dim)
+	}
+	_ = data[dim*16-1] // BCE hint
+	for i := range vec {
+		copy(vec[i][:], data[i*16:i*16+16])
 	}
 	*dst = vec
 	return nil

--- a/marshal.go
+++ b/marshal.go
@@ -1044,9 +1044,10 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 // vectorBufPool pools []byte buffers used by vector marshal fast paths.
 // Buffers are returned to the pool by putVectorBuf after the framer copies them.
 //
-// NOTE: putVectorBuf is currently exercised only by benchmarks/tests.
-// Wiring it into the connection write path (so production callers return
-// buffers after the framer copies them) is planned for a follow-up change.
+// vectorBufPool is used by the marshal fast paths (marshalVectorFloat32 etc.)
+// to allocate temporary byte buffers. After the framer copies the marshalled
+// bytes via writeBytes (append into framer.buf), the caller returns the buffer
+// to the pool via putVectorBuf.
 var vectorBufPool = sync.Pool{}
 
 func getVectorBuf(size int) []byte {
@@ -1073,6 +1074,17 @@ func putVectorBuf(buf []byte) {
 		return
 	}
 	vectorBufPool.Put(buf) //nolint:staticcheck // SA6002: []byte is a value type; boxing cost is acceptable for pool reuse
+}
+
+// vectorBufPoolSubtype returns true if the given VectorType's SubType uses a
+// marshal fast path that allocates from vectorBufPool via getVectorBuf.
+func vectorBufPoolSubtype(vt VectorType) bool {
+	switch vt.SubType.Type() {
+	case TypeFloat, TypeDouble, TypeInt, TypeBigInt:
+		return true
+	default:
+		return false
+	}
 }
 
 // vectorByteSize computes dim * elemBytes and returns an error if the result
@@ -1103,10 +1115,12 @@ func marshalVectorFloat32(dim int, vec []float32) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint32(buf[off:off+4], math.Float32bits(v))
-		off += 4
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*4-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint32(buf[i*4:i*4+4], math.Float32bits(v))
 	}
 	return buf, nil
 }
@@ -1128,10 +1142,12 @@ func marshalVectorFloat64(dim int, vec []float64) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint64(buf[off:off+8], math.Float64bits(v))
-		off += 8
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*8-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint64(buf[i*8:i*8+8], math.Float64bits(v))
 	}
 	return buf, nil
 }
@@ -1167,9 +1183,9 @@ func unmarshalVectorFloat32(dim int, data []byte, dst *[]float32) error {
 	} else {
 		vec = make([]float32, dim)
 	}
+	_ = data[dim*4-1] // BCE hint: compiler can prove data[i*4:i*4+4] is in-bounds
 	for i := range vec {
-		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[:4]))
-		data = data[4:]
+		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[i*4 : i*4+4]))
 	}
 	*dst = vec
 	return nil
@@ -1206,9 +1222,9 @@ func unmarshalVectorFloat64(dim int, data []byte, dst *[]float64) error {
 	} else {
 		vec = make([]float64, dim)
 	}
+	_ = data[dim*8-1] // BCE hint: compiler can prove data[i*8:i*8+8] is in-bounds
 	for i := range vec {
-		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[:8]))
-		data = data[8:]
+		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[i*8 : i*8+8]))
 	}
 	*dst = vec
 	return nil
@@ -1231,10 +1247,12 @@ func marshalVectorInt32(dim int, vec []int32) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint32(buf[off:off+4], uint32(v))
-		off += 4
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*4-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint32(buf[i*4:i*4+4], uint32(v))
 	}
 	return buf, nil
 }
@@ -1256,10 +1274,12 @@ func marshalVectorInt64(dim int, vec []int64) ([]byte, error) {
 		return nil, marshalErrorf("%v", err)
 	}
 	buf := getVectorBuf(size)
-	off := 0
-	for _, v := range vec {
-		binary.BigEndian.PutUint64(buf[off:off+8], uint64(v))
-		off += 8
+	if dim == 0 {
+		return buf, nil
+	}
+	_ = buf[dim*8-1] // BCE hint
+	for i, v := range vec {
+		binary.BigEndian.PutUint64(buf[i*8:i*8+8], uint64(v))
 	}
 	return buf, nil
 }
@@ -1295,9 +1315,9 @@ func unmarshalVectorInt32(dim int, data []byte, dst *[]int32) error {
 	} else {
 		vec = make([]int32, dim)
 	}
+	_ = data[dim*4-1] // BCE hint: compiler can prove data[i*4:i*4+4] is in-bounds
 	for i := range vec {
-		vec[i] = int32(binary.BigEndian.Uint32(data[:4]))
-		data = data[4:]
+		vec[i] = int32(binary.BigEndian.Uint32(data[i*4 : i*4+4]))
 	}
 	*dst = vec
 	return nil
@@ -1334,9 +1354,9 @@ func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
 	} else {
 		vec = make([]int64, dim)
 	}
+	_ = data[dim*8-1] // BCE hint: compiler can prove data[i*8:i*8+8] is in-bounds
 	for i := range vec {
-		vec[i] = int64(binary.BigEndian.Uint64(data[:8]))
-		data = data[8:]
+		vec[i] = int64(binary.BigEndian.Uint64(data[i*8 : i*8+8]))
 	}
 	*dst = vec
 	return nil

--- a/marshal.go
+++ b/marshal.go
@@ -33,6 +33,7 @@ import (
 	"math/big"
 	"math/bits"
 	"reflect"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -868,30 +869,24 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 		return nil, nil
 	}
 
-	// Fast paths for []float64/[]float32 — skip reflect/per-element dispatch.
-	// dim=0 falls through to the generic path (CQL null semantics).
-	if info.Dimensions > 0 {
-		switch info.SubType.Type() {
-		case TypeDouble:
-			if v, ok := value.([]float64); ok {
-				if v == nil {
-					return nil, nil
-				}
-				if len(v) != info.Dimensions {
-					return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, len(v))
-				}
-				return marshalVectorFloat64(info.Dimensions, v)
-			}
-		case TypeFloat:
-			if v, ok := value.([]float32); ok {
-				if v == nil {
-					return nil, nil
-				}
-				if len(v) != info.Dimensions {
-					return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, len(v))
-				}
-				return marshalVectorFloat32(info.Dimensions, v)
-			}
+	// Fast paths for common vector types — avoid reflect entirely.
+	// Dimension/nil/overflow validation happens inside the helpers below.
+	switch info.SubType.Type() {
+	case TypeFloat:
+		if vec, ok := value.([]float32); ok {
+			return marshalVectorFloat32(info.Dimensions, vec)
+		}
+	case TypeDouble:
+		if vec, ok := value.([]float64); ok {
+			return marshalVectorFloat64(info.Dimensions, vec)
+		}
+	case TypeInt:
+		if vec, ok := value.([]int32); ok {
+			return marshalVectorInt32(info.Dimensions, vec)
+		}
+	case TypeBigInt:
+		if vec, ok := value.([]int64); ok {
+			return marshalVectorInt64(info.Dimensions, vec)
 		}
 	}
 
@@ -907,6 +902,11 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 		n := rv.Len()
 		if n != info.Dimensions {
 			return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, n)
+		}
+		// Zero-dimension vectors encode as a non-nil empty value (not CQL NULL).
+		// bytes.Buffer{}.Bytes() returns nil, so we must special-case this.
+		if n == 0 {
+			return make([]byte, 0), nil
 		}
 
 		isLengthType := isVectorVariableLengthType(info.SubType)
@@ -933,78 +933,25 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 	return nil, marshalErrorf("can not marshal %T into %s. Accepted types: slice, array.", value, info)
 }
 
-// vectorSliceReuse reuses *dst's backing array when cap is sufficient.
-func vectorSliceReuse[T any](dst *[]T, dim int) []T {
-	vec := *dst
-	if cap(vec) >= dim {
-		vec = vec[:dim]
-	} else {
-		vec = make([]T, dim)
-	}
-	return vec
-}
-
-// marshalVectorFloat64 encodes []float64 as contiguous big-endian IEEE 754 doubles.
-func marshalVectorFloat64(dim int, vec []float64) ([]byte, error) {
-	buf := make([]byte, dim*8)
-	for i, v := range vec {
-		binary.BigEndian.PutUint64(buf[i*8:], math.Float64bits(v))
-	}
-	return buf, nil
-}
-
-// marshalVectorFloat32 encodes []float32 as contiguous big-endian IEEE 754 floats.
-func marshalVectorFloat32(dim int, vec []float32) ([]byte, error) {
-	buf := make([]byte, dim*4)
-	for i, v := range vec {
-		binary.BigEndian.PutUint32(buf[i*4:], math.Float32bits(v))
-	}
-	return buf, nil
-}
-
-// unmarshalVectorFloat64 decodes contiguous big-endian IEEE 754 doubles into vec.
-// The caller is responsible for ensuring data is dim*8 bytes and vec has length dim.
-func unmarshalVectorFloat64(data []byte, vec []float64) {
-	for i := range vec {
-		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[i*8:]))
-	}
-}
-
-// unmarshalVectorFloat32 decodes contiguous big-endian IEEE 754 floats into vec.
-// The caller is responsible for ensuring data is dim*4 bytes and vec has length dim.
-func unmarshalVectorFloat32(data []byte, vec []float32) {
-	for i := range vec {
-		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[i*4:]))
-	}
-}
-
 func unmarshalVector(info VectorType, data []byte, value any) error {
-	// Fast paths for *[]float64/*[]float32 — skip reflect/per-element dispatch.
-	// nil/empty and dim=0 fall through to the generic path.
-	if info.Dimensions > 0 && data != nil {
-		switch info.SubType.Type() {
-		case TypeDouble:
-			if dst, ok := value.(*[]float64); ok {
-				expected := info.Dimensions * 8
-				if len(data) != expected {
-					return unmarshalErrorf("unmarshal vector<double>: expected %d bytes, got %d", expected, len(data))
-				}
-				vec := vectorSliceReuse(dst, info.Dimensions)
-				unmarshalVectorFloat64(data, vec)
-				*dst = vec
-				return nil
-			}
-		case TypeFloat:
-			if dst, ok := value.(*[]float32); ok {
-				expected := info.Dimensions * 4
-				if len(data) != expected {
-					return unmarshalErrorf("unmarshal vector<float>: expected %d bytes, got %d", expected, len(data))
-				}
-				vec := vectorSliceReuse(dst, info.Dimensions)
-				unmarshalVectorFloat32(data, vec)
-				*dst = vec
-				return nil
-			}
+	// Fast paths for common vector types — avoid reflect entirely.
+	// Dimension/nil/overflow validation happens inside the helpers below.
+	switch info.SubType.Type() {
+	case TypeFloat:
+		if dst, ok := value.(*[]float32); ok {
+			return unmarshalVectorFloat32(info.Dimensions, data, dst)
+		}
+	case TypeDouble:
+		if dst, ok := value.(*[]float64); ok {
+			return unmarshalVectorFloat64(info.Dimensions, data, dst)
+		}
+	case TypeInt:
+		if dst, ok := value.(*[]int32); ok {
+			return unmarshalVectorInt32(info.Dimensions, data, dst)
+		}
+	case TypeBigInt:
+		if dst, ok := value.(*[]int64); ok {
+			return unmarshalVectorInt64(info.Dimensions, data, dst)
 		}
 	}
 
@@ -1052,6 +999,10 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 				return unmarshalErrorf("unmarshal vector: array of size %d cannot store vector of %d dimensions", rv.Len(), info.Dimensions)
 			}
 		} else {
+			// TODO: reuse existing slice backing array when cap >= info.Dimensions
+			// instead of unconditionally allocating. This would bring the generic path
+			// closer to the fast-path zero-alloc behavior. Can be done independently
+			// since this code predates the fast-path implementation.
 			rv.Set(reflect.MakeSlice(t, info.Dimensions, info.Dimensions))
 			if rv.Kind() == reflect.Interface {
 				rv = rv.Elem()
@@ -1090,6 +1041,316 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *slice, *array, *any.", info, value)
 }
 
+// vectorBufPool pools []byte buffers used by vector marshal fast paths.
+// Buffers are returned to the pool by putVectorBuf after the framer copies them.
+//
+// NOTE: putVectorBuf is currently exercised only by benchmarks/tests.
+// Wiring it into the connection write path (so production callers return
+// buffers after the framer copies them) is planned for a follow-up change.
+var vectorBufPool = sync.Pool{}
+
+func getVectorBuf(size int) []byte {
+	if size < 0 {
+		return nil
+	}
+	if size == 0 {
+		return make([]byte, 0)
+	}
+	if v := vectorBufPool.Get(); v != nil {
+		if buf, ok := v.([]byte); ok {
+			if cap(buf) >= size {
+				return buf[:size]
+			}
+			// Undersized buffer: return it so smaller vectors can reuse it.
+			vectorBufPool.Put(buf) //nolint:staticcheck // SA6002: []byte is a value type; boxing cost is acceptable for pool reuse
+		}
+	}
+	return make([]byte, size)
+}
+
+func putVectorBuf(buf []byte) {
+	if buf == nil || cap(buf) > 65536 {
+		return
+	}
+	vectorBufPool.Put(buf) //nolint:staticcheck // SA6002: []byte is a value type; boxing cost is acceptable for pool reuse
+}
+
+// vectorByteSize computes dim * elemBytes and returns an error if the result
+// would overflow int. This guards against corrupt or adversarial schema metadata
+// on 32-bit platforms where int is 32 bits.
+func vectorByteSize(dim, elemBytes int) (int, error) {
+	n := int64(dim) * int64(elemBytes)
+	if n < 0 || n > int64(math.MaxInt) {
+		return 0, fmt.Errorf("vector byte size overflow: %d dimensions * %d bytes/elem", dim, elemBytes)
+	}
+	return int(n), nil
+}
+
+// marshalVectorFloat32 encodes a float32 slice as a contiguous big-endian
+// IEEE 754 vector. Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorFloat32(dim int, vec []float32) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint32(buf[off:off+4], math.Float32bits(v))
+		off += 4
+	}
+	return buf, nil
+}
+
+// marshalVectorFloat64 encodes a float64 slice as a contiguous big-endian
+// IEEE 754 vector. Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorFloat64(dim int, vec []float64) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint64(buf[off:off+8], math.Float64bits(v))
+		off += 8
+	}
+	return buf, nil
+}
+
+// unmarshalVectorFloat32 decodes contiguous big-endian IEEE 754 floats.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorFloat32(dim int, data []byte, dst *[]float32) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<float, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]float32, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]float32, dim)
+	}
+	for i := range vec {
+		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[:4]))
+		data = data[4:]
+	}
+	*dst = vec
+	return nil
+}
+
+// unmarshalVectorFloat64 decodes contiguous big-endian IEEE 754 doubles.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorFloat64(dim int, data []byte, dst *[]float64) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<double, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]float64, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]float64, dim)
+	}
+	for i := range vec {
+		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[:8]))
+		data = data[8:]
+	}
+	*dst = vec
+	return nil
+}
+
+// marshalVectorInt32 encodes an int32 slice as a contiguous big-endian
+// vector (CQL int = 4 bytes). Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorInt32(dim int, vec []int32) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint32(buf[off:off+4], uint32(v))
+		off += 4
+	}
+	return buf, nil
+}
+
+// marshalVectorInt64 encodes an int64 slice as a contiguous big-endian
+// vector (CQL bigint = 8 bytes). Uses a pooled buffer for zero-alloc steady state.
+func marshalVectorInt64(dim int, vec []int64) ([]byte, error) {
+	if dim < 0 {
+		return nil, marshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if vec == nil {
+		return nil, nil
+	}
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return nil, marshalErrorf("%v", err)
+	}
+	buf := getVectorBuf(size)
+	off := 0
+	for _, v := range vec {
+		binary.BigEndian.PutUint64(buf[off:off+8], uint64(v))
+		off += 8
+	}
+	return buf, nil
+}
+
+// unmarshalVectorInt32 decodes contiguous big-endian CQL int (4-byte) values.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorInt32(dim int, data []byte, dst *[]int32) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<int, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]int32, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]int32, dim)
+	}
+	for i := range vec {
+		vec[i] = int32(binary.BigEndian.Uint32(data[:4]))
+		data = data[4:]
+	}
+	*dst = vec
+	return nil
+}
+
+// unmarshalVectorInt64 decodes contiguous big-endian CQL bigint (8-byte) values.
+// Reuses the destination slice's backing array when capacity allows (zero-alloc steady state).
+func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
+	if dim < 0 {
+		return unmarshalErrorf("vector has negative dimensions: %d", dim)
+	}
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<bigint, %d>: expected %d bytes, got %d", dim, expected, len(data))
+	}
+	if dim == 0 {
+		if *dst == nil {
+			*dst = make([]int64, 0)
+		} else {
+			*dst = (*dst)[:0]
+		}
+		return nil
+	}
+	vec := *dst
+	if cap(vec) >= dim {
+		vec = vec[:dim]
+	} else {
+		vec = make([]int64, dim)
+	}
+	for i := range vec {
+		vec[i] = int64(binary.BigEndian.Uint64(data[:8]))
+		data = data[8:]
+	}
+	*dst = vec
+	return nil
+}
+
+// vectorFixedElemSize returns the known wire-format byte size for fixed-length
+// CQL types used as vector elements, specifically the subset that
+// isVectorVariableLengthType classifies as fixed-length. Returns 0 for
+// variable-length or unknown types.
+//
+// NOTE: Some types that have a fixed wire size (TinyInt=1, SmallInt=2,
+// Date=4, Time=8, Counter=8) are classified as variable-length by
+// isVectorVariableLengthType due to discrepancies between Cassandra and
+// ScyllaDB implementations, and are deliberately excluded here.
 func vectorFixedElemSize(elemType TypeInfo) int {
 	switch elemType.Type() {
 	case TypeBoolean:
@@ -1100,8 +1361,9 @@ func vectorFixedElemSize(elemType TypeInfo) int {
 		return 8
 	case TypeUUID, TypeTimeUUID:
 		return 16
+	default:
+		return 0
 	}
-	return 0
 }
 
 // isVectorVariableLengthType determines if a type requires explicit length serialization within a vector.

--- a/marshal.go
+++ b/marshal.go
@@ -1170,20 +1170,23 @@ func unmarshalVectorFloat32(dim int, data []byte, dst *[]float32) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 4)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<float, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]float32, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<float, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1209,20 +1212,23 @@ func unmarshalVectorFloat64(dim int, data []byte, dst *[]float64) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 8)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<double, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]float64, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<double, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1302,20 +1308,23 @@ func unmarshalVectorInt32(dim int, data []byte, dst *[]int32) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 4)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<int, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]int32, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<int, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1341,20 +1350,23 @@ func unmarshalVectorInt64(dim int, data []byte, dst *[]int64) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 8)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<bigint, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]int64, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<bigint, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -1408,20 +1420,23 @@ func unmarshalVectorUUID(dim int, data []byte, dst *[]UUID) error {
 		*dst = nil
 		return nil
 	}
-	expected, err := vectorByteSize(dim, 16)
-	if err != nil {
-		return unmarshalErrorf("%v", err)
-	}
-	if len(data) != expected {
-		return unmarshalErrorf("unmarshal vector<uuid, %d>: expected %d bytes, got %d", dim, expected, len(data))
-	}
 	if dim == 0 {
+		if len(data) > 0 {
+			return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+		}
 		if *dst == nil {
 			*dst = make([]UUID, 0)
 		} else {
 			*dst = (*dst)[:0]
 		}
 		return nil
+	}
+	expected, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return unmarshalErrorf("%v", err)
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector<uuid, %d>: expected %d bytes, got %d", dim, expected, len(data))
 	}
 	vec := *dst
 	if cap(vec) >= dim {
@@ -2361,6 +2376,63 @@ func (v VectorType) Zero() any {
 		return nil
 	}
 	return reflect.Zero(reflect.SliceOf(reflect.TypeOf(t))).Interface()
+}
+
+// NewWithError creates a pointer to an empty slice of the appropriate Go type
+// for this vector's element type. Fast paths avoid reflection for the common
+// fixed-size element types (float, double, int, bigint, uuid/timeuuid).
+// Without this method, VectorType would inherit NativeType.NewWithError which
+// falls back to goType() → asVectorType(), re-parsing the full Java type
+// string (e.g. "org.apache.cassandra.db.marshal.VectorType(…)") on every call.
+func (v VectorType) NewWithError() (any, error) {
+	// Fast path: return *[]T directly for common element types.
+	if nt, ok := v.SubType.(NativeType); ok {
+		switch nt.typ {
+		case TypeFloat:
+			return new([]float32), nil
+		case TypeDouble:
+			return new([]float64), nil
+		case TypeInt:
+			return new([]int), nil
+		case TypeBigInt, TypeCounter:
+			return new([]int64), nil
+		case TypeSmallInt:
+			return new([]int16), nil
+		case TypeTinyInt:
+			return new([]int8), nil
+		case TypeBoolean:
+			return new([]bool), nil
+		case TypeUUID, TypeTimeUUID:
+			return new([]UUID), nil
+		case TypeVarchar, TypeAscii, TypeText, TypeInet:
+			return new([]string), nil
+		case TypeBlob:
+			return new([][]byte), nil
+		case TypeTimestamp, TypeDate:
+			return new([]time.Time), nil
+		case TypeTime:
+			return new([]time.Duration), nil
+		case TypeDecimal:
+			return new([]*inf.Dec), nil
+		case TypeVarint:
+			return new([]*big.Int), nil
+		case TypeDuration:
+			return new([]Duration), nil
+		}
+	}
+
+	// Fallback: derive the slice type via SubType.NewWithError() + reflect.
+	// This still avoids the expensive asVectorType() re-parse since we
+	// already have the SubType available directly.
+	innerPtr, err := v.SubType.NewWithError()
+	if err != nil {
+		return nil, err
+	}
+	elemType := reflect.TypeOf(innerPtr)
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+	return reflect.New(reflect.SliceOf(elemType)).Interface(), nil
 }
 
 func (t CollectionType) NewWithError() (any, error) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1248,3 +1248,84 @@ func TestCollectionNewWithErrorConsistentWithGoType(t *testing.T) {
 		}
 	}
 }
+
+// TestVectorNewWithErrorConsistentWithGoType verifies that VectorType.NewWithError()
+// returns the same underlying Go type as the canonical goType() mapping for every
+// supported element type. This guards against the fast-path and fallback drifting apart.
+func TestVectorNewWithErrorConsistentWithGoType(t *testing.T) {
+	elemTypes := []Type{
+		TypeFloat, TypeDouble,
+		TypeInt, TypeBigInt, TypeCounter,
+		TypeSmallInt, TypeTinyInt,
+		TypeBoolean,
+		TypeUUID, TypeTimeUUID,
+		TypeVarchar, TypeAscii, TypeText, TypeInet,
+		TypeBlob,
+		TypeTimestamp, TypeDate,
+		TypeTime,
+		TypeDecimal,
+		TypeVarint,
+		TypeDuration,
+	}
+
+	for _, elemTyp := range elemTypes {
+		vt := VectorType{
+			NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+			SubType:    NativeType{proto: protoVersion4, typ: elemTyp},
+			Dimensions: 1536,
+		}
+
+		fastVal, err := vt.NewWithError()
+		if err != nil {
+			t.Errorf("VectorType.NewWithError(vector<%s>): unexpected error: %v", elemTyp, err)
+			continue
+		}
+
+		// goType for TypeCustom goes through asVectorType → SubType.NewWithError → reflect.SliceOf.
+		// Build the canonical type the same way goType does.
+		canonicalType, err := goType(vt)
+		if err != nil {
+			t.Errorf("goType(vector<%s>): unexpected error: %v", elemTyp, err)
+			continue
+		}
+
+		fastType := reflect.TypeOf(fastVal)
+		if fastType.Kind() != reflect.Ptr {
+			t.Errorf("VectorType.NewWithError(vector<%s>): expected pointer, got %s", elemTyp, fastType.Kind())
+			continue
+		}
+
+		if fastType.Elem() != canonicalType {
+			t.Errorf("VectorType.NewWithError(vector<%s>) fast-path type %s does not match goType() canonical type %s",
+				elemTyp, fastType.Elem(), canonicalType)
+		}
+	}
+}
+
+// TestVectorNewWithErrorReturnsSlicePointer verifies that the returned value is
+// always a pointer to a slice, regardless of element type.
+func TestVectorNewWithErrorReturnsSlicePointer(t *testing.T) {
+	vt := VectorType{
+		NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+		SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+		Dimensions: 3,
+	}
+
+	val, err := vt.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rt := reflect.TypeOf(val)
+	if rt.Kind() != reflect.Ptr {
+		t.Fatalf("expected pointer, got %s", rt.Kind())
+	}
+	if rt.Elem().Kind() != reflect.Slice {
+		t.Fatalf("expected pointer to slice, got pointer to %s", rt.Elem().Kind())
+	}
+
+	// Verify the concrete type is *[]float32
+	if _, ok := val.(*[]float32); !ok {
+		t.Fatalf("expected *[]float32, got %T", val)
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1389,3 +1389,84 @@ func TestUnmarshalMapReflect_OversizedCount_RejectedBeforeAlloc(t *testing.T) {
 		t.Fatalf("expected dst to remain nil, got %#v", dst)
 	}
 }
+
+// TestVectorNewWithErrorConsistentWithGoType verifies that VectorType.NewWithError()
+// returns the same underlying Go type as the canonical goType() mapping for every
+// supported element type. This guards against the fast-path and fallback drifting apart.
+func TestVectorNewWithErrorConsistentWithGoType(t *testing.T) {
+	elemTypes := []Type{
+		TypeFloat, TypeDouble,
+		TypeInt, TypeBigInt, TypeCounter,
+		TypeSmallInt, TypeTinyInt,
+		TypeBoolean,
+		TypeUUID, TypeTimeUUID,
+		TypeVarchar, TypeAscii, TypeText, TypeInet,
+		TypeBlob,
+		TypeTimestamp, TypeDate,
+		TypeTime,
+		TypeDecimal,
+		TypeVarint,
+		TypeDuration,
+	}
+
+	for _, elemTyp := range elemTypes {
+		vt := VectorType{
+			NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+			SubType:    NativeType{proto: protoVersion4, typ: elemTyp},
+			Dimensions: 1536,
+		}
+
+		fastVal, err := vt.NewWithError()
+		if err != nil {
+			t.Errorf("VectorType.NewWithError(vector<%s>): unexpected error: %v", elemTyp, err)
+			continue
+		}
+
+		// goType for TypeCustom goes through asVectorType → SubType.NewWithError → reflect.SliceOf.
+		// Build the canonical type the same way goType does.
+		canonicalType, err := goType(vt)
+		if err != nil {
+			t.Errorf("goType(vector<%s>): unexpected error: %v", elemTyp, err)
+			continue
+		}
+
+		fastType := reflect.TypeOf(fastVal)
+		if fastType.Kind() != reflect.Ptr {
+			t.Errorf("VectorType.NewWithError(vector<%s>): expected pointer, got %s", elemTyp, fastType.Kind())
+			continue
+		}
+
+		if fastType.Elem() != canonicalType {
+			t.Errorf("VectorType.NewWithError(vector<%s>) fast-path type %s does not match goType() canonical type %s",
+				elemTyp, fastType.Elem(), canonicalType)
+		}
+	}
+}
+
+// TestVectorNewWithErrorReturnsSlicePointer verifies that the returned value is
+// always a pointer to a slice, regardless of element type.
+func TestVectorNewWithErrorReturnsSlicePointer(t *testing.T) {
+	vt := VectorType{
+		NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+		SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+		Dimensions: 3,
+	}
+
+	val, err := vt.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rt := reflect.TypeOf(val)
+	if rt.Kind() != reflect.Ptr {
+		t.Fatalf("expected pointer, got %s", rt.Kind())
+	}
+	if rt.Elem().Kind() != reflect.Slice {
+		t.Fatalf("expected pointer to slice, got pointer to %s", rt.Elem().Kind())
+	}
+
+	// Verify the concrete type is *[]float32
+	if _, ok := val.(*[]float32); !ok {
+		t.Fatalf("expected *[]float32, got %T", val)
+	}
+}

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -1,6 +1,4 @@
-// Copyright (c) 2012 The gocql Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// Copyright (C) 2026 ScyllaDB
 
 //go:build all || unit
 // +build all unit

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -170,6 +170,32 @@ func TestMarshalVector_RoundTrip(t *testing.T) {
 			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
 		}
 	})
+
+	t.Run("uuid", func(t *testing.T) {
+		dim := 3
+		info := makeUUIDVectorType(dim)
+		vec := []UUID{
+			{0x55, 0x0e, 0x84, 0x00, 0xe2, 0x9b, 0x41, 0xd4, 0xa7, 0x16, 0x44, 0x66, 0x55, 0x44, 0x00, 0x00},
+			{0xf4, 0x7a, 0xc1, 0x0b, 0x58, 0xcc, 0x43, 0x72, 0xa5, 0x67, 0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79},
+			{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*16 {
+			t.Fatalf("expected %d bytes, got %d", dim*16, len(data))
+		}
+
+		var result []UUID
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
 }
 
 // --- Test 2: Byte compatibility ---
@@ -238,6 +264,27 @@ func TestMarshalVector_ByteCompatibility(t *testing.T) {
 		}
 
 		info := makeInt64VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+
+	t.Run("uuid", func(t *testing.T) {
+		dim := 2
+		vec := []UUID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			{0xf0, 0xe0, 0xd0, 0xc0, 0xb0, 0xa0, 0x90, 0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10, 0x00},
+		}
+		// UUID is [16]byte — wire format is the raw bytes, no endian conversion.
+		expected := make([]byte, dim*16)
+		copy(expected[0:16], vec[0][:])
+		copy(expected[16:32], vec[1][:])
+
+		info := makeUUIDVectorType(dim)
 		data, err := marshalVector(info, vec)
 		if err != nil {
 			t.Fatalf("marshalVector: %v", err)
@@ -432,6 +479,49 @@ func TestUnmarshalVector_SliceReuse(t *testing.T) {
 			t.Error("expected reuse of pre-allocated backing array with excess capacity")
 		}
 	})
+
+	t.Run("uuid", func(t *testing.T) {
+		dim := 4
+		info := makeUUIDVectorType(dim)
+		data := make([]byte, dim*16)
+		for i := 0; i < dim; i++ {
+			data[i*16] = byte(i + 1) // put something identifiable in each UUID
+		}
+
+		result := make([]UUID, dim)
+		ptr := &result[0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array")
+		}
+	})
+
+	t.Run("uuid_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeUUIDVectorType(dim)
+		data := make([]byte, dim*16)
+		for i := 0; i < dim; i++ {
+			data[i*16] = byte(i + 1)
+		}
+
+		result := make([]UUID, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
 }
 
 // --- Test 4: Nil slice marshal ---
@@ -580,6 +670,18 @@ func TestMarshalVector_NilSlice(t *testing.T) {
 			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
 		}
 	})
+
+	t.Run("uuid_nil_slice", func(t *testing.T) {
+		info := makeUUIDVectorType(3)
+		var vec []UUID
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
 }
 
 // --- Test 5: Nil data unmarshal ---
@@ -672,6 +774,28 @@ func TestUnmarshalVector_NilData(t *testing.T) {
 			t.Errorf("expected nil result after nil data, got %v", result)
 		}
 	})
+
+	t.Run("uuid_nil_data_nil_dst", func(t *testing.T) {
+		info := makeUUIDVectorType(3)
+		var result []UUID
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("uuid_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeUUIDVectorType(3)
+		result := []UUID{{0x01}, {0x02}, {0x03}}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
 }
 
 // --- Test 6: Dimension mismatch ---
@@ -747,6 +871,25 @@ func TestMarshalVector_DimensionMismatch(t *testing.T) {
 		info := makeInt64VectorType(3)
 		data := make([]byte, 10) // not 8*3=24
 		var result []int64
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+
+	t.Run("uuid_marshal", func(t *testing.T) {
+		info := makeUUIDVectorType(3)
+		vec := []UUID{{0x01}, {0x02}}
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+
+	t.Run("uuid_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeUUIDVectorType(3)
+		data := make([]byte, 10) // not 16*3=48
+		var result []UUID
 		err := unmarshalVector(info, data, &result)
 		if err == nil {
 			t.Fatal("expected error for wrong data length, got nil")
@@ -841,6 +984,29 @@ func TestMarshalVector_EmptyVector(t *testing.T) {
 		}
 
 		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+
+	t.Run("uuid_dim0", func(t *testing.T) {
+		info := makeUUIDVectorType(0)
+		vec := []UUID{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
+		}
+
+		var result []UUID
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector: %v", err)
 		}
@@ -946,6 +1112,26 @@ func TestMarshalVector_PointerToSlice(t *testing.T) {
 		}
 
 		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("uuid_ptr_marshal", func(t *testing.T) {
+		info := makeUUIDVectorType(2)
+		vec := []UUID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			{0xf0, 0xe0, 0xd0, 0xc0, 0xb0, 0xa0, 0x90, 0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10, 0x00},
+		}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]UUID: %v", err)
+		}
+
+		var result []UUID
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector: %v", err)
 		}
@@ -1225,6 +1411,19 @@ func TestUnmarshalVectorFastPathZeroDimNonNilSlice(t *testing.T) {
 		}
 	})
 
+	t.Run("uuid", func(t *testing.T) {
+		var dst []UUID
+		if err := unmarshalVectorUUID(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
 	// Also verify that an existing non-nil dst is preserved as non-nil [:0].
 	t.Run("float32_existing_dst", func(t *testing.T) {
 		dst := make([]float32, 5)
@@ -1368,6 +1567,7 @@ func TestMarshalVectorNegativeDimensions(t *testing.T) {
 			{"float64", func() error { _, err := marshalVectorFloat64(-1, []float64{1}); return err }},
 			{"int32", func() error { _, err := marshalVectorInt32(-1, []int32{1}); return err }},
 			{"int64", func() error { _, err := marshalVectorInt64(-1, []int64{1}); return err }},
+			{"uuid", func() error { _, err := marshalVectorUUID(-1, []UUID{{0x01}}); return err }},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -1391,6 +1591,7 @@ func TestMarshalVectorNegativeDimensions(t *testing.T) {
 			{"float64", func() error { var v []float64; return unmarshalVectorFloat64(-1, []byte{0, 0, 0, 0, 0, 0, 0, 0}, &v) }},
 			{"int32", func() error { var v []int32; return unmarshalVectorInt32(-1, []byte{0, 0, 0, 0}, &v) }},
 			{"int64", func() error { var v []int64; return unmarshalVectorInt64(-1, []byte{0, 0, 0, 0, 0, 0, 0, 0}, &v) }},
+			{"uuid", func() error { var v []UUID; return unmarshalVectorUUID(-1, make([]byte, 16), &v) }},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -1504,7 +1705,7 @@ func TestVectorBufPoolSubtype(t *testing.T) {
 		{"float64", makeFloat64VectorType(3), true},
 		{"int32", makeInt32VectorType(3), true},
 		{"int64", makeInt64VectorType(3), true},
-		{"uuid", makeUUIDVectorType(3), false},
+		{"uuid", makeUUIDVectorType(3), true},
 		{"varchar", VectorType{
 			SubType:    NativeType{proto: protoVersion4, typ: TypeVarchar},
 			Dimensions: 3,
@@ -1578,26 +1779,22 @@ func TestVectorBufPoolReturnSimulation(t *testing.T) {
 }
 
 // TestVectorBufPoolReturnNonPooledType verifies that putVectorBuf is a no-op
-// for vector types that don't use the fast path (e.g. UUID vectors), and
+// for vector types that don't use the fast path (e.g. varchar vectors), and
 // that vectorBufPoolSubtype correctly excludes them.
 func TestVectorBufPoolReturnNonPooledType(t *testing.T) {
-	const dim = 4
-	vt := makeUUIDVectorType(dim)
+	vt := VectorType{
+		SubType:    NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Dimensions: 4,
+	}
 
 	if vectorBufPoolSubtype(vt) {
-		t.Fatal("vectorBufPoolSubtype should be false for UUID vectors")
+		t.Fatal("vectorBufPoolSubtype should be false for varchar vectors")
 	}
 
-	// The UUID marshal path does not use getVectorBuf, so putting its
-	// result back should be skipped by the type check. Verify no panic.
-	data, err := Marshal(vt, []UUID{
-		{0x01}, {0x02}, {0x03}, {0x04},
-	})
-	if err != nil {
-		t.Fatalf("Marshal UUID vector: %v", err)
-	}
-	// Even if we mistakenly call putVectorBuf, it should not panic.
-	putVectorBuf(data)
+	// Varchar marshal path does not use getVectorBuf, so putting a buffer
+	// back should be skipped by the type check. Verify no panic.
+	buf := make([]byte, 100)
+	putVectorBuf(buf)
 }
 
 // TestVectorBufPoolBatchSimulation simulates the batch buffer lifecycle:
@@ -1614,6 +1811,7 @@ func TestVectorBufPoolBatchSimulation(t *testing.T) {
 		{makeFloat64VectorType(dim), make([]float64, dim)},
 		{makeInt32VectorType(dim), make([]int32, dim)},
 		{makeInt64VectorType(dim), make([]int64, dim)},
+		{makeUUIDVectorType(dim), make([]UUID, dim)},
 	}
 
 	// Simulate batch: marshal all, collect buffers.
@@ -1628,8 +1826,8 @@ func TestVectorBufPoolBatchSimulation(t *testing.T) {
 		}
 	}
 
-	if len(vectorBufs) != 4 {
-		t.Fatalf("expected 4 pooled buffers, got %d", len(vectorBufs))
+	if len(vectorBufs) != 5 {
+		t.Fatalf("expected 5 pooled buffers, got %d", len(vectorBufs))
 	}
 
 	// Return all to pool (like the defer in executeBatch).

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -1491,3 +1491,156 @@ func TestGetVectorBuf_NonPositiveSize(t *testing.T) {
 		}
 	}
 }
+
+// TestVectorBufPoolSubtype verifies that vectorBufPoolSubtype correctly
+// identifies which vector subtypes use the pooled fast path.
+func TestVectorBufPoolSubtype(t *testing.T) {
+	tests := []struct {
+		name   string
+		vt     VectorType
+		expect bool
+	}{
+		{"float32", makeFloat32VectorType(3), true},
+		{"float64", makeFloat64VectorType(3), true},
+		{"int32", makeInt32VectorType(3), true},
+		{"int64", makeInt64VectorType(3), true},
+		{"uuid", makeUUIDVectorType(3), false},
+		{"varchar", VectorType{
+			SubType:    NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Dimensions: 3,
+		}, false},
+		{"boolean", VectorType{
+			SubType:    NativeType{proto: protoVersion4, typ: TypeBoolean},
+			Dimensions: 3,
+		}, false},
+		{"timestamp", VectorType{
+			SubType:    NativeType{proto: protoVersion4, typ: TypeTimestamp},
+			Dimensions: 3,
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vectorBufPoolSubtype(tt.vt)
+			if got != tt.expect {
+				t.Errorf("vectorBufPoolSubtype(%s) = %v, want %v", tt.name, got, tt.expect)
+			}
+		})
+	}
+}
+
+// TestVectorBufPoolReturnSimulation simulates the buffer lifecycle used in
+// executeQuery and executeBatch: marshal a vector value via marshalQueryValue,
+// then return the buffer to the pool via putVectorBuf. Verifies that the
+// returned buffer is reused by a subsequent getVectorBuf call.
+func TestVectorBufPoolReturnSimulation(t *testing.T) {
+	const dim = 128
+	vt := makeFloat32VectorType(dim)
+
+	// Create test data.
+	vec := make([]float32, dim)
+	for i := range vec {
+		vec[i] = float32(i)
+	}
+
+	// Marshal like marshalQueryValue does.
+	data, err := Marshal(vt, vec)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	expectedSize := dim * 4
+	if len(data) != expectedSize {
+		t.Fatalf("marshalled size = %d, want %d", len(data), expectedSize)
+	}
+
+	// Remember the backing array pointer before returning to pool.
+	origPtr := &data[:1][0]
+
+	// Simulate what the defer in executeQuery/executeBatch does.
+	if vectorBufPoolSubtype(vt) {
+		putVectorBuf(data)
+	}
+
+	// Get a buffer of the same size — should reuse the pooled one.
+	reused := getVectorBuf(expectedSize)
+	if len(reused) != expectedSize {
+		t.Fatalf("getVectorBuf(%d) returned len %d", expectedSize, len(reused))
+	}
+	reusedPtr := &reused[:1][0]
+	if origPtr != reusedPtr {
+		// sync.Pool makes no guarantees about reuse — the GC may clear the
+		// pool between Put and Get, especially under the race detector.
+		// This is expected behaviour, not a bug; log instead of failing.
+		t.Log("pooled buffer was not reused (GC may have cleared sync.Pool); this is expected under -race")
+	}
+
+	// Clean up.
+	putVectorBuf(reused)
+}
+
+// TestVectorBufPoolReturnNonPooledType verifies that putVectorBuf is a no-op
+// for vector types that don't use the fast path (e.g. UUID vectors), and
+// that vectorBufPoolSubtype correctly excludes them.
+func TestVectorBufPoolReturnNonPooledType(t *testing.T) {
+	const dim = 4
+	vt := makeUUIDVectorType(dim)
+
+	if vectorBufPoolSubtype(vt) {
+		t.Fatal("vectorBufPoolSubtype should be false for UUID vectors")
+	}
+
+	// The UUID marshal path does not use getVectorBuf, so putting its
+	// result back should be skipped by the type check. Verify no panic.
+	data, err := Marshal(vt, []UUID{
+		{0x01}, {0x02}, {0x03}, {0x04},
+	})
+	if err != nil {
+		t.Fatalf("Marshal UUID vector: %v", err)
+	}
+	// Even if we mistakenly call putVectorBuf, it should not panic.
+	putVectorBuf(data)
+}
+
+// TestVectorBufPoolBatchSimulation simulates the batch buffer lifecycle:
+// multiple statements with vector columns get their buffers collected and
+// returned after the framer copies them.
+func TestVectorBufPoolBatchSimulation(t *testing.T) {
+	const dim = 64
+
+	types := []struct {
+		vt  VectorType
+		val interface{}
+	}{
+		{makeFloat32VectorType(dim), make([]float32, dim)},
+		{makeFloat64VectorType(dim), make([]float64, dim)},
+		{makeInt32VectorType(dim), make([]int32, dim)},
+		{makeInt64VectorType(dim), make([]int64, dim)},
+	}
+
+	// Simulate batch: marshal all, collect buffers.
+	var vectorBufs [][]byte
+	for _, tt := range types {
+		data, err := Marshal(tt.vt, tt.val)
+		if err != nil {
+			t.Fatalf("Marshal %v: %v", tt.vt.SubType.Type(), err)
+		}
+		if vectorBufPoolSubtype(tt.vt) {
+			vectorBufs = append(vectorBufs, data)
+		}
+	}
+
+	if len(vectorBufs) != 4 {
+		t.Fatalf("expected 4 pooled buffers, got %d", len(vectorBufs))
+	}
+
+	// Return all to pool (like the defer in executeBatch).
+	for _, buf := range vectorBufs {
+		putVectorBuf(buf)
+	}
+
+	// Verify at least one can be reused.
+	reused := getVectorBuf(dim * 4) // float32 size
+	if reused == nil {
+		t.Fatal("expected to get a buffer from pool after returning batch buffers")
+	}
+	putVectorBuf(reused)
+}

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -1,0 +1,1493 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build all || unit
+// +build all unit
+
+package gocql
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// --- Test helpers ---
+
+func makeFloat32VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "FloatType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+		Dimensions: dim,
+	}
+}
+
+func makeFloat64VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "DoubleType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeDouble},
+		Dimensions: dim,
+	}
+}
+
+func makeUUIDVectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "UUIDType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeUUID},
+		Dimensions: dim,
+	}
+}
+
+func makeInt32VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "Int32Type, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeInt},
+		Dimensions: dim,
+	}
+}
+
+func makeInt64VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "LongType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Dimensions: dim,
+	}
+}
+
+// --- Test 1: Round-trip ---
+
+func TestMarshalVector_RoundTrip(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		dim := 5
+		info := makeFloat32VectorType(dim)
+		vec := []float32{1.1, 2.2, 3.3, 4.4, 5.5}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*4 {
+			t.Fatalf("expected %d bytes, got %d", dim*4, len(data))
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		dim := 5
+		info := makeFloat64VectorType(dim)
+		vec := []float64{1.1, 2.2, 3.3, 4.4, 5.5}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*8 {
+			t.Fatalf("expected %d bytes, got %d", dim*8, len(data))
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		dim := 5
+		info := makeInt32VectorType(dim)
+		vec := []int32{-100, 0, 42, math.MaxInt32, math.MinInt32}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*4 {
+			t.Fatalf("expected %d bytes, got %d", dim*4, len(data))
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		dim := 5
+		info := makeInt64VectorType(dim)
+		vec := []int64{-100, 0, 42, math.MaxInt64, math.MinInt64}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*8 {
+			t.Fatalf("expected %d bytes, got %d", dim*8, len(data))
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+}
+
+// --- Test 2: Byte compatibility ---
+
+func TestMarshalVector_ByteCompatibility(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		dim := 3
+		vec := []float32{-1.5, 0, 42.125}
+		expected := make([]byte, dim*4)
+		for i, v := range vec {
+			binary.BigEndian.PutUint32(expected[i*4:], math.Float32bits(v))
+		}
+
+		info := makeFloat32VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		dim := 3
+		vec := []float64{-1.5, 0, 42.125}
+		expected := make([]byte, dim*8)
+		for i, v := range vec {
+			binary.BigEndian.PutUint64(expected[i*8:], math.Float64bits(v))
+		}
+
+		info := makeFloat64VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		dim := 3
+		vec := []int32{-1, 0, 42}
+		expected := make([]byte, dim*4)
+		for i, v := range vec {
+			binary.BigEndian.PutUint32(expected[i*4:], uint32(v))
+		}
+
+		info := makeInt32VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		dim := 3
+		vec := []int64{-1, 0, 42}
+		expected := make([]byte, dim*8)
+		for i, v := range vec {
+			binary.BigEndian.PutUint64(expected[i*8:], uint64(v))
+		}
+
+		info := makeInt64VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+}
+
+// --- Test 3: Slice reuse ---
+
+func TestUnmarshalVector_SliceReuse(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		dim := 4
+		info := makeFloat32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i)))
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		dim := 4
+		info := makeFloat64VectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)))
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+
+	t.Run("float32_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeFloat32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i)+0.5))
+		}
+
+		result := make([]float32, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+
+	t.Run("float64_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeFloat64VectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)+0.5))
+		}
+
+		result := make([]float64, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		dim := 4
+		info := makeInt32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], uint32(int32(i)))
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		dim := 4
+		info := makeInt64VectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], uint64(int64(i)))
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+
+	t.Run("int32_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeInt32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], uint32(int32(i)+10))
+		}
+
+		result := make([]int32, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+
+	t.Run("int64_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeInt64VectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], uint64(int64(i)+10))
+		}
+
+		result := make([]int64, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+}
+
+// --- Test 4: Nil slice marshal ---
+
+func TestMarshalVector_NilSlice(t *testing.T) {
+	t.Run("float32_nil_slice", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var vec []float32
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+
+	t.Run("float64_nil_slice", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var vec []float64
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+
+	t.Run("float32_nil_ptr", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var ptr *[]float32
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+
+	t.Run("float64_nil_ptr", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var ptr *[]float64
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+
+	t.Run("float32_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var s []float32
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+
+	t.Run("float64_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var s []float64
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int32_nil_slice", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var vec []int32
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int64_nil_slice", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var vec []int64
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int32_nil_ptr", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var ptr *[]int32
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+
+	t.Run("int64_nil_ptr", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var ptr *[]int64
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+
+	t.Run("int32_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var s []int32
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int64_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var s []int64
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+}
+
+// --- Test 5: Nil data unmarshal ---
+
+func TestUnmarshalVector_NilData(t *testing.T) {
+	t.Run("float32_nil_data_nil_dst", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var result []float32
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("float32_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		result := []float32{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+
+	t.Run("float64_nil_data_nil_dst", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var result []float64
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("float64_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		result := []float64{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+
+	t.Run("int32_nil_data_nil_dst", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var result []int32
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("int32_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		result := []int32{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+
+	t.Run("int64_nil_data_nil_dst", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var result []int64
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("int64_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		result := []int64{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+}
+
+// --- Test 6: Dimension mismatch ---
+
+func TestMarshalVector_DimensionMismatch(t *testing.T) {
+	t.Run("float32_marshal", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		vec := []float32{1, 2}
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+
+	t.Run("float64_marshal", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		vec := []float64{1, 2}
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+
+	t.Run("float32_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		data := make([]byte, 10) // not 4*3=12
+		var result []float32
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+
+	t.Run("float64_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		data := make([]byte, 10) // not 8*3=24
+		var result []float64
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+
+	t.Run("int32_marshal", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		vec := []int32{1, 2}
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+
+	t.Run("int64_marshal", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		vec := []int64{1, 2}
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+
+	t.Run("int32_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		data := make([]byte, 10) // not 4*3=12
+		var result []int32
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+
+	t.Run("int64_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		data := make([]byte, 10) // not 8*3=24
+		var result []int64
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+}
+
+// --- Test 7: Empty vector (dim=0) ---
+
+func TestMarshalVector_EmptyVector(t *testing.T) {
+	t.Run("float32_dim0", func(t *testing.T) {
+		info := makeFloat32VectorType(0)
+		vec := []float32{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+
+	t.Run("float64_dim0", func(t *testing.T) {
+		info := makeFloat64VectorType(0)
+		vec := []float64{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+
+	t.Run("int32_dim0", func(t *testing.T) {
+		info := makeInt32VectorType(0)
+		vec := []int32{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+
+	t.Run("int64_dim0", func(t *testing.T) {
+		info := makeInt64VectorType(0)
+		vec := []int64{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+}
+
+// --- Test 7b: Empty vector (dim=0) via generic path ---
+
+func TestMarshalVector_EmptyVector_GenericPath(t *testing.T) {
+	// TypeBoolean vectors don't hit the fast paths, exercising the generic
+	// reflect-based marshalVector/unmarshalVector code for dim=0.
+	info := VectorType{
+		Dimensions: 0,
+		SubType:    NativeType{typ: TypeBoolean},
+	}
+	vec := []bool{}
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshalVector (generic, dim=0): %v", err)
+	}
+	if data == nil {
+		t.Error("expected non-nil empty data for non-nil empty vector via generic path, got nil (would encode as CQL NULL)")
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty data, got %d bytes", len(data))
+	}
+
+	var result []bool
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshalVector (generic, dim=0): %v", err)
+	}
+	if result == nil {
+		t.Error("expected non-nil empty slice for dim=0 unmarshal via generic path, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got len %d", len(result))
+	}
+}
+
+// --- Test 8: Pointer to slice ---
+
+func TestMarshalVector_PointerToSlice(t *testing.T) {
+	t.Run("float32_ptr_marshal", func(t *testing.T) {
+		info := makeFloat32VectorType(2)
+		vec := []float32{1.5, 2.5}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]float32: %v", err)
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("float64_ptr_marshal", func(t *testing.T) {
+		info := makeFloat64VectorType(2)
+		vec := []float64{1.5, 2.5}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]float64: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int32_ptr_marshal", func(t *testing.T) {
+		info := makeInt32VectorType(2)
+		vec := []int32{100, -200}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]int32: %v", err)
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int64_ptr_marshal", func(t *testing.T) {
+		info := makeInt64VectorType(2)
+		vec := []int64{100, -200}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]int64: %v", err)
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+}
+
+// --- Test 9: Special values ---
+
+func TestMarshalVector_SpecialValues(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		negZero := math.Float32frombits(0x80000000)
+		info := makeFloat32VectorType(5)
+		vec := []float32{float32(math.Inf(1)), float32(math.Inf(-1)), math.MaxFloat32, math.SmallestNonzeroFloat32, negZero}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
+		}
+		// reflect.DeepEqual treats -0.0 == +0.0; verify the sign bit explicitly.
+		if got := math.Float32bits(result[4]); got != 0x80000000 {
+			t.Errorf("negative zero sign bit lost: got bits %#08x, want 0x80000000", got)
+		}
+	})
+
+	t.Run("float32_nan", func(t *testing.T) {
+		info := makeFloat32VectorType(1)
+		vec := []float32{float32(math.NaN())}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 1 || !math.IsNaN(float64(result[0])) {
+			t.Errorf("expected NaN, got %v", result)
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		negZero := math.Float64frombits(0x8000000000000000)
+		info := makeFloat64VectorType(5)
+		vec := []float64{math.Inf(1), math.Inf(-1), math.MaxFloat64, math.SmallestNonzeroFloat64, negZero}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
+		}
+		// reflect.DeepEqual treats -0.0 == +0.0; verify the sign bit explicitly.
+		if got := math.Float64bits(result[4]); got != 0x8000000000000000 {
+			t.Errorf("negative zero sign bit lost: got bits %#016x, want 0x8000000000000000", got)
+		}
+	})
+
+	t.Run("float64_nan", func(t *testing.T) {
+		info := makeFloat64VectorType(1)
+		vec := []float64{math.NaN()}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 1 || !math.IsNaN(result[0]) {
+			t.Errorf("expected NaN, got %v", result)
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		info := makeInt32VectorType(5)
+		vec := []int32{0, 1, -1, math.MaxInt32, math.MinInt32}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		info := makeInt64VectorType(5)
+		vec := []int64{0, 1, -1, math.MaxInt64, math.MinInt64}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
+		}
+	})
+}
+
+// --- Test 10: Pool concurrency ---
+
+func TestVectorBufPool_Concurrency(t *testing.T) {
+	const goroutines = 100
+	const iterations = 100
+	const dim = 256
+	const bufSize = dim * 4
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				buf := getVectorBuf(bufSize)
+				if len(buf) != bufSize {
+					t.Errorf("getVectorBuf returned wrong size: got %d, want %d", len(buf), bufSize)
+					return
+				}
+				// Write some data to detect cross-goroutine corruption.
+				for j := range buf {
+					buf[j] = byte(j)
+				}
+				// Verify before returning.
+				for j := range buf {
+					if buf[j] != byte(j) {
+						t.Errorf("buffer corruption detected at index %d", j)
+						return
+					}
+				}
+				putVectorBuf(buf)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestVectorByteSizeErrorType verifies that vectorByteSize overflow errors,
+// when propagated through unmarshal fast paths, are returned as typed
+// UnmarshalError rather than plain fmt.Errorf values. The marshal fast paths
+// check len(vec) != dim before reaching vectorByteSize, so they cannot be
+// tested with real slices large enough to trigger overflow.
+func TestVectorByteSizeErrorType(t *testing.T) {
+	// Use a dimension that overflows on all platforms: math.MaxInt/4+1 * 4 > MaxInt.
+	overflowDim4 := math.MaxInt/4 + 1
+	overflowDim8 := math.MaxInt/8 + 1
+
+	t.Run("unmarshal_4byte", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float32", func() error { var dst []float32; return unmarshalVectorFloat32(overflowDim4, []byte{}, &dst) }},
+			{"int32", func() error { var dst []int32; return unmarshalVectorInt32(overflowDim4, []byte{}, &dst) }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected overflow error, got nil")
+				}
+				var ue UnmarshalError
+				if !errors.As(err, &ue) {
+					t.Errorf("expected UnmarshalError, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), "overflow") {
+					t.Errorf("expected overflow in error message, got: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("unmarshal_8byte", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float64", func() error { var dst []float64; return unmarshalVectorFloat64(overflowDim8, []byte{}, &dst) }},
+			{"int64", func() error { var dst []int64; return unmarshalVectorInt64(overflowDim8, []byte{}, &dst) }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected overflow error, got nil")
+				}
+				var ue UnmarshalError
+				if !errors.As(err, &ue) {
+					t.Errorf("expected UnmarshalError, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), "overflow") {
+					t.Errorf("expected overflow in error message, got: %v", err)
+				}
+			})
+		}
+	})
+}
+
+// TestUnmarshalVectorFastPathZeroDimNonNilSlice verifies that unmarshal fast
+// paths return a non-nil empty slice (not nil) when dim==0 and data is non-nil
+// empty, matching the generic path behavior.
+func TestUnmarshalVectorFastPathZeroDimNonNilSlice(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		var dst []float32
+		if err := unmarshalVectorFloat32(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		var dst []float64
+		if err := unmarshalVectorFloat64(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		var dst []int32
+		if err := unmarshalVectorInt32(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		var dst []int64
+		if err := unmarshalVectorInt64(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	// Also verify that an existing non-nil dst is preserved as non-nil [:0].
+	t.Run("float32_existing_dst", func(t *testing.T) {
+		dst := make([]float32, 5)
+		if err := unmarshalVectorFloat32(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+}
+
+// --- Test 11: Oversized buffers not pooled ---
+
+func TestVectorBufPool_OversizedNotPooled(t *testing.T) {
+	// A buffer larger than 65536 should not be returned to the pool.
+	big := make([]byte, 70000)
+	putVectorBuf(big)
+
+	// Getting a small buffer should not return the oversized one.
+	small := getVectorBuf(100)
+	if cap(small) >= 70000 {
+		t.Errorf("oversized buffer was returned from pool: cap=%d", cap(small))
+	}
+}
+
+// --- Test 12: vectorFixedElemSize ---
+
+func TestVectorFixedElemSize(t *testing.T) {
+	tests := []struct {
+		typ  Type
+		want int
+	}{
+		// Fixed-length types.
+		{TypeBoolean, 1},
+		{TypeInt, 4},
+		{TypeFloat, 4},
+		{TypeBigInt, 8},
+		{TypeDouble, 8},
+		{TypeTimestamp, 8},
+		{TypeUUID, 16},
+		{TypeTimeUUID, 16},
+		// Variable-length types — must return 0.
+		{TypeVarchar, 0},
+		{TypeBlob, 0},
+		{TypeText, 0},
+		{TypeVarint, 0},
+		{TypeDecimal, 0},
+		{TypeAscii, 0},
+		{TypeInet, 0},
+		{TypeDuration, 0},
+		{TypeList, 0},
+		{TypeSet, 0},
+		{TypeMap, 0},
+		{TypeUDT, 0},
+		{TypeTuple, 0},
+	}
+	for _, tt := range tests {
+		info := NewNativeType(protoVersion4, tt.typ)
+		got := vectorFixedElemSize(info)
+		if got != tt.want {
+			t.Errorf("vectorFixedElemSize(%v) = %d, want %d", tt.typ, got, tt.want)
+		}
+	}
+}
+
+// --- Test 13: Generic prealloc correctness ---
+
+func TestMarshalVector_GenericPrealloc(t *testing.T) {
+	// Test with UUID vectors — fixed-size (16 bytes) but not a float/int fast path.
+	// This exercises the generic path with buf.Grow() prealloc from Phase 1b.
+	dim := 3
+	info := makeUUIDVectorType(dim)
+
+	// Create UUID values as [16]byte arrays.
+	uuids := make([][16]byte, dim)
+	for i := range uuids {
+		for j := range uuids[i] {
+			uuids[i][j] = byte(i*16 + j)
+		}
+	}
+
+	// Marshal using the generic path (no fast path for UUID).
+	data, err := marshalVector(info, uuids[:])
+	if err != nil {
+		t.Fatalf("marshalVector: %v", err)
+	}
+
+	// UUID elements are fixed-size (16 bytes), no length prefix.
+	expectedLen := dim * 16
+	if len(data) != expectedLen {
+		t.Fatalf("expected %d bytes, got %d", expectedLen, len(data))
+	}
+
+	// Verify content by unmarshaling.
+	var result [][16]byte
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshalVector: %v", err)
+	}
+	if !reflect.DeepEqual(uuids[:], result) {
+		t.Errorf("round-trip mismatch: got %v, want %v", result, uuids[:])
+	}
+}
+
+func TestVectorByteSize_Overflow(t *testing.T) {
+	// On 32-bit, math.MaxInt is 2^31-1. dim=math.MaxInt/4+1 with elemBytes=4
+	// would overflow. On 64-bit this is just a sanity check.
+	_, err := vectorByteSize(math.MaxInt/4+1, 4)
+	if err == nil {
+		t.Error("expected overflow error for large dim*4")
+	}
+	_, err = vectorByteSize(math.MaxInt/8+1, 8)
+	if err == nil {
+		t.Error("expected overflow error for large dim*8")
+	}
+	// Normal case should succeed
+	n, err := vectorByteSize(1536, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 6144 {
+		t.Fatalf("expected 6144, got %d", n)
+	}
+}
+
+// TestMarshalVectorNegativeDimensions verifies that all fast-path marshal
+// and unmarshal functions return a clear "negative dimensions" error when
+// the VectorType has a negative Dimensions value (corrupt/adversarial metadata).
+func TestMarshalVectorNegativeDimensions(t *testing.T) {
+	const wantSubstr = "negative dimensions"
+
+	t.Run("marshal", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float32", func() error { _, err := marshalVectorFloat32(-1, []float32{1}); return err }},
+			{"float64", func() error { _, err := marshalVectorFloat64(-1, []float64{1}); return err }},
+			{"int32", func() error { _, err := marshalVectorInt32(-1, []int32{1}); return err }},
+			{"int64", func() error { _, err := marshalVectorInt64(-1, []int64{1}); return err }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected error for negative dimensions, got nil")
+				}
+				if !strings.Contains(err.Error(), wantSubstr) {
+					t.Errorf("error %q does not contain %q", err, wantSubstr)
+				}
+			})
+		}
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float32", func() error { var v []float32; return unmarshalVectorFloat32(-1, []byte{0, 0, 0, 0}, &v) }},
+			{"float64", func() error { var v []float64; return unmarshalVectorFloat64(-1, []byte{0, 0, 0, 0, 0, 0, 0, 0}, &v) }},
+			{"int32", func() error { var v []int32; return unmarshalVectorInt32(-1, []byte{0, 0, 0, 0}, &v) }},
+			{"int64", func() error { var v []int64; return unmarshalVectorInt64(-1, []byte{0, 0, 0, 0, 0, 0, 0, 0}, &v) }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected error for negative dimensions, got nil")
+				}
+				if !strings.Contains(err.Error(), wantSubstr) {
+					t.Errorf("error %q does not contain %q", err, wantSubstr)
+				}
+			})
+		}
+	})
+
+	// Also test via the public marshalVector/unmarshalVector entry points
+	// (which dispatch to fast paths).
+	t.Run("public_marshal", func(t *testing.T) {
+		info := makeFloat32VectorType(-3)
+		_, err := marshalVector(info, []float32{1, 2, 3})
+		if err == nil {
+			t.Fatal("expected error for negative dimensions via marshalVector")
+		}
+		if !strings.Contains(err.Error(), wantSubstr) {
+			t.Errorf("error %q does not contain %q", err, wantSubstr)
+		}
+	})
+
+	t.Run("public_unmarshal", func(t *testing.T) {
+		info := makeFloat32VectorType(-3)
+		var dst []float32
+		err := unmarshalVector(info, []byte{0, 0, 0, 0}, &dst)
+		if err == nil {
+			t.Fatal("expected error for negative dimensions via unmarshalVector")
+		}
+		if !strings.Contains(err.Error(), wantSubstr) {
+			t.Errorf("error %q does not contain %q", err, wantSubstr)
+		}
+	})
+}
+
+// TestUnmarshalVectorGenericPathZeroDimensions verifies the generic unmarshal
+// path (non-fast-path types like UUID) correctly handles Dimensions==0.
+func TestUnmarshalVectorGenericPathZeroDimensions(t *testing.T) {
+	info := makeUUIDVectorType(0) // UUID type goes through generic path
+
+	t.Run("nil_data", func(t *testing.T) {
+		var dst [][16]byte
+		err := unmarshalVector(info, nil, &dst)
+		if err != nil {
+			t.Fatalf("unexpected error for nil data: %v", err)
+		}
+		if dst != nil {
+			t.Errorf("expected nil slice for nil data, got %v", dst)
+		}
+	})
+
+	t.Run("empty_data", func(t *testing.T) {
+		var dst [][16]byte
+		err := unmarshalVector(info, []byte{}, &dst)
+		if err != nil {
+			t.Fatalf("unexpected error for empty data: %v", err)
+		}
+		if dst == nil || len(dst) != 0 {
+			t.Errorf("expected non-nil empty slice, got %v (nil=%v)", dst, dst == nil)
+		}
+	})
+
+	t.Run("non_empty_data_error", func(t *testing.T) {
+		var dst [][16]byte
+		err := unmarshalVector(info, []byte{1, 2, 3}, &dst)
+		if err == nil {
+			t.Fatal("expected error for non-empty data with 0 dimensions")
+		}
+		if !strings.Contains(err.Error(), "0-dimension") {
+			t.Errorf("error %q does not mention 0-dimension", err)
+		}
+	})
+}
+
+// TestGetVectorBuf_NonPositiveSize verifies that getVectorBuf handles
+// zero and negative sizes correctly without allocating or panicking.
+// Size 0 returns a non-nil empty slice (distinguishes empty vector from NULL).
+// Negative sizes return nil.
+func TestGetVectorBuf_NonPositiveSize(t *testing.T) {
+	// Zero size: non-nil empty slice (needed by marshalVector for dim=0).
+	buf := getVectorBuf(0)
+	if buf == nil {
+		t.Error("getVectorBuf(0) = nil, want non-nil empty slice")
+	} else if len(buf) != 0 {
+		t.Errorf("getVectorBuf(0) len = %d, want 0", len(buf))
+	}
+
+	// Negative sizes: nil.
+	for _, size := range []int{-1, -100} {
+		buf := getVectorBuf(size)
+		if buf != nil {
+			t.Errorf("getVectorBuf(%d) = %v, want nil", size, buf)
+		}
+	}
+}

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -6,6 +6,7 @@
 package gocql
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"math"
@@ -1839,4 +1840,98 @@ func TestVectorBufPoolBatchSimulation(t *testing.T) {
 		t.Fatal("expected to get a buffer from pool after returning batch buffers")
 	}
 	putVectorBuf(reused)
+}
+
+// Named slice types whose underlying type matches a fast-path element slice but
+// whose concrete type fails the `value.([]float32)` style type assertions in
+// marshalVector/unmarshalVector. Passing these forces the generic reflect-based
+// path, while passing the plain []T forces the fast path. This lets us compare
+// the two encoders byte-for-byte.
+type genericF32 []float32
+type genericF64 []float64
+type genericI32 []int32
+type genericI64 []int64
+type genericUUID []UUID
+
+// TestMarshalVector_FastPathMatchesGeneric is a differential test asserting that
+// the optimized fast paths produce byte-for-byte identical output to the generic
+// reflect-based path for every supported element type across nil, empty, single,
+// many, NaN/Inf/negative-zero, and negative-value cases. This is the highest-risk
+// area of the PR (the same nil-vs-empty / endianness divergence class found in
+// PR #744 and #871), so it is exercised explicitly here.
+func TestMarshalVector_FastPathMatchesGeneric(t *testing.T) {
+	nan32 := float32(math.NaN())
+	nan64 := math.NaN()
+	negZero32 := math.Float32frombits(0x80000000)
+	negZero64 := math.Float64frombits(0x8000000000000000)
+
+	cases := []struct {
+		name string
+		vt   VectorType
+		// fast is the concrete []T value taking the fast path.
+		// generic is the same logical value as a named type forcing the generic path.
+		fast    interface{}
+		generic interface{}
+	}{
+		// float32
+		{"f32/nil", makeFloat32VectorType(0), []float32(nil), genericF32(nil)},
+		{"f32/empty", makeFloat32VectorType(0), []float32{}, genericF32{}},
+		{"f32/one", makeFloat32VectorType(1), []float32{1.5}, genericF32{1.5}},
+		{"f32/many", makeFloat32VectorType(4), []float32{-1.5, 0, 42.125, 3.14}, genericF32{-1.5, 0, 42.125, 3.14}},
+		{"f32/special", makeFloat32VectorType(5), []float32{float32(math.Inf(1)), float32(math.Inf(-1)), nan32, negZero32, math.MaxFloat32}, genericF32{float32(math.Inf(1)), float32(math.Inf(-1)), nan32, negZero32, math.MaxFloat32}},
+
+		// float64
+		{"f64/nil", makeFloat64VectorType(0), []float64(nil), genericF64(nil)},
+		{"f64/empty", makeFloat64VectorType(0), []float64{}, genericF64{}},
+		{"f64/one", makeFloat64VectorType(1), []float64{1.5}, genericF64{1.5}},
+		{"f64/many", makeFloat64VectorType(4), []float64{-1.5, 0, 42.125, 3.14}, genericF64{-1.5, 0, 42.125, 3.14}},
+		{"f64/special", makeFloat64VectorType(5), []float64{math.Inf(1), math.Inf(-1), nan64, negZero64, math.MaxFloat64}, genericF64{math.Inf(1), math.Inf(-1), nan64, negZero64, math.MaxFloat64}},
+
+		// int32
+		{"i32/nil", makeInt32VectorType(0), []int32(nil), genericI32(nil)},
+		{"i32/empty", makeInt32VectorType(0), []int32{}, genericI32{}},
+		{"i32/one", makeInt32VectorType(1), []int32{-1}, genericI32{-1}},
+		{"i32/many", makeInt32VectorType(5), []int32{-1, 0, 42, math.MinInt32, math.MaxInt32}, genericI32{-1, 0, 42, math.MinInt32, math.MaxInt32}},
+
+		// int64
+		{"i64/nil", makeInt64VectorType(0), []int64(nil), genericI64(nil)},
+		{"i64/empty", makeInt64VectorType(0), []int64{}, genericI64{}},
+		{"i64/one", makeInt64VectorType(1), []int64{-1}, genericI64{-1}},
+		{"i64/many", makeInt64VectorType(5), []int64{-1, 0, 42, math.MinInt64, math.MaxInt64}, genericI64{-1, 0, 42, math.MinInt64, math.MaxInt64}},
+
+		// uuid
+		{"uuid/nil", makeUUIDVectorType(0), []UUID(nil), genericUUID(nil)},
+		{"uuid/empty", makeUUIDVectorType(0), []UUID{}, genericUUID{}},
+		{"uuid/many", makeUUIDVectorType(2), []UUID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			{0xf0, 0xe0, 0xd0, 0xc0, 0xb0, 0xa0, 0x90, 0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10, 0x00},
+		}, genericUUID{
+			{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			{0xf0, 0xe0, 0xd0, 0xc0, 0xb0, 0xa0, 0x90, 0x80, 0x70, 0x60, 0x50, 0x40, 0x30, 0x20, 0x10, 0x00},
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fastBytes, fastErr := marshalVector(tc.vt, tc.fast)
+			genBytes, genErr := marshalVector(tc.vt, tc.generic)
+
+			if (fastErr == nil) != (genErr == nil) {
+				t.Fatalf("error mismatch: fast=%v generic=%v", fastErr, genErr)
+			}
+			if fastErr != nil {
+				return
+			}
+			// nil vs empty distinction must be preserved exactly: a nil input
+			// must produce nil bytes (CQL null); an empty input must produce a
+			// non-nil zero-length slice.
+			if (fastBytes == nil) != (genBytes == nil) {
+				t.Fatalf("nil-vs-empty divergence: fast nil=%v (%#v) generic nil=%v (%#v)",
+					fastBytes == nil, fastBytes, genBytes == nil, genBytes)
+			}
+			if !bytes.Equal(fastBytes, genBytes) {
+				t.Fatalf("byte mismatch:\n  fast:    %x\n  generic: %x", fastBytes, genBytes)
+			}
+		})
+	}
 }

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -334,6 +334,9 @@ func TestUnmarshalVector_SliceReuse(t *testing.T) {
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector (first): %v", err)
 		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d after first unmarshal, got %d", dim, len(result))
+		}
 		ptr := &result[0]
 
 		if err := unmarshalVector(info, data, &result); err != nil {
@@ -424,6 +427,9 @@ func TestUnmarshalVector_SliceReuse(t *testing.T) {
 		var result []int64
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d after first unmarshal, got %d", dim, len(result))
 		}
 		ptr := &result[0]
 

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -896,6 +896,72 @@ func TestMarshalVector_DimensionMismatch(t *testing.T) {
 	})
 }
 
+// TestUnmarshalVector_ArrayDestDimensionMismatch verifies that unmarshalling
+// into a fixed-size array destination (*[N]T) whose length does not match the
+// vector dimensions reports a dimension-mismatch error rather than silently
+// succeeding and leaving the array unchanged.
+//
+// Array destinations never match the slice-typed fast-path assertions
+// (value.(*[]float32) etc.) in unmarshalVector, so they always fall through to
+// the generic reflect path. This test pins that the generic path validates the
+// array length for both the dim==0 early-return branch and the non-zero branch,
+// for both float (TypeFloat) and the dim==0 case across element types.
+func TestUnmarshalVector_ArrayDestDimensionMismatch(t *testing.T) {
+	t.Run("float32_array_too_small", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		data := make([]byte, 3*4)
+		var arr [2]float32
+		err := unmarshalVector(info, data, &arr)
+		if err == nil {
+			t.Fatal("expected dimension-mismatch error for [2]float32 dst of vector<float,3>, got nil")
+		}
+	})
+
+	t.Run("float32_array_too_large", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		data := make([]byte, 3*4)
+		var arr [5]float32
+		err := unmarshalVector(info, data, &arr)
+		if err == nil {
+			t.Fatal("expected dimension-mismatch error for [5]float32 dst of vector<float,3>, got nil")
+		}
+	})
+
+	t.Run("float32_array_match_ok", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		data := make([]byte, 3*4)
+		for i := 0; i < 3; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i+1)))
+		}
+		var arr [3]float32
+		if err := unmarshalVector(info, data, &arr); err != nil {
+			t.Fatalf("unexpected error for matching [3]float32: %v", err)
+		}
+		if arr != [3]float32{1, 2, 3} {
+			t.Errorf("array contents = %v, want [1 2 3]", arr)
+		}
+	})
+
+	// dim==0 early-return must still validate non-zero array destinations
+	// (otherwise a [N]T with N!=0 would be left unchanged and report success).
+	t.Run("float32_dim0_into_nonzero_array", func(t *testing.T) {
+		info := makeFloat32VectorType(0)
+		var arr [3]float32
+		err := unmarshalVector(info, []byte{}, &arr)
+		if err == nil {
+			t.Fatal("expected dimension-mismatch error for [3]float32 dst of vector<float,0>, got nil")
+		}
+	})
+
+	t.Run("float32_dim0_into_zero_array_ok", func(t *testing.T) {
+		info := makeFloat32VectorType(0)
+		var arr [0]float32
+		if err := unmarshalVector(info, []byte{}, &arr); err != nil {
+			t.Fatalf("unexpected error for [0]float32 dst of vector<float,0>: %v", err)
+		}
+	})
+}
+
 // --- Test 7: Empty vector (dim=0) ---
 
 func TestMarshalVector_EmptyVector(t *testing.T) {
@@ -1753,7 +1819,10 @@ func TestVectorBufPoolReturnSimulation(t *testing.T) {
 	}
 
 	// Remember the backing array pointer before returning to pool.
-	origPtr := &data[:1][0]
+	// data has len == expectedSize > 0 here, so &data[0] is the safe way to
+	// capture the backing-array pointer (avoids the fragile out-of-range
+	// reslice &data[:1][0] which would panic on a zero-length slice).
+	origPtr := &data[0]
 
 	// Simulate what the defer in executeQuery/executeBatch does.
 	if vectorBufPoolSubtype(vt) {
@@ -1765,7 +1834,7 @@ func TestVectorBufPoolReturnSimulation(t *testing.T) {
 	if len(reused) != expectedSize {
 		t.Fatalf("getVectorBuf(%d) returned len %d", expectedSize, len(reused))
 	}
-	reusedPtr := &reused[:1][0]
+	reusedPtr := &reused[0]
 	if origPtr != reusedPtr {
 		// sync.Pool makes no guarantees about reuse — the GC may clear the
 		// pool between Put and Get, especially under the race detector.

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -1,48 +1,25 @@
-//go:build unit
-// +build unit
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+//go:build all || unit
+// +build all unit
 
 package gocql
 
 import (
 	"encoding/binary"
+	"errors"
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 )
 
-// makeDoubleVectorType creates a VectorType for vector<double> with the given dimension.
-func makeDoubleVectorType(dim int) VectorType {
-	return VectorType{
-		NativeType: NativeType{
-			proto:  protoVersion4,
-			typ:    TypeCustom,
-			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "DoubleType, " + strconv.Itoa(dim) + ")",
-		},
-		SubType:    NativeType{proto: protoVersion4, typ: TypeDouble},
-		Dimensions: dim,
-	}
-}
+// --- Test helpers ---
 
-// makeFloat32VectorType creates a VectorType for vector<float> with the given dimension.
 func makeFloat32VectorType(dim int) VectorType {
 	return VectorType{
 		NativeType: NativeType{
@@ -55,71 +32,149 @@ func makeFloat32VectorType(dim int) VectorType {
 	}
 }
 
-func TestMarshalVectorFloat64_RoundTrip(t *testing.T) {
-	dim := 5
-	info := makeDoubleVectorType(dim)
-	vec := []float64{1.1, 2.2, 3.3, 4.4, 5.5}
-
-	data, err := marshalVector(info, vec)
-	if err != nil {
-		t.Fatalf("marshalVector: %v", err)
-	}
-	if len(data) != dim*8 {
-		t.Fatalf("expected %d bytes, got %d", dim*8, len(data))
-	}
-
-	var result []float64
-	if err := unmarshalVector(info, data, &result); err != nil {
-		t.Fatalf("unmarshalVector: %v", err)
-	}
-	if !reflect.DeepEqual(vec, result) {
-		t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+func makeFloat64VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "DoubleType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeDouble},
+		Dimensions: dim,
 	}
 }
 
-func TestMarshalVectorFloat32_RoundTrip(t *testing.T) {
-	dim := 5
-	info := makeFloat32VectorType(dim)
-	vec := []float32{1.1, 2.2, 3.3, 4.4, 5.5}
-
-	data, err := marshalVector(info, vec)
-	if err != nil {
-		t.Fatalf("marshalVector: %v", err)
-	}
-	if len(data) != dim*4 {
-		t.Fatalf("expected %d bytes, got %d", dim*4, len(data))
-	}
-
-	var result []float32
-	if err := unmarshalVector(info, data, &result); err != nil {
-		t.Fatalf("unmarshalVector: %v", err)
-	}
-	if !reflect.DeepEqual(vec, result) {
-		t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+func makeUUIDVectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "UUIDType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeUUID},
+		Dimensions: dim,
 	}
 }
 
-// TestVectorFloat_ByteCompatibility verifies that the fast path produces
-// identical bytes to what the generic reflect-based path would produce.
-func TestVectorFloat_ByteCompatibility(t *testing.T) {
-	t.Run("float64", func(t *testing.T) {
-		dim := 3
-		vec := []float64{-1.5, 0, 42.125}
-		// Build expected bytes manually using the same encoding the generic path uses.
-		expected := make([]byte, dim*8)
-		for i, v := range vec {
-			binary.BigEndian.PutUint64(expected[i*8:], math.Float64bits(v))
-		}
+func makeInt32VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "Int32Type, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeInt},
+		Dimensions: dim,
+	}
+}
 
-		info := makeDoubleVectorType(dim)
+func makeInt64VectorType(dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "LongType, " + strconv.Itoa(dim) + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Dimensions: dim,
+	}
+}
+
+// --- Test 1: Round-trip ---
+
+func TestMarshalVector_RoundTrip(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		dim := 5
+		info := makeFloat32VectorType(dim)
+		vec := []float32{1.1, 2.2, 3.3, 4.4, 5.5}
+
 		data, err := marshalVector(info, vec)
 		if err != nil {
 			t.Fatalf("marshalVector: %v", err)
 		}
-		if !reflect.DeepEqual(data, expected) {
-			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		if len(data) != dim*4 {
+			t.Fatalf("expected %d bytes, got %d", dim*4, len(data))
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
 		}
 	})
+
+	t.Run("float64", func(t *testing.T) {
+		dim := 5
+		info := makeFloat64VectorType(dim)
+		vec := []float64{1.1, 2.2, 3.3, 4.4, 5.5}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*8 {
+			t.Fatalf("expected %d bytes, got %d", dim*8, len(data))
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		dim := 5
+		info := makeInt32VectorType(dim)
+		vec := []int32{-100, 0, 42, math.MaxInt32, math.MinInt32}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*4 {
+			t.Fatalf("expected %d bytes, got %d", dim*4, len(data))
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		dim := 5
+		info := makeInt64VectorType(dim)
+		vec := []int64{-100, 0, 42, math.MaxInt64, math.MinInt64}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if len(data) != dim*8 {
+			t.Fatalf("expected %d bytes, got %d", dim*8, len(data))
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+}
+
+// --- Test 2: Byte compatibility ---
+
+func TestMarshalVector_ByteCompatibility(t *testing.T) {
 	t.Run("float32", func(t *testing.T) {
 		dim := 3
 		vec := []float32{-1.5, 0, 42.125}
@@ -137,37 +192,65 @@ func TestVectorFloat_ByteCompatibility(t *testing.T) {
 			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
 		}
 	})
-}
 
-func TestVectorFloat_SliceReuse(t *testing.T) {
 	t.Run("float64", func(t *testing.T) {
-		dim := 4
-		info := makeDoubleVectorType(dim)
-		data := make([]byte, dim*8)
-		for i := 0; i < dim; i++ {
-			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)))
+		dim := 3
+		vec := []float64{-1.5, 0, 42.125}
+		expected := make([]byte, dim*8)
+		for i, v := range vec {
+			binary.BigEndian.PutUint64(expected[i*8:], math.Float64bits(v))
 		}
 
-		// First unmarshal allocates.
-		var result []float64
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector (first): %v", err)
+		info := makeFloat64VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
 		}
-		if len(result) != dim {
-			t.Fatalf("expected len %d, got %d", dim, len(result))
-		}
-
-		// Save the underlying array pointer.
-		ptr := &result[0]
-
-		// Second unmarshal should reuse the same backing array.
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector (second): %v", err)
-		}
-		if &result[0] != ptr {
-			t.Error("expected slice reuse, but a new backing array was allocated")
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
 		}
 	})
+
+	t.Run("int32", func(t *testing.T) {
+		dim := 3
+		vec := []int32{-1, 0, 42}
+		expected := make([]byte, dim*4)
+		for i, v := range vec {
+			binary.BigEndian.PutUint32(expected[i*4:], uint32(v))
+		}
+
+		info := makeInt32VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		dim := 3
+		vec := []int64{-1, 0, 42}
+		expected := make([]byte, dim*8)
+		for i, v := range vec {
+			binary.BigEndian.PutUint64(expected[i*8:], uint64(v))
+		}
+
+		info := makeInt64VectorType(dim)
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(data, expected) {
+			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
+		}
+	})
+}
+
+// --- Test 3: Slice reuse ---
+
+func TestUnmarshalVector_SliceReuse(t *testing.T) {
 	t.Run("float32", func(t *testing.T) {
 		dim := 4
 		info := makeFloat32VectorType(dim)
@@ -180,6 +263,9 @@ func TestVectorFloat_SliceReuse(t *testing.T) {
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector (first): %v", err)
 		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
 		ptr := &result[0]
 
 		if err := unmarshalVector(info, data, &result); err != nil {
@@ -189,27 +275,29 @@ func TestVectorFloat_SliceReuse(t *testing.T) {
 			t.Error("expected slice reuse, but a new backing array was allocated")
 		}
 	})
-	t.Run("float64_excess_cap", func(t *testing.T) {
+
+	t.Run("float64", func(t *testing.T) {
 		dim := 4
-		info := makeDoubleVectorType(dim)
+		info := makeFloat64VectorType(dim)
 		data := make([]byte, dim*8)
 		for i := 0; i < dim; i++ {
-			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)+0.5))
+			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)))
 		}
 
-		// Pre-allocate with excess capacity.
-		result := make([]float64, 0, dim+10)
-		ptr := &result[:1][0] // get pointer to backing array
+		var result []float64
 		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
+			t.Fatalf("unmarshalVector (first): %v", err)
 		}
-		if len(result) != dim {
-			t.Fatalf("expected len %d, got %d", dim, len(result))
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
 		}
 		if &result[0] != ptr {
-			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+			t.Error("expected slice reuse, but a new backing array was allocated")
 		}
 	})
+
 	t.Run("float32_excess_cap", func(t *testing.T) {
 		dim := 4
 		info := makeFloat32VectorType(dim)
@@ -218,8 +306,122 @@ func TestVectorFloat_SliceReuse(t *testing.T) {
 			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i)+0.5))
 		}
 
-		result := make([]float32, 0, dim+10)
-		ptr := &result[:1][0]
+		result := make([]float32, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+
+	t.Run("float64_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeFloat64VectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)+0.5))
+		}
+
+		result := make([]float64, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		dim := 4
+		info := makeInt32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], uint32(int32(i)))
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		dim := 4
+		info := makeInt64VectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], uint64(int64(i)))
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (first): %v", err)
+		}
+		ptr := &result[0]
+
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector (second): %v", err)
+		}
+		if &result[0] != ptr {
+			t.Error("expected slice reuse, but a new backing array was allocated")
+		}
+	})
+
+	t.Run("int32_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeInt32VectorType(dim)
+		data := make([]byte, dim*4)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint32(data[i*4:], uint32(int32(i)+10))
+		}
+
+		result := make([]int32, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != dim {
+			t.Fatalf("expected len %d, got %d", dim, len(result))
+		}
+		if &result[0] != ptr {
+			t.Error("expected reuse of pre-allocated backing array with excess capacity")
+		}
+	})
+
+	t.Run("int64_excess_cap", func(t *testing.T) {
+		dim := 4
+		info := makeInt64VectorType(dim)
+		data := make([]byte, dim*8)
+		for i := 0; i < dim; i++ {
+			binary.BigEndian.PutUint64(data[i*8:], uint64(int64(i)+10))
+		}
+
+		result := make([]int64, 1, dim+10)
+		ptr := &result[0]
+		result = result[:0]
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector: %v", err)
 		}
@@ -232,61 +434,9 @@ func TestVectorFloat_SliceReuse(t *testing.T) {
 	})
 }
 
-func TestVectorFloat_NilData(t *testing.T) {
-	t.Run("float64_nil_data_nil_dst", func(t *testing.T) {
-		info := makeDoubleVectorType(3)
-		var result []float64
-		if err := unmarshalVector(info, nil, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if result != nil {
-			t.Errorf("expected nil result, got %v", result)
-		}
-	})
-	t.Run("float64_nil_data_non_nil_dst", func(t *testing.T) {
-		info := makeDoubleVectorType(3)
-		result := []float64{1, 2, 3}
-		if err := unmarshalVector(info, nil, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if result != nil {
-			t.Errorf("expected nil result after nil data, got %v", result)
-		}
-	})
-	t.Run("float32_nil_data_nil_dst", func(t *testing.T) {
-		info := makeFloat32VectorType(3)
-		var result []float32
-		if err := unmarshalVector(info, nil, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if result != nil {
-			t.Errorf("expected nil result, got %v", result)
-		}
-	})
-	t.Run("float32_nil_data_non_nil_dst", func(t *testing.T) {
-		info := makeFloat32VectorType(3)
-		result := []float32{1, 2, 3}
-		if err := unmarshalVector(info, nil, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if result != nil {
-			t.Errorf("expected nil result after nil data, got %v", result)
-		}
-	})
-}
+// --- Test 4: Nil slice marshal ---
 
-func TestVectorFloat_NilSliceMarshal(t *testing.T) {
-	t.Run("float64_nil_slice", func(t *testing.T) {
-		info := makeDoubleVectorType(3)
-		var vec []float64
-		data, err := marshalVector(info, vec)
-		if err != nil {
-			t.Fatalf("marshalVector: %v", err)
-		}
-		if data != nil {
-			t.Errorf("expected nil data for nil slice, got %v", data)
-		}
-	})
+func TestMarshalVector_NilSlice(t *testing.T) {
 	t.Run("float32_nil_slice", func(t *testing.T) {
 		info := makeFloat32VectorType(3)
 		var vec []float32
@@ -298,18 +448,19 @@ func TestVectorFloat_NilSliceMarshal(t *testing.T) {
 			t.Errorf("expected nil data for nil slice, got %v", data)
 		}
 	})
-	t.Run("float64_nil_ptr", func(t *testing.T) {
-		info := makeDoubleVectorType(3)
-		var ptr *[]float64
-		// Nil pointer handling is Marshal()'s responsibility, not marshalVector's.
-		data, err := Marshal(info, ptr)
+
+	t.Run("float64_nil_slice", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var vec []float64
+		data, err := marshalVector(info, vec)
 		if err != nil {
-			t.Fatalf("Marshal: %v", err)
+			t.Fatalf("marshalVector: %v", err)
 		}
 		if data != nil {
-			t.Errorf("expected nil data for nil ptr, got %v", data)
+			t.Errorf("expected nil data for nil slice, got %v", data)
 		}
 	})
+
 	t.Run("float32_nil_ptr", func(t *testing.T) {
 		info := makeFloat32VectorType(3)
 		var ptr *[]float32
@@ -321,10 +472,22 @@ func TestVectorFloat_NilSliceMarshal(t *testing.T) {
 			t.Errorf("expected nil data for nil ptr, got %v", data)
 		}
 	})
-	t.Run("float64_non_nil_ptr_nil_slice", func(t *testing.T) {
-		info := makeDoubleVectorType(3)
-		var s []float64 // nil slice
-		// Non-nil pointer to nil slice — Marshal() dereferences, marshalVector sees nil slice.
+
+	t.Run("float64_nil_ptr", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var ptr *[]float64
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+
+	t.Run("float32_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var s []float32
 		data, err := Marshal(info, &s)
 		if err != nil {
 			t.Fatalf("Marshal: %v", err)
@@ -333,9 +496,82 @@ func TestVectorFloat_NilSliceMarshal(t *testing.T) {
 			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
 		}
 	})
-	t.Run("float32_non_nil_ptr_nil_slice", func(t *testing.T) {
-		info := makeFloat32VectorType(3)
-		var s []float32 // nil slice
+
+	t.Run("float64_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var s []float64
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int32_nil_slice", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var vec []int32
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int64_nil_slice", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var vec []int64
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int32_nil_ptr", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var ptr *[]int32
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+
+	t.Run("int64_nil_ptr", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var ptr *[]int64
+		data, err := Marshal(info, ptr)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for nil ptr, got %v", data)
+		}
+	})
+
+	t.Run("int32_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var s []int32
+		data, err := Marshal(info, &s)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for non-nil ptr to nil slice, got %v", data)
+		}
+	})
+
+	t.Run("int64_non_nil_ptr_nil_slice", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var s []int64
 		data, err := Marshal(info, &s)
 		if err != nil {
 			t.Fatalf("Marshal: %v", err)
@@ -346,32 +582,119 @@ func TestVectorFloat_NilSliceMarshal(t *testing.T) {
 	})
 }
 
-func TestVectorFloat_DimensionMismatch(t *testing.T) {
-	t.Run("float64_marshal", func(t *testing.T) {
-		info := makeDoubleVectorType(3)
-		vec := []float64{1, 2} // wrong dimension
-		_, err := marshalVector(info, vec)
-		if err == nil {
-			t.Fatal("expected error for dimension mismatch, got nil")
+// --- Test 5: Nil data unmarshal ---
+
+func TestUnmarshalVector_NilData(t *testing.T) {
+	t.Run("float32_nil_data_nil_dst", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		var result []float32
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
 		}
 	})
+
+	t.Run("float32_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeFloat32VectorType(3)
+		result := []float32{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+
+	t.Run("float64_nil_data_nil_dst", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		var result []float64
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("float64_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		result := []float64{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+
+	t.Run("int32_nil_data_nil_dst", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		var result []int32
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("int32_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		result := []int32{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+
+	t.Run("int64_nil_data_nil_dst", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		var result []int64
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("int64_nil_data_non_nil_dst", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		result := []int64{1, 2, 3}
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result after nil data, got %v", result)
+		}
+	})
+}
+
+// --- Test 6: Dimension mismatch ---
+
+func TestMarshalVector_DimensionMismatch(t *testing.T) {
 	t.Run("float32_marshal", func(t *testing.T) {
 		info := makeFloat32VectorType(3)
-		vec := []float32{1, 2} // wrong dimension
+		vec := []float32{1, 2}
 		_, err := marshalVector(info, vec)
 		if err == nil {
 			t.Fatal("expected error for dimension mismatch, got nil")
 		}
 	})
-	t.Run("float64_unmarshal_wrong_data_len", func(t *testing.T) {
-		info := makeDoubleVectorType(3)
-		data := make([]byte, 10) // not divisible by 8*3=24
-		var result []float64
-		err := unmarshalVector(info, data, &result)
+
+	t.Run("float64_marshal", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		vec := []float64{1, 2}
+		_, err := marshalVector(info, vec)
 		if err == nil {
-			t.Fatal("expected error for wrong data length, got nil")
+			t.Fatal("expected error for dimension mismatch, got nil")
 		}
 	})
+
 	t.Run("float32_unmarshal_wrong_data_len", func(t *testing.T) {
 		info := makeFloat32VectorType(3)
 		data := make([]byte, 10) // not 4*3=12
@@ -381,31 +704,59 @@ func TestVectorFloat_DimensionMismatch(t *testing.T) {
 			t.Fatal("expected error for wrong data length, got nil")
 		}
 	})
-}
 
-func TestVectorFloat_EmptyVector(t *testing.T) {
-	t.Run("float64_dim0", func(t *testing.T) {
-		info := makeDoubleVectorType(0)
-		vec := []float64{}
-		data, err := marshalVector(info, vec)
-		if err != nil {
-			t.Fatalf("marshalVector: %v", err)
-		}
-		// A 0-dimension vector must marshal to CQL null (nil), matching the
-		// generic reflect path; the float fast path must not produce a non-nil
-		// zero-length slice here.
-		if data != nil {
-			t.Errorf("expected nil data for 0-dim vector, got %d bytes (% x)", len(data), data)
-		}
-
+	t.Run("float64_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeFloat64VectorType(3)
+		data := make([]byte, 10) // not 8*3=24
 		var result []float64
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if len(result) != 0 {
-			t.Errorf("expected empty result, got len %d", len(result))
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
 		}
 	})
+
+	t.Run("int32_marshal", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		vec := []int32{1, 2}
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+
+	t.Run("int64_marshal", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		vec := []int64{1, 2}
+		_, err := marshalVector(info, vec)
+		if err == nil {
+			t.Fatal("expected error for dimension mismatch, got nil")
+		}
+	})
+
+	t.Run("int32_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeInt32VectorType(3)
+		data := make([]byte, 10) // not 4*3=12
+		var result []int32
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+
+	t.Run("int64_unmarshal_wrong_data_len", func(t *testing.T) {
+		info := makeInt64VectorType(3)
+		data := make([]byte, 10) // not 8*3=24
+		var result []int64
+		err := unmarshalVector(info, data, &result)
+		if err == nil {
+			t.Fatal("expected error for wrong data length, got nil")
+		}
+	})
+}
+
+// --- Test 7: Empty vector (dim=0) ---
+
+func TestMarshalVector_EmptyVector(t *testing.T) {
 	t.Run("float32_dim0", func(t *testing.T) {
 		info := makeFloat32VectorType(0)
 		vec := []float32{}
@@ -413,8 +764,11 @@ func TestVectorFloat_EmptyVector(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshalVector: %v", err)
 		}
-		if data != nil {
-			t.Errorf("expected nil data for 0-dim vector, got %d bytes (% x)", len(data), data)
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
 		}
 
 		var result []float32
@@ -425,27 +779,113 @@ func TestVectorFloat_EmptyVector(t *testing.T) {
 			t.Errorf("expected empty result, got len %d", len(result))
 		}
 	})
-}
 
-func TestVectorFloat_PointerToSlice(t *testing.T) {
-	t.Run("float64_ptr_marshal", func(t *testing.T) {
-		info := makeDoubleVectorType(2)
-		vec := []float64{1.5, 2.5}
-		// Marshal() dereferences the pointer, then marshalVector hits the []float64 fast path.
-		data, err := Marshal(info, &vec)
+	t.Run("float64_dim0", func(t *testing.T) {
+		info := makeFloat64VectorType(0)
+		vec := []float64{}
+		data, err := marshalVector(info, vec)
 		if err != nil {
-			t.Fatalf("Marshal with *[]float64: %v", err)
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
 		}
 
-		// Verify the data is correct by unmarshaling.
 		var result []float64
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector: %v", err)
 		}
-		if !reflect.DeepEqual(vec, result) {
-			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
 		}
 	})
+
+	t.Run("int32_dim0", func(t *testing.T) {
+		info := makeInt32VectorType(0)
+		vec := []int32{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+
+	t.Run("int64_dim0", func(t *testing.T) {
+		info := makeInt64VectorType(0)
+		vec := []int64{}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+		if data == nil {
+			t.Error("expected non-nil empty data for non-nil empty vector, got nil (would encode as CQL NULL)")
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d bytes", len(data))
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got len %d", len(result))
+		}
+	})
+}
+
+// --- Test 7b: Empty vector (dim=0) via generic path ---
+
+func TestMarshalVector_EmptyVector_GenericPath(t *testing.T) {
+	// TypeBoolean vectors don't hit the fast paths, exercising the generic
+	// reflect-based marshalVector/unmarshalVector code for dim=0.
+	info := VectorType{
+		Dimensions: 0,
+		SubType:    NativeType{typ: TypeBoolean},
+	}
+	vec := []bool{}
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshalVector (generic, dim=0): %v", err)
+	}
+	if data == nil {
+		t.Error("expected non-nil empty data for non-nil empty vector via generic path, got nil (would encode as CQL NULL)")
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty data, got %d bytes", len(data))
+	}
+
+	var result []bool
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshalVector (generic, dim=0): %v", err)
+	}
+	if result == nil {
+		t.Error("expected non-nil empty slice for dim=0 unmarshal via generic path, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got len %d", len(result))
+	}
+}
+
+// --- Test 8: Pointer to slice ---
+
+func TestMarshalVector_PointerToSlice(t *testing.T) {
 	t.Run("float32_ptr_marshal", func(t *testing.T) {
 		info := makeFloat32VectorType(2)
 		vec := []float32{1.5, 2.5}
@@ -462,53 +902,64 @@ func TestVectorFloat_PointerToSlice(t *testing.T) {
 			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
 		}
 	})
+
+	t.Run("float64_ptr_marshal", func(t *testing.T) {
+		info := makeFloat64VectorType(2)
+		vec := []float64{1.5, 2.5}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]float64: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int32_ptr_marshal", func(t *testing.T) {
+		info := makeInt32VectorType(2)
+		vec := []int32{100, -200}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]int32: %v", err)
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int64_ptr_marshal", func(t *testing.T) {
+		info := makeInt64VectorType(2)
+		vec := []int64{100, -200}
+		data, err := Marshal(info, &vec)
+		if err != nil {
+			t.Fatalf("Marshal with *[]int64: %v", err)
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
+		}
+	})
 }
 
-func TestVectorFloat_SpecialValues(t *testing.T) {
-	t.Run("float64", func(t *testing.T) {
-		negZero := math.Float64frombits(0x8000000000000000) // -0.0
-		info := makeDoubleVectorType(5)
-		vec := []float64{math.Inf(1), math.Inf(-1), math.MaxFloat64, math.SmallestNonzeroFloat64, negZero}
-		data, err := marshalVector(info, vec)
-		if err != nil {
-			t.Fatalf("marshalVector: %v", err)
-		}
+// --- Test 9: Special values ---
 
-		var result []float64
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		// Compare bit patterns: reflect.DeepEqual uses == for floats, where
-		// -0.0 == 0.0, so it would not catch a flipped sign bit on negative
-		// zero. Float64bits makes the negZero element actually verifiable.
-		if len(result) != len(vec) {
-			t.Fatalf("special values length mismatch: got %d, want %d", len(result), len(vec))
-		}
-		for i := range vec {
-			if math.Float64bits(result[i]) != math.Float64bits(vec[i]) {
-				t.Errorf("special values mismatch at %d: got %x, want %x",
-					i, math.Float64bits(result[i]), math.Float64bits(vec[i]))
-			}
-		}
-	})
-	t.Run("float64_nan", func(t *testing.T) {
-		info := makeDoubleVectorType(1)
-		vec := []float64{math.NaN()}
-		data, err := marshalVector(info, vec)
-		if err != nil {
-			t.Fatalf("marshalVector: %v", err)
-		}
-
-		var result []float64
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if len(result) != 1 || !math.IsNaN(result[0]) {
-			t.Errorf("expected NaN, got %v", result)
-		}
-	})
+func TestMarshalVector_SpecialValues(t *testing.T) {
 	t.Run("float32", func(t *testing.T) {
-		negZero := math.Float32frombits(0x80000000) // -0.0
+		negZero := math.Float32frombits(0x80000000)
 		info := makeFloat32VectorType(5)
 		vec := []float32{float32(math.Inf(1)), float32(math.Inf(-1)), math.MaxFloat32, math.SmallestNonzeroFloat32, negZero}
 		data, err := marshalVector(info, vec)
@@ -520,18 +971,15 @@ func TestVectorFloat_SpecialValues(t *testing.T) {
 		if err := unmarshalVector(info, data, &result); err != nil {
 			t.Fatalf("unmarshalVector: %v", err)
 		}
-		// Bitwise compare so the negative-zero element is actually verified
-		// (reflect.DeepEqual treats -0.0 and 0.0 as equal for floats).
-		if len(result) != len(vec) {
-			t.Fatalf("special values length mismatch: got %d, want %d", len(result), len(vec))
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
 		}
-		for i := range vec {
-			if math.Float32bits(result[i]) != math.Float32bits(vec[i]) {
-				t.Errorf("special values mismatch at %d: got %x, want %x",
-					i, math.Float32bits(result[i]), math.Float32bits(vec[i]))
-			}
+		// reflect.DeepEqual treats -0.0 == +0.0; verify the sign bit explicitly.
+		if got := math.Float32bits(result[4]); got != 0x80000000 {
+			t.Errorf("negative zero sign bit lost: got bits %#08x, want 0x80000000", got)
 		}
 	})
+
 	t.Run("float32_nan", func(t *testing.T) {
 		info := makeFloat32VectorType(1)
 		vec := []float32{float32(math.NaN())}
@@ -548,4 +996,498 @@ func TestVectorFloat_SpecialValues(t *testing.T) {
 			t.Errorf("expected NaN, got %v", result)
 		}
 	})
+
+	t.Run("float64", func(t *testing.T) {
+		negZero := math.Float64frombits(0x8000000000000000)
+		info := makeFloat64VectorType(5)
+		vec := []float64{math.Inf(1), math.Inf(-1), math.MaxFloat64, math.SmallestNonzeroFloat64, negZero}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
+		}
+		// reflect.DeepEqual treats -0.0 == +0.0; verify the sign bit explicitly.
+		if got := math.Float64bits(result[4]); got != 0x8000000000000000 {
+			t.Errorf("negative zero sign bit lost: got bits %#016x, want 0x8000000000000000", got)
+		}
+	})
+
+	t.Run("float64_nan", func(t *testing.T) {
+		info := makeFloat64VectorType(1)
+		vec := []float64{math.NaN()}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if len(result) != 1 || !math.IsNaN(result[0]) {
+			t.Errorf("expected NaN, got %v", result)
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		info := makeInt32VectorType(5)
+		vec := []int32{0, 1, -1, math.MaxInt32, math.MinInt32}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []int32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		info := makeInt64VectorType(5)
+		vec := []int64{0, 1, -1, math.MaxInt64, math.MinInt64}
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("marshalVector: %v", err)
+		}
+
+		var result []int64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("unmarshalVector: %v", err)
+		}
+		if !reflect.DeepEqual(vec, result) {
+			t.Errorf("special values mismatch: got %v, want %v", result, vec)
+		}
+	})
+}
+
+// --- Test 10: Pool concurrency ---
+
+func TestVectorBufPool_Concurrency(t *testing.T) {
+	const goroutines = 100
+	const iterations = 100
+	const dim = 256
+	const bufSize = dim * 4
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				buf := getVectorBuf(bufSize)
+				if len(buf) != bufSize {
+					t.Errorf("getVectorBuf returned wrong size: got %d, want %d", len(buf), bufSize)
+					return
+				}
+				// Write some data to detect cross-goroutine corruption.
+				for j := range buf {
+					buf[j] = byte(j)
+				}
+				// Verify before returning.
+				for j := range buf {
+					if buf[j] != byte(j) {
+						t.Errorf("buffer corruption detected at index %d", j)
+						return
+					}
+				}
+				putVectorBuf(buf)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestVectorByteSizeErrorType verifies that vectorByteSize overflow errors,
+// when propagated through unmarshal fast paths, are returned as typed
+// UnmarshalError rather than plain fmt.Errorf values. The marshal fast paths
+// check len(vec) != dim before reaching vectorByteSize, so they cannot be
+// tested with real slices large enough to trigger overflow.
+func TestVectorByteSizeErrorType(t *testing.T) {
+	// Use a dimension that overflows on all platforms: math.MaxInt/4+1 * 4 > MaxInt.
+	overflowDim4 := math.MaxInt/4 + 1
+	overflowDim8 := math.MaxInt/8 + 1
+
+	t.Run("unmarshal_4byte", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float32", func() error { var dst []float32; return unmarshalVectorFloat32(overflowDim4, []byte{}, &dst) }},
+			{"int32", func() error { var dst []int32; return unmarshalVectorInt32(overflowDim4, []byte{}, &dst) }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected overflow error, got nil")
+				}
+				var ue UnmarshalError
+				if !errors.As(err, &ue) {
+					t.Errorf("expected UnmarshalError, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), "overflow") {
+					t.Errorf("expected overflow in error message, got: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("unmarshal_8byte", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float64", func() error { var dst []float64; return unmarshalVectorFloat64(overflowDim8, []byte{}, &dst) }},
+			{"int64", func() error { var dst []int64; return unmarshalVectorInt64(overflowDim8, []byte{}, &dst) }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected overflow error, got nil")
+				}
+				var ue UnmarshalError
+				if !errors.As(err, &ue) {
+					t.Errorf("expected UnmarshalError, got %T: %v", err, err)
+				}
+				if !strings.Contains(err.Error(), "overflow") {
+					t.Errorf("expected overflow in error message, got: %v", err)
+				}
+			})
+		}
+	})
+}
+
+// TestUnmarshalVectorFastPathZeroDimNonNilSlice verifies that unmarshal fast
+// paths return a non-nil empty slice (not nil) when dim==0 and data is non-nil
+// empty, matching the generic path behavior.
+func TestUnmarshalVectorFastPathZeroDimNonNilSlice(t *testing.T) {
+	t.Run("float32", func(t *testing.T) {
+		var dst []float32
+		if err := unmarshalVectorFloat32(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		var dst []float64
+		if err := unmarshalVectorFloat64(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		var dst []int32
+		if err := unmarshalVectorInt32(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		var dst []int64
+		if err := unmarshalVectorInt64(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+
+	// Also verify that an existing non-nil dst is preserved as non-nil [:0].
+	t.Run("float32_existing_dst", func(t *testing.T) {
+		dst := make([]float32, 5)
+		if err := unmarshalVectorFloat32(0, []byte{}, &dst); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dst == nil {
+			t.Error("expected non-nil empty slice, got nil")
+		}
+		if len(dst) != 0 {
+			t.Errorf("expected len 0, got %d", len(dst))
+		}
+	})
+}
+
+// --- Test 11: Oversized buffers not pooled ---
+
+func TestVectorBufPool_OversizedNotPooled(t *testing.T) {
+	// A buffer larger than 65536 should not be returned to the pool.
+	big := make([]byte, 70000)
+	putVectorBuf(big)
+
+	// Getting a small buffer should not return the oversized one.
+	small := getVectorBuf(100)
+	if cap(small) >= 70000 {
+		t.Errorf("oversized buffer was returned from pool: cap=%d", cap(small))
+	}
+}
+
+// --- Test 12: vectorFixedElemSize ---
+
+func TestVectorFixedElemSize(t *testing.T) {
+	tests := []struct {
+		typ  Type
+		want int
+	}{
+		// Fixed-length types.
+		{TypeBoolean, 1},
+		{TypeInt, 4},
+		{TypeFloat, 4},
+		{TypeBigInt, 8},
+		{TypeDouble, 8},
+		{TypeTimestamp, 8},
+		{TypeUUID, 16},
+		{TypeTimeUUID, 16},
+		// Variable-length types — must return 0.
+		{TypeVarchar, 0},
+		{TypeBlob, 0},
+		{TypeText, 0},
+		{TypeVarint, 0},
+		{TypeDecimal, 0},
+		{TypeAscii, 0},
+		{TypeInet, 0},
+		{TypeDuration, 0},
+		{TypeList, 0},
+		{TypeSet, 0},
+		{TypeMap, 0},
+		{TypeUDT, 0},
+		{TypeTuple, 0},
+	}
+	for _, tt := range tests {
+		info := NewNativeType(protoVersion4, tt.typ)
+		got := vectorFixedElemSize(info)
+		if got != tt.want {
+			t.Errorf("vectorFixedElemSize(%v) = %d, want %d", tt.typ, got, tt.want)
+		}
+	}
+}
+
+// --- Test 13: Generic prealloc correctness ---
+
+func TestMarshalVector_GenericPrealloc(t *testing.T) {
+	// Test with UUID vectors — fixed-size (16 bytes) but not a float/int fast path.
+	// This exercises the generic path with buf.Grow() prealloc from Phase 1b.
+	dim := 3
+	info := makeUUIDVectorType(dim)
+
+	// Create UUID values as [16]byte arrays.
+	uuids := make([][16]byte, dim)
+	for i := range uuids {
+		for j := range uuids[i] {
+			uuids[i][j] = byte(i*16 + j)
+		}
+	}
+
+	// Marshal using the generic path (no fast path for UUID).
+	data, err := marshalVector(info, uuids[:])
+	if err != nil {
+		t.Fatalf("marshalVector: %v", err)
+	}
+
+	// UUID elements are fixed-size (16 bytes), no length prefix.
+	expectedLen := dim * 16
+	if len(data) != expectedLen {
+		t.Fatalf("expected %d bytes, got %d", expectedLen, len(data))
+	}
+
+	// Verify content by unmarshaling.
+	var result [][16]byte
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshalVector: %v", err)
+	}
+	if !reflect.DeepEqual(uuids[:], result) {
+		t.Errorf("round-trip mismatch: got %v, want %v", result, uuids[:])
+	}
+}
+
+func TestVectorByteSize_Overflow(t *testing.T) {
+	// On 32-bit, math.MaxInt is 2^31-1. dim=math.MaxInt/4+1 with elemBytes=4
+	// would overflow. On 64-bit this is just a sanity check.
+	_, err := vectorByteSize(math.MaxInt/4+1, 4)
+	if err == nil {
+		t.Error("expected overflow error for large dim*4")
+	}
+	_, err = vectorByteSize(math.MaxInt/8+1, 8)
+	if err == nil {
+		t.Error("expected overflow error for large dim*8")
+	}
+	// Normal case should succeed
+	n, err := vectorByteSize(1536, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 6144 {
+		t.Fatalf("expected 6144, got %d", n)
+	}
+}
+
+// TestMarshalVectorNegativeDimensions verifies that all fast-path marshal
+// and unmarshal functions return a clear "negative dimensions" error when
+// the VectorType has a negative Dimensions value (corrupt/adversarial metadata).
+func TestMarshalVectorNegativeDimensions(t *testing.T) {
+	const wantSubstr = "negative dimensions"
+
+	t.Run("marshal", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float32", func() error { _, err := marshalVectorFloat32(-1, []float32{1}); return err }},
+			{"float64", func() error { _, err := marshalVectorFloat64(-1, []float64{1}); return err }},
+			{"int32", func() error { _, err := marshalVectorInt32(-1, []int32{1}); return err }},
+			{"int64", func() error { _, err := marshalVectorInt64(-1, []int64{1}); return err }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected error for negative dimensions, got nil")
+				}
+				if !strings.Contains(err.Error(), wantSubstr) {
+					t.Errorf("error %q does not contain %q", err, wantSubstr)
+				}
+			})
+		}
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		tests := []struct {
+			name string
+			fn   func() error
+		}{
+			{"float32", func() error { var v []float32; return unmarshalVectorFloat32(-1, []byte{0, 0, 0, 0}, &v) }},
+			{"float64", func() error { var v []float64; return unmarshalVectorFloat64(-1, []byte{0, 0, 0, 0, 0, 0, 0, 0}, &v) }},
+			{"int32", func() error { var v []int32; return unmarshalVectorInt32(-1, []byte{0, 0, 0, 0}, &v) }},
+			{"int64", func() error { var v []int64; return unmarshalVectorInt64(-1, []byte{0, 0, 0, 0, 0, 0, 0, 0}, &v) }},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.fn()
+				if err == nil {
+					t.Fatal("expected error for negative dimensions, got nil")
+				}
+				if !strings.Contains(err.Error(), wantSubstr) {
+					t.Errorf("error %q does not contain %q", err, wantSubstr)
+				}
+			})
+		}
+	})
+
+	// Also test via the public marshalVector/unmarshalVector entry points
+	// (which dispatch to fast paths).
+	t.Run("public_marshal", func(t *testing.T) {
+		info := makeFloat32VectorType(-3)
+		_, err := marshalVector(info, []float32{1, 2, 3})
+		if err == nil {
+			t.Fatal("expected error for negative dimensions via marshalVector")
+		}
+		if !strings.Contains(err.Error(), wantSubstr) {
+			t.Errorf("error %q does not contain %q", err, wantSubstr)
+		}
+	})
+
+	t.Run("public_unmarshal", func(t *testing.T) {
+		info := makeFloat32VectorType(-3)
+		var dst []float32
+		err := unmarshalVector(info, []byte{0, 0, 0, 0}, &dst)
+		if err == nil {
+			t.Fatal("expected error for negative dimensions via unmarshalVector")
+		}
+		if !strings.Contains(err.Error(), wantSubstr) {
+			t.Errorf("error %q does not contain %q", err, wantSubstr)
+		}
+	})
+}
+
+// TestUnmarshalVectorGenericPathZeroDimensions verifies the generic unmarshal
+// path (non-fast-path types like UUID) correctly handles Dimensions==0.
+func TestUnmarshalVectorGenericPathZeroDimensions(t *testing.T) {
+	info := makeUUIDVectorType(0) // UUID type goes through generic path
+
+	t.Run("nil_data", func(t *testing.T) {
+		var dst [][16]byte
+		err := unmarshalVector(info, nil, &dst)
+		if err != nil {
+			t.Fatalf("unexpected error for nil data: %v", err)
+		}
+		if dst != nil {
+			t.Errorf("expected nil slice for nil data, got %v", dst)
+		}
+	})
+
+	t.Run("empty_data", func(t *testing.T) {
+		var dst [][16]byte
+		err := unmarshalVector(info, []byte{}, &dst)
+		if err != nil {
+			t.Fatalf("unexpected error for empty data: %v", err)
+		}
+		if dst == nil || len(dst) != 0 {
+			t.Errorf("expected non-nil empty slice, got %v (nil=%v)", dst, dst == nil)
+		}
+	})
+
+	t.Run("non_empty_data_error", func(t *testing.T) {
+		var dst [][16]byte
+		err := unmarshalVector(info, []byte{1, 2, 3}, &dst)
+		if err == nil {
+			t.Fatal("expected error for non-empty data with 0 dimensions")
+		}
+		if !strings.Contains(err.Error(), "0-dimension") {
+			t.Errorf("error %q does not mention 0-dimension", err)
+		}
+	})
+}
+
+// TestGetVectorBuf_NonPositiveSize verifies that getVectorBuf handles
+// zero and negative sizes correctly without allocating or panicking.
+// Size 0 returns a non-nil empty slice (distinguishes empty vector from NULL).
+// Negative sizes return nil.
+func TestGetVectorBuf_NonPositiveSize(t *testing.T) {
+	// Zero size: non-nil empty slice (needed by marshalVector for dim=0).
+	buf := getVectorBuf(0)
+	if buf == nil {
+		t.Error("getVectorBuf(0) = nil, want non-nil empty slice")
+	} else if len(buf) != 0 {
+		t.Errorf("getVectorBuf(0) len = %d, want 0", len(buf))
+	}
+
+	// Negative sizes: nil.
+	for _, size := range []int{-1, -100} {
+		buf := getVectorBuf(size)
+		if buf != nil {
+			t.Errorf("getVectorBuf(%d) = %v, want nil", size, buf)
+		}
+	}
 }

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -789,7 +789,7 @@ func TestIterWarningHandler(t *testing.T) {
 
 	t.Run("CloseDispatchesAccumulatedWarnings", func(t *testing.T) {
 		handler := &recordingWarningHandler{}
-		host := &HostInfo{hostId: "host-1"}
+		host := &HostInfo{hostId: UUID{1}}
 		qry := &Query{
 			routingInfo: &queryRoutingInfo{},
 			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
@@ -868,7 +868,7 @@ func TestIterWarningHandler(t *testing.T) {
 
 	t.Run("HostPreservedAcrossClose", func(t *testing.T) {
 		handler := &recordingWarningHandler{}
-		host := &HostInfo{port: 9042, hostId: "host-2"}
+		host := &HostInfo{port: 9042, hostId: UUID{2}}
 		iter := (&Iter{
 			framer: &testWarningFramer{warnings: []string{"warn"}},
 			host:   host,
@@ -937,7 +937,7 @@ func TestIterWarningHandler(t *testing.T) {
 		handler := &recordingWarningHandler{}
 		iter := (&Iter{
 			allWarnings: []string{"warn1"},
-			host:        &HostInfo{hostId: "host-3"},
+			host:        &HostInfo{hostId: UUID{3}},
 		}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
 			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
@@ -1095,7 +1095,7 @@ func TestQueryExecutorRetryAndDiscardWarningHandling(t *testing.T) {
 	t.Parallel()
 
 	t.Run("SpeculativeLoserIsDiscardedWithoutWarnings", func(t *testing.T) {
-		host := (&HostInfo{hostId: "host-4"}).setState(NodeUp)
+		host := (&HostInfo{hostId: UUID{4}}).setState(NodeUp)
 		handler := &recordingWarningHandler{}
 		framer := &testWarningFramer{warnings: []string{"loser"}}
 		qry := &executorTestQuery{
@@ -1125,7 +1125,7 @@ func TestQueryExecutorRetryAndDiscardWarningHandling(t *testing.T) {
 	})
 
 	t.Run("RetriedAttemptStillWarnsOnce", func(t *testing.T) {
-		host := (&HostInfo{hostId: "host-5"}).setState(NodeUp)
+		host := (&HostInfo{hostId: UUID{5}}).setState(NodeUp)
 		handler := &recordingWarningHandler{}
 		firstFramer := &testWarningFramer{warnings: []string{"retry-warn"}}
 		finalFramer := &testWarningFramer{}

--- a/tests/bench/bench_vector_public_test.go
+++ b/tests/bench/bench_vector_public_test.go
@@ -113,3 +113,139 @@ func BenchmarkVectorRoundTripPublic(b *testing.B) {
 		})
 	}
 }
+
+func makeInt32VectorType(dim int) gocql.VectorType {
+	dimStr := strconv.Itoa(dim)
+	return gocql.VectorType{
+		NativeType: gocql.NewCustomType(
+			vectorProto,
+			gocql.TypeCustom,
+			apacheCassandraTypePrefix+"VectorType("+apacheCassandraTypePrefix+"Int32Type, "+dimStr+")",
+		),
+		SubType:    gocql.NewNativeType(vectorProto, gocql.TypeInt),
+		Dimensions: dim,
+	}
+}
+
+func makeInt64VectorType(dim int) gocql.VectorType {
+	dimStr := strconv.Itoa(dim)
+	return gocql.VectorType{
+		NativeType: gocql.NewCustomType(
+			vectorProto,
+			gocql.TypeCustom,
+			apacheCassandraTypePrefix+"VectorType("+apacheCassandraTypePrefix+"LongType, "+dimStr+")",
+		),
+		SubType:    gocql.NewNativeType(vectorProto, gocql.TypeBigInt),
+		Dimensions: dim,
+	}
+}
+
+func BenchmarkVectorMarshalInt32Public(b *testing.B) {
+	dims := []int{128, 384, 768, 1536}
+
+	for _, dim := range dims {
+		dimStr := strconv.Itoa(dim)
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]int32, dim)
+			for i := range vec {
+				vec[i] = int32(i) * 7
+			}
+
+			info := makeInt32VectorType(dim)
+
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := gocql.Marshal(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkVectorUnmarshalInt32Public(b *testing.B) {
+	dims := []int{128, 384, 768, 1536}
+
+	for _, dim := range dims {
+		dimStr := strconv.Itoa(dim)
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			data := make([]byte, dim*4)
+			for i := 0; i < dim; i++ {
+				binary.BigEndian.PutUint32(data[i*4:], uint32(int32(i)*7))
+			}
+
+			info := makeInt32VectorType(dim)
+			var result []int32
+
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if err := gocql.Unmarshal(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkVectorMarshalInt64Public(b *testing.B) {
+	dims := []int{128, 384, 768, 1536}
+
+	for _, dim := range dims {
+		dimStr := strconv.Itoa(dim)
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]int64, dim)
+			for i := range vec {
+				vec[i] = int64(i) * 7
+			}
+
+			info := makeInt64VectorType(dim)
+
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := gocql.Marshal(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkVectorUnmarshalInt64Public(b *testing.B) {
+	dims := []int{128, 384, 768, 1536}
+
+	for _, dim := range dims {
+		dimStr := strconv.Itoa(dim)
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			data := make([]byte, dim*8)
+			for i := 0; i < dim; i++ {
+				binary.BigEndian.PutUint64(data[i*8:], uint64(int64(i)*7))
+			}
+
+			info := makeInt64VectorType(dim)
+			var result []int64
+
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if err := gocql.Unmarshal(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/vector_bench_test.go
+++ b/vector_bench_test.go
@@ -146,3 +146,436 @@ func BenchmarkVectorRoundTrip(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkMarshalVectorFloat32Pooled measures marshal with buffer pool return.
+// This simulates the real usage pattern where buffers are returned after framer consumption.
+func BenchmarkMarshalVectorFloat32Pooled(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]float32, dim)
+			for i := range vec {
+				vec[i] = float32(i) * 0.1
+			}
+
+			info := makeFloatVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				data, err := marshalVector(info, vec)
+				if err != nil {
+					b.Fatal(err)
+				}
+				// Simulate framer consuming the buffer, then returning it to pool
+				putVectorBuf(data)
+			}
+		})
+	}
+}
+
+func makeDoubleVectorType(dim int, dimStr string) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "DoubleType, " + dimStr + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeDouble},
+		Dimensions: dim,
+	}
+}
+
+// BenchmarkMarshalVectorFloat64 measures marshal performance for float64 vectors.
+func BenchmarkMarshalVectorFloat64(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]float64, dim)
+			for i := range vec {
+				vec[i] = float64(i) * 0.1
+			}
+
+			info := makeDoubleVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := marshalVector(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkVectorWritePath simulates the full marshal + framer.writeBytes path,
+// measuring total latency and allocations as seen in the real CQL write path.
+func BenchmarkVectorWritePath(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]float32, dim)
+			for i := range vec {
+				vec[i] = float32(i) * 0.1
+			}
+
+			info := makeFloatVectorType(dim, dimStr)
+
+			// Pre-allocate a framer to simulate the write path
+			f := newFramer(nil, protoVersion4)
+
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				// 1. Marshal the vector
+				data, err := marshalVector(info, vec)
+				if err != nil {
+					b.Fatal(err)
+				}
+				// 2. Write into framer (simulates writeBytes in writeQueryParams)
+				f.buf = f.buf[:0] // reset framer buffer
+				f.writeBytes(data)
+				// 3. Return pooled buffer
+				putVectorBuf(data)
+			}
+		})
+	}
+}
+
+// BenchmarkVectorRoundTripPooled measures full marshal -> unmarshal with pool return.
+func BenchmarkVectorRoundTripPooled(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			srcVec := make([]float32, dim)
+			for i := range srcVec {
+				srcVec[i] = float32(i) * 0.1
+			}
+
+			info := makeFloatVectorType(dim, dimStr)
+			var dstVec []float32
+
+			b.SetBytes(int64(dim * 4 * 2))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				data, err := marshalVector(info, srcVec)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := unmarshalVector(info, data, &dstVec); err != nil {
+					b.Fatal(err)
+				}
+				putVectorBuf(data)
+			}
+		})
+	}
+}
+
+func makeIntVectorType(dim int, dimStr string) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "Int32Type, " + dimStr + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeInt},
+		Dimensions: dim,
+	}
+}
+
+func makeBigIntVectorType(dim int, dimStr string) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "LongType, " + dimStr + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Dimensions: dim,
+	}
+}
+
+// BenchmarkMarshalVectorInt32 measures marshal performance for int32 vectors.
+func BenchmarkMarshalVectorInt32(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]int32, dim)
+			for i := range vec {
+				vec[i] = int32(i) * 7
+			}
+
+			info := makeIntVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := marshalVector(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMarshalVectorInt32Pooled measures marshal with buffer pool return for int32.
+func BenchmarkMarshalVectorInt32Pooled(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]int32, dim)
+			for i := range vec {
+				vec[i] = int32(i) * 7
+			}
+
+			info := makeIntVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				data, err := marshalVector(info, vec)
+				if err != nil {
+					b.Fatal(err)
+				}
+				putVectorBuf(data)
+			}
+		})
+	}
+}
+
+// BenchmarkUnmarshalVectorInt32 measures unmarshal performance for int32 vectors.
+func BenchmarkUnmarshalVectorInt32(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			data := make([]byte, dim*4)
+			for i := 0; i < dim; i++ {
+				binary.BigEndian.PutUint32(data[i*4:], uint32(int32(i)*7))
+			}
+
+			info := makeIntVectorType(dim, dimStr)
+			var result []int32
+
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if err := unmarshalVector(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMarshalVectorInt64 measures marshal performance for int64 vectors.
+func BenchmarkMarshalVectorInt64(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]int64, dim)
+			for i := range vec {
+				vec[i] = int64(i) * 7
+			}
+
+			info := makeBigIntVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := marshalVector(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMarshalVectorInt64Pooled measures marshal with buffer pool return for int64.
+func BenchmarkMarshalVectorInt64Pooled(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]int64, dim)
+			for i := range vec {
+				vec[i] = int64(i) * 7
+			}
+
+			info := makeBigIntVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				data, err := marshalVector(info, vec)
+				if err != nil {
+					b.Fatal(err)
+				}
+				putVectorBuf(data)
+			}
+		})
+	}
+}
+
+// BenchmarkUnmarshalVectorInt64 measures unmarshal performance for int64 vectors.
+func BenchmarkUnmarshalVectorInt64(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			data := make([]byte, dim*8)
+			for i := 0; i < dim; i++ {
+				binary.BigEndian.PutUint64(data[i*8:], uint64(int64(i)*7))
+			}
+
+			info := makeBigIntVectorType(dim, dimStr)
+			var result []int64
+
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if err := unmarshalVector(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/vector_bench_test.go
+++ b/vector_bench_test.go
@@ -708,3 +708,36 @@ func BenchmarkUnmarshalVectorUUID(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkVectorNewWithError measures VectorType.NewWithError() which avoids
+// the expensive goType() → asVectorType() re-parse path that NativeType.NewWithError()
+// falls into for TypeCustom vectors.
+func BenchmarkVectorNewWithError(b *testing.B) {
+	vt := makeFloatVectorType(1536, "1536")
+
+	b.Run("VectorType", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			val, err := vt.NewWithError()
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = val
+		}
+	})
+
+	// Benchmark the old path: NativeType.NewWithError() on a TypeCustom with
+	// vector custom string. This simulates what happened before VectorType had
+	// its own NewWithError — it fell through to goType() → asVectorType().
+	b.Run("NativeType_fallback", func(b *testing.B) {
+		nt := vt.NativeType // extract the embedded NativeType
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			val, err := nt.NewWithError()
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = val
+		}
+	})
+}

--- a/vector_bench_test.go
+++ b/vector_bench_test.go
@@ -579,3 +579,132 @@ func BenchmarkUnmarshalVectorInt64(b *testing.B) {
 		})
 	}
 }
+
+func makeUUIDBenchVectorType(dim int, dimStr string) VectorType {
+	return VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "UUIDType, " + dimStr + ")",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeUUID},
+		Dimensions: dim,
+	}
+}
+
+// BenchmarkMarshalVectorUUID measures marshal performance for UUID vectors.
+func BenchmarkMarshalVectorUUID(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]UUID, dim)
+			for i := range vec {
+				vec[i][0] = byte(i)
+				vec[i][1] = byte(i >> 8)
+			}
+
+			info := makeUUIDBenchVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 16))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := marshalVector(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMarshalVectorUUIDPooled measures marshal with buffer pool return for UUID.
+func BenchmarkMarshalVectorUUIDPooled(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			vec := make([]UUID, dim)
+			for i := range vec {
+				vec[i][0] = byte(i)
+				vec[i][1] = byte(i >> 8)
+			}
+
+			info := makeUUIDBenchVectorType(dim, dimStr)
+
+			b.SetBytes(int64(dim * 16))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				data, err := marshalVector(info, vec)
+				if err != nil {
+					b.Fatal(err)
+				}
+				putVectorBuf(data)
+			}
+		})
+	}
+}
+
+// BenchmarkUnmarshalVectorUUID measures unmarshal performance for UUID vectors.
+func BenchmarkUnmarshalVectorUUID(b *testing.B) {
+	dims := []struct {
+		dim    int
+		dimStr string
+	}{
+		{dim: 128, dimStr: "128"},
+		{dim: 384, dimStr: "384"},
+		{dim: 768, dimStr: "768"},
+		{dim: 1536, dimStr: "1536"},
+	}
+
+	for _, entry := range dims {
+		dim := entry.dim
+		dimStr := entry.dimStr
+		b.Run("dim_"+dimStr, func(b *testing.B) {
+			b.ReportAllocs()
+
+			data := make([]byte, dim*16)
+			for i := 0; i < dim; i++ {
+				data[i*16] = byte(i)
+				data[i*16+1] = byte(i >> 8)
+			}
+
+			info := makeUUIDBenchVectorType(dim, dimStr)
+			var result []UUID
+
+			b.SetBytes(int64(dim * 16))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if err := unmarshalVector(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Type-specialized fast paths for `vector<float>`, `vector<double>`, `vector<int>`, `vector<bigint>`, and `vector<uuid>`/`vector<timeuuid>` that bypass reflect-based per-element marshaling in favor of direct `encoding/binary` bulk conversion, plus `sync.Pool` buffer reuse wired into the connection write path, and a `VectorType.NewWithError()` fast path that eliminates the expensive `goType()` → `asVectorType()` re-parse on every call.

### Commit 1: [`d527db1`](https://github.com/mykaul/gocql/commit/d527db1) `perf: optimize vector marshal/unmarshal for float32/float64/int32/int64`

Fast-path type switches, 8 dedicated marshal/unmarshal functions, `sync.Pool` infrastructure (`getVectorBuf`/`putVectorBuf`), unmarshal slice reuse, generic-path `buf.Grow()` preallocation via `vectorFixedElemSize()`, and comprehensive tests (58 subtests across 13 categories).

### Commit 2: [`04f0783`](https://github.com/mykaul/gocql/commit/04f0783) `perf: wire putVectorBuf into connection write path`

Adds `defer putVectorBuf(...)` calls in `executeQuery()` and `executeBatch()` in `conn.go`, so production callers return pooled marshal buffers after the framer copies them. This closes the pool lifecycle and achieves 48 B/op steady-state on the write path.

### Commit 3: [`d48f44f`](https://github.com/mykaul/gocql/commit/d48f44f) `perf: add UUID/TimeUUID vector fast path`

Adds marshal/unmarshal fast paths for `vector<uuid>` and `vector<timeuuid>` — bulk `copy()` of fixed 16-byte elements with zero per-element allocations. UUID vectors are common in similarity search use cases (storing document IDs alongside embeddings).

### Commit 4: [`66ed9aa`](https://github.com/mykaul/gocql/commit/66ed9aa) `perf: add VectorType.NewWithError() to avoid goType/asVectorType re-parse`

`VectorType` embeds `NativeType` but had no `NewWithError()` method. When called, it dispatched to `NativeType.NewWithError()` which hit `TypeCustom` → `goType()` → `asVectorType()`, re-parsing the full Java type string on every call. The new method returns `*[]SubType` directly: 10.7x faster (181ns → 17ns), 75% fewer allocs (4 → 1), 74% less memory (92B → 24B).

## Headline numbers (`vector<float, 1536>`, typical embedding dimension)

- **22x faster marshal** (fast paths alone), **41x with pool recycling** (see Pooled benchmarks)
- **36x faster unmarshal**, zero allocations steady state
- **99.93% fewer allocations** on marshal (3,074 → 2)
- **Marshal memory**: 18,456 B/op → 6,172 B/op (fast paths) → **48 B/op** (with pool recycling)
- **Unmarshal memory**: 6,168 B/op → **0 B/op**
- **10.7x faster `NewWithError()`** for `VectorType` (181ns → 17ns)

## Benchmark results

All benchmarks: 6 iterations, `benchstat`, all p=0.002. Machine: 12th Gen Intel Core i7-1270P.

**Master** = [`3881f1e`](https://github.com/scylladb/gocql/commit/3881f1e) (origin/master), **Optimized** = [`66ed9aa`](https://github.com/mykaul/gocql/commit/66ed9aa) (this branch HEAD).

### Latency (ns/op) — Master vs Optimized (all 4 commits)

| Benchmark | Master | Optimized | Speedup |
|---|---:|---:|---:|
| **float32** | | | |
| MarshalVectorFloat32/dim_128 | 4,641 | 285 | **16.3x** |
| MarshalVectorFloat32/dim_384 | 16,237 | 699 | **23.2x** |
| MarshalVectorFloat32/dim_768 | 26,785 | 1,234 | **21.7x** |
| MarshalVectorFloat32/dim_1536 | 54,049 | 2,415 | **22.4x** |
| UnmarshalVectorFloat32/dim_128 | 3,116 | 95 | **32.8x** |
| UnmarshalVectorFloat32/dim_384 | 10,647 | 280 | **38.0x** |
| UnmarshalVectorFloat32/dim_768 | 18,536 | 586 | **31.6x** |
| UnmarshalVectorFloat32/dim_1536 | 39,186 | 1,092 | **35.9x** |
| **float64** | | | |
| MarshalVectorFloat64/dim_128 | 4,700 | 380 | **12.4x** |
| MarshalVectorFloat64/dim_384 | 13,125 | 985 | **13.3x** |
| MarshalVectorFloat64/dim_768 | 29,809 | 1,905 | **15.6x** |
| MarshalVectorFloat64/dim_1536 | 59,207 | 3,754 | **15.8x** |
| **int32** | | | |
| MarshalVectorInt32/dim_128 | 4,599 | 249 | **18.5x** |
| MarshalVectorInt32/dim_384 | 13,560 | 654 | **20.7x** |
| MarshalVectorInt32/dim_768 | 25,402 | 1,166 | **21.8x** |
| MarshalVectorInt32/dim_1536 | 47,432 | 2,262 | **21.0x** |
| UnmarshalVectorInt32/dim_128 | 3,201 | 94 | **34.1x** |
| UnmarshalVectorInt32/dim_384 | 9,763 | 279 | **35.0x** |
| UnmarshalVectorInt32/dim_768 | 19,700 | 547 | **36.0x** |
| UnmarshalVectorInt32/dim_1536 | 40,106 | 1,073 | **37.4x** |
| **int64** | | | |
| MarshalVectorInt64/dim_128 | 4,643 | 368 | **12.6x** |
| MarshalVectorInt64/dim_384 | 13,578 | 952 | **14.3x** |
| MarshalVectorInt64/dim_768 | 26,887 | 1,834 | **14.7x** |
| MarshalVectorInt64/dim_1536 | 62,726 | 3,636 | **17.3x** |
| UnmarshalVectorInt64/dim_128 | 3,387 | 111 | **30.5x** |
| UnmarshalVectorInt64/dim_384 | 9,854 | 343 | **28.7x** |
| UnmarshalVectorInt64/dim_768 | 21,628 | 601 | **36.0x** |
| UnmarshalVectorInt64/dim_1536 | 44,880 | 1,190 | **37.7x** |
| **UUID** | | | |
| MarshalVectorUUID/dim_128 | 8,154 | 710 | **11.5x** |
| MarshalVectorUUID/dim_384 | 25,949 | 1,994 | **13.0x** |
| MarshalVectorUUID/dim_768 | 52,738 | 3,861 | **13.7x** |
| MarshalVectorUUID/dim_1536 | 95,785 | 7,480 | **12.8x** |
| UnmarshalVectorUUID/dim_128 | 3,688 | 119 | **31.0x** |
| UnmarshalVectorUUID/dim_384 | 11,164 | 330 | **33.8x** |
| UnmarshalVectorUUID/dim_768 | 22,201 | 651 | **34.1x** |
| UnmarshalVectorUUID/dim_1536 | 44,435 | 1,294 | **34.3x** |
| **NewWithError / RowData** | | | |
| VectorNewWithError/VectorType | 181 | 17 | **10.7x** |
| VectorNewWithError/NativeType_fallback | 183 | 168 | 1.1x |
| RowDataWithVector | 503 | 108 | **4.7x** |

### Pool wiring benefit (Commit 2) — production write path

The table above measures `Marshal()`/`Unmarshal()` via the public API, which does not return buffers to the pool. In production, `executeQuery()`/`executeBatch()` return the buffer via `putVectorBuf()` after the framer copies it. The `Pooled` benchmarks simulate this:

| Benchmark | Master | Fast-path only | Speedup vs master | + Pool return | Speedup vs master |
|---|---:|---:|---:|---:|---:|
| MarshalFloat32Pooled/dim_128 | 4,641 | 285 | 16.3x | **161** | **28.8x** |
| MarshalFloat32Pooled/dim_384 | 16,237 | 699 | 23.2x | **369** | **44.0x** |
| MarshalFloat32Pooled/dim_768 | 26,785 | 1,234 | 21.7x | **679** | **39.4x** |
| MarshalFloat32Pooled/dim_1536 | 54,049 | 2,415 | 22.4x | **1,306** | **41.4x** |
| MarshalInt32Pooled/dim_1536 | 47,432 | 2,262 | 21.0x | **1,100** | **43.1x** |
| MarshalInt64Pooled/dim_1536 | 62,726 | 3,636 | 17.3x | **1,299** | **48.3x** |
| MarshalUUIDPooled/dim_1536 | 95,785 | 7,480 | 12.8x | **1,440** | **66.5x** |

Memory with pool return is **48 B/op** constant, regardless of vector dimension or element type (from `sync.Pool` interface boxing overhead, irreducible). Compare to master: 18,456 B/op for float32/dim_1536, 98,328 B/op for UUID/dim_1536.

<details>
<summary><b>Full benchstat details: memory and allocations (click to expand)</b></summary>

### Memory (B/op)

| Benchmark | Master | Optimized | Change |
|---|---:|---:|---:|
| RowDataWithVector | 216 | 144 | **-33.33%** |
| UnmarshalVectorFloat32/dim_128 | 536 | 0 | **-100.00%** |
| UnmarshalVectorFloat32/dim_384 | 1,560 | 0 | **-100.00%** |
| UnmarshalVectorFloat32/dim_768 | 3,096 | 0 | **-100.00%** |
| UnmarshalVectorFloat32/dim_1536 | 6,168 | 0 | **-100.00%** |
| MarshalVectorFloat32/dim_128 | 1,560 | 536 | **-65.64%** |
| MarshalVectorFloat32/dim_384 | 4,632 | 1,561 | **-66.30%** |
| MarshalVectorFloat32/dim_768 | 9,240 | 3,098 | **-66.47%** |
| MarshalVectorFloat32/dim_1536 | 18,456 | 6,172 | **-66.55%** |
| MarshalVectorFloat64/dim_128 | 3,096 | 1,048 | **-66.15%** |
| MarshalVectorFloat64/dim_384 | 9,240 | 3,098 | **-66.47%** |
| MarshalVectorFloat64/dim_768 | 18,456 | 6,173 | **-66.55%** |
| MarshalVectorFloat64/dim_1536 | 36,888 | 12,319 | **-66.60%** |
| MarshalVectorInt32/dim_128 | 1,560 | 536 | **-65.64%** |
| MarshalVectorInt32/dim_384 | 4,632 | 1,561 | **-66.30%** |
| MarshalVectorInt32/dim_768 | 9,240 | 3,098 | **-66.47%** |
| MarshalVectorInt32/dim_1536 | 18,456 | 6,172 | **-66.55%** |
| MarshalVectorInt64/dim_128 | 3,096 | 1,048 | **-66.15%** |
| MarshalVectorInt64/dim_384 | 9,240 | 3,098 | **-66.47%** |
| MarshalVectorInt64/dim_768 | 18,456 | 6,173 | **-66.55%** |
| MarshalVectorInt64/dim_1536 | 36,888 | 12,319 | **-66.60%** |
| MarshalVectorUUID/dim_128 | 8,216 | 2,072 | **-74.77%** |
| MarshalVectorUUID/dim_384 | 24,600 | 6,172 | **-74.91%** |
| MarshalVectorUUID/dim_768 | 49,176 | 12,312 | **-74.94%** |
| MarshalVectorUUID/dim_1536 | 98,328 | 24,600 | **-74.96%** |
| UnmarshalVectorInt32 (all dims) | 536–6,168 | 0 | **-100.00%** |
| UnmarshalVectorInt64 (all dims) | 1,048–12,312 | 0 | **-100.00%** |
| UnmarshalVectorUUID (all dims) | 2,072–24,600 | 0 | **-100.00%** |
| VectorNewWithError/VectorType | 92 | 24 | **-73.91%** |

### Allocations (allocs/op)

| Benchmark | Master | Optimized | Change |
|---|---:|---:|---:|
| RowDataWithVector | 8 | 5 | **-37.50%** |
| MarshalVectorFloat32/dim_128 | 258 | 2 | **-99.22%** |
| MarshalVectorFloat32/dim_384 | 770 | 2 | **-99.74%** |
| MarshalVectorFloat32/dim_768 | 1,538 | 2 | **-99.87%** |
| MarshalVectorFloat32/dim_1536 | 3,074 | 2 | **-99.93%** |
| MarshalVectorFloat64 (all dims) | 258–3,074 | 2 | **-99.22% to -99.93%** |
| MarshalVectorInt32 (all dims) | 258–3,074 | 2 | **-99.22% to -99.93%** |
| MarshalVectorInt64 (all dims) | 258–3,074 | 2 | **-99.22% to -99.93%** |
| MarshalVectorUUID/dim_128 | 386 | 2 | **-99.48%** |
| MarshalVectorUUID/dim_384 | 1,154 | 2 | **-99.83%** |
| MarshalVectorUUID/dim_768 | 2,306 | 2 | **-99.91%** |
| MarshalVectorUUID/dim_1536 | 4,610 | 2 | **-99.96%** |
| All unmarshal (all types, all dims) | 2 | 0 | **-100.00%** |
| VectorNewWithError/VectorType | 4 | 1 | **-75.00%** |

### Pooled marshal memory (B/op) — with pool return

| Benchmark | B/op |
|---|---:|
| MarshalFloat32Pooled (all dims) | **48** |
| MarshalInt32Pooled (all dims) | **48** |
| MarshalInt64Pooled (all dims) | **48** |
| MarshalUUIDPooled (all dims) | **48** |

</details>

## What changed

### `marshal.go`

1. **Fast-path type switches** in `marshalVector()` and `unmarshalVector()` — before the existing reflect-based generic path, a switch on `info.SubType.Type()` intercepts `[]float32`, `[]float64`, `[]int32`, `[]int64`, `[]UUID` and dispatches to 10 dedicated functions. Falls through to the generic path for all other types.

2. **10 new marshal/unmarshal functions** — `marshalVectorFloat32/Float64/Int32/Int64/UUID` and corresponding `unmarshalVector*`. Float/int functions use `encoding/binary.BigEndian.PutUint32/PutUint64` with `math.Float32bits`/`Float64bits`. UUID functions use bulk `copy()` of 16-byte elements.

3. **`sync.Pool` buffer reuse** — `vectorBufPool`, `getVectorBuf(size)`, `putVectorBuf(buf)` with 64 KiB cap guard.

4. **Unmarshal slice reuse** — All unmarshal fast paths reuse the destination slice's backing array when capacity is sufficient, achieving zero allocations on repeated reads.

5. **Generic path preallocation** — `vectorFixedElemSize()` returns the wire-format byte size for fixed-length CQL types. The generic path calls `buf.Grow()` upfront.

6. **`VectorType.NewWithError()`** — Returns `*[]SubType` directly without going through `goType()` → `asVectorType()`. 10.7x faster, 75% fewer allocs.

### `conn.go`

7. **Pool return wiring** — `executeQuery()` and `executeBatch()` call `defer putVectorBuf(...)` on each `queryValues.value`, closing the pool lifecycle.

### Test files

- **`marshal_vector_test.go`** — 58 unit subtests across 13 categories including UUID-specific tests
- **`vector_bench_test.go`** — Benchmarks for all 5 types: marshal, pooled marshal, unmarshal, across dimensions 128/384/768/1536
- **`marshal_test.go`** — `TestVectorNewWithErrorConsistentWithGoType`, `TestVectorNewWithErrorReturnsSlicePointer`
- **`helpers_bench_test.go`** — `BenchmarkVectorNewWithError`, `BenchmarkRowDataWithVector`

## How the bottleneck was eliminated

The original generic path for `vector<float, 1536>`:
1. Called `Marshal()` 1,536 times through reflect dispatch
2. Each call allocated a 4-byte `[]byte` via `encFloat32` (1,536 allocs)
3. Appended each to a `bytes.Buffer` that grew incrementally (additional allocs)
4. The buffer was then copied into `framer.buf` by `writeBytes()`

The fast path:
1. Single `getVectorBuf(6144)` (pooled, zero-alloc steady state)
2. Tight loop: `binary.BigEndian.PutUint32(buf[i*4:], math.Float32bits(v))`
3. No reflect, no per-element dispatch, no intermediate allocations
4. `putVectorBuf()` returns the buffer to the pool after `c.exec()`

## Design decisions

- **Phase 3 (write-through to framer) was deliberately skipped** — encoding directly into `framer.buf` would save ~0.4 µs (~21% marginal over the pooled path) but requires invasive changes to the `queryValues` struct used by all query paths. The risk/reward ratio is unfavorable.
- **Phase 4 (fix `isVectorVariableLengthType`) was deliberately skipped** — there is a discrepancy in how some types are handled between Cassandra and ScyllaDB implementations. We focus only on the 5 types where the wire format is unambiguous.

## Relationship to open PRs

### Replaces PR #744 (float fast paths) and PR #745 (generic prealloc)

This PR is a **strict superset** of both:

| Feature | PR #744 | PR #745 | This PR |
|---|---|---|---|
| Float32/Float64 fast marshal | yes | — | yes |
| Float32/Float64 fast unmarshal + slice reuse | yes | — | yes |
| Int32/Int64 fast marshal/unmarshal | — | — | yes |
| UUID/TimeUUID fast marshal/unmarshal | — | — | yes |
| `sync.Pool` buffer reuse | — | — | yes |
| Pool wiring in `conn.go` | — | — | yes |
| `VectorType.NewWithError()` | — | — | yes |
| `vectorFixedElemSize()` helper | — | yes | yes |
| Generic `buf.Grow()` prealloc | — | yes | yes |

If this PR merges first, #744 and #745 become no-ops and should be closed.

### Orthogonal to PRs #751, #752, #753

These PRs reduce per-request allocations in the connection/framing layer. This PR reduces allocations in the marshal/unmarshal layer. They are **fully complementary** — different files, different allocation sites, additive benefits.

Note: PR #749 (pool write-side framers) was closed — fully superseded by [`3e1e7e4`](https://github.com/scylladb/gocql/commit/3e1e7e44a3e32fd38a1792958dde58e6522651c6) on master.

### Depends on PR #838

PR [#838](https://github.com/scylladb/gocql/pull/838) fixes a pre-existing build failure in `session_unit_test.go` where `hostId` changed from `string` to `UUID` but test literals were not updated. This branch carries the same fix; once #838 merges, the fix becomes a no-op on rebase.
