### PR TITLE
perf: eliminate reflection overhead in RowData() and type instantiation

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -376,6 +376,11 @@ func (iter *Iter) RowData() (RowData, error) {
 	idx := 0
 	for _, column := range iter.Columns() {
 		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
+			if idx >= actualSize {
+				err := fmt.Errorf("gocql: column count overflow in RowData: metadata predicted %d columns but encountered more", actualSize)
+				iter.err = err
+				return RowData{}, err
+			}
 			val, err := column.TypeInfo.NewWithError()
 			if err != nil {
 				iter.err = err
@@ -386,6 +391,11 @@ func (iter *Iter) RowData() (RowData, error) {
 			idx++
 		} else {
 			for i, elem := range c.Elems {
+				if idx >= actualSize {
+					err := fmt.Errorf("gocql: column count overflow in RowData: metadata predicted %d columns but encountered more", actualSize)
+					iter.err = err
+					return RowData{}, err
+				}
 				columns[idx] = TupleColumnName(column.Name, i)
 				val, err := elem.NewWithError()
 				if err != nil {
@@ -396,6 +406,12 @@ func (iter *Iter) RowData() (RowData, error) {
 				idx++
 			}
 		}
+	}
+
+	if idx != actualSize {
+		err := fmt.Errorf("gocql: column count mismatch in RowData: metadata predicted %d columns but got %d", actualSize, idx)
+		iter.err = err
+		return RowData{}, err
 	}
 
 	rowData := RowData{

--- a/helpers_bench_test.go
+++ b/helpers_bench_test.go
@@ -20,7 +20,6 @@ package gocql
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 )
 
@@ -226,63 +225,5 @@ func BenchmarkRowDataAllocation(b *testing.B) {
 				_ = rd
 			}
 		})
-	}
-}
-
-// TestNewWithErrorConsistentWithGoType verifies that the fast-path type mapping
-// in NativeType.NewWithError() stays consistent with the canonical goType() mapping.
-// This guards against future changes to one mapping that forget to update the other.
-func TestNewWithErrorConsistentWithGoType(t *testing.T) {
-	// All NativeType type codes that goType handles (excluding collection/tuple/UDT
-	// which are separate TypeInfo implementations).
-	nativeTypes := []Type{
-		TypeVarchar, TypeAscii, TypeText, TypeInet,
-		TypeBigInt, TypeCounter,
-		TypeTime,
-		TypeTimestamp,
-		TypeBlob,
-		TypeBoolean,
-		TypeFloat,
-		TypeDouble,
-		TypeInt,
-		TypeSmallInt,
-		TypeTinyInt,
-		TypeDecimal,
-		TypeUUID, TypeTimeUUID,
-		TypeVarint,
-		TypeDate,
-		TypeDuration,
-	}
-
-	for _, typ := range nativeTypes {
-		nt := NativeType{typ: typ, proto: protoVersion4}
-
-		// Get the fast-path result from NewWithError
-		fastVal, err := nt.NewWithError()
-		if err != nil {
-			t.Errorf("NewWithError(%s): unexpected error: %v", typ, err)
-			continue
-		}
-
-		// Get the canonical type from goType
-		canonicalType, err := goType(nt)
-		if err != nil {
-			t.Errorf("goType(%s): unexpected error: %v", typ, err)
-			continue
-		}
-
-		// NewWithError returns a pointer (reflect.New(typ).Interface()), so the
-		// underlying type is reflect.TypeOf(val).Elem()
-		fastType := reflect.TypeOf(fastVal)
-		if fastType.Kind() != reflect.Ptr {
-			t.Errorf("NewWithError(%s): expected pointer, got %s", typ, fastType.Kind())
-			continue
-		}
-		fastElemType := fastType.Elem()
-
-		if fastElemType != canonicalType {
-			t.Errorf("NewWithError(%s) fast-path type %s does not match goType() canonical type %s",
-				typ, fastElemType, canonicalType)
-		}
 	}
 }

