### PR TITLE
ci: fix resolve-cassandra-version GitHub API rate limit (403 error)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,7 @@ jobs:
       fail-fast: false
     env:
       CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,26 @@ resolve-cassandra-version: .prepare-get-version
 		exit 0
 	fi
 
-	if [[ "${CASSANDRA_VERSION}" == "LATEST" ]]; then
+	if echo "${CASSANDRA_VERSION}" | grep -qP '^[0-9\.]+$$'; then
+		CASSANDRA_VERSION_RESOLVED=${CASSANDRA_VERSION}
+	elif command -v gh >/dev/null 2>&1 && [[ -n "$${GH_TOKEN:-}" || -n "$${GITHUB_TOKEN:-}" ]]; then
+		echo "Using gh CLI for authenticated GitHub API access"
+		ALL_VERSIONS=$$(gh api repos/apache/cassandra/tags --paginate -q '.[].name' | \
+			grep -P '^cassandra-[0-9]+\.[0-9]+\.[0-9]+$$' | \
+			sed 's/^cassandra-//' | sort -V)
+		if [[ "${CASSANDRA_VERSION}" == "LATEST" ]]; then
+			CASSANDRA_VERSION_RESOLVED=$$(echo "$${ALL_VERSIONS}" | tail -1)
+		elif [[ "${CASSANDRA_VERSION}" == "5-LATEST" ]]; then
+			CASSANDRA_VERSION_RESOLVED=$$(echo "$${ALL_VERSIONS}" | grep '^5\.' | tail -1)
+		elif [[ "${CASSANDRA_VERSION}" == "4-LATEST" ]]; then
+			CASSANDRA_VERSION_RESOLVED=$$(echo "$${ALL_VERSIONS}" | grep '^4\.' | tail -1)
+		elif [[ "${CASSANDRA_VERSION}" == "3-LATEST" ]]; then
+			CASSANDRA_VERSION_RESOLVED=$$(echo "$${ALL_VERSIONS}" | grep '^3\.' | tail -1)
+		else
+			echo "Unknown Cassandra version name '${CASSANDRA_VERSION}'"
+			exit 1
+		fi
+	elif [[ "${CASSANDRA_VERSION}" == "LATEST" ]]; then
 		CASSANDRA_VERSION_RESOLVED=`get-version -source github-tag -repo apache/cassandra -prefix "cassandra-" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and LAST.LAST.LAST" | tr -d '\"'`
 	elif [[ "${CASSANDRA_VERSION}" == "5-LATEST" ]]; then
 		CASSANDRA_VERSION_RESOLVED=`get-version -source github-tag -repo apache/cassandra -prefix "cassandra-" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 5.LAST.LAST" | tr -d '\"'`
@@ -116,8 +135,6 @@ resolve-cassandra-version: .prepare-get-version
 		CASSANDRA_VERSION_RESOLVED=`get-version -source github-tag -repo apache/cassandra -prefix "cassandra-" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 4.LAST.LAST" | tr -d '\"'`
 	elif [[ "${CASSANDRA_VERSION}" == "3-LATEST" ]]; then
 		CASSANDRA_VERSION_RESOLVED=`get-version -source github-tag -repo apache/cassandra -prefix "cassandra-" -out-no-prefix -filters "^[0-9]+$$.^[0-9]+$$.^[0-9]+$$ and 3.LAST.LAST" | tr -d '\"'`
-	elif echo "${CASSANDRA_VERSION}" | grep -P '^[0-9\.]+'; then
-		CASSANDRA_VERSION_RESOLVED=${CASSANDRA_VERSION}
 	else
 		echo "Unknown Cassandra version name '${CASSANDRA_VERSION}'"
 		exit 1


### PR DESCRIPTION
## Summary

- Use `gh` CLI with authenticated GitHub API access for Cassandra version resolution in CI, avoiding the 60 req/hr unauthenticated rate limit that causes 403 errors on shared GitHub Actions runner IPs
- Fall back to the existing `get-version` tool for environments without `gh` CLI or a GitHub token (e.g., developer laptops)
- Set `GH_TOKEN` in the `test-integration-cassandra` workflow job

## Problem

`make resolve-cassandra-version` fails in CI because the `get-version` tool (`scylladb-actions/get-version` v0.4.3) makes **unauthenticated** requests to `https://api.github.com/repos/apache/cassandra/tags`. The unauthenticated rate limit is 60 requests/hour per IP, and GitHub-hosted runners share IPs, so the limit is frequently hit. The tool has exponential backoff retry, but cannot recover when the rate window hasn't reset.

The `get-version` tool has no `--token` flag or `GITHUB_TOKEN` env var support ([source](https://github.com/scylladb-actions/get-version/blob/main/sources/github/github.go#L63-L66)), so the fix must be done on the caller side.

## Solution

When `gh` CLI is available and `GH_TOKEN`/`GITHUB_TOKEN` is set (always true in GitHub Actions), use `gh api --paginate` for authenticated tag fetching (5000 req/hr). Otherwise, fall back to `get-version` as before.

Fixes #794