### PR TITLE
fix: resolve self-deadlock in hostConnPool.Close() for defaultConnPicker (note: cassandra only issue?!)

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -348,9 +348,6 @@ func (pool *hostConnPool) Close() {
 	pool.closed = true
 	pool.mu.Unlock()
 
-	// Close connections outside the lock to avoid self-deadlock:
-	// conn.Close() triggers HandleError() which tries to acquire pool.mu.
-	// See scylladb/gocql#53 for the equivalent fix in scyllaConnPicker.
 	pool.connPicker.Close()
 }
 

--- a/connectionpool_test.go
+++ b/connectionpool_test.go
@@ -116,8 +116,8 @@ func TestSetupTLSConfig(t *testing.T) {
 	}
 }
 
-// errorConn is a mock net.Conn whose Close always returns an error,
-// which triggers the HandleError callback path in Conn.closeWithError.
+// errorConn is a mock net.Conn whose Close returns an error,
+// triggering HandleError via Conn.closeWithError.
 type errorConn struct {
 	net.Conn
 }
@@ -130,16 +130,9 @@ func (e errorConn) Close() error {
 // self-deadlock when defaultConnPicker closes connections that trigger
 // HandleError callbacks.
 //
-// The deadlock chain (before the fix):
+// Deadlock chain (before fix):
 //
-//	hostConnPool.Close()             — acquires pool.mu.Lock()
-//	  └── defaultConnPicker.Close()  — iterates conns
-//	        └── conn.Close()
-//	              └── closeWithError(nil)
-//	                    └── HandleError()
-//	                          └── pool.mu.Lock() — DEADLOCK
-//
-// See scylladb/gocql#53 for the equivalent issue in scyllaConnPicker.
+//	Close() -> connPicker.Close() -> conn.Close() -> HandleError() -> pool.mu.Lock() (DEADLOCK)
 func TestHostConnPoolCloseDeadlock(t *testing.T) {
 	t.Parallel()
 
@@ -162,9 +155,7 @@ func TestHostConnPoolCloseDeadlock(t *testing.T) {
 		debouncer:  debounce.NewSimpleDebouncer(),
 	}
 
-	// Create a defaultConnPicker with real Conn objects that will trigger
-	// HandleError on Close. Each Conn uses an errorConn (mock net.Conn
-	// whose Close returns an error) and has the pool as its errorHandler.
+	// Build a defaultConnPicker with Conns that trigger HandleError on Close.
 	picker := newDefaultConnPicker(2)
 	for i := 0; i < 2; i++ {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -179,8 +170,7 @@ func TestHostConnPoolCloseDeadlock(t *testing.T) {
 	}
 	pool.connPicker = picker
 
-	// Close the pool in a goroutine with a deadline. If the call doesn't
-	// return within the deadline, the pool is deadlocked.
+	// Close must return before timeout; otherwise the pool is deadlocked.
 	done := make(chan struct{})
 	go func() {
 		pool.Close()


### PR DESCRIPTION
## Summary

`hostConnPool.Close()` self-deadlocks when using `defaultConnPicker` (Cassandra path). The lock is held while closing connections, but `conn.Close()` triggers `HandleError()` which tries to acquire the same lock.

## Deadlock Chain

```
hostConnPool.Close()             — acquires pool.mu.Lock()
  └── defaultConnPicker.Close()  — iterates conns
        └── conn.Close()
              └── closeWithError(nil)
                    └── HandleError()
                          └── pool.mu.Lock() — DEADLOCK
```

## Root Cause

This is a regression introduced in commit 5a13421 ("hostConnPool: introduced ConnPicker interface to abstract pool storage"), which replaced the safe unlock-before-close pattern from the upstream `apache/cassandra-gocql-driver` repo with `defer pool.mu.Unlock()` + delegating to `connPicker.Close()` while still holding the lock.

The `scyllaConnPicker` path avoids this because it uses `go closeConns(conns...)` (async close, fixed in #55 for #53). But `defaultConnPicker.Close()` closes connections synchronously, triggering the deadlock on Cassandra test runs.

## Fix

Set `pool.closed = true` while holding the lock (so `HandleError` and `fill` see it and return early), then release the lock **before** calling `connPicker.Close()`. This matches:
- The upstream `apache/cassandra-gocql-driver` pattern (which has a detailed TODO comment explaining this exact deadlock)
- The spirit of the `scyllaConnPicker` fix (#55 / #53)

## Evidence

Goroutine dumps from CI (Cassandra 5-LATEST) show 3 distinct `hostConnPool` instances deadlocked in this exact pattern, with goroutines blocked for 6+ minutes on `pool.mu.Lock()` in `HandleError` and `fillingStopped`.

## Test

Added `TestHostConnPoolCloseDeadlock` unit test that:
- **Deadlocks (times out after 5s) without the fix** — verified before applying the code change
- **Passes instantly with the fix**