### PR TITLE
fix: ignore expected connection close errors in mock test server

### DIFF
--- a/scylla_shard_aware_port_common_test.go
+++ b/scylla_shard_aware_port_common_test.go
@@ -99,10 +99,11 @@ func testShardAwarePortNoReconnections(t *testing.T, makeCluster makeClusterTest
 					shardAwareConnectionCount++
 
 					shard := scyllaShardForSourcePort(evt.sourcePort, numberOfShards)
-					if oldPort, hasShard := shardsConnected[shard]; hasShard {
+					if oldEvt, hasShard := shardsConnected[shard]; hasShard {
 						t.Errorf("there was more than one connection to the shard aware port from the same shard (shard %d, port %d and %d)",
-							shard, oldPort, evt.sourcePort)
+							shard, oldEvt.sourcePort, evt.sourcePort)
 					}
+					shardsConnected[shard] = evt
 				}
 
 				if shardAwareConnectionCount != numberOfShards-1 {


### PR DESCRIPTION
The TestServer's serve() goroutine only treated io.EOF as a clean shutdown. For TLS connections, closing the client side produces net.ErrClosed instead of EOF, causing errorLocked() to call t.Error() with 'use of closed network connection' before Stop() sets srv.closed. This made TestShardAwarePortMockedNoReconnections/with_TLS flaky.

Also fix shardsConnected map never being populated in testShardAwarePortNoReconnections, which prevented duplicate shard detection from working.