### PR TITLE
fix: correct logger format calls in getStrategy

### DIFF
--- a/topology.go
+++ b/topology.go
@@ -108,7 +108,7 @@ func getStrategy(ks *KeyspaceMetadata, logger StdLogger) placementStrategy {
 
 			rf, err := getReplicationFactorFromOpts(rf)
 			if err != nil {
-				logger.Println("parse rf for keyspace %q, dc %q: %v", err)
+				logger.Printf("parse rf for keyspace %q, dc %q: %v", ks.Name, dc, err)
 				// skip DC if the rf is invalid/unsupported, so that we can at least work with other working DCs.
 				continue
 			}
@@ -119,7 +119,7 @@ func getStrategy(ks *KeyspaceMetadata, logger StdLogger) placementStrategy {
 	case strings.Contains(ks.StrategyClass, "LocalStrategy"):
 		return nil
 	default:
-		logger.Printf("parse rf for keyspace %q: unsupported strategy class: %v", ks.StrategyClass)
+		logger.Printf("parse rf for keyspace %q: unsupported strategy class: %v", ks.Name, ks.StrategyClass)
 		return nil
 	}
 }


### PR DESCRIPTION
## Problem

`getStrategy()` in `topology.go` has two logging bugs:

1. **Line 111**: Uses `logger.Println` with format verbs (`%q`, `%q`, `%v`), but `Println` does not perform formatting — it passes arguments to `fmt.Fprintln`, so the format verbs are printed literally. Additionally, only `err` is passed as an argument, but the format string expects three values (`ks.Name`, `dc`, `err`). The result is a garbled log line like: `parse rf for keyspace %q, dc %q: %v some error`.

2. **Line 122**: Uses `logger.Printf` with two format verbs (`%q`, `%v`) but only one argument (`ks.StrategyClass`). The keyspace name (`ks.Name`) is never passed, so `%q` is filled with the strategy class and `%v` prints `%!v(MISSING)`.

Both bugs are present since the original code was written and affect any deployment using NetworkTopologyStrategy with an invalid replication factor, or any unsupported strategy class.

## Fix

- Line 111: `Println` → `Printf`, add `ks.Name` and `dc` arguments.
- Line 122: Add `ks.Name` as first argument.