### PR TITLE
fix: escape double quotes in UseKeyspace to prevent CQL injection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -33,6 +33,7 @@ import (
 	"io"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1677,8 +1678,12 @@ func (c *Conn) AvailableStreams() int {
 	return c.streams.Available()
 }
 
+func useKeyspaceStmt(keyspace string) string {
+	return `USE "` + strings.ReplaceAll(keyspace, `"`, `""`) + `"`
+}
+
 func (c *Conn) UseKeyspace(keyspace string) error {
-	q := &writeQueryFrame{statement: `USE "` + keyspace + `"`}
+	q := &writeQueryFrame{statement: useKeyspaceStmt(keyspace)}
 	q.params.consistency = c.session.cons
 
 	framer, err := c.exec(c.ctx, q, nil, c.cfg.ConnectTimeout)

--- a/conn_test.go
+++ b/conn_test.go
@@ -1616,3 +1616,22 @@ func TestGetSchemaAgreement(t *testing.T) {
 		assert.NoError(t, err, "expected no error when all nodes have the same schema")
 	})
 }
+
+func TestUseKeyspaceQuoteEscaping(t *testing.T) {
+	tests := []struct {
+		keyspace string
+		want     string
+	}{
+		{"simple", `USE "simple"`},
+		{`my"ks`, `USE "my""ks"`},
+		{`a""b`, `USE "a""""b"`},
+		{`"`, `USE """"`},
+		{"", `USE ""`},
+	}
+	for _, tt := range tests {
+		got := useKeyspaceStmt(tt.keyspace)
+		if got != tt.want {
+			t.Errorf("keyspace %q: got %q, want %q", tt.keyspace, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`UseKeyspace()` in `conn.go` constructs a CQL `USE` statement by directly concatenating the keyspace name into a quoted identifier:

```go
q := &writeQueryFrame{statement: `USE "` + keyspace + `"`}
```

If the keyspace name contains a double-quote character, this produces malformed or injectable CQL. For example, a keyspace named `foo"bar` generates `USE "foo"bar"`, which is a CQL syntax error. Per the CQL specification, double quotes inside quoted identifiers must be escaped by doubling them (`""`).

In practice this is low severity since keyspace names typically come from application configuration, not user input. However it is a correctness bug — any keyspace name containing `"` will fail to be selected.

## Fix

Apply `strings.ReplaceAll(keyspace, `"``, `""`)` before concatenation.