### PR TITLE
chore: update get-version from v0.4.3 to v0.4.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ print-config:
 .prepare-get-version: .prepare-bin
 	@if [[ ! -f "$(MAKEFILE_PATH)/bin/get-version" ]]; then
 		echo "bin/get-version is not found, installing it"
-		curl -sSLo /tmp/get-version.zip https://github.com/scylladb-actions/get-version/releases/download/v0.4.3/get-version_0.4.3_linux_amd64v3.zip
+		curl -sSLo /tmp/get-version.zip https://github.com/scylladb-actions/get-version/releases/download/v0.4.5/get-version_0.4.5_linux_amd64v3.zip
 		unzip /tmp/get-version.zip get-version -d "$(MAKEFILE_PATH)/bin" >/dev/null
 	fi
 


### PR DESCRIPTION
Update the `get-version` CLI tool used in the Makefile for resolving Cassandra and ScyllaDB versions.

This update suppose to address https://github.com/scylladb/gocql/issues/794 by pulling credentials from GH

### Changes
- Updated download URL in `.prepare-get-version` Makefile target from `v0.4.3` to `v0.4.5`

### Release notes
- https://github.com/scylladb-actions/get-version/releases/tag/v0.4.4
- https://github.com/scylladb-actions/get-version/releases/tag/v0.4.5