### PR TITLE
fix: guard against divide-by-zero in unmarshalVector when Dimensions is 0

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -901,7 +901,11 @@ func unmarshalVector(info VectorType, data []byte, value interface{}) error {
 			if len(data) > 0 {
 				return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
 			}
-			if k == reflect.Slice {
+			if k == reflect.Array {
+				if rv.Len() != 0 {
+					return unmarshalErrorf("unmarshal vector: array of size %d cannot store vector of 0 dimensions", rv.Len())
+				}
+			} else if k == reflect.Slice {
 				rv.Set(reflect.MakeSlice(t, 0, 0))
 			}
 			return nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1038,8 +1038,8 @@ func bytesWithLength(data ...[]byte) []byte {
 
 func TestUnmarshalVectorZeroDimensions(t *testing.T) {
 	info := VectorType{
-		NativeType: NativeType{typ: TypeCustom},
-		SubType:    NativeType{typ: TypeFloat},
+		NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+		SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
 		Dimensions: 0,
 	}
 
@@ -1071,6 +1071,31 @@ func TestUnmarshalVectorZeroDimensions(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "0-dimension") {
 			t.Fatalf("expected error mentioning 0-dimension, got: %v", err)
+		}
+	})
+
+	t.Run("empty_data_into_zero_length_array", func(t *testing.T) {
+		var result [0]float32
+		if err := unmarshalVector(info, []byte{}, &result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty_data_into_nonzero_length_array_errors", func(t *testing.T) {
+		var result [5]float32
+		err := unmarshalVector(info, []byte{}, &result)
+		if err == nil {
+			t.Fatal("expected error for 0-dimension vector into non-zero-length array")
+		}
+		if !strings.Contains(err.Error(), "array of size 5") {
+			t.Fatalf("expected error mentioning array size, got: %v", err)
+		}
+	})
+
+	t.Run("empty_data_into_interface", func(t *testing.T) {
+		var result interface{}
+		if err := unmarshalVector(info, []byte{}, &result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
unmarshalVector computes elemSize = len(data) / info.Dimensions without checking for zero dimensions, causing a panic on the generic reflect-based path.
Add an early guard that returns an empty slice for empty data, or a descriptive error when non-empty data is paired with 0 dimensions.