### PR TITLE
perf: streamline readHeader() function

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -315,30 +315,19 @@ type frame interface {
 }
 
 func readHeader(r io.Reader, p []byte) (head frm.FrameHeader, err error) {
-	_, err = io.ReadFull(r, p[:1])
+	_, err = io.ReadFull(r, p[:headSize])
 	if err != nil {
 		return frm.FrameHeader{}, err
 	}
 
-	version := p[0] & protoVersionMask
+	head.Version = frm.ProtoVersion(p[0])
+	version := head.Version.Version()
 
 	if version < protoVersion3 || version > protoVersion5 {
 		return frm.FrameHeader{}, fmt.Errorf("gocql: unsupported protocol response version: %d", version)
 	}
 
-	_, err = io.ReadFull(r, p[1:headSize])
-	if err != nil {
-		return frm.FrameHeader{}, err
-	}
-
-	p = p[:headSize]
-
-	head.Version = frm.ProtoVersion(p[0])
 	head.Flags = p[1]
-
-	if len(p) != 9 {
-		return frm.FrameHeader{}, fmt.Errorf("not enough bytes to read header require 9 got: %d", len(p))
-	}
 
 	head.Stream = int(int16(binary.BigEndian.Uint16(p[2:4])))
 	head.Op = frm.Op(p[4])


### PR DESCRIPTION
## Summary

Streamline `readHeader()` by reading the full 9-byte frame header in a single `io.ReadFull()` call instead of two separate calls (1 byte + 8 bytes), eliminating one read operation per frame received.

**Changes:**
- Merge two `io.ReadFull()` calls into one for the complete 9-byte header
- Parse and check the version field once using `head.Version.Version()` instead of manual bit masking followed by re-assignment
- Remove unreachable `len(p) != 9` check (the buffer is always `headSize` or larger at that point)

**Benchmark results** (Intel i7-1270P):

```
                              Before              After
BenchmarkReadHeader           ~35 ns/op           ~35 ns/op  (48 B/op, 1 alloc)
BenchmarkReadHeaderParallel   ~43 ns/op           ~35 ns/op  (48 B/op, 1 alloc)
```

The improvement is modest in synthetic micro-benchmarks since `bytes.Reader` satisfies both reads from memory. The real benefit is in production where the underlying reader is a network connection — one fewer `io.ReadFull()` call means one fewer potential syscall and context switch per frame.

Extracted from #699.

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>