### PR TITLE
test: fix P0 blockers for parallel test execution

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1073,6 +1073,11 @@ func TestCreateSessionTimeout(t *testing.T) {
 	}
 }
 
+// TestReconnection verifies that a node marked down is eventually reconnected.
+// WARNING: This test must NOT use t.Parallel(). It calls session.handleNodeDown()
+// which mutates shared HostInfo state visible to all concurrent sessions.
+//
+//nolint:paralleltest // mutates shared HostInfo state via handleNodeDown()
 func TestReconnection(t *testing.T) {
 	cluster := createCluster()
 	cluster.ReconnectInterval = 1 * time.Second
@@ -3294,7 +3299,11 @@ func TestQuery_NamedValues(t *testing.T) {
 	}
 }
 
-// This test ensures that queries are sent to the specified host only
+// TestQuery_SetHostID ensures that queries are sent to the specified host only.
+// WARNING: This test must NOT use t.Parallel(). It calls pool.host.setState(NodeDown)
+// which mutates shared HostInfo state visible to all concurrent sessions.
+//
+//nolint:paralleltest // mutates shared HostInfo state via setState(NodeDown)
 func TestQuery_SetHostID(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()

--- a/common_test.go
+++ b/common_test.go
@@ -479,6 +479,18 @@ func testTableName(t testing.TB, parts ...string) string {
 	return name
 }
 
+// testTypeName builds a CQL-safe UDT type name from t.Name() and optional parts.
+// Analogous to testTableName but intended for CREATE TYPE / frozen<type> references.
+func testTypeName(t testing.TB, parts ...string) string {
+	return testTableName(t, parts...)
+}
+
+// testKeyspaceName builds a CQL-safe keyspace name from t.Name() and optional parts.
+// Analogous to testTableName but intended for CREATE/DROP KEYSPACE statements.
+func testKeyspaceName(t testing.TB, parts ...string) string {
+	return testTableName(t, parts...)
+}
+
 func staticAddressTranslator(newAddr net.IP, newPort int) AddressTranslator {
 	return AddressTranslatorFunc(func(addr net.IP, port int) (net.IP, int) {
 		return newAddr, newPort

--- a/control_integration_test.go
+++ b/control_integration_test.go
@@ -56,7 +56,7 @@ func TestUnixSockets(t *testing.T) {
 
 	defer sess.Close()
 
-	keyspace := "test1"
+	keyspace := testKeyspaceName(t)
 
 	err = createTable(sess, `DROP KEYSPACE IF EXISTS `+keyspace)
 	if err != nil {

--- a/keyspace_table_test.go
+++ b/keyspace_table_test.go
@@ -49,7 +49,7 @@ func TestKeyspaceTable(t *testing.T) {
 
 	cluster.Keyspace = "wrong_keyspace"
 
-	keyspace := "test1"
+	keyspace := testKeyspaceName(t)
 	table := testTableName(t)
 
 	err = createTable(session, `DROP KEYSPACE IF EXISTS `+keyspace)

--- a/policies_integration_test.go
+++ b/policies_integration_test.go
@@ -89,7 +89,11 @@ func testIfPolicyInitializedProperly(t *testing.T, cluster *ClusterConfig, polic
 	}
 }
 
-// This test ensures  that when all hosts are down, the query execution does not hang.
+// TestNoHangAllHostsDown ensures that when all hosts are down, the query execution does not hang.
+// WARNING: This test must NOT use t.Parallel(). It sets ALL hosts to NodeDown state,
+// which mutates shared HostInfo objects visible to all concurrent sessions.
+//
+//nolint:paralleltest // mutates shared HostInfo state (sets all hosts to NodeDown)
 func TestNoHangAllHostsDown(t *testing.T) {
 	cluster := createCluster()
 	session := createSessionFromCluster(cluster, t)

--- a/udt_test.go
+++ b/udt_test.go
@@ -73,11 +73,12 @@ func TestUDT_Marshaler(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.position(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		lat int,
 		lon int,
-		padding text);`)
+		padding text);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,10 +86,10 @@ func TestUDT_Marshaler(t *testing.T) {
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		id int,
 		name text,
-		loc frozen<position>,
+		loc frozen<%s>,
 
 		primary key(id)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,20 +129,21 @@ func TestUDT_Reflect(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.horse(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		name text,
-		owner text);`)
+		owner text);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		position int,
-		horse frozen<horse>,
+		horse frozen<%s>,
 
 		primary key(position)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,20 +179,21 @@ func TestUDT_NullObject(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.udt_null_type(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		name text,
-		owner text);`)
+		owner text);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		id uuid,
-		udt_col frozen<udt_null_type>,
+		udt_col frozen<%s>,
 
 		primary key(id)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,11 +232,12 @@ func TestMapScanUDT(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.log_entry (
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s (
 		created_timestamp timestamp,
 		message text
-	);`)
+	);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,8 +245,8 @@ func TestMapScanUDT(t *testing.T) {
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s (
 		id uuid PRIMARY KEY,
 		type int,
-		log_entries list<frozen <log_entry>>
-	);`, table))
+		log_entries list<frozen <%s>>
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,20 +318,21 @@ func TestUDT_MissingField(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.missing_field(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		name text,
-		owner text);`)
+		owner text);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		id uuid,
-		udt_col frozen<udt_null_type>,
+		udt_col frozen<%s>,
 
 		primary key(id)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,22 +367,23 @@ func TestUDT_EmptyCollections(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.nil_collections(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		a list<text>,
 		b map<text, text>,
 		c set<text>
-	);`)
+	);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		id uuid,
-		udt_col frozen<nil_collections>,
+		udt_col frozen<%s>,
 
 		primary key(id)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,20 +422,21 @@ func TestUDT_UpdateField(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.update_field_udt(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		name text,
-		owner text);`)
+		owner text);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		id uuid,
-		udt_col frozen<update_field_udt>,
+		udt_col frozen<%s>,
 
 		primary key(id)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +458,7 @@ func TestUDT_UpdateField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := createTable(session, `ALTER TYPE gocql_test.update_field_udt ADD data text;`); err != nil {
+	if err := createTable(session, fmt.Sprintf(`ALTER TYPE gocql_test.%s ADD data text;`, typeName)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -471,11 +478,12 @@ func TestUDT_ScanNullUDT(t *testing.T) {
 	defer session.Close()
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.scan_null_udt_position(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		lat int,
 		lon int,
-		padding text);`)
+		padding text);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -483,9 +491,9 @@ func TestUDT_ScanNullUDT(t *testing.T) {
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		id int,
 		name text,
-		loc frozen<position>,
+		loc frozen<%s>,
 		primary key(id)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vector_test.go
+++ b/vector_test.go
@@ -267,20 +267,21 @@ func TestVector_MarshalerUDT(t *testing.T) {
 	}
 
 	table := testTableName(t)
+	typeName := testTypeName(t)
 
-	err := createTable(session, `CREATE TYPE gocql_test.person(
+	err := createTable(session, fmt.Sprintf(`CREATE TYPE gocql_test.%s(
 		first_name text,
 		last_name text,
-		age int);`)
+		age int);`, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	err = createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s(
 		id int,
-		couple vector<person, 2>,
+		couple vector<%s, 2>,
 		primary key(id)
-	);`, table))
+	);`, table, typeName))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Fixes the three **P0 / CRITICAL** blockers from #812 that must be resolved before any `t.Parallel()` calls can be added to integration tests.

## Changes

### 1. Unique UDT type names per test (fixes #801, ref #802)

- Added `testTypeName(t)` helper in `common_test.go` (analogous to `testTableName`)
- Replaced all 9 hardcoded UDT type names across `udt_test.go` and `vector_test.go` with dynamic per-test names generated from `t.Name()`
- Also fixes the cross-test dependency where `TestUDT_MissingField` referenced `udt_null_type` created by `TestUDT_NullObject` (P1 issue #802) — each test now creates its own type

### 2. Fence node-manipulation tests as non-parallel (fixes #803)

- Added explicit `WARNING` comments and `// nolint:paralleltest` directives to:
  - `TestReconnection` — calls `session.handleNodeDown()`
  - `TestQuery_SetHostID` — calls `pool.host.setState(NodeDown)`
  - `TestNoHangAllHostsDown` — sets **all** hosts to `NodeDown`
- These tests mutate shared `HostInfo` state visible to all concurrent sessions

### 3. Fix hardcoded keyspace `test1` collision (fixes #804)

- Added `testKeyspaceName(t)` helper in `common_test.go`
- Replaced hardcoded `test1` keyspace in `TestKeyspaceTable` and `TestUnixSockets` with unique per-test keyspace names

## Files Changed

| File | What changed |
|---|---|
| `common_test.go` | Added `testTypeName()` and `testKeyspaceName()` helpers |
| `udt_test.go` | All 8 UDT tests use dynamic type names |
| `vector_test.go` | `TestVector_MarshalerUDT` uses dynamic type name |
| `cassandra_test.go` | Fencing comments on `TestReconnection`, `TestQuery_SetHostID` |
| `policies_integration_test.go` | Fencing comment on `TestNoHangAllHostsDown` |
| `keyspace_table_test.go` | `TestKeyspaceTable` uses `testKeyspaceName(t)` |
| `control_integration_test.go` | `TestUnixSockets` uses `testKeyspaceName(t)` |

## Testing

- `go vet -tags integration ./...` passes
- No behavioral changes to test logic — only naming isolation and documentation
