### PR TITLE
fix: return correct error from routingKeyInfo when scyllaGetTablePartitioner fails

### DIFF
--- a/session.go
+++ b/session.go
@@ -819,9 +819,10 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string, requestTimeou
 
 	partitioner, err := scyllaGetTablePartitioner(s, keyspace, table)
 	if err != nil {
-		// don't cache this error
+		// don't cache this error, but make sure all waiters see the same failure.
+		inflight.err = err
 		s.routingKeyInfoCache.Remove(stmt)
-		return nil, inflight.err
+		return nil, err
 	}
 
 	if len(info.request.pkeyColumns) > 0 {


### PR DESCRIPTION
## Problem

`routingKeyInfo()` in `session.go` silently swallows errors from `scyllaGetTablePartitioner()`. At line 824, the error return is `inflight.err` instead of the local `err`:

```go
partitioner, err := scyllaGetTablePartitioner(s, keyspace, table)
if err != nil {
    s.routingKeyInfoCache.Remove(stmt)
    return nil, inflight.err  // BUG: inflight.err is nil here
}
```

At this point in the code, `inflight.err` was last set by `conn.prepareStatement()` on line 802. If `prepareStatement` succeeded (the normal case), `inflight.err` is `nil`. So when `scyllaGetTablePartitioner` subsequently fails, the caller receives `(nil, nil)` — which it interprets as "no routing key info available" rather than "an error occurred".

The consequence is that token-aware routing silently degrades to random/round-robin routing whenever `scyllaGetTablePartitioner` fails, with no error logged or returned to the caller.

## Fix

Change `inflight.err` to `err` on line 824.