### PR TITLE
fix: handle net.ErrClosed in TestServer to fix flaky TLS shard-aware test (TestShardAwarePortMockedNoReconnections)

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -1298,7 +1298,7 @@ func (srv *TestServer) serve() {
 			for !srv.isClosed() {
 				framer, err := srv.readFrame(conn)
 				if err != nil {
-					if err == io.EOF {
+					if err == io.EOF || errors.Is(err, net.ErrClosed) {
 						return
 					}
 					srv.errorLocked(err)
@@ -1530,7 +1530,9 @@ func (srv *TestServer) process(conn net.Conn, reqFrame *framer, exts map[string]
 	}
 
 	if err := respFrame.writeTo(conn); err != nil {
-		srv.errorLocked(err)
+		if !errors.Is(err, net.ErrClosed) {
+			srv.errorLocked(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes `TestShardAwarePortMockedNoReconnections/with_TLS` flaky test by handling `net.ErrClosed` in the mock `TestServer`'s serve loop and process function
- TLS connection teardown can produce `net.ErrClosed` instead of `io.EOF`, which was not handled, causing `errorLocked()` to spuriously mark the test as failed

## Root Cause

The `TestServer.serve()` loop in `conn_test.go` only treated `io.EOF` as a benign connection-closed signal. When TLS connections are torn down (e.g., when `sess.Close()` is called in test goroutines), the server-side read can return `net.ErrClosed` instead of `io.EOF`. Since the server hasn't been stopped yet at that point (`srv.closed == false`), `errorLocked()` reports it as a test failure.

The `process()` function's `writeTo` call has the same issue — writing a response to a closed TLS connection triggers `errorLocked()`.

## Changes

- `serve()` loop: Handle `net.ErrClosed` alongside `io.EOF` when reading frames
- `process()`: Skip `errorLocked` for `net.ErrClosed` on write errors

## Verification

Ran `TestShardAwarePortMockedNoReconnections` **100 times** with `-race` — all 100 passed.

Fixes #455