### PR TITLE
perf: pool callReq structs to reduce per-query allocations

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -686,7 +686,11 @@ func (c *Conn) closeWithError(err error) {
 		// we need to send the error to all waiting queries.
 		select {
 		case req.resp <- callResp{err: err}:
+			// exec() received the error. Wait for it to close(call.timeout)
+			// signaling it is done accessing the callReq.
+			<-req.timeout
 		case <-req.timeout:
+			// exec() already timed out and returned.
 		}
 		if req.streamObserverContext != nil {
 			req.streamObserverEndOnce.Do(func() {
@@ -695,6 +699,7 @@ func (c *Conn) closeWithError(err error) {
 				})
 			})
 		}
+		putCallReq(req)
 	}
 
 	// if error was nil then unblock the quit channel
@@ -906,10 +911,6 @@ func (c *Conn) recv(ctx context.Context) error {
 }
 
 func (c *Conn) releaseStream(call *callReq) {
-	if call.timer != nil {
-		call.timer.Stop()
-	}
-
 	c.streams.Clear(call.streamID)
 
 	if call.streamObserverContext != nil {
@@ -919,6 +920,8 @@ func (c *Conn) releaseStream(call *callReq) {
 			})
 		})
 	}
+
+	putCallReq(call)
 }
 
 type callReq struct {
@@ -932,6 +935,33 @@ type callReq struct {
 	// streamObserverEndOnce ensures that either StreamAbandoned or StreamFinished is called,
 	// but not both.
 	streamObserverEndOnce sync.Once
+}
+
+var callReqPool = sync.Pool{
+	New: func() interface{} {
+		return &callReq{
+			resp: make(chan callResp),
+		}
+	},
+}
+
+func getCallReq(streamID int) *callReq {
+	call := callReqPool.Get().(*callReq)
+	call.timeout = make(chan struct{})
+	call.streamID = streamID
+	call.streamObserverContext = nil
+	call.streamObserverEndOnce = sync.Once{}
+	return call
+}
+
+func putCallReq(call *callReq) {
+	if call.timer != nil {
+		call.timer.Stop()
+	}
+	call.streamObserverContext = nil
+	call.streamObserverEndOnce = sync.Once{}
+	call.timeout = nil
+	callReqPool.Put(call)
 }
 
 type callResp struct {
@@ -1189,17 +1219,14 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 	framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts, c.logger)
 	c.setTabletSupported(framer.tabletsRoutingV1)
 
-	call := &callReq{
-		timeout:  make(chan struct{}),
-		streamID: stream,
-		resp:     make(chan callResp),
-	}
+	call := getCallReq(stream)
 
 	if c.streamObserver != nil {
 		call.streamObserverContext = c.streamObserver.StreamContext(ctx)
 	}
 
 	if err := c.addCall(call); err != nil {
+		putCallReq(call)
 		return nil, &QueryError{err: err, potentiallyExecuted: false}
 	}
 
@@ -1266,8 +1293,7 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 	var timeoutCh <-chan time.Time
 	if requestTimeout > 0 {
 		if call.timer == nil {
-			call.timer = time.NewTimer(0)
-			<-call.timer.C
+			call.timer = time.NewTimer(requestTimeout)
 		} else {
 			if !call.timer.Stop() {
 				select {
@@ -1275,9 +1301,9 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 				default:
 				}
 			}
+			call.timer.Reset(requestTimeout)
 		}
 
-		call.timer.Reset(requestTimeout)
 		timeoutCh = call.timer.C
 	}
 


### PR DESCRIPTION
## Summary

Pool `callReq` structs using `sync.Pool` to eliminate per-query heap allocations of the request tracking object, its channels, and timer, reducing allocations by ~18% and latency by ~8-15% on the query hot path.

## Context

Every call to `Conn.exec()` allocates a fresh `callReq` struct with two channels (`resp`, `timeout`) and a `time.Timer`. These short-lived objects are created and discarded on every single query, creating significant GC pressure under high throughput. CPU profiling of the benchmark suite showed `runtime.mallocgc` consuming ~20% of total CPU time, with `runtime.chanrecv` at ~25% -- both heavily driven by per-query allocations.

Additionally, the existing timer pattern created a `time.NewTimer(0)` that fires immediately, drained it, then called `Reset(requestTimeout)` -- a wasteful three-step sequence. The `else` branch that would reuse an existing timer was dead code because `callReq` was always freshly allocated.

## Changes

- Added `callReqPool` (`sync.Pool`) to reuse `callReq` structs across queries
- Unbuffered `resp` channel is preserved across pool cycles (original semantics maintained)
- `timeout` channel is recreated each cycle (it must be, since it is `close()`d as a broadcast signal rather than sent to)
- `time.Timer` is preserved and reused across pool cycles
- Fixed `time.NewTimer(0)` + drain + `Reset()` pattern to use direct `time.NewTimer(requestTimeout)`, which also activates the previously-dead timer reuse branch for pooled objects
- Added `<-req.timeout` handshake in `closeWithError()` to safely return `callReq` to the pool after connection close without racing with `exec()`
- `putCallReq` is called from `releaseStream` (normal path), `closeWithError` (connection close path), and `addCall` failure path

### Key Implementation Details

The `callReq.timeout` channel uses `close()` as a broadcast signal (checked via `select` in `recv()` and `closeWithError()`). A closed channel cannot be reused, so it must be freshly allocated each cycle. The `resp` channel is unbuffered (matching original semantics) and is reused across pool cycles.

In `closeWithError()`, after delivering an error on `req.resp`, we wait for `exec()` to `close(call.timeout)` -- this confirms `exec()` is done accessing the `callReq`, making it safe to run observer cleanup and return the object to the pool.

The timer reuse path (`call.timer != nil`) was previously unreachable because `callReq` was always freshly created. With pooling, a returned `callReq` retains its stopped timer, and the `else` branch now correctly stops, drains, and resets it.

## Testing

All existing unit tests pass with race detector:
```bash
go test -tags "unit" -race -timeout=180s ./...
```

All CI checks pass: Build, unit tests, race detection, integration tests on Scylla (LATEST, LTS-LATEST, LTS-PRIOR, PRIOR) and Cassandra (4-LATEST, 5-LATEST).

Benchmark results collected with `benchstat` (5 runs each):

| Benchmark | Metric | Before | After | Change | p-value |
|---|---|---|---|---|---|
| SingleConnectionSelect | sec/op | 3.642 us | 3.102 us | **-14.83%** | 0.008 |
| | B/op | 2,455 | 2,052 | **-16.43%** | 0.008 |
| | allocs/op | 28 | 23 | **-17.86%** | 0.008 |
| SingleConnectionInsert | sec/op | 3.556 us | 3.264 us | **-8.21%** | 0.032 |
| | B/op | 2,416 | 1,999 | **-17.26%** | 0.008 |
| | allocs/op | 28 | 23 | **-17.86%** | 0.008 |
| SingleConn (mock) | B/op | 3,116 | 2,702 | **-13.29%** | 0.008 |
| | allocs/op | 36 | 31 | **-13.89%** | 0.008 |

To reproduce:
```bash
# Baseline (on master)
go test -tags "unit" -bench="BenchmarkSingleConn" -benchmem -count=5 -benchtime=3s . > before.txt

# After (this branch)
go test -tags "unit" -bench="BenchmarkSingleConn" -benchmem -count=5 -benchtime=3s . > after.txt

# Compare
benchstat before.txt after.txt
```