--- a/marshal.go
+++ b/marshal.go
@@ -1875,6 +1875,8 @@ func (t CollectionType) NewWithError() (interface{}, error) {
 						return new(map[string]string), nil
 					case TypeBoolean:
 						return new(map[string]bool), nil
+					case TypeFloat:
+						return new(map[string]float32), nil
 					case TypeDouble:
 						return new(map[string]float64), nil
 					case TypeUUID:
@@ -1888,6 +1890,8 @@ func (t CollectionType) NewWithError() (interface{}, error) {
 						return new(map[int]string), nil
 					case TypeInt:
 						return new(map[int]int), nil
+					case TypeFloat:
+						return new(map[int]float32), nil
 					}
 				}
 			}
@@ -1939,7 +1943,7 @@ func (t TupleTypeInfo) String() string {
 }
 
 func (t TupleTypeInfo) NewWithError() (interface{}, error) {
-	// Tuples scan into *[]interface{} (pointer to a slice of interface values).
+	// Tuples scan into *[]interface{} — no reflection needed.
 	return new([]interface{}), nil
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1099,3 +1099,152 @@ func TestUnmarshalVectorZeroDimensions(t *testing.T) {
 		}
 	})
 }
+
+// TestNativeNewWithErrorConsistentWithGoType verifies that the fast-path type mapping
+// in NativeType.NewWithError() stays consistent with the canonical goType() mapping.
+// This guards against future changes to one mapping that forget to update the other.
+func TestNativeNewWithErrorConsistentWithGoType(t *testing.T) {
+	// All NativeType type codes that goType handles (excluding collection/tuple/UDT
+	// which are separate TypeInfo implementations).
+	nativeTypes := []Type{
+		TypeVarchar, TypeAscii, TypeText, TypeInet,
+		TypeBigInt, TypeCounter,
+		TypeTime,
+		TypeTimestamp,
+		TypeBlob,
+		TypeBoolean,
+		TypeFloat,
+		TypeDouble,
+		TypeInt,
+		TypeSmallInt,
+		TypeTinyInt,
+		TypeDecimal,
+		TypeUUID, TypeTimeUUID,
+		TypeVarint,
+		TypeDate,
+		TypeDuration,
+	}
+
+	for _, typ := range nativeTypes {
+		nt := NativeType{typ: typ, proto: protoVersion4}
+
+		// Get the fast-path result from NewWithError
+		fastVal, err := nt.NewWithError()
+		if err != nil {
+			t.Errorf("NewWithError(%s): unexpected error: %v", typ, err)
+			continue
+		}
+
+		// Get the canonical type from goType
+		canonicalType, err := goType(nt)
+		if err != nil {
+			t.Errorf("goType(%s): unexpected error: %v", typ, err)
+			continue
+		}
+
+		// NewWithError returns a pointer (reflect.New(typ).Interface()), so the
+		// underlying type is reflect.TypeOf(val).Elem()
+		fastType := reflect.TypeOf(fastVal)
+		if fastType.Kind() != reflect.Ptr {
+			t.Errorf("NewWithError(%s): expected pointer, got %s", typ, fastType.Kind())
+			continue
+		}
+		fastElemType := fastType.Elem()
+
+		if fastElemType != canonicalType {
+			t.Errorf("NewWithError(%s) fast-path type %s does not match goType() canonical type %s",
+				typ, fastElemType, canonicalType)
+		}
+	}
+}
+
+// TestCollectionNewWithErrorConsistentWithGoType verifies that the fast-path type mapping
+// in CollectionType.NewWithError() stays consistent with the canonical goType() mapping.
+func TestCollectionNewWithErrorConsistentWithGoType(t *testing.T) {
+	elemTypes := []Type{
+		TypeInt, TypeBigInt, TypeCounter,
+		TypeText, TypeVarchar, TypeAscii,
+		TypeBoolean,
+		TypeFloat, TypeDouble,
+		TypeUUID, TypeTimeUUID,
+		TypeTimestamp, TypeDate,
+		TypeSmallInt, TypeTinyInt,
+		TypeBlob,
+	}
+
+	// Test list and set types
+	for _, collTyp := range []Type{TypeList, TypeSet} {
+		for _, elemTyp := range elemTypes {
+			ct := CollectionType{
+				NativeType: NativeType{typ: collTyp, proto: protoVersion4},
+				Elem:       NativeType{typ: elemTyp, proto: protoVersion4},
+			}
+
+			fastVal, err := ct.NewWithError()
+			if err != nil {
+				t.Errorf("NewWithError(%s<%s>): unexpected error: %v", collTyp, elemTyp, err)
+				continue
+			}
+
+			canonicalType, err := goType(ct)
+			if err != nil {
+				t.Errorf("goType(%s<%s>): unexpected error: %v", collTyp, elemTyp, err)
+				continue
+			}
+
+			fastType := reflect.TypeOf(fastVal)
+			if fastType.Kind() != reflect.Ptr {
+				t.Errorf("NewWithError(%s<%s>): expected pointer, got %s", collTyp, elemTyp, fastType.Kind())
+				continue
+			}
+
+			if fastType.Elem() != canonicalType {
+				t.Errorf("NewWithError(%s<%s>) fast-path type %s does not match goType() canonical type %s",
+					collTyp, elemTyp, fastType.Elem(), canonicalType)
+			}
+		}
+	}
+
+	// Test map types with common key/value combinations
+	keyTypes := []Type{TypeText, TypeVarchar, TypeInt}
+	valTypes := []Type{
+		TypeInt, TypeBigInt,
+		TypeText, TypeVarchar,
+		TypeBoolean,
+		TypeFloat, TypeDouble,
+		TypeUUID,
+	}
+
+	for _, keyTyp := range keyTypes {
+		for _, valTyp := range valTypes {
+			ct := CollectionType{
+				NativeType: NativeType{typ: TypeMap, proto: protoVersion4},
+				Key:        NativeType{typ: keyTyp, proto: protoVersion4},
+				Elem:       NativeType{typ: valTyp, proto: protoVersion4},
+			}
+
+			fastVal, err := ct.NewWithError()
+			if err != nil {
+				t.Errorf("NewWithError(map<%s, %s>): unexpected error: %v", keyTyp, valTyp, err)
+				continue
+			}
+
+			canonicalType, err := goType(ct)
+			if err != nil {
+				t.Errorf("goType(map<%s, %s>): unexpected error: %v", keyTyp, valTyp, err)
+				continue
+			}
+
+			fastType := reflect.TypeOf(fastVal)
+			if fastType.Kind() != reflect.Ptr {
+				t.Errorf("NewWithError(map<%s, %s>): expected pointer, got %s", keyTyp, valTyp, fastType.Kind())
+				continue
+			}
+
+			if fastType.Elem() != canonicalType {
+				t.Errorf("NewWithError(map<%s, %s>) fast-path type %s does not match goType() canonical type %s",
+					keyTyp, valTyp, fastType.Elem(), canonicalType)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Eliminate reflection overhead in the hot path of `RowData()` → `NewWithError()` by adding direct type instantiation fast paths for all native CQL types, common collection patterns, and tuples.

Extracted from #699.

---

### Commit 1: Optimize RowData() allocation and assignment performance
- Pre-size slices using `iter.meta.actualColCount` (accounts for tuple expansion)
- Replace `append` with direct slice indexing to avoid bounds checking overhead
- Add comprehensive benchmark suite in `helpers_bench_test.go`

### Commit 2: Eliminate reflection in NativeType.NewWithError()
- Add type switch with direct `new()` calls for all 17 native CQL types
- Falls back to reflection only for `TypeCustom` and complex types

### Commit 3: Eliminate reflection for collection and tuple types
- Fast paths for common list/set element types (int, int64, string, bool, float32, float64, UUID, time.Time, etc.)
- Fast paths for common map key/value combinations (string→int, string→string, etc.)
- `TupleTypeInfo.NewWithError()` now always returns `new([]interface{})` — no reflection needed

### Commit 4: Harden RowData + improve NewWithError test coverage
- Add defensive guard in `RowData()` to detect `actualColCount` metadata inconsistency (returns clear error instead of silent corruption or index-out-of-bounds panic)
- Set `iter.err` in column count mismatch guard to match error contract
- Add overflow bounds checks before slice indexing to prevent panics
- Add `TypeFloat` fast-path for map values in `CollectionType.NewWithError()`
- Move `TestNewWithErrorConsistentWithGoType` to `marshal_test.go` (unit build tag)
- Add `TestCollectionNewWithErrorConsistentWithGoType` to verify collection fast-paths stay in sync with `goType()`

---

## Benchmark results

`origin/master` vs this branch — `benchstat` comparison (10 runs each, Intel i7-1270P).

**All results statistically significant at p=0.000, n=10.**

### Speed — 55.2% geomean improvement

| Benchmark | master (ns/op) | PR (ns/op) | vs base |
|---|---|---|---|
| RowData-16 | 477.8 ±3% | 198.5 ±2% | **-58.47%** |
| RowDataSmall-16 | 164.0 ±2% | 75.2 ±2% | **-54.15%** |
| RowDataLarge-16 | 2286.5 ±3% | 840.4 ±1% | **-63.24%** |
| RowDataWithTypes-16 | 547.8 ±3% | 248.8 ±2% | **-54.58%** |
| RowDataWithTuples-16 | 641.9 ±1% | 417.7 ±2% | **-34.94%** |
| RowDataRepeated-16 | 49.16 µs ±2% | 20.80 µs ±2% | **-57.68%** |
| Alloc/10cols-16 | 496.9 ±1% | 211.0 ±4% | **-57.55%** |
| Alloc/100cols-16 | 4611 ±3% | 1694 ±2% | **-63.26%** |
| Alloc/1000cols-16 | 44960 ±3% | 16500 ±1% | **-63.29%** |
| Alloc/WithTuples-16 | 647.8 ±1% | 426.2 ±2% | **-34.22%** |
| **geomean** | **1704** | **764.5** | **-55.15%** |

### Memory (B/op) — 44.1% geomean reduction

| Benchmark | master (B) | PR (B) | vs base |
|---|---|---|---|
| RowData-16 | 720 ±0% | 400 ±0% | **-44.44%** |
| RowDataSmall-16 | 216 ±0% | 120 ±0% | **-44.44%** |
| RowDataLarge-16 | 3,792 ±0% | 2,192 ±0% | **-42.19%** |
| RowDataWithTypes-16 | 776 ±0% | 456 ±0% | **-41.24%** |
| RowDataWithTuples-16 | 616 ±0% | 328 ±0% | **-46.75%** |
| RowDataRepeated-16 | 72,000 ±0% | 40,000 ±0% | **-44.44%** |
| Alloc/10cols-16 | 720 ±0% | 400 ±0% | **-44.44%** |
| Alloc/100cols-16 | 7,584 ±0% | 4,384 ±0% | **-42.19%** |
| Alloc/1000cols-16 | 72,768 ±0% | 40,768 ±0% | **-43.98%** |
| Alloc/WithTuples-16 | 616 ±0% | 328 ±0% | **-46.75%** |

### Allocations (allocs/op) — 44.0% geomean reduction

| Benchmark | master | PR | vs base |
|---|---|---|---|
| RowData-16 | 22 ±0% | 12 ±0% | **-45.45%** |
| RowDataSmall-16 | 8 ±0% | 5 ±0% | **-37.50%** |
| RowDataLarge-16 | 102 ±0% | 52 ±0% | **-49.02%** |
| RowDataWithTypes-16 | 22 ±0% | 12 ±0% | **-45.45%** |
| RowDataWithTuples-16 | 20 ±0% | 13 ±0% | **-35.00%** |
| RowDataRepeated-16 | 2,200 ±0% | 1,200 ±0% | **-45.45%** |
| Alloc/10cols-16 | 22 ±0% | 12 ±0% | **-45.45%** |
| Alloc/100cols-16 | 202 ±0% | 102 ±0% | **-49.50%** |
| Alloc/1000cols-16 | 2,002 ±0% | 1,002 ±0% | **-49.95%** |
| Alloc/WithTuples-16 | 20 ±0% | 13 ±0% | **-35.00%** |

Every column in `RowData()` calls `NewWithError()`, making this optimization highly impactful for queries with many columns. The improvement compounds: pre-sizing eliminates reallocation, and direct instantiation eliminates reflection — together achieving ~55-63% speedup with ~44% fewer allocations.

## Related PRs

The following changes were previously bundled in this PR and have been split out:
- #824 — Generic LRU cache with struct key for prepared statement cache
- #825 — Reduce token-aware Pick() allocations

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>