### PR TITLE
fix: guard against divide-by-zero in unmarshalVector when Dimensions is 0

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -897,6 +897,15 @@ func unmarshalVector(info VectorType, data []byte, value interface{}) error {
 			rv.Set(reflect.Zero(t))
 			return nil
 		}
+		if info.Dimensions == 0 {
+			if len(data) > 0 {
+				return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+			}
+			if k == reflect.Slice {
+				rv.Set(reflect.MakeSlice(t, 0, 0))
+			}
+			return nil
+		}
 		if k == reflect.Array {
 			if rv.Len() != info.Dimensions {
 				return unmarshalErrorf("unmarshal vector: array of size %d cannot store vector of %d dimensions", rv.Len(), info.Dimensions)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1035,3 +1035,42 @@ func bytesWithLength(data ...[]byte) []byte {
 	}
 	return ret
 }
+
+func TestUnmarshalVectorZeroDimensions(t *testing.T) {
+	info := VectorType{
+		NativeType: NativeType{typ: TypeCustom},
+		SubType:    NativeType{typ: TypeFloat},
+		Dimensions: 0,
+	}
+
+	t.Run("nil_data", func(t *testing.T) {
+		var result []float32
+		if err := unmarshalVector(info, nil, &result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty_data", func(t *testing.T) {
+		var result []float32
+		if err := unmarshalVector(info, []byte{}, &result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil empty slice")
+		}
+		if len(result) != 0 {
+			t.Fatalf("expected len 0, got %d", len(result))
+		}
+	})
+
+	t.Run("nonempty_data_errors", func(t *testing.T) {
+		var result []float32
+		err := unmarshalVector(info, []byte{0x01, 0x02}, &result)
+		if err == nil {
+			t.Fatal("expected error for non-empty data with 0 dimensions")
+		}
+		if !strings.Contains(err.Error(), "0-dimension") {
+			t.Fatalf("expected error mentioning 0-dimension, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- `unmarshalVector` computes `elemSize = len(data) / info.Dimensions` without checking for zero dimensions, causing a runtime panic on the generic reflect-based path
- Adds an early guard after the `data == nil` check: returns an empty slice for empty data with 0 dimensions, or a descriptive error when non-empty data is paired with 0 dimensions
- Adds 3 unit test cases covering nil data, empty data, and non-empty data with 0-dimension vectors

## Context

This is a pre-existing bug in the generic `unmarshalVector` path, not introduced by any recent PR. It was identified during review of PR #770 (vector marshal optimization) but exists independently on master.

The fast-path code in #770 is not affected since its type-specialized functions handle the dimension count via `len(data) / elemByteSize` (byte size is always > 0 for float32/float64/int32/int64).