### PR TITLE
perf: pool framer structs and cache extension values on Conn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ docs/source/.doctrees
 TODO*.md
 
 # Codex - AI assistant metadata
+.codex
 .codex/
 .codex-cache/
 .codex-config.json

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ func main() {
 }
 ```
 
+`SliceMap()` consumes and closes the iterator before it returns.
+
 ## 4. Data Types
 
 Here's an list of all CQL Types reflected in the GoCQL environment:

--- a/callreq_wait.go
+++ b/callreq_wait.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package gocql
+
+func waitCallReqDone(call *callReq, where string) {
+	call.done.Wait()
+}

--- a/callreq_wait_race.go
+++ b/callreq_wait_race.go
@@ -1,0 +1,25 @@
+//go:build race
+
+package gocql
+
+import (
+	"fmt"
+	"time"
+)
+
+func waitCallReqDone(call *callReq, where string) {
+	done := make(chan struct{})
+	go func() {
+		call.done.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+	case <-timer.C:
+		panic(fmt.Sprintf("gocql: timed out waiting for exec cleanup in %s (stream=%d)", where, call.streamID))
+	}
+}

--- a/common_test.go
+++ b/common_test.go
@@ -27,6 +27,7 @@ package gocql
 import (
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"log"
 	"net"
 	"os"
@@ -523,9 +524,11 @@ func createAggregate(t *testing.T, session *Session) {
 }
 
 const maxCQLIdentifierLen = 48
+const testTableNameHashLen = 16
 
 // testTableName builds a CQL-safe table name from t.Name() and optional parts.
-// Truncates to 48 chars (CQL limit) using <first20>_<last20> when needed.
+// Truncates to 48 chars (CQL limit) using <first-n>_<fnv64a hash>_<last-n>
+// when needed.
 func testTableName(t testing.TB, parts ...string) string {
 	name := strings.ToLower(t.Name())
 	for _, p := range parts {
@@ -546,7 +549,13 @@ func testTableName(t testing.TB, parts ...string) string {
 	name = strings.Trim(b.String(), "_")
 
 	if len(name) > maxCQLIdentifierLen {
-		name = name[:20] + "_" + name[len(name)-20:]
+		h := fnv.New64a()
+		h.Write([]byte(name))
+		hash := fmt.Sprintf("%016x", h.Sum64()) // 16 hex chars for better collision resistance
+		remaining := maxCQLIdentifierLen - testTableNameHashLen - 2
+		prefixLen := remaining / 2
+		suffixLen := remaining - prefixLen
+		name = name[:prefixLen] + "_" + hash + "_" + name[len(name)-suffixLen:]
 	}
 	return name
 }

--- a/conn.go
+++ b/conn.go
@@ -197,6 +197,7 @@ type Conn struct {
 	calls                map[int]*callReq
 	r                    *bufio.Reader
 	session              *Session
+	framerConstructor    connFramers
 	cancel               context.CancelFunc
 	addr                 string
 	usingTimeoutClause   string
@@ -531,6 +532,15 @@ func (s *startupCoordinator) setupConn(ctx context.Context) error {
 	return nil
 }
 
+// write sends the given frame on the connection during startup and returns
+// the parsed response frame.
+//
+// NOTE: The returned frame must not retain any byte-slice references to the
+// framer's read buffer, because the framer is released back to the pool
+// immediately after parseFrame returns (via defer). Frame types that use
+// readBytesCopy (e.g. SupportedFrame, AuthChallengeFrame, AuthSuccessFrame)
+// are safe; frame types that use readBytes and expose []byte fields would not
+// be safe and must not be returned from this function.
 func (s *startupCoordinator) write(ctx context.Context, frame frameBuilder) (frame, error) {
 	select {
 	case s.frameTicker <- struct{}{}:
@@ -542,6 +552,7 @@ func (s *startupCoordinator) write(ctx context.Context, frame frameBuilder) (fra
 	if err != nil {
 		return nil, err
 	}
+	defer framer.Release()
 
 	return framer.parseFrame()
 }
@@ -565,7 +576,16 @@ func (s *startupCoordinator) options(ctx context.Context) error {
 	}
 	s.conn.cqlProtoExts = parseCQLProtocolExtensions(s.conn.supported, s.conn.logger)
 
-	return s.startup(ctx)
+	// initFramerCache must be called after startup(), because startup() may
+	// nil out c.compressor if the server does not support the requested
+	// compression algorithm. Calling it before would snapshot a stale
+	// compressor and set FlagCompress, causing protocol errors.
+	err = s.startup(ctx)
+	if err != nil {
+		return err
+	}
+	s.conn.initFramerCache()
+	return nil
 }
 
 func (s *startupCoordinator) startup(ctx context.Context) error {
@@ -669,29 +689,31 @@ func (c *Conn) closeWithError(err error) {
 		return
 	}
 	c.closed = true
-
-	var callsToClose map[int]*callReq
-
-	// We should attempt to deliver the error back to the caller if it
-	// exists. However, don't block c.mu while we are delivering the
-	// error to outstanding calls.
-	if err != nil {
-		callsToClose = c.calls
-		// It is safe to change c.calls to nil. Nobody should use it after c.closed is set to true.
-		c.calls = nil
-	}
+	callsToClose := c.calls
+	// It is safe to change c.calls to nil. Nobody should use it after c.closed is set to true.
+	c.calls = nil
 	c.mu.Unlock()
 
+	var cerr error
+	if err == nil {
+		// Graceful closes do not inject an error into call.resp, so cancel the
+		// connection first to unblock any exec() calls before waiting for them.
+		c.cancel()
+		cerr = c.close()
+	}
+
 	for _, req := range callsToClose {
-		// we need to send the error to all waiting queries.
-		select {
-		case req.resp <- callResp{err: err}:
-			// exec() received the error. Wait for it to close(call.timeout)
-			// signaling it is done accessing the callReq.
-			<-req.timeout
-		case <-req.timeout:
-			// exec() already timed out and returned.
+		if err != nil {
+			// We need to send the error to all waiting queries.
+			select {
+			case req.resp <- callResp{err: err}:
+				// exec() received the error. Wait for it to finish touching the callReq
+				// before recycling it.
+			case <-req.timeout:
+				// exec() already timed out and returned.
+			}
 		}
+		req.waitExecDone("closeWithError")
 		if req.streamObserverContext != nil {
 			req.streamObserverEndOnce.Do(func() {
 				req.streamObserverContext.StreamAbandoned(ObservedStream{
@@ -702,9 +724,15 @@ func (c *Conn) closeWithError(err error) {
 		putCallReq(req)
 	}
 
-	// if error was nil then unblock the quit channel
-	c.cancel()
-	cerr := c.close()
+	// Allow GC of pooled framers. Safe to do after the drain loop above has
+	// resolved all in-flight exec() calls. Any event goroutines still running
+	// will see pool==nil in releaseFramer and simply drop the framer.
+	c.framerConstructor.close()
+
+	if err != nil {
+		c.cancel()
+		cerr = c.close()
+	}
 
 	if err != nil {
 		c.errorHandler.HandleError(c, err, true)
@@ -793,6 +821,7 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		}
 
 		resp, err := framer.parseFrame()
+		framer.Release()
 		if err != nil {
 			// invalid frame
 			failures++
@@ -850,13 +879,16 @@ func (c *Conn) recv(ctx context.Context) error {
 	} else if head.Stream <= 0 {
 		// reserved stream that we dont use, probably due to a protocol error
 		// or a bug in Cassandra, this should be an error, parse it and return.
-		framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts, c.logger)
-		c.setTabletSupported(framer.tabletsRoutingV1)
-		if err := framer.readFrame(c, &head); err != nil {
+		framer, err := c.readFrameIntoFramer(head)
+		if err != nil {
 			return err
 		}
 
 		frame, err := framer.parseFrame()
+		// NOTE: Safe to release the framer here because all error frame types
+		// (from parseErrorFrame) contain only strings, scalars, and defensively-
+		// copied []byte fields. None retain sub-slices of the framer's read buffer.
+		c.releaseReadFramer(framer)
 		if err != nil {
 			if head.Stream == -1 {
 				// Event frame parse errors should not close the connection.
@@ -867,7 +899,9 @@ func (c *Conn) recv(ctx context.Context) error {
 		}
 
 		if head.Stream == -1 { // reserved stream for events
-			go c.session.handleEvent(frame)
+			if c.session != nil {
+				go c.session.handleEvent(frame)
+			}
 			return nil
 		}
 
@@ -891,13 +925,14 @@ func (c *Conn) recv(ctx context.Context) error {
 		panic(fmt.Sprintf("call has incorrect streamID: got %d expected %d", call.streamID, head.Stream))
 	}
 
-	framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts, c.logger)
+	framer := c.getReadFramer()
 
 	err = framer.readFrame(c, &head)
 	if err != nil {
 		// only net errors should cause the connection to be closed. Though
 		// cassandra returning corrupt frames will be returned here as well.
 		if _, ok := err.(net.Error); ok {
+			c.releaseReadFramer(framer)
 			return err
 		}
 	}
@@ -906,12 +941,30 @@ func (c *Conn) recv(ctx context.Context) error {
 	// connection has closed. Either way we should never block indefinatly here
 	select {
 	case call.resp <- callResp{framer: framer, err: err}:
+		// Framer ownership transferred to caller
 	case <-call.timeout:
-		c.releaseStream(call)
+		c.abandonRecvCall(call, framer)
 	case <-ctx.Done():
+		c.abandonRecvCall(call, framer)
 	}
 
 	return nil
+}
+
+func (c *Conn) readFrameIntoFramer(head frm.FrameHeader) (*framer, error) {
+	framer := c.getReadFramer()
+	if err := framer.readFrame(c, &head); err != nil {
+		c.releaseReadFramer(framer)
+		return nil, err
+	}
+	return framer, nil
+}
+
+func (c *Conn) abandonRecvCall(call *callReq, framer *framer) {
+	c.releaseReadFramer(framer)
+	c.releaseStream(call)
+	call.waitExecDone("abandonRecvCall")
+	putCallReq(call)
 }
 
 func (c *Conn) releaseStream(call *callReq) {
@@ -924,8 +977,6 @@ func (c *Conn) releaseStream(call *callReq) {
 			})
 		})
 	}
-
-	putCallReq(call)
 }
 
 type callReq struct {
@@ -939,6 +990,7 @@ type callReq struct {
 	// streamObserverEndOnce ensures that either StreamAbandoned or StreamFinished is called,
 	// but not both.
 	streamObserverEndOnce sync.Once
+	done                  sync.WaitGroup
 }
 
 var callReqPool = sync.Pool{
@@ -955,17 +1007,48 @@ func getCallReq(streamID int) *callReq {
 	call.streamID = streamID
 	call.streamObserverContext = nil
 	call.streamObserverEndOnce = sync.Once{}
+	call.done = sync.WaitGroup{}
+	call.done.Add(1)
 	return call
 }
 
 func putCallReq(call *callReq) {
 	if call.timer != nil {
-		call.timer.Stop()
+		if !call.timer.Stop() {
+			select {
+			case <-call.timer.C:
+			default:
+			}
+		}
 	}
 	call.streamObserverContext = nil
 	call.streamObserverEndOnce = sync.Once{}
+	call.streamID = 0
 	call.timeout = nil
 	callReqPool.Put(call)
+}
+
+func (call *callReq) finishExec() {
+	call.done.Done()
+}
+
+func (call *callReq) waitExecDone(where string) {
+	waitCallReqDone(call, where)
+}
+
+// removeCallIfOpen removes a call from c.calls only if exec() still owns its
+// cleanup. Once the connection has started closing, closeWithError() becomes
+// responsible for draining and recycling detached callReqs.
+func (c *Conn) removeCallIfOpen(streamID int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed || c.calls == nil {
+		return false
+	}
+
+	delete(c.calls, streamID)
+	return true
 }
 
 type callResp struct {
@@ -1208,6 +1291,15 @@ func (c *Conn) addCall(call *callReq) error {
 	return nil
 }
 
+// exec executes a frame on the connection and returns the response framer.
+//
+// IMPORTANT: The caller takes ownership of the returned framer and MUST call
+// framer.Release() when done reading the response. Failure to release the framer
+// will leak memory and prevent buffer reuse.
+//
+// The framer should be released as soon as the response data is no longer needed,
+// typically via defer immediately after parsing or after transferring ownership
+// to an Iter.
 func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, requestTimeout time.Duration) (*framer, error) {
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, &QueryError{err: ctxErr, potentiallyExecuted: false}
@@ -1220,8 +1312,7 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 	}
 
 	// resp is basically a waiting semaphore protecting the framer
-	framer := newFramerWithExts(c.compressor, c.version, c.cqlProtoExts, c.logger)
-	c.setTabletSupported(framer.tabletsRoutingV1)
+	framer := c.getWriteFramer()
 
 	call := getCallReq(stream)
 
@@ -1230,13 +1321,41 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 	}
 
 	if err := c.addCall(call); err != nil {
+		call.finishExec()
 		putCallReq(call)
+		c.releaseWriteFramer(framer)
 		return nil, &QueryError{err: err, potentiallyExecuted: false}
 	}
 
 	// After this point, we need to either read from call.resp or close(call.timeout)
 	// since closeWithError can try to write a connection close error to call.resp.
 	// If we don't close(call.timeout) or read from call.resp, closeWithError can deadlock.
+
+	var (
+		stopWaiting   bool
+		releaseStream bool
+		recycleCall   bool
+		closeErr      error
+	)
+
+	defer func() {
+		if closeErr != nil {
+			c.closeWithError(closeErr)
+		}
+	}()
+
+	defer func() {
+		if stopWaiting {
+			close(call.timeout)
+		}
+		call.finishExec()
+		if releaseStream {
+			c.releaseStream(call)
+		}
+		if recycleCall {
+			putCallReq(call)
+		}
+	}()
 
 	if tracer != nil {
 		framer.trace()
@@ -1250,46 +1369,42 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 
 	err := req.buildFrame(framer, stream)
 	if err != nil {
-		// closeWithError will block waiting for this stream to either receive a response
-		// or for us to timeout.
-		close(call.timeout)
-		// We failed to serialize the frame into a buffer.
-		// This should not affect the connection as we didn't write anything. We just free the current call.
-		c.mu.Lock()
-		if !c.closed {
-			delete(c.calls, call.streamID)
+		c.releaseWriteFramer(framer)
+		// closeWithError waits for exec() to stop touching the callReq, so the
+		// deferred epilogue below is responsible for signaling completion.
+		stopWaiting = true
+		if c.removeCallIfOpen(call.streamID) {
+			// We failed to serialize the frame into a buffer. This should not affect
+			// the connection as we didn't write anything, so exec() still owns the
+			// stream/call cleanup.
+			releaseStream = true
+			recycleCall = true
 		}
-		c.mu.Unlock()
-		// We need to release the stream after we remove the call from c.calls, otherwise the existingCall != nil
-		// check above could fail.
-		c.releaseStream(call)
 		return nil, &QueryError{err: err, potentiallyExecuted: false}
 	}
 
 	n, err := c.w.writeContext(ctx, framer.buf)
+	c.releaseWriteFramer(framer)
 	if err != nil {
-		// closeWithError will block waiting for this stream to either receive a response
-		// or for us to timeout, close the timeout chan here. Im not entirely sure
-		// but we should not get a response after an error on the write side.
-		close(call.timeout)
+		// closeWithError waits for exec() to stop touching the callReq, so defer
+		// the completion signal and only record the cleanup we need here.
+		stopWaiting = true
 		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && n == 0 {
 			// We have not started to write this frame.
 			// Release the stream as no response can come from the server on the stream.
-			c.mu.Lock()
-			if !c.closed {
-				delete(c.calls, call.streamID)
+			if c.removeCallIfOpen(call.streamID) {
+				// We need to release the stream after we remove the call from c.calls,
+				// otherwise the existingCall != nil check above could fail.
+				releaseStream = true
+				recycleCall = true
 			}
-			c.mu.Unlock()
-			// We need to release the stream after we remove the call from c.calls, otherwise the existingCall != nil
-			// check above could fail.
-			c.releaseStream(call)
 		} else {
 			// I think this is the correct thing to do, im not entirely sure. It is not
 			// ideal as readers might still get some data, but they probably wont.
 			// Here we need to be careful as the stream is not available and if all
 			// writes just timeout or fail then the pool might use this connection to
 			// send a frame on, with all the streams used up and not returned.
-			c.closeWithError(err)
+			closeErr = err
 		}
 		return nil, &QueryError{err: err, potentiallyExecuted: true}
 	}
@@ -1307,7 +1422,6 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 			}
 			call.timer.Reset(requestTimeout)
 		}
-
 		timeoutCh = call.timer.C
 	}
 
@@ -1318,14 +1432,16 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 
 	select {
 	case resp := <-call.resp:
-		close(call.timeout)
+		stopWaiting = true
 		if resp.err != nil {
+			c.releaseReadFramer(resp.framer)
 			if !c.Closed() {
 				// if the connection is closed then we cant release the stream,
 				// this is because the request is still outstanding and we have
 				// been handed another error from another stream which caused the
 				// connection to close.
-				c.releaseStream(call)
+				releaseStream = true
+				recycleCall = true
 			}
 			return nil, &QueryError{err: resp.err, potentiallyExecuted: true}
 		}
@@ -1335,21 +1451,26 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 		//
 		// Ensure that the stream is not released if there are potentially outstanding
 		// requests on the stream to prevent nil pointer dereferences in recv().
-		defer c.releaseStream(call)
+		releaseStream = true
+		recycleCall = true
 
 		if v := resp.framer.header.Version.Version(); v != c.version {
+			c.releaseReadFramer(resp.framer)
 			return nil, &QueryError{err: NewErrProtocol("unexpected protocol version in response: got %d expected %d", v, c.version), potentiallyExecuted: true}
 		}
 
+		// NOTE: The returned framer becomes the caller's responsibility to release.
+		// It is not released here to allow zero-copy access to the response data.
+		// The caller must call Release() on the returned read framer when done reading the response.
 		return resp.framer, nil
 	case <-timeoutCh:
-		close(call.timeout)
+		stopWaiting = true
 		return nil, &QueryError{err: ErrTimeoutNoResponse, potentiallyExecuted: true}
 	case <-ctxDone:
-		close(call.timeout)
+		stopWaiting = true
 		return nil, &QueryError{err: ctx.Err(), potentiallyExecuted: true}
 	case <-c.ctx.Done():
-		close(call.timeout)
+		stopWaiting = true
 		return nil, &QueryError{err: ErrConnectionClosed, potentiallyExecuted: true}
 	}
 }
@@ -1443,6 +1564,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer,
 				c.session.stmtsLRU.remove(cacheKey)
 				return
 			}
+			defer framer.Release()
 
 			frame, err := framer.parseFrame()
 			if err != nil {
@@ -1460,11 +1582,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer,
 			switch x := frame.(type) {
 			case *resultPreparedFrame:
 				flight.preparedStatment = &preparedStatment{
-					// defensively copy as we will recycle the underlying buffer after we
-					// return.
-					id: copyBytes(x.preparedID),
-					// the type info's should _not_ have a reference to the framers read buffer,
-					// therefore we can just copy them directly.
+					id:       x.preparedID,
 					request:  x.reqMeta,
 					response: x.respMeta,
 				}
@@ -1509,15 +1627,6 @@ func marshalQueryValue(typ TypeInfo, value interface{}, dst *queryValues) error 
 }
 
 func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
-	defer func() {
-		if iter == nil || c.session == nil {
-			return
-		}
-		warnings := iter.Warnings()
-		if len(warnings) > 0 && c.session.warningHandler != nil {
-			c.session.warningHandler.HandleWarnings(qry, iter.host, warnings)
-		}
-	}()
 	params := queryParams{
 		consistency: qry.cons,
 	}
@@ -1605,17 +1714,21 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 	if err != nil {
 		return &Iter{err: err}
 	}
+	warningHandler := WarningHandler(nil)
+	if c.session != nil {
+		warningHandler = c.session.warningHandler
+	}
 
 	resp, err := framer.parseFrame()
 	if err != nil {
-		return &Iter{err: err}
+		return newErrorIterWithReleasedFramer(err, framer).bindWarningHandler(qry, warningHandler)
 	}
 
 	if len(framer.customPayload) > 0 {
 		if hint, ok := framer.customPayload["tablets-routing-v1"]; ok {
 			tablet, err := unmarshalTabletHint(hint, c.version, qry.routingInfo.keyspace, qry.routingInfo.table)
 			if err != nil {
-				return &Iter{err: err}
+				return newErrorIterWithReleasedFramer(err, framer).bindWarningHandler(qry, warningHandler)
 			}
 			c.session.metadataDescriber.AddTablet(tablet)
 		}
@@ -1627,33 +1740,32 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 
 	switch x := resp.(type) {
 	case *resultVoidFrame:
-		return &Iter{framer: framer}
+		return (&Iter{framer: framer}).bindWarningHandler(qry, warningHandler)
 	case *resultRowsFrame:
-		iter := &Iter{
+		iter := (&Iter{
 			meta:    x.meta,
 			framer:  framer,
 			numRows: x.numRows,
-		}
+		}).bindWarningHandler(qry, warningHandler)
 
 		if params.skipMeta {
 			if info != nil {
 				iter.meta = info.response
-				iter.meta.pagingState = copyBytes(x.meta.pagingState)
+				// pagingState is already independently allocated by readBytesCopy()
+				// during frame parsing, no additional copy needed.
+				iter.meta.pagingState = x.meta.pagingState
 			} else {
-				return &Iter{framer: framer, err: errors.New("gocql: did not receive metadata but prepared info is nil")}
+				return newErrorIterWithReleasedFramer(errors.New("gocql: did not receive metadata but prepared info is nil"), framer).bindWarningHandler(qry, warningHandler)
 			}
 		}
 
 		if x.meta.morePages() && !qry.disableAutoPage {
 			newQry := new(Query)
 			*newQry = *qry
-			newQry.pageState = copyBytes(x.meta.pagingState)
+			newQry.pageState = x.meta.pagingState
 			newQry.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
 
-			iter.next = &nextIter{
-				qry: newQry,
-				pos: int((1 - qry.prefetch) * float64(x.numRows)),
-			}
+			iter.next = newNextIter(newQry, int((1-qry.prefetch)*float64(x.numRows)))
 
 			if iter.next.pos < 1 {
 				iter.next.pos = 1
@@ -1662,9 +1774,9 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 
 		return iter
 	case *resultKeyspaceFrame:
-		return &Iter{framer: framer}
+		return (&Iter{framer: framer}).bindWarningHandler(qry, warningHandler)
 	case *frm.SchemaChangeKeyspace, *frm.SchemaChangeTable, *frm.SchemaChangeFunction, *frm.SchemaChangeAggregate, *frm.SchemaChangeType:
-		iter := &Iter{framer: framer}
+		iter := (&Iter{framer: framer}).bindWarningHandler(qry, warningHandler)
 		if err := c.awaitSchemaAgreement(ctx); err != nil {
 			// TODO: should have this behind a flag
 			c.logger.Println(err)
@@ -1674,16 +1786,14 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 		// is not consistent with regards to its schema.
 		return iter
 	case *RequestErrUnprepared:
-		cacheKey := c.session.stmtsLRU.keyFor(c.host.HostID(), c.currentKeyspace, qry.stmt)
-		c.session.stmtsLRU.evictPreparedID(cacheKey, x.StatementId)
+		stmtCacheKey := c.session.stmtsLRU.keyFor(c.host.HostID(), c.currentKeyspace, qry.stmt)
+		c.session.stmtsLRU.evictPreparedID(stmtCacheKey, x.StatementId)
+		framer.Release()
 		return c.executeQuery(ctx, qry)
 	case error:
-		return &Iter{err: x, framer: framer}
+		return newErrorIterWithReleasedFramer(x, framer).bindWarningHandler(qry, warningHandler)
 	default:
-		return &Iter{
-			err:    NewErrProtocol("Unknown type in response to execute query (%T): %s", x, x),
-			framer: framer,
-		}
+		return newErrorIterWithReleasedFramer(NewErrProtocol("Unknown type in response to execute query (%T): %s", x, x), framer).bindWarningHandler(qry, warningHandler)
 	}
 }
 
@@ -1720,6 +1830,7 @@ func (c *Conn) UseKeyspace(keyspace string) error {
 	if err != nil {
 		return err
 	}
+	defer framer.Release()
 
 	resp, err := framer.parseFrame()
 	if err != nil {
@@ -1740,16 +1851,6 @@ func (c *Conn) UseKeyspace(keyspace string) error {
 }
 
 func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
-	defer func() {
-		if iter == nil || c.session == nil {
-			return
-		}
-		warnings := iter.Warnings()
-		if len(warnings) > 0 && c.session.warningHandler != nil {
-			c.session.warningHandler.HandleWarnings(batch, iter.host, warnings)
-		}
-	}()
-
 	n := len(batch.Entries)
 	req := &writeBatchFrame{
 		typ:                   batch.Type,
@@ -1827,10 +1928,14 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 	if err != nil {
 		return &Iter{err: err}
 	}
+	warningHandler := WarningHandler(nil)
+	if c.session != nil {
+		warningHandler = c.session.warningHandler
+	}
 
 	resp, err := framer.parseFrame()
 	if err != nil {
-		return &Iter{err: err, framer: framer}
+		return newErrorIterWithReleasedFramer(err, framer).bindWarningHandler(batch, warningHandler)
 	}
 
 	if len(framer.traceID) > 0 && batch.trace != nil {
@@ -1839,26 +1944,27 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 
 	switch x := resp.(type) {
 	case *resultVoidFrame:
-		return &Iter{}
+		return (&Iter{framer: framer}).bindWarningHandler(batch, warningHandler)
 	case *RequestErrUnprepared:
 		stmt, found := stmts[string(x.StatementId)]
 		if found {
 			key := c.session.stmtsLRU.keyFor(c.host.HostID(), c.currentKeyspace, stmt)
 			c.session.stmtsLRU.evictPreparedID(key, x.StatementId)
 		}
+		framer.Release()
 		return c.executeBatch(ctx, batch)
 	case *resultRowsFrame:
-		iter := &Iter{
+		iter := (&Iter{
 			meta:    x.meta,
 			framer:  framer,
 			numRows: x.numRows,
-		}
+		}).bindWarningHandler(batch, warningHandler)
 
 		return iter
 	case error:
-		return &Iter{err: x, framer: framer}
+		return newErrorIterWithReleasedFramer(x, framer).bindWarningHandler(batch, warningHandler)
 	default:
-		return &Iter{err: NewErrProtocol("Unknown type in response to batch statement: %s", x), framer: framer}
+		return newErrorIterWithReleasedFramer(NewErrProtocol("Unknown type in response to batch statement: %s", x), framer).bindWarningHandler(batch, warningHandler)
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -197,7 +197,7 @@ type Conn struct {
 	calls                map[int]*callReq
 	r                    *bufio.Reader
 	session              *Session
-	framerConstructor    connFramers
+	framers              connFramers
 	cancel               context.CancelFunc
 	addr                 string
 	usingTimeoutClause   string
@@ -727,7 +727,7 @@ func (c *Conn) closeWithError(err error) {
 	// Allow GC of pooled framers. Safe to do after the drain loop above has
 	// resolved all in-flight exec() calls. Any event goroutines still running
 	// will see pool==nil in releaseFramer and simply drop the framer.
-	c.framerConstructor.close()
+	c.framers.close()
 
 	if err != nil {
 		c.cancel()

--- a/conn_test.go
+++ b/conn_test.go
@@ -2198,10 +2198,10 @@ func TestUseKeyspaceQuoteEscaping(t *testing.T) {
 // suitable for testing releaseFramer and EWMA logic.
 func newTestConnWithFramerPool() *Conn {
 	c := &Conn{}
-	c.framerConstructor.defaults = framerConfig{
+	c.framers.defaults = framerConfig{
 		proto: protoVersion4 & protoVersionMask,
 	}
-	c.initFramerPool()
+	c.framers.initPool(c)
 	return c
 }
 
@@ -2234,7 +2234,7 @@ func TestReleaseFramer(t *testing.T) {
 			c.releaseReadFramer(f)
 		}
 
-		avg := c.framerConstructor.readPool.bufAvgSize.Load()
+		avg := c.framers.readPool.bufAvgSize.Load()
 		if avg != defaultBufSize {
 			t.Errorf("EWMA should stay at defaultBufSize=%d when all buffers equal, got %d", defaultBufSize, avg)
 		}
@@ -2248,14 +2248,14 @@ func TestReleaseFramer(t *testing.T) {
 
 		f.Release()
 
-		avgAfterFirstRelease := c.framerConstructor.readPool.bufAvgSize.Load()
+		avgAfterFirstRelease := c.framers.readPool.bufAvgSize.Load()
 		if avgAfterFirstRelease <= defaultBufSize {
 			t.Fatalf("framer.Release() should route through Conn.releaseFramer and update EWMA, got %d", avgAfterFirstRelease)
 		}
 
 		f.Release()
 
-		if avgAfterSecondRelease := c.framerConstructor.readPool.bufAvgSize.Load(); avgAfterSecondRelease != avgAfterFirstRelease {
+		if avgAfterSecondRelease := c.framers.readPool.bufAvgSize.Load(); avgAfterSecondRelease != avgAfterFirstRelease {
 			t.Fatalf("second framer.Release() should be a no-op: first avg=%d second avg=%d", avgAfterFirstRelease, avgAfterSecondRelease)
 		}
 	})
@@ -2271,7 +2271,7 @@ func TestReleaseFramer(t *testing.T) {
 			c.releaseReadFramer(f)
 		}
 
-		avg := c.framerConstructor.readPool.bufAvgSize.Load()
+		avg := c.framers.readPool.bufAvgSize.Load()
 		// After 100 iterations with weight=8, avg should be very close to targetSize.
 		// Allow 1% tolerance.
 		if avg < targetSize*99/100 || avg > targetSize*101/100 {
@@ -2298,7 +2298,7 @@ func TestReleaseFramer(t *testing.T) {
 			c.releaseReadFramer(f)
 		}
 
-		avg := c.framerConstructor.readPool.bufAvgSize.Load()
+		avg := c.framers.readPool.bufAvgSize.Load()
 		// Due to the upward-biased rounding (+framerBufEWMAWeight/2), the EWMA settles
 		// slightly above the actual sample value when converging downward. The steady-state
 		// offset is at most framerBufEWMAWeight/2 (i.e., 4) per step which compounds to
@@ -2396,7 +2396,7 @@ func TestReleaseFramer(t *testing.T) {
 		writeFramer.buf = make([]byte, 0, 8192)
 		c.releaseWriteFramer(writeFramer)
 
-		if writeAvg := c.framerConstructor.writePool.bufAvgSize.Load(); writeAvg <= defaultBufSize {
+		if writeAvg := c.framers.writePool.bufAvgSize.Load(); writeAvg <= defaultBufSize {
 			t.Fatalf("writer pool should track its own EWMA, got %d", writeAvg)
 		}
 
@@ -2424,15 +2424,15 @@ func TestReleaseFramer(t *testing.T) {
 		}
 
 		c.releaseWriteFramer(f)
-		if got, want := f.flags, c.framerConstructor.defaults.flags; got != want {
+		if got, want := f.flags, c.framers.defaults.flags; got != want {
 			t.Fatalf("releaseWriteFramer should restore default flags: got %08b want %08b", got, want)
 		}
 
 		f = c.getWriteFramer()
 		plainReq := &writeQueryFrame{statement: "SELECT now() FROM system.local"}
 		plainBuf, plainHeader := buildTestFrame(t, f, plainReq, streamID)
-		if plainHeader.Flags != c.framerConstructor.defaults.flags {
-			t.Fatalf("plain query should use default flags after pooled reuse: got %08b want %08b", plainHeader.Flags, c.framerConstructor.defaults.flags)
+		if plainHeader.Flags != c.framers.defaults.flags {
+			t.Fatalf("plain query should use default flags after pooled reuse: got %08b want %08b", plainHeader.Flags, c.framers.defaults.flags)
 		}
 
 		fresh := newFramer(nil, protoVersion4)
@@ -2460,7 +2460,7 @@ func TestReleaseFramer(t *testing.T) {
 		}
 
 		c.releaseWriteFramer(f)
-		if got, want := f.flags, c.framerConstructor.defaults.flags; got != want {
+		if got, want := f.flags, c.framers.defaults.flags; got != want {
 			t.Fatalf("releaseWriteFramer should restore default flags: got %08b want %08b", got, want)
 		}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -834,7 +834,10 @@ func TestInitialRetryPolicy(t *testing.T) {
 		t.Run(fmt.Sprintf("NumRetries=%d_ProtocolVersion=%d", tc.NumRetries, tc.ProtoVersion), func(t *testing.T) {
 			t.Parallel()
 
-			cluster := NewCluster("127.254.254.254")
+			// Use a loopback address with a well-known closed port so the test
+			// remains deterministic even when a local Cassandra-compatible
+			// service is listening on 9042.
+			cluster := NewCluster("127.0.0.1:1")
 			policy := &TestReconnectionPolicy{NumRetries: tc.NumRetries}
 			cluster.InitialReconnectionPolicy = policy
 			cluster.ProtoVersion = tc.ProtoVersion
@@ -899,6 +902,483 @@ func TestContext_CanceledBeforeExec(t *testing.T) {
 	if queryRequestCount != 0 {
 		t.Fatalf("expected that no request is sent to server, sent %d requests", queryRequestCount)
 	}
+}
+
+func TestCallReqReuseDoesNotInvalidateOutstandingTimeout(t *testing.T) {
+	t.Parallel()
+
+	oldCall := getCallReq(1)
+	oldTimeout := oldCall.timeout
+	oldCall.done.Done()
+	putCallReq(oldCall)
+
+	newCall := getCallReq(2)
+	defer newCall.done.Done()
+	defer close(newCall.timeout)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("closing old timeout should not panic after putCallReq: %v", r)
+		}
+	}()
+
+	close(oldTimeout)
+
+	select {
+	case <-newCall.timeout:
+		t.Fatal("closing the old timeout unexpectedly closed the new call timeout")
+	default:
+	}
+}
+
+type testContextWriter struct {
+	n       int
+	err     error
+	onWrite func()
+}
+
+func (w testContextWriter) writeContext(ctx context.Context, p []byte) (int, error) {
+	if w.onWrite != nil {
+		w.onWrite()
+	}
+	if w.n == 0 && w.err == nil {
+		return len(p), nil
+	}
+	return w.n, w.err
+}
+
+func (w testContextWriter) setWriteTimeout(timeout time.Duration) {}
+
+type contextWriterFunc func(context.Context, []byte) (int, error)
+
+func (fn contextWriterFunc) writeContext(ctx context.Context, p []byte) (int, error) {
+	return fn(ctx, p)
+}
+
+func (fn contextWriterFunc) setWriteTimeout(timeout time.Duration) {}
+
+func newTestExecConn(t *testing.T, w contextWriter) (*Conn, net.Conn) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	server, client := net.Pipe()
+	c := newTestConnWithFramerPool()
+	c.ctx = ctx
+	c.cancel = cancel
+	c.conn = client
+	c.w = w
+	c.logger = nopLogger{}
+	c.errorHandler = connErrorHandlerFn(func(*Conn, error, bool) {})
+	c.streams = streams.New()
+	c.calls = make(map[int]*callReq)
+
+	return c, server
+}
+
+func waitForSingleCall(t *testing.T, c *Conn) *callReq {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		c.mu.Lock()
+		for _, call := range c.calls {
+			c.mu.Unlock()
+			return call
+		}
+		c.mu.Unlock()
+
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for in-flight call")
+		case <-ticker.C:
+		}
+	}
+}
+
+func detachSingleCall(t *testing.T, c *Conn) *callReq {
+	t.Helper()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for streamID, call := range c.calls {
+		delete(c.calls, streamID)
+		return call
+	}
+
+	t.Fatal("expected an in-flight call")
+	return nil
+}
+
+type testStreamObserver struct {
+	ctx *testStreamObserverContext
+}
+
+func (o *testStreamObserver) StreamContext(context.Context) StreamObserverContext {
+	return o.ctx
+}
+
+type testStreamObserverContext struct {
+	started   chan struct{}
+	abandoned chan struct{}
+	finished  chan struct{}
+}
+
+func newTestStreamObserverContext() *testStreamObserverContext {
+	return &testStreamObserverContext{
+		started:   make(chan struct{}, 1),
+		abandoned: make(chan struct{}, 1),
+		finished:  make(chan struct{}, 1),
+	}
+}
+
+func (o *testStreamObserverContext) StreamStarted(ObservedStream) {
+	select {
+	case o.started <- struct{}{}:
+	default:
+	}
+}
+
+func (o *testStreamObserverContext) StreamAbandoned(ObservedStream) {
+	select {
+	case o.abandoned <- struct{}{}:
+	default:
+	}
+}
+
+func (o *testStreamObserverContext) StreamFinished(ObservedStream) {
+	select {
+	case o.finished <- struct{}{}:
+	default:
+	}
+}
+
+func TestExecCloseWithError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("BuildFrameErrorReleasesResources", func(t *testing.T) {
+		c, server := newTestExecConn(t, testContextWriter{})
+		defer server.Close()
+
+		_, err := c.exec(context.Background(), frameWriterFunc(func(f *framer, streamID int) error {
+			return io.ErrUnexpectedEOF
+		}), nil, 0)
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("expected build error %v, got %v", io.ErrUnexpectedEOF, err)
+		}
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if len(c.calls) != 0 {
+			t.Fatalf("expected no in-flight calls after build error, got %d", len(c.calls))
+		}
+	})
+
+	t.Run("ContextCanceledBeforeWriteReleasesResources", func(t *testing.T) {
+		writeEntered := make(chan struct{})
+		c, server := newTestExecConn(t, contextWriterFunc(func(ctx context.Context, p []byte) (int, error) {
+			close(writeEntered)
+			<-ctx.Done()
+			return 0, ctx.Err()
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := c.exec(ctx, frameWriterFunc(func(f *framer, streamID int) error {
+				f.buf = append(f.buf[:0], 'x')
+				return nil
+			}), nil, 0)
+			errCh <- err
+		}()
+
+		select {
+		case <-writeEntered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec never reached the write path")
+		}
+		cancel()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected context cancel error %v, got %v", context.Canceled, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec deadlocked after context cancellation before write")
+		}
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if len(c.calls) != 0 {
+			t.Fatalf("expected no in-flight calls after canceled write, got %d", len(c.calls))
+		}
+	})
+
+	t.Run("ResponseErrorReleasesResources", func(t *testing.T) {
+		c, server := newTestExecConn(t, testContextWriter{})
+		defer server.Close()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := c.exec(context.Background(), frameWriterFunc(func(f *framer, streamID int) error {
+				f.buf = append(f.buf[:0], 'x')
+				return nil
+			}), nil, 0)
+			errCh <- err
+		}()
+
+		waitForSingleCall(t, c)
+		call := detachSingleCall(t, c)
+		call.resp <- callResp{err: io.EOF}
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, io.EOF) {
+				t.Fatalf("expected response error %v, got %v", io.EOF, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec deadlocked after response error")
+		}
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if len(c.calls) != 0 {
+			t.Fatalf("expected no in-flight calls after response error, got %d", len(c.calls))
+		}
+	})
+
+	t.Run("PartialWriteDoesNotDeadlock", func(t *testing.T) {
+		c, server := newTestExecConn(t, testContextWriter{
+			n:   1,
+			err: io.ErrUnexpectedEOF,
+		})
+		defer server.Close()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := c.exec(context.Background(), frameWriterFunc(func(f *framer, streamID int) error {
+				f.buf = append(f.buf[:0], 'x')
+				return nil
+			}), nil, 0)
+			errCh <- err
+		}()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("expected write error %v, got %v", io.ErrUnexpectedEOF, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec deadlocked after partial write failure")
+		}
+	})
+
+	t.Run("ConnectionCloseErrorDoesNotDeadlock", func(t *testing.T) {
+		writeStarted := make(chan struct{})
+		var writeStartedOnce sync.Once
+		c, server := newTestExecConn(t, testContextWriter{
+			onWrite: func() {
+				writeStartedOnce.Do(func() {
+					close(writeStarted)
+				})
+			},
+		})
+		defer server.Close()
+
+		closeDone := make(chan struct{})
+		go func() {
+			<-writeStarted
+			c.closeWithError(io.EOF)
+			close(closeDone)
+		}()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := c.exec(context.Background(), frameWriterFunc(func(f *framer, streamID int) error {
+				f.buf = append(f.buf[:0], 'x')
+				return nil
+			}), nil, 0)
+			errCh <- err
+		}()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, io.EOF) {
+				t.Fatalf("expected close error %v, got %v", io.EOF, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec deadlocked after closeWithError")
+		}
+
+		select {
+		case <-closeDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("closeWithError deadlocked waiting for exec to release the call")
+		}
+	})
+
+	t.Run("TimeoutUnblocksAbandonRecvCall", func(t *testing.T) {
+		c, server := newTestExecConn(t, testContextWriter{})
+		defer server.Close()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := c.exec(context.Background(), frameWriterFunc(func(f *framer, streamID int) error {
+				f.buf = append(f.buf[:0], 'x')
+				return nil
+			}), nil, time.Millisecond)
+			errCh <- err
+		}()
+
+		call := waitForSingleCall(t, c)
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, ErrTimeoutNoResponse) {
+				t.Fatalf("expected timeout error %v, got %v", ErrTimeoutNoResponse, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec deadlocked waiting for timeout")
+		}
+
+		if !c.removeCallIfOpen(call.streamID) {
+			t.Fatal("expected timed out call to still be registered")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			c.abandonRecvCall(call, c.getReadFramer())
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("abandonRecvCall deadlocked after timeout")
+		}
+	})
+
+	t.Run("ContextCancelUnblocksAbandonRecvCall", func(t *testing.T) {
+		c, server := newTestExecConn(t, testContextWriter{})
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := c.exec(ctx, frameWriterFunc(func(f *framer, streamID int) error {
+				f.buf = append(f.buf[:0], 'x')
+				return nil
+			}), nil, 0)
+			errCh <- err
+		}()
+
+		call := waitForSingleCall(t, c)
+		cancel()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected context cancel error %v, got %v", context.Canceled, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec deadlocked waiting for context cancellation")
+		}
+
+		if !c.removeCallIfOpen(call.streamID) {
+			t.Fatal("expected canceled call to still be registered")
+		}
+
+		done := make(chan struct{})
+		go func() {
+			c.abandonRecvCall(call, c.getReadFramer())
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("abandonRecvCall deadlocked after context cancellation")
+		}
+	})
+
+	t.Run("ConnectionCloseAbandonsInflightStream", func(t *testing.T) {
+		writeStarted := make(chan struct{})
+		var writeStartedOnce sync.Once
+		observerCtx := newTestStreamObserverContext()
+		c, server := newTestExecConn(t, testContextWriter{
+			onWrite: func() {
+				writeStartedOnce.Do(func() {
+					close(writeStarted)
+				})
+			},
+		})
+		c.streamObserver = &testStreamObserver{ctx: observerCtx}
+		defer server.Close()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := c.exec(context.Background(), frameWriterFunc(func(f *framer, streamID int) error {
+				f.buf = append(f.buf[:0], 'x')
+				return nil
+			}), nil, 0)
+			errCh <- err
+		}()
+
+		select {
+		case <-observerCtx.started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("stream observer did not observe the request start")
+		}
+
+		select {
+		case <-writeStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec never reached the write path")
+		}
+
+		closeDone := make(chan struct{})
+		go func() {
+			c.Close()
+			close(closeDone)
+		}()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, ErrConnectionClosed) {
+				t.Fatalf("expected close error %v, got %v", ErrConnectionClosed, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("exec deadlocked after Close")
+		}
+
+		select {
+		case <-observerCtx.abandoned:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Close did not abandon the in-flight stream")
+		}
+
+		select {
+		case <-observerCtx.finished:
+			t.Fatal("Close should not mark the in-flight stream as finished")
+		default:
+		}
+
+		select {
+		case <-closeDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Close did not wait for the in-flight exec cleanup")
+		}
+
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.calls != nil {
+			t.Fatal("expected in-flight calls to be detached on Close")
+		}
+	})
 }
 
 // tcpConnPair returns a matching set of a TCP client side and server side connection.
@@ -1547,7 +2027,7 @@ func (srv *TestServer) process(conn net.Conn, reqFrame *framer, exts map[string]
 			respFrame.writeString("unsupported query: " + name)
 		}
 	case frm.OpExecute:
-		b := reqFrame.readShortBytes()
+		b := reqFrame.readShortBytesCopy()
 		id := binary.BigEndian.Uint64(b)
 		// <query_parameters>
 		reqFrame.readConsistency() // <consistency>
@@ -1712,4 +2192,284 @@ func TestUseKeyspaceQuoteEscaping(t *testing.T) {
 			t.Errorf("keyspace %q: got %q, want %q", tt.keyspace, got, tt.want)
 		}
 	}
+}
+
+// newTestConnWithFramerPool creates a minimal Conn with an initialized framer pool
+// suitable for testing releaseFramer and EWMA logic.
+func newTestConnWithFramerPool() *Conn {
+	c := &Conn{}
+	c.framerConstructor.defaults = framerConfig{
+		proto: protoVersion4 & protoVersionMask,
+	}
+	c.initFramerPool()
+	return c
+}
+
+func buildTestFrame(t *testing.T, f *framer, req frameBuilder, streamID int) ([]byte, frm.FrameHeader) {
+	t.Helper()
+
+	if err := req.buildFrame(f, streamID); err != nil {
+		t.Fatalf("buildFrame failed: %v", err)
+	}
+
+	buf := append([]byte(nil), f.buf...)
+	header, err := readHeader(bytes.NewReader(buf), make([]byte, headSize))
+	if err != nil {
+		t.Fatalf("readHeader failed: %v", err)
+	}
+
+	return buf, header
+}
+
+func TestReleaseFramer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EWMAEquilibrium", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		// Release framers with bufCap == avg. EWMA should not drift.
+		for i := 0; i < 20; i++ {
+			f := c.getReadFramer()
+			// readBuffer is defaultBufSize (128), avg starts at defaultBufSize
+			c.releaseReadFramer(f)
+		}
+
+		avg := c.framerConstructor.readPool.bufAvgSize.Load()
+		if avg != defaultBufSize {
+			t.Errorf("EWMA should stay at defaultBufSize=%d when all buffers equal, got %d", defaultBufSize, avg)
+		}
+	})
+
+	t.Run("DelegatesFramerReleaseToConn", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		f := c.getReadFramer()
+		f.readBuffer = make([]byte, 4096)
+
+		f.Release()
+
+		avgAfterFirstRelease := c.framerConstructor.readPool.bufAvgSize.Load()
+		if avgAfterFirstRelease <= defaultBufSize {
+			t.Fatalf("framer.Release() should route through Conn.releaseFramer and update EWMA, got %d", avgAfterFirstRelease)
+		}
+
+		f.Release()
+
+		if avgAfterSecondRelease := c.framerConstructor.readPool.bufAvgSize.Load(); avgAfterSecondRelease != avgAfterFirstRelease {
+			t.Fatalf("second framer.Release() should be a no-op: first avg=%d second avg=%d", avgAfterFirstRelease, avgAfterSecondRelease)
+		}
+	})
+
+	t.Run("EWMAConvergesUpward", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		// Release framers with a larger buffer; EWMA should converge toward it.
+		const targetSize = 4096
+		for i := 0; i < 100; i++ {
+			f := c.getReadFramer()
+			f.readBuffer = make([]byte, targetSize)
+			c.releaseReadFramer(f)
+		}
+
+		avg := c.framerConstructor.readPool.bufAvgSize.Load()
+		// After 100 iterations with weight=8, avg should be very close to targetSize.
+		// Allow 1% tolerance.
+		if avg < targetSize*99/100 || avg > targetSize*101/100 {
+			t.Errorf("EWMA should converge to ~%d, got %d", targetSize, avg)
+		}
+	})
+
+	t.Run("EWMAConvergesDownward", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		// First, push EWMA up.
+		for i := 0; i < 100; i++ {
+			f := c.getReadFramer()
+			f.readBuffer = make([]byte, 4096)
+			c.releaseReadFramer(f)
+		}
+
+		// Now release framers with small buffers; EWMA should converge back down.
+		// Due to upward bias (+4 rounding), convergence downward is slower.
+		const smallSize = 256
+		for i := 0; i < 200; i++ {
+			f := c.getReadFramer()
+			f.readBuffer = make([]byte, smallSize)
+			c.releaseReadFramer(f)
+		}
+
+		avg := c.framerConstructor.readPool.bufAvgSize.Load()
+		// Due to the upward-biased rounding (+framerBufEWMAWeight/2), the EWMA settles
+		// slightly above the actual sample value when converging downward. The steady-state
+		// offset is at most framerBufEWMAWeight/2 (i.e., 4) per step which compounds to
+		// roughly framerBufEWMAWeight/2 above the target. Allow generous tolerance.
+		if avg < smallSize || avg > smallSize+2*framerBufEWMAWeight {
+			t.Errorf("EWMA should converge toward ~%d (with upward bias), got %d", smallSize, avg)
+		}
+	})
+
+	t.Run("ShrinkOversizedBuffer", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		// EWMA starts at defaultBufSize (128). Release a very large framer.
+		f := c.getReadFramer()
+		f.readBuffer = make([]byte, 100000)
+		origBuf := f.readBuffer
+		c.releaseReadFramer(f)
+
+		// Get the framer back from the pool and check that its buffer was shrunk.
+		f2 := c.getReadFramer()
+		if cap(f2.readBuffer) >= cap(origBuf) {
+			t.Errorf("oversized buffer should have been shrunk: original cap=%d, new cap=%d",
+				cap(origBuf), cap(f2.readBuffer))
+		}
+		// Shrink target should be at least defaultBufSize.
+		if cap(f2.readBuffer) < defaultBufSize {
+			t.Errorf("shrunk buffer should be at least defaultBufSize=%d, got cap=%d",
+				defaultBufSize, cap(f2.readBuffer))
+		}
+		c.releaseReadFramer(f2)
+	})
+
+	t.Run("NoShrinkNormalBuffer", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		// Release a few framers with identical buffers; none should be shrunk.
+		for i := 0; i < 10; i++ {
+			f := c.getReadFramer()
+			origCap := cap(f.readBuffer)
+			c.releaseReadFramer(f)
+			f2 := c.getReadFramer()
+			if cap(f2.readBuffer) != origCap {
+				t.Errorf("iteration %d: normal-sized buffer should not be shrunk: orig cap=%d, new cap=%d",
+					i, origCap, cap(f2.readBuffer))
+			}
+			c.releaseReadFramer(f2)
+		}
+	})
+
+	t.Run("ShrinkFloorIsDefaultBufSize", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		// Push EWMA down to a very small value by releasing tiny buffers.
+		// The shrink target should never go below defaultBufSize.
+		for i := 0; i < 100; i++ {
+			f := c.getReadFramer()
+			f.readBuffer = make([]byte, 1) // Tiny buffer
+			c.releaseReadFramer(f)
+		}
+
+		// Now release a moderately large buffer that triggers shrink.
+		f := c.getReadFramer()
+		f.readBuffer = make([]byte, 10000)
+		c.releaseReadFramer(f)
+
+		f2 := c.getReadFramer()
+		if cap(f2.readBuffer) < defaultBufSize {
+			t.Errorf("shrink target should respect defaultBufSize floor: got cap=%d, want >= %d",
+				cap(f2.readBuffer), defaultBufSize)
+		}
+		c.releaseReadFramer(f2)
+	})
+
+	t.Run("NilFramer", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+		// Should not panic.
+		c.releaseReadFramer(nil)
+	})
+
+	t.Run("NoPool", func(t *testing.T) {
+		c := &Conn{} // No pool initialized.
+		f := newFramer(nil, protoVersion4)
+		// Should not panic, framer is just dropped.
+		c.releaseReadFramer(f)
+	})
+
+	t.Run("ReadAndWritePoolsAreSeparate", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+
+		readFramer := c.getReadFramer()
+		readFramer.readBuffer = make([]byte, 100000)
+		c.releaseReadFramer(readFramer)
+
+		writeFramer := c.getWriteFramer()
+		writeFramer.buf = make([]byte, 0, 8192)
+		c.releaseWriteFramer(writeFramer)
+
+		if writeAvg := c.framerConstructor.writePool.bufAvgSize.Load(); writeAvg <= defaultBufSize {
+			t.Fatalf("writer pool should track its own EWMA, got %d", writeAvg)
+		}
+
+		writeFramer = c.getWriteFramer()
+		if cap(writeFramer.buf) >= cap(readFramer.readBuffer) {
+			t.Fatalf("writer framer should not inherit oversized reader buffer state, got writer cap=%d reader cap=%d", cap(writeFramer.buf), cap(readFramer.readBuffer))
+		}
+		c.releaseWriteFramer(writeFramer)
+	})
+
+	t.Run("WriteFramerResetsCustomPayloadFlagBetweenUses", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+		const streamID = 7
+
+		f := c.getWriteFramer()
+		payloadReq := &writeQueryFrame{
+			statement: "SELECT now() FROM system.local",
+			customPayload: map[string][]byte{
+				"k": []byte("v"),
+			},
+		}
+		_, payloadHeader := buildTestFrame(t, f, payloadReq, streamID)
+		if payloadHeader.Flags&frm.FlagCustomPayload == 0 {
+			t.Fatalf("custom payload frame should set %v, got flags=%08b", frm.FlagCustomPayload, payloadHeader.Flags)
+		}
+
+		c.releaseWriteFramer(f)
+		if got, want := f.flags, c.framerConstructor.defaults.flags; got != want {
+			t.Fatalf("releaseWriteFramer should restore default flags: got %08b want %08b", got, want)
+		}
+
+		f = c.getWriteFramer()
+		plainReq := &writeQueryFrame{statement: "SELECT now() FROM system.local"}
+		plainBuf, plainHeader := buildTestFrame(t, f, plainReq, streamID)
+		if plainHeader.Flags != c.framerConstructor.defaults.flags {
+			t.Fatalf("plain query should use default flags after pooled reuse: got %08b want %08b", plainHeader.Flags, c.framerConstructor.defaults.flags)
+		}
+
+		fresh := newFramer(nil, protoVersion4)
+		freshBuf, freshHeader := buildTestFrame(t, fresh, plainReq, streamID)
+		if plainHeader.Flags != freshHeader.Flags {
+			t.Fatalf("reused plain query flags do not match fresh framer: got %08b want %08b", plainHeader.Flags, freshHeader.Flags)
+		}
+		if !bytes.Equal(plainBuf, freshBuf) {
+			t.Fatal("reused plain query frame does not match fresh framer output")
+		}
+
+		c.releaseWriteFramer(f)
+	})
+
+	t.Run("WriteFramerResetsTracingFlagBetweenUses", func(t *testing.T) {
+		c := newTestConnWithFramerPool()
+		const streamID = 9
+
+		f := c.getWriteFramer()
+		f.trace()
+		tracedReq := &writeQueryFrame{statement: "SELECT now() FROM system.local"}
+		_, tracedHeader := buildTestFrame(t, f, tracedReq, streamID)
+		if tracedHeader.Flags&frm.FlagTracing == 0 {
+			t.Fatalf("traced query should set %v, got flags=%08b", frm.FlagTracing, tracedHeader.Flags)
+		}
+
+		c.releaseWriteFramer(f)
+		if got, want := f.flags, c.framerConstructor.defaults.flags; got != want {
+			t.Fatalf("releaseWriteFramer should restore default flags: got %08b want %08b", got, want)
+		}
+
+		f = c.getWriteFramer()
+		_, plainHeader := buildTestFrame(t, f, tracedReq, streamID)
+		if plainHeader.Flags&frm.FlagTracing != 0 {
+			t.Fatalf("plain query should not inherit tracing flag after pooled reuse: got %08b", plainHeader.Flags)
+		}
+
+		c.releaseWriteFramer(f)
+	})
 }

--- a/control.go
+++ b/control.go
@@ -388,6 +388,7 @@ func (c *controlConn) registerEvents(conn *Conn) error {
 	if err != nil {
 		return err
 	}
+	defer framer.Release()
 
 	frame, err := framer.parseFrame()
 	if err != nil {
@@ -510,6 +511,15 @@ func (c *controlConn) getConn() *connHost {
 	return c.conn.Load().(*connHost)
 }
 
+// writeFrame sends frame w on the control connection and returns the parsed
+// response frame.
+//
+// NOTE: The returned frame must not retain any byte-slice references to the
+// framer's read buffer, because the framer is released back to the pool
+// immediately after parseFrame returns (via defer). Frame types that use
+// readBytesCopy (e.g. SupportedFrame, AuthChallengeFrame, AuthSuccessFrame)
+// are safe; frame types that use readBytes and expose []byte fields would not
+// be safe and must not be returned from this function.
 func (c *controlConn) writeFrame(w frameBuilder) (frame, error) {
 	ch := c.getConn()
 	if ch == nil {
@@ -520,6 +530,7 @@ func (c *controlConn) writeFrame(w frameBuilder) (frame, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer framer.Release()
 
 	return framer.parseFrame()
 }
@@ -554,6 +565,7 @@ func (c *controlConn) runQuery(qry *Query) (iter *Iter) {
 		if iter.err == nil || !c.retry.Attempt(qry) {
 			break
 		}
+		iter.finalize(true)
 	}
 
 	return

--- a/events_unit_test.go
+++ b/events_unit_test.go
@@ -1200,6 +1200,48 @@ func TestSchemaRefreshConcurrent(t *testing.T) {
 			t.Errorf("expected %d queries (single table refresh), got %d", tableRefreshCount, got)
 		}
 	})
+
+	t.Run("GetTable/stale_snapshot_after_refresh_does_not_refresh_twice", func(t *testing.T) {
+		t.Parallel()
+		ctrl := &schemaDataMock{
+			knownKeyspaces: knownKeyspaces,
+		}
+		s := newSchemaEventTestSessionWithMock(ctrl)
+		defer s.Close()
+		populateKeyspace(s, "test_ks", "tbl_a")
+
+		s.handleSchemaEvent([]frame{
+			&frm.SchemaChangeTable{Change: "UPDATED", Keyspace: "test_ks", Object: "tbl_a"},
+		})
+
+		staleKeyspace, wasReloaded, err := s.metadataDescriber.getKeyspaceInternal("test_ks")
+		if err != nil {
+			t.Fatalf("getKeyspaceInternal returned unexpected error: %v", err)
+		}
+		if _, found := staleKeyspace.Tables["tbl_a"]; found {
+			t.Fatal("expected stale keyspace snapshot to have invalidated table removed")
+		}
+
+		if err := s.metadataDescriber.deduplicatedRefreshTable("test_ks", "tbl_a"); err != nil {
+			t.Fatalf("deduplicatedRefreshTable returned unexpected error: %v", err)
+		}
+
+		ctrl.resetQueries()
+
+		tbl, refreshNeeded, err := s.metadataDescriber.getTableFromSnapshot("test_ks", "tbl_a", staleKeyspace, wasReloaded)
+		if err != nil {
+			t.Fatalf("getTableFromSnapshot returned unexpected error: %v", err)
+		}
+		if refreshNeeded {
+			t.Fatal("expected latest published keyspace metadata to suppress an extra refresh")
+		}
+		if tbl == nil || tbl.Name != "tbl_a" {
+			t.Fatalf("unexpected table metadata: %#v", tbl)
+		}
+		if got := ctrl.getQueryCount(); got != 0 {
+			t.Fatalf("expected stale snapshot lookup to avoid extra queries, got %d", got)
+		}
+	})
 }
 
 // TestConcurrentSchemaRefreshErrorHandling verifies that concurrent

--- a/frame.go
+++ b/frame.go
@@ -34,6 +34,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	frm "github.com/gocql/gocql/internal/frame"
@@ -216,32 +217,43 @@ type FrameHeaderObserver interface {
 	ObserveFrameHeader(context.Context, ObservedFrameHeader)
 }
 
+// framerInterface represents a frame reader/writer for the CQL protocol.
+//
+// Framers are pooled and reused. Any byte slices returned from frame parsing
+// methods may be backed by pooled buffers that are reused after Release() is
+// called. If data must outlive the framer, use readBytesCopy() instead of
+// readBytes() when implementing parseFrame(), or copy returned byte slices
+// before calling Release().
+//
+// After Release() is called, the framer and any slices derived from its
+// buffers must not be accessed.
 type framerInterface interface {
 	ReadBytesInternal() ([]byte, error)
 	GetCustomPayload() map[string][]byte
 	GetHeaderWarnings() []string
+	// Release returns the framer to its pool (if pooled).
+	// Must be called when the framer is no longer needed.
+	// Safe to call multiple times; subsequent calls are no-ops.
+	Release()
 }
 
 const headSize = 9
 
 // a framer is responsible for reading, writing and parsing frames on a single stream
 type framer struct {
-	compres Compressor
-	// if this frame was read then the header will be here
-	header        *frm.FrameHeader
-	customPayload map[string][]byte
-	// if tracing flag is set this is not nil
-	traceID []byte
-	// holds a ref to the whole byte slice for buf so that it can be reset to
-	// 0 after a read.
+	compressor            Compressor
+	header                *frm.FrameHeader
+	customPayload         map[string][]byte
+	release               func()
+	traceID               []byte
 	readBuffer            []byte
 	buf                   []byte
 	flagLWT               int
 	rateLimitingErrorCode int
+	flags                 byte
 	proto                 byte
-	// flags are for outgoing flags, enabling compression and tracing etc
-	flags            byte
-	tabletsRoutingV1 bool
+	tabletsRoutingV1      bool
+	released              atomic.Bool
 }
 
 func newFramer(compressor Compressor, version byte) *framer {
@@ -259,7 +271,7 @@ func newFramer(compressor Compressor, version byte) *framer {
 	}
 
 	version &= protoVersionMask
-	f.compres = compressor
+	f.compressor = compressor
 	f.proto = version
 	f.flags = flags
 	f.header = nil
@@ -268,6 +280,17 @@ func newFramer(compressor Compressor, version byte) *framer {
 	f.tabletsRoutingV1 = false
 
 	return f
+}
+
+// Release returns the framer to its pool. If the framer was not obtained
+// from a pool (release is nil), this is a no-op.
+//
+// Conn.releaseFramer owns the released-state guard, so this method delegates
+// directly to the release closure.
+func (f *framer) Release() {
+	if f.release != nil {
+		f.release()
+	}
 }
 
 func newFramerWithExts(compressor Compressor, version byte, cqlProtoExts []cqlProtocolExtension, logger StdLogger) *framer {
@@ -373,11 +396,11 @@ func (f *framer) readFrame(r io.Reader, head *frm.FrameHeader) error {
 	}
 
 	if head.Flags&frm.FlagCompress == frm.FlagCompress {
-		if f.compres == nil {
+		if f.compressor == nil {
 			return NewErrProtocol("no compressor available with compressed frame body")
 		}
 
-		f.buf, err = f.compres.Decode(f.buf)
+		f.buf, err = f.compressor.Decode(f.buf)
 		if err != nil {
 			return err
 		}
@@ -492,10 +515,9 @@ func (f *framer) parseErrorFrame() frame {
 			Table:      table,
 		}
 	case ErrCodeUnprepared:
-		stmtId := f.readShortBytes()
 		return &RequestErrUnprepared{
 			ErrorFrame:  errD,
-			StatementId: copyBytes(stmtId), // defensively copy
+			StatementId: f.readShortBytesCopy(),
 		}
 	case ErrCodeReadFailure:
 		res := &RequestErrReadFailure{
@@ -604,12 +626,12 @@ func (f *framer) finish() error {
 	}
 
 	if f.buf[1]&frm.FlagCompress == frm.FlagCompress {
-		if f.compres == nil {
+		if f.compressor == nil {
 			panic("compress flag set with no compressor")
 		}
 
 		// TODO: only compress frames which are big enough
-		compressed, err := f.compres.Encode(f.buf[headSize:])
+		compressed, err := f.compressor.Encode(f.buf[headSize:])
 		if err != nil {
 			return err
 		}
@@ -1065,7 +1087,7 @@ type resultPreparedFrame struct {
 func (f *framer) parseResultPrepared() frame {
 	frame := &resultPreparedFrame{
 		FrameHeader: *f.header,
-		preparedID:  f.readShortBytes(),
+		preparedID:  f.readShortBytesCopy(),
 		reqMeta:     f.parsePreparedMetadata(),
 	}
 
@@ -1131,14 +1153,14 @@ func (f *framer) parseAuthenticateFrame() frame {
 func (f *framer) parseAuthSuccessFrame() frame {
 	return &frm.AuthSuccessFrame{
 		FrameHeader: *f.header,
-		Data:        f.readBytes(),
+		Data:        f.readBytesCopy(),
 	}
 }
 
 func (f *framer) parseAuthChallengeFrame() frame {
 	return &frm.AuthChallengeFrame{
 		FrameHeader: *f.header,
-		Data:        f.readBytes(),
+		Data:        f.readBytesCopy(),
 	}
 }
 
@@ -1580,22 +1602,6 @@ func (f *framer) ReadBytesInternal() ([]byte, error) {
 	return l, nil
 }
 
-func (f *framer) readBytes() []byte {
-	size := f.readInt()
-	if size < 0 {
-		return nil
-	}
-
-	if len(f.buf) < size {
-		panic(fmt.Errorf("not enough bytes in buffer to read bytes require %d got: %d", size, len(f.buf)))
-	}
-
-	l := f.buf[:size]
-	f.buf = f.buf[size:]
-
-	return l
-}
-
 func (f *framer) readBytesCopy() []byte {
 	size := f.readInt()
 	if size < 0 {
@@ -1612,16 +1618,17 @@ func (f *framer) readBytesCopy() []byte {
 	return out
 }
 
-func (f *framer) readShortBytes() []byte {
+func (f *framer) readShortBytesCopy() []byte {
 	size := f.readShort()
 	if len(f.buf) < int(size) {
 		panic(fmt.Errorf("not enough bytes in buffer to read short bytes: require %d got %d", size, len(f.buf)))
 	}
 
-	l := f.buf[:size]
+	out := make([]byte, size)
+	copy(out, f.buf[:size])
 	f.buf = f.buf[size:]
 
-	return l
+	return out
 }
 
 func (f *framer) readInetAdressOnly() net.IP {

--- a/framer.go
+++ b/framer.go
@@ -73,7 +73,7 @@ const maxCASRetries = 100
 // initFramerCache precomputes framer fields from cqlProtoExts so that
 // per-query framer creation avoids repeated linear scans and allocations.
 func (c *Conn) initFramerCache() {
-	c.framerConstructor.initCache(c)
+	c.framers.initCache(c)
 }
 
 func (cf *connFramers) initCache(c *Conn) {
@@ -113,13 +113,6 @@ func (cf *connFramers) initCache(c *Conn) {
 	cf.initPool(c)
 }
 
-// initFramerPool initializes the per-connection framer pool.
-// Framers created by the pool are pre-populated with the connection's
-// cached defaults so getFramer only needs to reset per-request fields.
-func (c *Conn) initFramerPool() {
-	c.framerConstructor.initPool(c)
-}
-
 func (cf *connFramers) initPool(c *Conn) {
 	defaults := cf.defaults
 	cf.readPool.init(defaults, func(f *framer) { c.releaseReadFramer(f) })
@@ -128,7 +121,7 @@ func (cf *connFramers) initPool(c *Conn) {
 
 // getReadFramer returns a pooled framer for reading responses and events.
 func (c *Conn) getReadFramer() *framer {
-	return c.framerConstructor.getRead(c)
+	return c.framers.getRead(c)
 }
 
 func (cf *connFramers) getRead(c *Conn) *framer {
@@ -139,7 +132,7 @@ func (cf *connFramers) getRead(c *Conn) *framer {
 
 // getWriteFramer returns a pooled framer for building outgoing requests.
 func (c *Conn) getWriteFramer() *framer {
-	return c.framerConstructor.getWrite(c)
+	return c.framers.getWrite(c)
 }
 
 func (cf *connFramers) getWrite(c *Conn) *framer {
@@ -151,7 +144,7 @@ func (cf *connFramers) getWrite(c *Conn) *framer {
 
 // releaseReadFramer returns a response/event framer to the reader pool.
 func (c *Conn) releaseReadFramer(f *framer) {
-	c.framerConstructor.releaseRead(c, f)
+	c.framers.releaseRead(c, f)
 }
 
 func (cf *connFramers) releaseRead(c *Conn, f *framer) {
@@ -179,7 +172,7 @@ func (cf *connFramers) releaseRead(c *Conn, f *framer) {
 
 // releaseWriteFramer returns a request-builder framer to the writer pool.
 func (c *Conn) releaseWriteFramer(f *framer) {
-	c.framerConstructor.releaseWrite(f)
+	c.framers.releaseWrite(f)
 }
 
 func (cf *connFramers) releaseWrite(f *framer) {

--- a/framer.go
+++ b/framer.go
@@ -113,7 +113,7 @@ func (cf *connFramers) initCache(c *Conn) {
 	cf.initPool(c)
 }
 
-// initFramerPool initializes the per-c-onnection framer pool.
+// initFramerPool initializes the per-connection framer pool.
 // Framers created by the pool are pre-populated with the connection's
 // cached defaults so getFramer only needs to reset per-request fields.
 func (c *Conn) initFramerPool() {

--- a/framer.go
+++ b/framer.go
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2026 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"sync"
+	"sync/atomic"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+// framerPool owns one sync.Pool plus the adaptive buffer-sizing state for one
+// framer usage class.
+type framerPool struct {
+	pool       sync.Pool
+	bufAvgSize atomic.Int64
+	enabled    atomic.Bool
+}
+
+// connFramers owns connection-scoped framer configuration and reader/writer pools.
+type connFramers struct {
+	readPool  framerPool
+	writePool framerPool
+	defaults  framerConfig
+}
+
+// framerConfig holds precomputed default framer parameters for the connection.
+// Populated once during connection setup and used to initialize framers from the pool.
+type framerConfig struct {
+	compressor            Compressor
+	flagLWT               int
+	rateLimitingErrorCode int
+	proto                 byte
+	flags                 byte
+	tabletsRoutingV1      bool
+}
+
+// framerBufEWMAWeight controls how quickly the exponential weighted moving average
+// of framer buffer sizes adapts. A value of 8 means each sample contributes ~12.5%,
+// so it takes roughly 8 samples to converge to a new steady state.
+//
+// Lower values (e.g., 4) adapt faster but are more sensitive to outliers.
+// Higher values (e.g., 16) are more stable but adapt slower to workload changes.
+// The value 8 was chosen as a reasonable balance for typical CQL query patterns.
+const framerBufEWMAWeight = 8
+
+// framerBufShrinkThreshold is the multiplier applied to the EWMA to decide when a
+// framer's read buffer is too large relative to typical usage and should be shrunk.
+const framerBufShrinkThreshold = 2
+
+// maxReasonableBufferSize is a safety limit to prevent overflow in EWMA calculations
+// and to catch pathological cases where buffers grow unreasonably large.
+const maxReasonableBufferSize = 512 * 1024 * 1024 // 512MB
+
+// maxCASRetries is the maximum number of CAS retries for updating EWMA.
+// This prevents infinite loops under extreme contention.
+const maxCASRetries = 100
+
+// initFramerCache precomputes framer fields from cqlProtoExts so that
+// per-query framer creation avoids repeated linear scans and allocations.
+func (c *Conn) initFramerCache() {
+	c.framerConstructor.initCache(c)
+}
+
+func (cf *connFramers) initCache(c *Conn) {
+	cfg := framerConfig{
+		compressor: c.compressor,
+		proto:      c.version & protoVersionMask,
+	}
+	if c.compressor != nil {
+		cfg.flags |= frm.FlagCompress
+	}
+	if c.version == protoVersion5 {
+		cfg.flags |= frm.FlagBetaProtocol
+	}
+	if lwtExt := findCQLProtoExtByName(c.cqlProtoExts, lwtAddMetadataMarkKey); lwtExt != nil {
+		if castedExt, ok := lwtExt.(*lwtAddMetadataMarkExt); ok {
+			cfg.flagLWT = castedExt.lwtOptMetaBitMask
+		} else {
+			c.logger.Printf("gocql: failed to cast CQL protocol extension %s to %T", lwtAddMetadataMarkKey, lwtAddMetadataMarkExt{})
+		}
+	}
+	if rateLimitErrorExt := findCQLProtoExtByName(c.cqlProtoExts, rateLimitError); rateLimitErrorExt != nil {
+		if castedExt, ok := rateLimitErrorExt.(*rateLimitExt); ok {
+			cfg.rateLimitingErrorCode = castedExt.rateLimitErrorCode
+		} else {
+			c.logger.Printf("gocql: failed to cast CQL protocol extension %s to %T", rateLimitError, rateLimitExt{})
+		}
+	}
+	if tabletsExt := findCQLProtoExtByName(c.cqlProtoExts, tabletsRoutingV1); tabletsExt != nil {
+		if _, ok := tabletsExt.(*tabletsRoutingV1Ext); ok {
+			cfg.tabletsRoutingV1 = true
+		} else {
+			c.logger.Printf("gocql: failed to cast CQL protocol extension %s to %T", tabletsRoutingV1, tabletsRoutingV1Ext{})
+		}
+	}
+	cf.defaults = cfg
+	c.setTabletSupported(cfg.tabletsRoutingV1)
+	cf.initPool(c)
+}
+
+// initFramerPool initializes the per-c-onnection framer pool.
+// Framers created by the pool are pre-populated with the connection's
+// cached defaults so getFramer only needs to reset per-request fields.
+func (c *Conn) initFramerPool() {
+	c.framerConstructor.initPool(c)
+}
+
+func (cf *connFramers) initPool(c *Conn) {
+	defaults := cf.defaults
+	cf.readPool.init(defaults, func(f *framer) { c.releaseReadFramer(f) })
+	cf.writePool.init(defaults, func(f *framer) { c.releaseWriteFramer(f) })
+}
+
+// getReadFramer returns a pooled framer for reading responses and events.
+func (c *Conn) getReadFramer() *framer {
+	return c.framerConstructor.getRead(c)
+}
+
+func (cf *connFramers) getRead(c *Conn) *framer {
+	f := cf.readPool.get(c)
+	f.released.Store(false)
+	return f
+}
+
+// getWriteFramer returns a pooled framer for building outgoing requests.
+func (c *Conn) getWriteFramer() *framer {
+	return c.framerConstructor.getWrite(c)
+}
+
+func (cf *connFramers) getWrite(c *Conn) *framer {
+	f := cf.writePool.get(c)
+	f.released.Store(false)
+	f.flags = cf.defaults.flags
+	return f
+}
+
+// releaseReadFramer returns a response/event framer to the reader pool.
+func (c *Conn) releaseReadFramer(f *framer) {
+	c.framerConstructor.releaseRead(c, f)
+}
+
+func (cf *connFramers) releaseRead(c *Conn, f *framer) {
+	if f == nil {
+		return
+	}
+	if f.released.Swap(true) {
+		return // already released
+	}
+	f.header = nil
+	f.traceID = nil
+	f.customPayload = nil
+	if !cf.readPool.enabled.Load() {
+		return
+	}
+
+	bufCap := int64(cap(f.readBuffer))
+	newAvg, success := cf.readPool.updateAvg(c.logger, bufCap)
+	if !success {
+		cf.readPool.resetAndPut(f, false, 0)
+		return
+	}
+	cf.readPool.resetAndPut(f, true, fpShrinkSize(bufCap, newAvg))
+}
+
+// releaseWriteFramer returns a request-builder framer to the writer pool.
+func (c *Conn) releaseWriteFramer(f *framer) {
+	c.framerConstructor.releaseWrite(f)
+}
+
+func (cf *connFramers) releaseWrite(f *framer) {
+	if f == nil {
+		return
+	}
+	if f.released.Swap(true) {
+		return
+	}
+	f.header = nil
+	f.traceID = nil
+	f.customPayload = nil
+	f.flags = cf.defaults.flags
+	if !cf.writePool.enabled.Load() {
+		return
+	}
+	bufCap := int64(cap(f.buf))
+	newAvg, success := cf.writePool.updateAvg(nil, bufCap)
+	if !success {
+		cf.writePool.resetAndPut(f, false, 0)
+		return
+	}
+	cf.writePool.resetAndPut(f, false, fpShrinkSize(bufCap, newAvg))
+}
+
+func (cf *connFramers) close() {
+	cf.readPool.close()
+	cf.writePool.close()
+}
+
+func (fp *framerPool) init(defaults framerConfig, release func(*framer)) {
+	fp.bufAvgSize.Store(int64(defaultBufSize))
+	fp.enabled.Store(true)
+	fp.pool = sync.Pool{
+		New: func() interface{} {
+			buf := make([]byte, defaultBufSize)
+			f := &framer{
+				buf:                   buf[:0],
+				readBuffer:            buf,
+				compressor:            defaults.compressor,
+				proto:                 defaults.proto,
+				flags:                 defaults.flags,
+				flagLWT:               defaults.flagLWT,
+				rateLimitingErrorCode: defaults.rateLimitingErrorCode,
+				tabletsRoutingV1:      defaults.tabletsRoutingV1,
+			}
+			f.release = func() { release(f) }
+			return f
+		},
+	}
+}
+
+func (fp *framerPool) get(c *Conn) *framer {
+	if !fp.enabled.Load() {
+		return newFramer(c.compressor, c.version)
+	}
+	return fp.pool.Get().(*framer)
+}
+
+func (fp *framerPool) put(f *framer) {
+	if !fp.enabled.Load() {
+		return
+	}
+	fp.pool.Put(f)
+}
+
+func (fp *framerPool) close() {
+	fp.enabled.Store(false)
+}
+
+func (fp *framerPool) updateAvg(logger StdLogger, bufCap int64) (int64, bool) {
+	if bufCap > maxReasonableBufferSize {
+		bufCap = maxReasonableBufferSize
+	}
+	if bufCap < 0 {
+		bufCap = defaultBufSize
+	}
+
+	for i := 0; i < maxCASRetries; i++ {
+		avg := fp.bufAvgSize.Load()
+		// EWMA update with upward-biased rounding: the +framerBufEWMAWeight/2 term
+		// biases the integer division toward ceiling for all deltas. This means:
+		// - When bufCap > avg (growth): the average increases slightly faster
+		// - When bufCap < avg (shrink): the average decreases slightly slower
+		// Both effects are intentional — favoring larger buffers reduces
+		// reallocation churn at the cost of slightly more memory.
+		// In practice, this means the steady-state EWMA settles ~framerBufEWMAWeight/2
+		// bytes above the true average when tracking decreasing buffer sizes.
+		newAvg := avg + (bufCap-avg+framerBufEWMAWeight/2)/framerBufEWMAWeight
+		if fp.bufAvgSize.CompareAndSwap(avg, newAvg) {
+			return newAvg, true
+		}
+	}
+
+	if logger != nil {
+		logger.Printf("gocql: EWMA update failed after %d retries, skipping shrink decision", maxCASRetries)
+	}
+	return fp.bufAvgSize.Load(), false
+}
+
+func fpShrinkSize(bufCap, newAvg int64) int64 {
+	// If this framer's buffer is much larger than the running average,
+	// reallocate it to prevent a single large query from permanently
+	// bloating all pooled framers.
+	if bufCap <= newAvg*framerBufShrinkThreshold {
+		return 0
+	}
+	if newAvg < defaultBufSize {
+		return defaultBufSize
+	}
+	return newAvg
+}
+
+func (fp *framerPool) resetAndPut(f *framer, alignBufWithReadBuffer bool, shrinkSize int64) {
+	if shrinkSize > 0 {
+		buf := make([]byte, shrinkSize)
+		f.readBuffer = buf
+		f.buf = buf[:0]
+		fp.put(f)
+		return
+	}
+	if alignBufWithReadBuffer {
+		f.buf = f.readBuffer[:0]
+	} else {
+		f.buf = f.buf[:0]
+	}
+	fp.put(f)
+}

--- a/helpers.go
+++ b/helpers.go
@@ -438,9 +438,12 @@ func (iter *Iter) rowMap() (map[string]interface{}, error) {
 	return m, nil
 }
 
-// SliceMap is a helper function to make the API easier to use
-// returns the data from the query in the form of []map[string]interface{}
+// SliceMap is a helper function to make the API easier to use.
+// It consumes the remaining rows, closes the iterator, and returns the data
+// in the form of []map[string]interface{}.
 func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
+	defer iter.Close()
+
 	if iter.err != nil {
 		return nil, iter.err
 	}
@@ -481,6 +484,9 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 //			fmt.Printf("Full Name: %s\n", fullname)
 //		}
 //	}
+//	if err := iter.Close(); err != nil {
+//		return err
+//	}
 //
 // You can also pass pointers in the map before each call
 //
@@ -499,6 +505,9 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 //			break
 //		}
 //		fmt.Printf("First: %s Age: %d Address: %q\n", fullName.FirstName, age, address)
+//	}
+//	if err := iter.Close(); err != nil {
+//		return err
 //	}
 func (iter *Iter) MapScan(m map[string]interface{}) bool {
 	if iter.err != nil {

--- a/host_source.go
+++ b/host_source.go
@@ -599,6 +599,10 @@ func (h *HostInfo) getTranslatedConnectionInfo() *translatedAddresses {
 // Returns true if we are using system_schema.keyspaces instead of system.schema_keyspaces
 func checkSystemSchema(control controlConnection) (bool, error) {
 	iter := control.querySystem("SELECT * FROM system_schema.keyspaces")
+	if iter == nil {
+		return false, errNoControl
+	}
+	defer iter.Close()
 	if err := iter.err; err != nil {
 		if errf, ok := err.(*frm.ErrorFrame); ok {
 			if errf.Code == ErrCodeSyntax {
@@ -737,6 +741,8 @@ func hostInfoFromMap(row map[string]interface{}, defaultPort int) (*HostInfo, er
 }
 
 func hostInfoFromIter(iter *Iter, defaultPort int) (*HostInfo, error) {
+	defer iter.Close()
+
 	rows, err := iter.SliceMap()
 	if err != nil {
 		// TODO(zariel): make typed error

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -30,7 +30,33 @@ package gocql
 import (
 	"net"
 	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
+	"github.com/gocql/gocql/internal/tests/mock"
 )
+
+type trackingMockFramer struct {
+	mock.MockFramer
+	released bool
+}
+
+func (f *trackingMockFramer) Release() {
+	f.released = true
+}
+
+type systemSchemaTestControl struct {
+	iter *Iter
+}
+
+func (*systemSchemaTestControl) getConn() *connHost                                { return nil }
+func (*systemSchemaTestControl) awaitSchemaAgreement() error                       { return nil }
+func (*systemSchemaTestControl) query(string, ...interface{}) (iter *Iter)         { return nil }
+func (c *systemSchemaTestControl) querySystem(string, ...interface{}) (iter *Iter) { return c.iter }
+func (*systemSchemaTestControl) discoverProtocol([]*HostInfo) (int, error)         { return 0, nil }
+func (*systemSchemaTestControl) connect([]*HostInfo) error                         { return nil }
+func (*systemSchemaTestControl) close()                                            {}
+func (*systemSchemaTestControl) getSession() *Session                              { return nil }
+func (*systemSchemaTestControl) reconnect() error                                  { return nil }
 
 func TestUnmarshalCassVersion(t *testing.T) {
 	t.Parallel()
@@ -124,6 +150,98 @@ func TestIsZeroToken(t *testing.T) {
 	host.tokens = []string{}
 	if !isZeroToken(host) {
 		t.Errorf("expected %+v to be a zero-token host", host)
+	}
+}
+
+func TestCheckSystemSchemaClosesIter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NilIterReturnsNoControl", func(t *testing.T) {
+		ok, err := checkSystemSchema(&systemSchemaTestControl{})
+		if err != errNoControl {
+			t.Fatalf("expected errNoControl, got %v", err)
+		}
+		if ok {
+			t.Fatal("expected system schema v2 detection to fail without a control iterator")
+		}
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		framer := &trackingMockFramer{}
+		ok, err := checkSystemSchema(&systemSchemaTestControl{
+			iter: &Iter{framer: framer},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected system schema v2 detection to succeed")
+		}
+		if !framer.released {
+			t.Fatal("expected iterator framer to be released")
+		}
+	})
+
+	t.Run("SyntaxError", func(t *testing.T) {
+		framer := &trackingMockFramer{}
+		ok, err := checkSystemSchema(&systemSchemaTestControl{
+			iter: &Iter{
+				err:    &frm.ErrorFrame{Code: ErrCodeSyntax},
+				framer: framer,
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ok {
+			t.Fatal("expected schema v2 detection to fall back on syntax error")
+		}
+		if !framer.released {
+			t.Fatal("expected iterator framer to be released")
+		}
+	})
+}
+
+func TestHostInfoFromIterClosesIter(t *testing.T) {
+	t.Parallel()
+
+	row := []interface{}{
+		"local",
+		"COMPLETED",
+		net.IPv4(192, 168, 100, 12),
+		"cluster",
+		"3.3.1",
+		"datacenter1",
+		1733834239,
+		ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"),
+		net.IPv4(192, 168, 100, 12),
+		"4",
+		"org.apache.cassandra.dht.Murmur3Partitioner",
+		"rack1",
+		"3.0.8",
+		net.IPv4(192, 168, 100, 12),
+		ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"),
+		"",
+		[]string{"1"},
+		map[UUID]byte{},
+	}
+	framer := &trackingMockFramer{
+		MockFramer: mock.MockFramer{Data: marshalMetadataMust(systemLocalResultMetadata, row)},
+	}
+
+	host, err := hostInfoFromIter(&Iter{
+		meta:    systemLocalResultMetadata,
+		framer:  framer,
+		numRows: 1,
+	}, 9042)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if host == nil {
+		t.Fatal("expected host info")
+	}
+	if !framer.released {
+		t.Fatal("expected iterator framer to be released")
 	}
 }
 

--- a/internal/tests/mock/mock_framer.go
+++ b/internal/tests/mock/mock_framer.go
@@ -15,3 +15,4 @@ func (m *MockFramer) ReadBytesInternal() ([]byte, error) {
 
 func (*MockFramer) GetCustomPayload() map[string][]byte { return map[string][]byte{} }
 func (*MockFramer) GetHeaderWarnings() []string         { return []string{} }
+func (*MockFramer) Release()                            {}

--- a/marshal.go
+++ b/marshal.go
@@ -99,6 +99,11 @@ func (m DirectMarshal) MarshalCQL(_ TypeInfo) ([]byte, error) {
 //  1. When <value_len> is 'nil' gocql feeds nil to 'data []byte'
 //  2. When <value_len> is 'zero' gocql feeds []byte{} to 'data []byte'
 //
+// The data []byte slice passed to UnmarshalCQL is only valid for the duration
+// of the call. The backing memory may be reused after the call returns.
+// Implementations that need to retain data must copy it (e.g. using
+// bytes.Clone or append([]byte(nil), data...)).
+//
 // Some CQL databases have proprietary value coding features, which you may want to consider.
 // CQL binary protocol info:https://github.com/apache/cassandra/tree/trunk/doc
 type Unmarshaler interface {
@@ -1506,6 +1511,10 @@ type UDTUnmarshaler interface {
 	// UnmarshalUDT will be called for each field in the UDT return by Cassandra,
 	// the implementor should unmarshal the data into the value of their chosing,
 	// for example by calling Unmarshal.
+	//
+	// The data []byte slice is only valid for the duration of the call.
+	// The backing memory may be reused after the call returns.
+	// Implementations that need to retain data must copy it.
 	UnmarshalUDT(name string, info TypeInfo, data []byte) error
 }
 

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -576,23 +576,53 @@ func (s *metadataDescriber) GetKeyspace(keyspaceName string) (*KeyspaceMetadata,
 	return metadata, err
 }
 
+func tableNotFoundError(keyspaceName, tableName string) error {
+	return fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
+}
+
+// getTableFromSnapshot resolves a table lookup against a keyspace snapshot.
+// It re-reads the latest published keyspace metadata before deciding that an
+// invalidated table still needs a refresh, which avoids duplicate refreshes
+// for callers holding a stale snapshot.
+func (s *metadataDescriber) getTableFromSnapshot(
+	keyspaceName, tableName string,
+	keyspaceMetadata *KeyspaceMetadata,
+	wasReloaded bool,
+) (tableMetadata *TableMetadata, refreshNeeded bool, err error) {
+	if tableMetadata, found := keyspaceMetadata.Tables[tableName]; found {
+		return tableMetadata, false, nil
+	}
+
+	if latestMetadata, found := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName); found && latestMetadata != keyspaceMetadata {
+		keyspaceMetadata = latestMetadata
+		if tableMetadata, found := keyspaceMetadata.Tables[tableName]; found {
+			return tableMetadata, false, nil
+		}
+	}
+
+	if wasReloaded {
+		return nil, false, tableNotFoundError(keyspaceName, tableName)
+	}
+
+	if _, ok := keyspaceMetadata.tablesInvalidated[tableName]; !ok {
+		return nil, false, tableNotFoundError(keyspaceName, tableName)
+	}
+
+	return nil, true, nil
+}
+
 func (s *metadataDescriber) GetTable(keyspaceName, tableName string) (*TableMetadata, error) {
 	keyspaceMetadata, wasReloaded, err := s.getKeyspaceInternal(keyspaceName)
 	if err != nil {
 		return nil, err
 	}
 
-	tableMetadata, found := keyspaceMetadata.Tables[tableName]
-	if found {
+	tableMetadata, refreshNeeded, err := s.getTableFromSnapshot(keyspaceName, tableName, keyspaceMetadata, wasReloaded)
+	if err != nil {
+		return nil, err
+	}
+	if !refreshNeeded {
 		return tableMetadata, nil
-	}
-
-	if wasReloaded {
-		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
-	}
-
-	if _, ok := keyspaceMetadata.tablesInvalidated[tableName]; !ok {
-		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
 	}
 
 	err = s.deduplicatedRefreshTable(keyspaceName, tableName)
@@ -600,14 +630,14 @@ func (s *metadataDescriber) GetTable(keyspaceName, tableName string) (*TableMeta
 		return nil, err
 	}
 
-	keyspaceMetadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+	keyspaceMetadata, found := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
 	if !found {
-		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
+		return nil, tableNotFoundError(keyspaceName, tableName)
 	}
 
 	tableMetadata, found = keyspaceMetadata.Tables[tableName]
 	if !found {
-		return nil, fmt.Errorf("table %s.%s: %w", keyspaceName, tableName, ErrNotFound)
+		return nil, tableNotFoundError(keyspaceName, tableName)
 	}
 
 	return tableMetadata, nil
@@ -1110,6 +1140,7 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 
 	iter := session.control.querySystem(stmt, keyspaceName)
 	if iter.NumRows() == 0 {
+		iter.Close()
 		return nil, ErrKeyspaceDoesNotExist
 	}
 	iter.Scan(&keyspace.DurableWrites, &replication)

--- a/metadata_scylla_test.go
+++ b/metadata_scylla_test.go
@@ -11,6 +11,27 @@ import (
 	"testing"
 )
 
+func TestGetKeyspaceMetadataMissingKeyspaceClosesIter(t *testing.T) {
+	t.Parallel()
+
+	framer := &trackingMockFramer{}
+	session := &Session{
+		useSystemSchema: true,
+		control: &systemSchemaTestControl{
+			iter: &Iter{framer: framer},
+		},
+	}
+
+	_, err := getKeyspaceMetadata(session, "missing_keyspace")
+
+	if err != ErrKeyspaceDoesNotExist {
+		t.Fatalf("getKeyspaceMetadata() error = %v, want %v", err, ErrKeyspaceDoesNotExist)
+	}
+	if !framer.released {
+		t.Fatal("expected iterator framer to be released on missing keyspace")
+	}
+}
+
 // Tests metadata "compilation" from example data which might be returned
 // from metadata schema queries (see getKeyspaceMetadata, getTableMetadata, and getColumnMetadata)
 func TestCompileMetadata(t *testing.T) {

--- a/query_executor.go
+++ b/query_executor.go
@@ -253,11 +253,13 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 		// If query is unsuccessful, check the error with RetryPolicy to retry
 		switch retryType {
 		case Retry:
+			iter.finalize(true)
 			// retry on the same host
 			continue
 		case Rethrow, Ignore:
 			return iter
 		case RetryNextHost:
+			iter.finalize(true)
 			// retry on the next host
 			selectedHost = hostIter()
 			continue
@@ -273,9 +275,11 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 }
 
 func (q *queryExecutor) run(ctx context.Context, qry ExecutableQuery, hostIter NextHost, results chan<- *Iter) {
+	iter := q.do(ctx, qry, hostIter)
 	select {
-	case results <- q.do(ctx, qry, hostIter):
+	case results <- iter:
 	case <-ctx.Done():
+		iter.discard()
 	}
 	qry.releaseAfterExecution()
 }

--- a/ring_describer.go
+++ b/ring_describer.go
@@ -55,6 +55,7 @@ func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo, c ConnInterface)
 	if iter == nil {
 		return nil, errNoControl
 	}
+	defer iter.Close()
 
 	rows, err := iter.SliceMap()
 	if err != nil {

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -328,6 +328,26 @@ func marshalMetadataMust(metadata resultMetadata, data []interface{}) [][]byte {
 	return res
 }
 
+type trackingRingConnection struct {
+	iter     *Iter
+	schemaV2 bool
+}
+
+func (*trackingRingConnection) Close() {}
+func (*trackingRingConnection) exec(context.Context, frameBuilder, Tracer, time.Duration) (*framer, error) {
+	return nil, nil
+}
+func (*trackingRingConnection) awaitSchemaAgreement(context.Context) error { return nil }
+func (*trackingRingConnection) executeQuery(context.Context, *Query) *Iter { return nil }
+func (c *trackingRingConnection) querySystem(context.Context, string, ...interface{}) *Iter {
+	return c.iter
+}
+func (c *trackingRingConnection) getIsSchemaV2() bool { return c.schemaV2 }
+func (*trackingRingConnection) setSchemaV2(bool)      {}
+func (*trackingRingConnection) getScyllaSupported() ScyllaConnectionFeatures {
+	return ScyllaConnectionFeatures{}
+}
+
 func TestMockGetHostsFromSystem(t *testing.T) {
 	t.Parallel()
 
@@ -341,6 +361,44 @@ func TestMockGetHostsFromSystem(t *testing.T) {
 	// local host and one of the peers are zero token so only one peer should be returned with 2 tokens
 	tests.AssertEqual(t, "hosts length", 1, len(hosts))
 	tests.AssertEqual(t, "host token length", 2, len(hosts[0].tokens))
+}
+
+func TestRingDescriberGetClusterPeerInfoClosesIter(t *testing.T) {
+	t.Parallel()
+
+	row := []interface{}{
+		net.IPv4(192, 168, 100, 13),
+		"datacenter1",
+		ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"),
+		net.IP{},
+		"rack1",
+		"3.0.8",
+		net.IPv4(192, 168, 100, 13),
+		ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"),
+		"",
+		[]string{"-1032311531684407545"},
+	}
+	framer := &trackingMockFramer{
+		MockFramer: mock.MockFramer{Data: marshalMetadataMust(systemPeersResultMetadata, row)},
+	}
+	r := &ringDescriber{cfg: &ClusterConfig{}}
+
+	peers, err := r.getClusterPeerInfo(&HostInfo{}, &trackingRingConnection{
+		iter: &Iter{
+			meta:    systemPeersResultMetadata,
+			framer:  framer,
+			numRows: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(peers))
+	}
+	if !framer.released {
+		t.Fatal("expected iterator framer to be released")
+	}
 }
 
 func TestRing_AddHostIfMissing_Missing(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -29,7 +29,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1188,14 +1190,17 @@ func (qm *queryMetrics) attempt(addAttempts int, addLatency time.Duration,
 
 // Query represents a CQL statement that can be executed.
 type Query struct {
-	trace    Tracer
-	context  context.Context
-	spec     SpeculativeExecutionPolicy
-	rt       RetryPolicy
-	conn     ConnInterface
-	observer QueryObserver
-	metrics  *queryMetrics
-	session  *Session
+	trace   Tracer
+	context context.Context
+	// pageContextParent keeps paging fetch contexts anchored to the original
+	// query context instead of chaining each page under the previous page fetch.
+	pageContextParent context.Context
+	spec              SpeculativeExecutionPolicy
+	rt                RetryPolicy
+	conn              ConnInterface
+	observer          QueryObserver
+	metrics           *queryMetrics
+	session           *Session
 	// Timeout on waiting for response from server
 	customPayload map[string][]byte
 	// getKeyspace is field so that it can be overriden in tests
@@ -1211,18 +1216,19 @@ type Query struct {
 	values     []interface{}
 	pageState  []byte
 	// requestTimeout is a timeout on waiting for response from server
-	requestTimeout        time.Duration
-	defaultTimestampValue int64
-	prefetch              float64
-	pageSize              int
-	refCount              uint32
-	cons                  Consistency
-	serialCons            Consistency
-	disableAutoPage       bool
-	idempotent            bool
-	skipPrepare           bool
-	disableSkipMetadata   bool
-	defaultTimestamp      bool
+	requestTimeout             time.Duration
+	defaultTimestampValue      int64
+	prefetch                   float64
+	pageSize                   int
+	refCount                   uint32
+	cons                       Consistency
+	serialCons                 Consistency
+	disableAutoPage            bool
+	deferReleasedErrorFinalize bool
+	idempotent                 bool
+	skipPrepare                bool
+	disableSkipMetadata        bool
+	defaultTimestamp           bool
 	// prepareCache caches whether shouldPrepare has been computed.
 	// Since q.stmt is immutable after construction, the result never
 	// changes. Accessed atomically because speculative execution may
@@ -1719,12 +1725,32 @@ func (q *Query) Iter() *Iter {
 	}
 
 	// Retry on empty page if pagination is manual
-	iter := q.executeQuery()
+	iter := q.executeQueryForIterPostProcessing()
+	var hiddenWarnings []string
 	for iter.err == nil && iter.numRows == 0 && !iter.LastPage() {
-		q.PageState(iter.PageState())
-		iter = q.executeQuery()
+		if warnings := iter.Warnings(); len(warnings) > 0 {
+			hiddenWarnings = append(hiddenWarnings, warnings...)
+		}
+		ps := iter.PageState()
+		iter.discard()
+		q.PageState(ps)
+		iter = q.executeQueryForIterPostProcessing()
+	}
+	if len(hiddenWarnings) > 0 {
+		iter.allWarnings = append(hiddenWarnings, iter.allWarnings...)
+	}
+	if iter.err != nil && iter.framer == nil && iter.next == nil {
+		iter.finalize(true)
 	}
 	return iter
+}
+
+func (q *Query) executeQueryForIterPostProcessing() (iter *Iter) {
+	q.deferReleasedErrorFinalize = true
+	defer func() {
+		q.deferReleasedErrorFinalize = false
+	}()
+	return q.executeQuery()
 }
 
 func (q *Query) executeQuery() *Iter {
@@ -1745,6 +1771,7 @@ func (q *Query) executeQuery() *Iter {
 func (q *Query) MapScan(m map[string]interface{}) error {
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
+		iter.Close()
 		return err
 	}
 	iter.MapScan(m)
@@ -1757,6 +1784,7 @@ func (q *Query) MapScan(m map[string]interface{}) error {
 func (q *Query) Scan(dest ...interface{}) error {
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
+		iter.Close()
 		return err
 	}
 	iter.Scan(dest...)
@@ -1775,6 +1803,7 @@ func (q *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 	q.disableSkipMetadata = true
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
+		iter.Close()
 		return false, err
 	}
 	if len(iter.Columns()) > 1 {
@@ -1798,11 +1827,12 @@ func (q *Query) MapScanCAS(dest map[string]interface{}) (applied bool, err error
 	q.disableSkipMetadata = true
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
+		iter.Close()
 		return false, err
 	}
 	iter.MapScan(dest)
 	if iter.err != nil {
-		return false, iter.err
+		return false, iter.Close()
 	}
 	// check if [applied] was returned, otherwise it might not be CAS
 	if appliedRaw, ok := dest["[applied]"]; ok {
@@ -1870,15 +1900,43 @@ func (q *Query) GetHostID() string {
 // Iter represents an iterator that can be used to iterate over all rows that
 // were returned by a query. The iterator might send additional queries to the
 // database during the iteration if paging was enabled.
+//
+// IMPORTANT: Close should still be called whenever iteration may stop early.
+// Iterators that run to exhaustion through Scan/Scanner.Next auto-finalize when
+// they become terminal, but Close remains the safest pattern and is still needed
+// to surface errors after manual early termination. Use defer immediately after
+// obtaining an Iter when in doubt:
+//
+//	iter := session.Query("...").Iter()
+//	defer iter.Close()
+//
+// Failure to call Close() after early termination may leak resources and prevent
+// buffer reuse.
+//
+// CONCURRENCY: Iter is NOT safe for concurrent use. An Iter instance should only
+// be used from a single goroutine at a time. While Close() is safe to call multiple
+// times (idempotent), calling Scan(), Next(), or other methods concurrently with
+// Close() or each other will result in undefined behavior.
+//
+//nolint:govet // Keeping iterator lifetime/ownership state together is more important here than field packing.
 type Iter struct {
-	err     error
-	framer  framerInterface
-	next    *nextIter
-	host    *HostInfo
-	meta    resultMetadata
-	pos     int
-	numRows int
-	closed  int32
+	err    error
+	framer framerInterface
+	// allWarnings accumulates warnings across page boundaries.
+	// When a page's framer is released during fetchNextPage(), its warnings
+	// are appended here so they are not lost.
+	allWarnings           []string
+	releasedCustomPayload map[string][]byte
+	next                  *nextIter
+	host                  *HostInfo
+	meta                  resultMetadata
+	warningHandler        WarningHandler
+	warningQuery          ExecutableQuery
+	warningQueryOwned     bool
+	pos                   int
+	numRows               int
+	closed                int32
+	warningsHandled       int32
 }
 
 // Host returns the host which the query was sent to.
@@ -1889,6 +1947,156 @@ func (iter *Iter) Host() *HostInfo {
 // Columns returns the name and type of the selected columns.
 func (iter *Iter) Columns() []ColumnInfo {
 	return iter.meta.columns
+}
+
+// copyPageData copies page-related fields from src to iter, excluding the closed flag.
+// This is used when fetching the next page to avoid races with concurrent Close() calls.
+//
+// After this call, src must not be used because its framer ownership has been
+// transferred to iter (src.framer is set to nil to prevent double-release).
+func (iter *Iter) copyPageData(src *Iter) {
+	iter.err = src.err
+	iter.framer = src.framer
+	iter.next = src.next
+	iter.host = src.host
+	iter.meta = src.meta
+	iter.allWarnings = append(iter.allWarnings, src.allWarnings...)
+	iter.releasedCustomPayload = src.releasedCustomPayload
+	iter.pos = src.pos
+	iter.numRows = src.numRows
+	if iter.warningQuery == nil {
+		iter.warningHandler = src.warningHandler
+		iter.warningQuery = src.warningQuery
+		iter.warningQueryOwned = src.warningQueryOwned
+	} else {
+		src.releaseWarningQuery()
+	}
+
+	// Clear source framer to prevent double-release: ownership is now with iter.
+	src.framer = nil
+	src.allWarnings = nil
+	src.releasedCustomPayload = nil
+	src.next = nil
+	src.warningHandler = nil
+	src.warningQuery = nil
+	src.warningQueryOwned = false
+	// Intentionally don't copy iter.closed - it's managed with atomic operations
+}
+
+func (iter *Iter) bindWarningHandler(qry ExecutableQuery, handler WarningHandler) *Iter {
+	if iter == nil || handler == nil {
+		return iter
+	}
+	iter.warningQuery = qry
+	iter.warningHandler = handler
+	if pooledQuery, ok := qry.(*Query); ok {
+		pooledQuery.incRefCount()
+		iter.warningQueryOwned = true
+		if iter.err != nil && iter.framer == nil && iter.next == nil && !pooledQuery.deferReleasedErrorFinalize {
+			iter.finalize(true)
+		}
+		return iter
+	}
+	if iter.err != nil && iter.framer == nil && iter.next == nil {
+		iter.finalize(true)
+	}
+	return iter
+}
+
+func (iter *Iter) releaseWarningQuery() {
+	qry := iter.warningQuery
+	owned := iter.warningQueryOwned
+	iter.warningQueryOwned = false
+	iter.warningQuery = nil
+
+	if !owned {
+		return
+	}
+	pooledQuery, ok := qry.(*Query)
+	if !ok {
+		return
+	}
+	pooledQuery.decRefCount()
+}
+
+func (iter *Iter) collectReleasedFramerMetadata(f framerInterface) {
+	if f == nil {
+		return
+	}
+	if warnings := f.GetHeaderWarnings(); len(warnings) > 0 {
+		iter.allWarnings = append(iter.allWarnings, warnings...)
+	}
+	if payload := f.GetCustomPayload(); len(payload) > 0 {
+		iter.releasedCustomPayload = maps.Clone(payload)
+	}
+}
+
+func (iter *Iter) handleWarningsOnce() {
+	if iter.warningHandler == nil {
+		return
+	}
+	if !atomic.CompareAndSwapInt32(&iter.warningsHandled, 0, 1) {
+		return
+	}
+	if warnings := iter.Warnings(); len(warnings) > 0 {
+		iter.warningHandler.HandleWarnings(iter.warningQuery, iter.host, warnings)
+	}
+}
+
+func (iter *Iter) finalize(dispatchWarnings bool) {
+	if !atomic.CompareAndSwapInt32(&iter.closed, 0, 1) {
+		return
+	}
+	if iter.framer != nil {
+		iter.collectReleasedFramerMetadata(iter.framer)
+		iter.framer.Release()
+		iter.framer = nil
+	}
+	if iter.next != nil {
+		iter.next.close()
+		iter.next = nil
+	}
+	if dispatchWarnings {
+		iter.handleWarningsOnce()
+	}
+	iter.releaseWarningQuery()
+	iter.warningHandler = nil
+}
+
+func (iter *Iter) discard() {
+	iter.finalize(false)
+}
+
+func newErrorIterWithReleasedFramer(err error, framer framerInterface) *Iter {
+	iter := &Iter{err: err}
+	if framer != nil {
+		iter.collectReleasedFramerMetadata(framer)
+		framer.Release()
+	}
+	return iter
+}
+
+// fetchNextPage releases the current page's framer and loads the next page
+// into iter. Returns true if a new page was successfully loaded,
+// false if no more pages or if the fetch produced an error.
+func (iter *Iter) fetchNextPage() bool {
+	if iter.pos < iter.numRows || iter.next == nil {
+		return false
+	}
+	currentNext := iter.next
+	if iter.framer != nil {
+		// Accumulate warnings from the current page before releasing its framer,
+		// so they are not lost across page boundaries.
+		if w := iter.framer.GetHeaderWarnings(); len(w) > 0 {
+			iter.allWarnings = append(iter.allWarnings, w...)
+		}
+		iter.framer.Release()
+		iter.framer = nil // prevent accidental use of released framer
+	}
+	next := currentNext.fetch()
+	currentNext.consume()
+	iter.copyPageData(next)
+	return iter.err == nil
 }
 
 type Scanner interface {
@@ -1919,21 +2127,22 @@ type iterScanner struct {
 func (is *iterScanner) Next() bool {
 	iter := is.iter
 	if iter.err != nil {
+		iter.finalize(true)
 		return false
 	}
 
-	if iter.pos >= iter.numRows {
-		if iter.next != nil {
-			is.iter = iter.next.fetch()
-			return is.Next()
+	for iter.pos >= iter.numRows {
+		if !iter.fetchNextPage() {
+			iter.finalize(true)
+			return false
 		}
-		return false
 	}
 
 	for i := 0; i < len(is.cols); i++ {
 		col, err := iter.readColumn()
 		if err != nil {
 			iter.err = err
+			iter.finalize(true)
 			return false
 		}
 		is.cols[i] = col
@@ -2016,6 +2225,12 @@ func (iter *Iter) Scanner() Scanner {
 }
 
 func (iter *Iter) readColumn() ([]byte, error) {
+	if atomic.LoadInt32(&iter.closed) != 0 {
+		return nil, errors.New("iterator closed")
+	}
+	if iter.framer == nil {
+		return nil, errors.New("no framer available")
+	}
 	return iter.framer.ReadBytesInternal()
 }
 
@@ -2029,15 +2244,15 @@ func (iter *Iter) readColumn() ([]byte, error) {
 // be called afterwards to retrieve any potential errors.
 func (iter *Iter) Scan(dest ...interface{}) bool {
 	if iter.err != nil {
+		iter.finalize(true)
 		return false
 	}
 
-	if iter.pos >= iter.numRows {
-		if iter.next != nil {
-			*iter = *iter.next.fetch()
-			return iter.Scan(dest...)
+	for iter.pos >= iter.numRows {
+		if !iter.fetchNextPage() {
+			iter.finalize(true)
+			return false
 		}
-		return false
 	}
 
 	if iter.next != nil && iter.pos >= iter.next.pos {
@@ -2048,6 +2263,7 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 	// as scanning in more values from a single column
 	if len(dest) != iter.meta.actualColCount {
 		iter.err = fmt.Errorf("gocql: not enough columns to scan into: have %d want %d", len(dest), iter.meta.actualColCount)
+		iter.finalize(true)
 		return false
 	}
 
@@ -2058,12 +2274,14 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 		colBytes, err := iter.readColumn()
 		if err != nil {
 			iter.err = err
+			iter.finalize(true)
 			return false
 		}
 
 		n, err := scanColumn(colBytes, col, dest[i:])
 		if err != nil {
 			iter.err = err
+			iter.finalize(true)
 			return false
 		}
 		i += n
@@ -2074,7 +2292,12 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 }
 
 // GetCustomPayload returns any parsed custom payload results if given in the
-// response from Cassandra. Note that the result is not a copy.
+// response from Cassandra. The returned map is a shallow copy and is safe to
+// retain after the Iter advances or is closed.
+//
+// When paging is enabled, this returns the custom payload from the most recently
+// loaded page only. Custom payloads from previously consumed pages are not retained.
+// If you need the payload, retrieve it before advancing to the next page.
 //
 // This additional feature of CQL Protocol v4
 // allows additional results and query information to be returned by
@@ -2082,30 +2305,34 @@ func (iter *Iter) Scan(dest ...interface{}) bool {
 // See https://datastax.github.io/java-driver/manual/custom_payloads/
 func (iter *Iter) GetCustomPayload() map[string][]byte {
 	if iter.framer != nil {
-		return iter.framer.GetCustomPayload()
+		return maps.Clone(iter.framer.GetCustomPayload())
 	}
-	return nil
+	return maps.Clone(iter.releasedCustomPayload)
 }
 
 // Warnings returns any warnings generated if given in the response from Cassandra.
+// When paging is enabled, warnings are accumulated across all pages that have been
+// consumed so far plus the warnings from the current (not yet released) page.
 //
 // This is only available starting with CQL Protocol v4.
 func (iter *Iter) Warnings() []string {
+	var current []string
 	if iter.framer != nil {
-		return iter.framer.GetHeaderWarnings()
+		current = iter.framer.GetHeaderWarnings()
 	}
-	return nil
+	if len(iter.allWarnings) == 0 {
+		return slices.Clone(current) // always return a caller-owned slice
+	}
+	if len(current) == 0 {
+		return slices.Clone(iter.allWarnings)
+	}
+	return slices.Concat(iter.allWarnings, current)
 }
 
 // Close closes the iterator and returns any errors that happened during
 // the query or the iteration.
 func (iter *Iter) Close() error {
-	if atomic.CompareAndSwapInt32(&iter.closed, 0, 1) {
-		if iter.framer != nil {
-			iter.framer = nil
-		}
-	}
-
+	iter.finalize(true)
 	return iter.err
 }
 
@@ -2146,11 +2373,29 @@ func (iter *Iter) NumRows() int {
 // nextIter holds state for fetching a single page in an iterator.
 // single page might be attempted multiple times due to retries.
 type nextIter struct {
-	qry   *Query
-	next  *Iter
-	pos   int
-	oncea sync.Once
-	once  sync.Once
+	qry    *Query
+	next   *Iter
+	cancel context.CancelFunc
+	oncea  sync.Once
+	once   sync.Once
+	mu     sync.Mutex
+	pos    int
+	closed bool
+}
+
+func newNextIter(qry *Query, pos int) *nextIter {
+	parentCtx := qry.pageContextParent
+	if parentCtx == nil {
+		parentCtx = qry.Context()
+	}
+	ctx, cancel := context.WithCancel(parentCtx)
+	nextQry := qry.WithContext(ctx)
+	nextQry.pageContextParent = parentCtx
+	return &nextIter{
+		qry:    nextQry,
+		pos:    pos,
+		cancel: cancel,
+	}
 }
 
 func (n *nextIter) fetchAsync() {
@@ -2159,17 +2404,68 @@ func (n *nextIter) fetchAsync() {
 	})
 }
 
+func (n *nextIter) storeFetched(next *Iter) {
+	if next == nil {
+		return
+	}
+
+	n.mu.Lock()
+	if n.closed {
+		n.mu.Unlock()
+		next.discard()
+		return
+	}
+	n.next = next
+	n.mu.Unlock()
+}
+
+func (n *nextIter) close() {
+	if n.cancel != nil {
+		n.cancel()
+	}
+
+	n.mu.Lock()
+	n.closed = true
+	next := n.next
+	n.next = nil
+	n.mu.Unlock()
+
+	if next != nil {
+		next.discard()
+	}
+}
+
+// consume retires the next-page fetch context after the fetched page has been
+// handed off to the caller. Unlike close(), it keeps the fetched Iter alive so
+// its page data can become the current iterator state.
+func (n *nextIter) consume() {
+	if n.cancel != nil {
+		n.cancel()
+	}
+
+	n.mu.Lock()
+	n.closed = true
+	n.next = nil
+	n.mu.Unlock()
+}
+
 func (n *nextIter) fetch() *Iter {
 	n.once.Do(func() {
 		// if the query was specifically run on a connection then re-use that
 		// connection when fetching the next results
+		var next *Iter
 		if n.qry.conn != nil {
-			n.next = n.qry.conn.executeQuery(n.qry.Context(), n.qry)
+			next = n.qry.conn.executeQuery(n.qry.Context(), n.qry)
 		} else {
-			n.next = n.qry.session.executeQuery(n.qry)
+			next = n.qry.session.executeQuery(n.qry)
 		}
+		n.storeFetched(next)
 	})
-	return n.next
+
+	n.mu.Lock()
+	next := n.next
+	n.mu.Unlock()
+	return next
 }
 
 type Batch struct {

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -30,8 +30,12 @@ package gocql
 import (
 	"context"
 	"errors"
+	"reflect"
+	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gocql/gocql/tablets"
 )
@@ -421,8 +425,24 @@ func TestTestTableNameTruncation(t *testing.T) {
 		if len(got) > maxCQLIdentifierLen {
 			t.Errorf("len = %d, want <= %d; value = %q", len(got), maxCQLIdentifierLen, got)
 		}
+		// Should preserve chars from both the start and end around the hash.
 		if got[:5] != "testt" {
 			t.Errorf("expected prefix from test name, got %q", got)
+		}
+		if !strings.HasSuffix(got, "_extra") {
+			t.Errorf("expected suffix from test name and parts, got %q", got)
+		}
+		if len(got) != maxCQLIdentifierLen {
+			t.Errorf("expected truncated name to use full identifier budget, got len=%d value=%q", len(got), got)
+		}
+		if got[15] != '_' || got[32] != '_' {
+			t.Errorf("expected <first-n>_<hash>_<last-n> structure, got %q", got)
+		}
+		for _, ch := range got[16:32] {
+			if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+				t.Errorf("expected hex hash in the middle, got %q", got)
+				break
+			}
 		}
 	})
 }
@@ -434,6 +454,983 @@ func TestTestTableNameUniqueness(t *testing.T) {
 	b := testTableName(t, "beta")
 	if a == b {
 		t.Errorf("expected different names, both got %q", a)
+	}
+}
+
+// testWarningFramer is a mock framerInterface that returns configurable warnings.
+type testWarningFramer struct {
+	warnings      []string
+	customPayload map[string][]byte
+	released      bool
+}
+
+func (f *testWarningFramer) ReadBytesInternal() ([]byte, error) { return nil, nil }
+func (f *testWarningFramer) GetCustomPayload() map[string][]byte {
+	return f.customPayload
+}
+func (f *testWarningFramer) GetHeaderWarnings() []string { return f.warnings }
+func (f *testWarningFramer) Release()                    { f.released = true }
+
+type recordingWarningHandler struct {
+	calls     int
+	lastHost  *HostInfo
+	lastQry   ExecutableQuery
+	queryStmt string
+	warnings  []string
+}
+
+func (h *recordingWarningHandler) HandleWarnings(qry ExecutableQuery, host *HostInfo, warnings []string) {
+	h.calls++
+	h.lastQry = qry
+	h.lastHost = host
+	if query, ok := qry.(*Query); ok {
+		h.queryStmt = query.stmt
+	}
+	h.warnings = slices.Clone(warnings)
+}
+
+type staticConnPicker struct {
+	conn *Conn
+}
+
+func (p staticConnPicker) Pick(Token, ExecutableQuery) *Conn { return p.conn }
+func (p staticConnPicker) Put(*Conn) error                   { return nil }
+func (p staticConnPicker) Remove(*Conn)                      {}
+func (p staticConnPicker) InFlight() int                     { return 0 }
+func (p staticConnPicker) Size() (int, int)                  { return 1, 0 }
+func (p staticConnPicker) Close()                            {}
+func (p staticConnPicker) NextShard() (shardID, nrShards int) {
+	return 0, 0
+}
+func (p staticConnPicker) GetConnectionCount() int       { return 1 }
+func (p staticConnPicker) GetExcessConnectionCount() int { return 0 }
+func (p staticConnPicker) GetShardCount() int            { return 0 }
+
+type staticSelectedHost struct {
+	host *HostInfo
+}
+
+func (h staticSelectedHost) Info() *HostInfo { return h.host }
+func (h staticSelectedHost) Token() Token    { return nil }
+func (h staticSelectedHost) Mark(error)      {}
+
+type pagingTestConn struct {
+	executeQueryFunc func(ctx context.Context, qry *Query) *Iter
+}
+
+func (*pagingTestConn) Close() {}
+func (*pagingTestConn) exec(context.Context, frameBuilder, Tracer, time.Duration) (*framer, error) {
+	return nil, nil
+}
+func (*pagingTestConn) awaitSchemaAgreement(context.Context) error { return nil }
+func (c *pagingTestConn) executeQuery(ctx context.Context, qry *Query) *Iter {
+	return c.executeQueryFunc(ctx, qry)
+}
+func (*pagingTestConn) querySystem(context.Context, string, ...interface{}) *Iter { return nil }
+func (*pagingTestConn) getIsSchemaV2() bool                                       { return false }
+func (*pagingTestConn) setSchemaV2(bool)                                          {}
+func (*pagingTestConn) getScyllaSupported() ScyllaConnectionFeatures {
+	return ScyllaConnectionFeatures{}
+}
+
+type fixedRetryPolicy struct {
+	maxRetries int
+	retryType  RetryType
+}
+
+func (p *fixedRetryPolicy) Attempt(q RetryableQuery) bool {
+	return q.Attempts() <= p.maxRetries
+}
+
+func (p *fixedRetryPolicy) GetRetryType(error) RetryType {
+	return p.retryType
+}
+
+type executorTestQuery struct {
+	ctx         context.Context
+	rt          RetryPolicy
+	spec        SpeculativeExecutionPolicy
+	idempotent  bool
+	consistency Consistency
+	attempts    int
+	borrowed    int
+	released    int
+	executeFunc func(context.Context, *Conn) *Iter
+}
+
+func (q *executorTestQuery) borrowForExecution() {
+	q.borrowed++
+}
+
+func (q *executorTestQuery) releaseAfterExecution() {
+	q.released++
+}
+
+func (q *executorTestQuery) execute(ctx context.Context, conn *Conn) *Iter {
+	return q.executeFunc(ctx, conn)
+}
+
+func (q *executorTestQuery) attempt(string, time.Time, time.Time, *Iter, *HostInfo) {
+	q.attempts++
+}
+
+func (q *executorTestQuery) retryPolicy() RetryPolicy {
+	return q.rt
+}
+
+func (q *executorTestQuery) speculativeExecutionPolicy() SpeculativeExecutionPolicy {
+	if q.spec == nil {
+		return NonSpeculativeExecution{}
+	}
+	return q.spec
+}
+
+func (q *executorTestQuery) GetRoutingKey() ([]byte, error) { return nil, nil }
+func (q *executorTestQuery) Keyspace() string               { return "" }
+func (q *executorTestQuery) Table() string                  { return "" }
+func (q *executorTestQuery) IsIdempotent() bool             { return q.idempotent }
+func (q *executorTestQuery) IsLWT() bool                    { return false }
+func (q *executorTestQuery) GetCustomPartitioner() Partitioner {
+	return nil
+}
+func (q *executorTestQuery) GetHostID() string { return "" }
+
+func (q *executorTestQuery) withContext(ctx context.Context) ExecutableQuery {
+	q2 := *q
+	q2.ctx = ctx
+	return &q2
+}
+
+func (q *executorTestQuery) Attempts() int {
+	return q.attempts
+}
+
+func (q *executorTestQuery) SetConsistency(c Consistency) {
+	q.consistency = c
+}
+
+func (q *executorTestQuery) GetConsistency() Consistency {
+	return q.consistency
+}
+
+func (q *executorTestQuery) Context() context.Context {
+	if q.ctx == nil {
+		return context.Background()
+	}
+	return q.ctx
+}
+
+func (q *executorTestQuery) GetSession() *Session { return nil }
+
+func newTestQueryExecutor(host *HostInfo) *queryExecutor {
+	return &queryExecutor{
+		pool: &policyConnPool{
+			hostConnPools: map[string]*hostConnPool{
+				host.HostID(): &hostConnPool{
+					host:       host,
+					connPicker: staticConnPicker{conn: &Conn{}},
+				},
+			},
+		},
+	}
+}
+
+func newWarningTestQuery() *Query {
+	return &Query{
+		context:     context.Background(),
+		routingInfo: &queryRoutingInfo{},
+		metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+		rt:          &SimpleRetryPolicy{NumRetries: 0},
+		spec:        NonSpeculativeExecution{},
+	}
+}
+
+func TestIterWarnings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoFramer", func(t *testing.T) {
+		iter := &Iter{}
+		warnings := iter.Warnings()
+		if len(warnings) != 0 {
+			t.Errorf("expected no warnings, got %v", warnings)
+		}
+	})
+
+	t.Run("SinglePage", func(t *testing.T) {
+		framer := &testWarningFramer{warnings: []string{"warn1", "warn2"}}
+		iter := &Iter{framer: framer}
+
+		warnings := iter.Warnings()
+		want := []string{"warn1", "warn2"}
+		if !slices.Equal(warnings, want) {
+			t.Errorf("Warnings() = %v, want %v", warnings, want)
+		}
+	})
+
+	t.Run("ReturnsCopy", func(t *testing.T) {
+		framer := &testWarningFramer{warnings: []string{"warn1"}}
+		iter := &Iter{framer: framer}
+
+		w1 := iter.Warnings()
+		w2 := iter.Warnings()
+
+		// Mutating w1 should not affect w2
+		w1[0] = "mutated"
+		if w2[0] == "mutated" {
+			t.Error("Warnings() returned a shared slice, expected independent copies")
+		}
+	})
+
+	t.Run("AccumulatedAcrossPages", func(t *testing.T) {
+		page1Framer := &testWarningFramer{warnings: []string{"page1-warn1", "page1-warn2"}}
+		iter := &Iter{
+			framer:  page1Framer,
+			numRows: 1,
+			pos:     1,
+			next:    nil,
+		}
+
+		if w := iter.framer.GetHeaderWarnings(); len(w) > 0 {
+			iter.allWarnings = append(iter.allWarnings, w...)
+		}
+		iter.framer.Release()
+		page2Framer := &testWarningFramer{warnings: []string{"page2-warn1"}}
+		iter.framer = page2Framer
+
+		warnings := iter.Warnings()
+		want := []string{"page1-warn1", "page1-warn2", "page2-warn1"}
+		if !slices.Equal(warnings, want) {
+			t.Errorf("Warnings() = %v, want %v", warnings, want)
+		}
+
+		if !page1Framer.released {
+			t.Error("page 1 framer was not released")
+		}
+	})
+
+	t.Run("AfterClose", func(t *testing.T) {
+		framer := &testWarningFramer{warnings: []string{"last-page-warn"}}
+		iter := &Iter{
+			framer:      framer,
+			allWarnings: []string{"prev-page-warn"},
+		}
+
+		iter.Close()
+
+		if !framer.released {
+			t.Error("framer was not released on Close()")
+		}
+		if iter.framer != nil {
+			t.Error("framer was not nilled on Close()")
+		}
+
+		warnings := iter.Warnings()
+		want := []string{"prev-page-warn", "last-page-warn"}
+		if !slices.Equal(warnings, want) {
+			t.Errorf("Warnings() after Close() = %v, want %v", warnings, want)
+		}
+	})
+
+	t.Run("EmptyPages", func(t *testing.T) {
+		iter := &Iter{
+			allWarnings: []string{"page1-warn"},
+		}
+		page2Framer := &testWarningFramer{warnings: nil}
+		iter.framer = page2Framer
+
+		warnings := iter.Warnings()
+		want := []string{"page1-warn"}
+		if !slices.Equal(warnings, want) {
+			t.Errorf("Warnings() = %v, want %v", warnings, want)
+		}
+	})
+
+	t.Run("CloseIdempotent", func(t *testing.T) {
+		framer := &testWarningFramer{warnings: []string{"warn"}}
+		iter := &Iter{framer: framer}
+
+		iter.Close()
+		iter.Close()
+
+		warnings := iter.Warnings()
+		want := []string{"warn"}
+		if !slices.Equal(warnings, want) {
+			t.Errorf("Warnings() after double Close() = %v, want %v", warnings, want)
+		}
+	})
+}
+
+func TestNewErrorIterWithReleasedFramer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PreservesMetadata", func(t *testing.T) {
+		payload := map[string][]byte{"tablet": {1, 2, 3}}
+		framer := &testWarningFramer{
+			warnings:      []string{"warn1"},
+			customPayload: payload,
+		}
+
+		iter := newErrorIterWithReleasedFramer(errors.New("boom"), framer)
+
+		if !framer.released {
+			t.Fatal("expected framer to be released")
+		}
+		if !slices.Equal(iter.Warnings(), []string{"warn1"}) {
+			t.Fatalf("Warnings() = %v, want %v", iter.Warnings(), []string{"warn1"})
+		}
+		if !reflect.DeepEqual(iter.GetCustomPayload(), payload) {
+			t.Fatalf("GetCustomPayload() = %v, want %v", iter.GetCustomPayload(), payload)
+		}
+	})
+}
+
+func TestIterWarningHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CloseDispatchesAccumulatedWarnings", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		host := &HostInfo{hostId: "host-1"}
+		qry := &Query{
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+		}
+		iter := (&Iter{
+			framer:      &testWarningFramer{warnings: []string{"page2"}},
+			allWarnings: []string{"page1"},
+			host:        host,
+		}).bindWarningHandler(qry, handler)
+
+		if err := iter.Close(); err != nil {
+			t.Fatalf("Close() returned unexpected error: %v", err)
+		}
+
+		want := []string{"page1", "page2"}
+		if !slices.Equal(handler.warnings, want) {
+			t.Fatalf("handler warnings = %v, want %v", handler.warnings, want)
+		}
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+		if handler.lastHost != host {
+			t.Fatal("handler host mismatch")
+		}
+		if handler.lastQry != qry {
+			t.Fatal("handler query mismatch")
+		}
+	})
+
+	t.Run("CloseIsIdempotent", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		iter := (&Iter{
+			framer: &testWarningFramer{warnings: []string{"warn"}},
+		}).bindWarningHandler(&Query{
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+		}, handler)
+
+		iter.Close()
+		iter.Close()
+
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+	})
+
+	t.Run("CopyPageDataTransfersReleasedMetadata", func(t *testing.T) {
+		src := newErrorIterWithReleasedFramer(errors.New("boom"), &testWarningFramer{
+			warnings:      []string{"warn"},
+			customPayload: map[string][]byte{"k": {9}},
+		})
+		dst := &Iter{
+			allWarnings: []string{"first-page"},
+		}
+
+		dst.copyPageData(src)
+
+		wantWarnings := []string{"first-page", "warn"}
+		if !slices.Equal(dst.Warnings(), wantWarnings) {
+			t.Fatalf("Warnings() = %v, want %v", dst.Warnings(), wantWarnings)
+		}
+		if !reflect.DeepEqual(dst.GetCustomPayload(), map[string][]byte{"k": {9}}) {
+			t.Fatalf("GetCustomPayload() = %v, want %v", dst.GetCustomPayload(), map[string][]byte{"k": {9}})
+		}
+	})
+
+	t.Run("BindIgnoresNilHandler", func(t *testing.T) {
+		iter := (&Iter{}).bindWarningHandler(&Query{
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+		}, nil)
+		if iter.warningHandler != nil {
+			t.Fatal("expected warning handler to remain nil")
+		}
+	})
+
+	t.Run("HostPreservedAcrossClose", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		host := &HostInfo{port: 9042, hostId: "host-2"}
+		iter := (&Iter{
+			framer: &testWarningFramer{warnings: []string{"warn"}},
+			host:   host,
+		}).bindWarningHandler(&Batch{
+			context:     context.Background(),
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			rt:          &SimpleRetryPolicy{NumRetries: 0},
+			spec:        NonSpeculativeExecution{},
+		}, handler)
+
+		iter.Close()
+
+		if handler.lastHost != host {
+			t.Fatal("expected handler to receive the iterator host")
+		}
+	})
+
+	t.Run("CloseClearsBatchWarningQueryReference", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		batch := &Batch{
+			context:     context.Background(),
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			rt:          &SimpleRetryPolicy{NumRetries: 0},
+			spec:        NonSpeculativeExecution{},
+		}
+		iter := (&Iter{
+			framer: &testWarningFramer{warnings: []string{"warn"}},
+		}).bindWarningHandler(batch, handler)
+
+		if err := iter.Close(); err != nil {
+			t.Fatalf("Close() returned unexpected error: %v", err)
+		}
+		if handler.lastQry != batch {
+			t.Fatal("handler batch mismatch")
+		}
+		if iter.warningQuery != nil {
+			t.Fatal("expected warning query to be cleared after Close")
+		}
+		if iter.warningQueryOwned {
+			t.Fatal("expected warningQueryOwned to be false after Close")
+		}
+	})
+
+	t.Run("CloseWithoutWarningsDoesNotInvokeHandler", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		iter := (&Iter{
+			framer: &testWarningFramer{},
+		}).bindWarningHandler(&Query{
+			context:     context.Background(),
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			rt:          &SimpleRetryPolicy{NumRetries: 0},
+			spec:        NonSpeculativeExecution{},
+		}, handler)
+
+		iter.Close()
+
+		if handler.calls != 0 {
+			t.Fatalf("handler call count = %d, want 0", handler.calls)
+		}
+	})
+
+	t.Run("HandleWarningsOnceAfterManualAccumulation", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		iter := (&Iter{
+			allWarnings: []string{"warn1"},
+			host:        &HostInfo{hostId: "host-3"},
+		}).bindWarningHandler(&Query{
+			routingInfo: &queryRoutingInfo{},
+			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+		}, handler)
+
+		iter.handleWarningsOnce()
+		iter.handleWarningsOnce()
+
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+	})
+
+	t.Run("QueryReleaseBeforeCloseKeepsWarningQueryAlive", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		qry := newWarningTestQuery()
+		qry.refCount = 1
+		qry.stmt = "SELECT now() FROM system.local"
+		iter := (&Iter{
+			framer: &testWarningFramer{warnings: []string{"warn"}},
+		}).bindWarningHandler(qry, handler)
+
+		qry.Release()
+
+		if qry.stmt != "SELECT now() FROM system.local" {
+			t.Fatalf("query statement reset before iterator close: %q", qry.stmt)
+		}
+		if err := iter.Close(); err != nil {
+			t.Fatalf("Close() returned unexpected error: %v", err)
+		}
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+		capturedQry, ok := handler.lastQry.(*Query)
+		if !ok {
+			t.Fatalf("handler query type = %T, want *Query", handler.lastQry)
+		}
+		if capturedQry != qry {
+			t.Fatal("handler query mismatch")
+		}
+		if handler.queryStmt != "SELECT now() FROM system.local" {
+			t.Fatalf("handler saw query statement %q, want %q", handler.queryStmt, "SELECT now() FROM system.local")
+		}
+	})
+
+	t.Run("ReleasedErrorIterAutoFinalizesOnBind", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		qry := newWarningTestQuery()
+		qry.refCount = 1
+		qry.stmt = "SELECT fail()"
+
+		iter := newErrorIterWithReleasedFramer(errors.New("boom"), &testWarningFramer{
+			warnings: []string{"warn"},
+		}).bindWarningHandler(qry, handler)
+
+		if got := atomic.LoadUint32(&qry.refCount); got != 1 {
+			t.Fatalf("query refCount = %d, want 1", got)
+		}
+		if iter.warningQuery != nil {
+			t.Fatal("expected warning query to be released")
+		}
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+		if !slices.Equal(handler.warnings, []string{"warn"}) {
+			t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"warn"})
+		}
+		if err := iter.Close(); err == nil || err.Error() != "boom" {
+			t.Fatalf("Close() = %v, want boom", err)
+		}
+	})
+}
+
+func TestIterAutoFinalizeOnTerminalConsumption(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ScanEOFReleasesResources", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		qry := newWarningTestQuery()
+		qry.refCount = 1
+		framer := &testWarningFramer{warnings: []string{"scan-eof"}}
+		iter := (&Iter{
+			framer:  framer,
+			numRows: 1,
+			meta: resultMetadata{
+				actualColCount: 0,
+			},
+		}).bindWarningHandler(qry, handler)
+
+		if !iter.Scan() {
+			t.Fatal("expected first Scan() to succeed")
+		}
+		if iter.Scan() {
+			t.Fatal("expected second Scan() to report EOF")
+		}
+		if !framer.released {
+			t.Fatal("expected EOF to release the framer")
+		}
+		if iter.framer != nil {
+			t.Fatal("expected framer to be cleared after EOF")
+		}
+		if got := atomic.LoadUint32(&qry.refCount); got != 1 {
+			t.Fatalf("query refCount = %d, want 1", got)
+		}
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+		if !slices.Equal(handler.warnings, []string{"scan-eof"}) {
+			t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"scan-eof"})
+		}
+	})
+
+	t.Run("ScannerNextEOFReleasesResources", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		qry := newWarningTestQuery()
+		qry.refCount = 1
+		framer := &testWarningFramer{warnings: []string{"scanner-eof"}}
+		iter := (&Iter{
+			framer:  framer,
+			numRows: 1,
+			meta: resultMetadata{
+				actualColCount: 0,
+			},
+		}).bindWarningHandler(qry, handler)
+		scanner := iter.Scanner()
+
+		if !scanner.Next() {
+			t.Fatal("expected first Next() to succeed")
+		}
+		if err := scanner.Scan(); err != nil {
+			t.Fatalf("Scan() returned unexpected error: %v", err)
+		}
+		if scanner.Next() {
+			t.Fatal("expected second Next() to report EOF")
+		}
+		if !framer.released {
+			t.Fatal("expected EOF to release the framer")
+		}
+		if iter.framer != nil {
+			t.Fatal("expected framer to be cleared after EOF")
+		}
+		if got := atomic.LoadUint32(&qry.refCount); got != 1 {
+			t.Fatalf("query refCount = %d, want 1", got)
+		}
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+		if !slices.Equal(handler.warnings, []string{"scanner-eof"}) {
+			t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"scanner-eof"})
+		}
+	})
+}
+
+func TestQueryExecutorRetryAndDiscardWarningHandling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SpeculativeLoserIsDiscardedWithoutWarnings", func(t *testing.T) {
+		host := (&HostInfo{hostId: "host-4"}).setState(NodeUp)
+		handler := &recordingWarningHandler{}
+		framer := &testWarningFramer{warnings: []string{"loser"}}
+		qry := &executorTestQuery{
+			rt:         &fixedRetryPolicy{maxRetries: 0, retryType: Rethrow},
+			spec:       NonSpeculativeExecution{},
+			idempotent: true,
+		}
+		qry.executeFunc = func(context.Context, *Conn) *Iter {
+			return (&Iter{framer: framer}).bindWarningHandler(qry, handler)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		executor := newTestQueryExecutor(host)
+		executor.run(ctx, qry, func() SelectedHost { return staticSelectedHost{host: host} }, make(chan *Iter))
+
+		if handler.calls != 0 {
+			t.Fatalf("handler call count = %d, want 0", handler.calls)
+		}
+		if !framer.released {
+			t.Fatal("speculative loser framer was not released")
+		}
+		if qry.released != 1 {
+			t.Fatalf("releaseAfterExecution calls = %d, want 1", qry.released)
+		}
+	})
+
+	t.Run("RetriedAttemptStillWarnsOnce", func(t *testing.T) {
+		host := (&HostInfo{hostId: "host-5"}).setState(NodeUp)
+		handler := &recordingWarningHandler{}
+		firstFramer := &testWarningFramer{warnings: []string{"retry-warn"}}
+		finalFramer := &testWarningFramer{}
+		qry := &executorTestQuery{
+			ctx:        context.Background(),
+			rt:         &fixedRetryPolicy{maxRetries: 1, retryType: Retry},
+			spec:       NonSpeculativeExecution{},
+			idempotent: true,
+		}
+
+		attempt := 0
+		qry.executeFunc = func(context.Context, *Conn) *Iter {
+			attempt++
+			if attempt == 1 {
+				return (&Iter{err: errors.New("boom"), framer: firstFramer}).bindWarningHandler(qry, handler)
+			}
+			return (&Iter{framer: finalFramer}).bindWarningHandler(qry, handler)
+		}
+
+		executor := newTestQueryExecutor(host)
+		iter := executor.do(context.Background(), qry, func() SelectedHost { return staticSelectedHost{host: host} })
+		defer iter.Close()
+
+		if iter.err != nil {
+			t.Fatalf("unexpected final error: %v", iter.err)
+		}
+		if !firstFramer.released {
+			t.Fatal("retried attempt framer was not released")
+		}
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+		if !slices.Equal(handler.warnings, []string{"retry-warn"}) {
+			t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"retry-warn"})
+		}
+	})
+}
+
+func TestIterCloseCleansPrefetchedNextPage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MaterializedNextPageIsReleasedWithoutDispatchingItsWarnings", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		qry := newWarningTestQuery()
+		currentFramer := &testWarningFramer{warnings: []string{"current"}}
+		nextFramer := &testWarningFramer{warnings: []string{"prefetched"}}
+		iter := (&Iter{
+			framer: currentFramer,
+			next: &nextIter{
+				next: (&Iter{framer: nextFramer}).bindWarningHandler(qry, handler),
+			},
+		}).bindWarningHandler(qry, handler)
+
+		iter.Close()
+
+		if !currentFramer.released {
+			t.Fatal("current framer was not released")
+		}
+		if !nextFramer.released {
+			t.Fatal("prefetched next framer was not released")
+		}
+		if handler.calls != 1 {
+			t.Fatalf("handler call count = %d, want 1", handler.calls)
+		}
+		if !slices.Equal(handler.warnings, []string{"current"}) {
+			t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"current"})
+		}
+		if iter.next != nil {
+			t.Fatal("expected prefetched next iterator to be cleared on Close")
+		}
+	})
+
+	t.Run("LatePrefetchResultIsClosedAfterCancellation", func(t *testing.T) {
+		handler := &recordingWarningHandler{}
+		next := newNextIter(newWarningTestQuery(), 1)
+
+		next.close()
+		select {
+		case <-next.qry.Context().Done():
+		default:
+			t.Fatal("expected next-page context to be canceled")
+		}
+
+		lateFramer := &testWarningFramer{warnings: []string{"late"}}
+		next.storeFetched((&Iter{framer: lateFramer}).bindWarningHandler(next.qry, handler))
+
+		if !lateFramer.released {
+			t.Fatal("late prefetched framer was not released")
+		}
+		if handler.calls != 0 {
+			t.Fatalf("handler call count = %d, want 0", handler.calls)
+		}
+	})
+}
+
+func TestSliceMapClosesIterator(t *testing.T) {
+	t.Parallel()
+
+	handler := &recordingWarningHandler{}
+	qry := newWarningTestQuery()
+	framer := &testWarningFramer{warnings: []string{"slice-map"}}
+	iter := (&Iter{
+		framer: framer,
+		meta: resultMetadata{
+			actualColCount: 0,
+		},
+	}).bindWarningHandler(qry, handler)
+
+	rows, err := iter.SliceMap()
+	if err != nil {
+		t.Fatalf("unexpected SliceMap error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected no rows, got %d", len(rows))
+	}
+	if !framer.released {
+		t.Fatal("expected SliceMap to release the iterator framer")
+	}
+	if handler.calls != 1 {
+		t.Fatalf("handler call count = %d, want 1", handler.calls)
+	}
+	if !slices.Equal(handler.warnings, []string{"slice-map"}) {
+		t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"slice-map"})
+	}
+}
+
+func TestIterFetchNextPageRetiresConsumedFetchContextOnly(t *testing.T) {
+	t.Parallel()
+
+	rootCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var fetchedQry *Query
+	nextPageFramer := &testWarningFramer{warnings: []string{"next"}}
+	conn := &pagingTestConn{
+		executeQueryFunc: func(_ context.Context, qry *Query) *Iter {
+			fetchedQry = qry
+			return &Iter{
+				framer:  nextPageFramer,
+				numRows: 1,
+				next:    newNextIter(qry, 1),
+			}
+		},
+	}
+
+	baseQry := newWarningTestQuery().WithContext(rootCtx)
+	baseQry.conn = conn
+	currentFramer := &testWarningFramer{warnings: []string{"current"}}
+	iter := &Iter{
+		framer:  currentFramer,
+		numRows: 1,
+		pos:     1,
+		next:    newNextIter(baseQry, 1),
+	}
+	defer iter.Close()
+
+	if !iter.fetchNextPage() {
+		t.Fatal("expected next page fetch to succeed")
+	}
+	if fetchedQry == nil {
+		t.Fatal("expected next-page query to execute")
+	}
+	select {
+	case <-fetchedQry.Context().Done():
+	default:
+		t.Fatal("expected consumed next-page context to be canceled")
+	}
+	select {
+	case <-iter.next.qry.Context().Done():
+		t.Fatal("expected following page context to remain active")
+	default:
+	}
+	if !currentFramer.released {
+		t.Fatal("expected current page framer to be released")
+	}
+	if iter.framer != nextPageFramer {
+		t.Fatal("expected fetched page framer to become current")
+	}
+}
+
+func TestQueryIterManualPagingDefersHiddenEmptyPageWarnings(t *testing.T) {
+	t.Parallel()
+
+	handler := &recordingWarningHandler{}
+	firstFramer := &testWarningFramer{warnings: []string{"empty-page"}}
+	finalFramer := &testWarningFramer{warnings: []string{"final-page"}}
+	baseQry := newWarningTestQuery()
+	baseQry.refCount = 1
+	baseQry.PageState([]byte("initial"))
+
+	call := 0
+	baseQry.conn = &pagingTestConn{
+		executeQueryFunc: func(_ context.Context, qry *Query) *Iter {
+			call++
+			switch call {
+			case 1:
+				if !slices.Equal(qry.pageState, []byte("initial")) {
+					t.Fatalf("first page state = %q, want %q", qry.pageState, []byte("initial"))
+				}
+				return (&Iter{
+					framer:  firstFramer,
+					numRows: 0,
+					meta: resultMetadata{
+						pagingState: []byte("next"),
+					},
+				}).bindWarningHandler(qry, handler)
+			case 2:
+				if !slices.Equal(qry.pageState, []byte("next")) {
+					t.Fatalf("second page state = %q, want %q", qry.pageState, []byte("next"))
+				}
+				return (&Iter{
+					framer:  finalFramer,
+					numRows: 1,
+				}).bindWarningHandler(qry, handler)
+			default:
+				t.Fatalf("unexpected executeQuery call %d", call)
+				return nil
+			}
+		},
+	}
+
+	iter := baseQry.Iter()
+
+	if call != 2 {
+		t.Fatalf("executeQuery call count = %d, want 2", call)
+	}
+	if handler.calls != 0 {
+		t.Fatalf("handler call count before Close = %d, want 0", handler.calls)
+	}
+	if !firstFramer.released {
+		t.Fatal("hidden empty-page framer was not released")
+	}
+	if warnings := iter.Warnings(); !slices.Equal(warnings, []string{"empty-page", "final-page"}) {
+		t.Fatalf("Warnings() = %v, want %v", warnings, []string{"empty-page", "final-page"})
+	}
+
+	if err := iter.Close(); err != nil {
+		t.Fatalf("Close() returned unexpected error: %v", err)
+	}
+	if handler.calls != 1 {
+		t.Fatalf("handler call count after Close = %d, want 1", handler.calls)
+	}
+	if !slices.Equal(handler.warnings, []string{"empty-page", "final-page"}) {
+		t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"empty-page", "final-page"})
+	}
+}
+
+func TestQueryIterManualPagingPreservesHiddenWarningsOnTerminalError(t *testing.T) {
+	t.Parallel()
+
+	handler := &recordingWarningHandler{}
+	firstFramer := &testWarningFramer{warnings: []string{"empty-page"}}
+	baseQry := newWarningTestQuery()
+	baseQry.refCount = 1
+	baseQry.PageState([]byte("initial"))
+
+	call := 0
+	baseQry.conn = &pagingTestConn{
+		executeQueryFunc: func(_ context.Context, qry *Query) *Iter {
+			call++
+			switch call {
+			case 1:
+				if !slices.Equal(qry.pageState, []byte("initial")) {
+					t.Fatalf("first page state = %q, want %q", qry.pageState, []byte("initial"))
+				}
+				return (&Iter{
+					framer:  firstFramer,
+					numRows: 0,
+					meta: resultMetadata{
+						pagingState: []byte("next"),
+					},
+				}).bindWarningHandler(qry, handler)
+			case 2:
+				if !slices.Equal(qry.pageState, []byte("next")) {
+					t.Fatalf("second page state = %q, want %q", qry.pageState, []byte("next"))
+				}
+				return newErrorIterWithReleasedFramer(errors.New("boom"), &testWarningFramer{
+					warnings: []string{"final-error"},
+				}).bindWarningHandler(qry, handler)
+			default:
+				t.Fatalf("unexpected executeQuery call %d", call)
+				return nil
+			}
+		},
+	}
+
+	iter := baseQry.Iter()
+
+	if call != 2 {
+		t.Fatalf("executeQuery call count = %d, want 2", call)
+	}
+	if !firstFramer.released {
+		t.Fatal("hidden empty-page framer was not released")
+	}
+	if handler.calls != 1 {
+		t.Fatalf("handler call count after Iter = %d, want 1", handler.calls)
+	}
+	if !slices.Equal(handler.warnings, []string{"empty-page", "final-error"}) {
+		t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"empty-page", "final-error"})
+	}
+	if warnings := iter.Warnings(); !slices.Equal(warnings, []string{"empty-page", "final-error"}) {
+		t.Fatalf("Warnings() = %v, want %v", warnings, []string{"empty-page", "final-error"})
+	}
+	if err := iter.Close(); err == nil || err.Error() != "boom" {
+		t.Fatalf("Close() = %v, want boom", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Pool `framer` structs using `sync.Pool` and cache CQL protocol extension values on the `Conn` struct, eliminating per-query framer allocation overhead and redundant linear scans of the extension list.

## Context

Every call to `Conn.exec()` and `Conn.recv()` created a new `framer` via `newFramerWithExts()`, which:

1. **Allocated a `framer` struct** on the heap
2. **Allocated a 128-byte buffer** (`make([]byte, defaultBufSize)`) that grows dynamically
3. **Scanned `cqlProtoExts` three times** via `findCQLProtoExtByName()` to extract `flagLWT`, `rateLimitingErrorCode`, and `tabletsRoutingV1` — values constant for the lifetime of a connection
4. **Called `setTabletSupported()`** (an `atomic.StoreInt32`) with the same value every time

There were 4 call sites in `conn.go`, all passing identical arguments: `c.compressor, c.version, c.cqlProtoExts, c.logger`.

## Changes

**Framer pooling:**
- Added `framerPool` (`sync.Pool`) to reuse `framer` structs and their backing read buffers
- Added `Conn.getFramer()` / `putFramer()` helpers that apply connection settings and reset per-frame state
- Write framers in `exec()` are pooled after `writeContext()` completes (fully local scope)
- Event and error-stream framers in `recv()` are pooled after `parseFrame()` / `handleEvent()` completes
- Response framers passed to callers via `exec()` return value are **not pooled** because `Iter.Scan()` reads rows from the framer buffer
- Framers are returned to pool on all error paths: net.Error, timeout, context cancel, `addCall` failure, `buildFrame` failure

**Extension value caching:**
- Added `initFramerCache()` called once after `cqlProtoExts` is populated during connection setup
- Caches `framerFlagLWT`, `framerRateLimitCode`, `framerTabletsV1` on the `Conn` struct
- Eliminates 3x `findCQLProtoExtByName` linear scans per framer creation
- Removed redundant `setTabletSupported()` calls from per-query paths (called once in `initFramerCache`)

**Note:** `proto` and `flags` are computed directly in `getFramer()` from `c.version` and `c.compressor` (not cached), because `getFramer()` is called during startup before `initFramerCache()` runs. These are simple bitmask operations with no allocation cost.

## Testing

All unit tests pass with race detector:
```bash
go test -tags "unit" -race -timeout=180s ./...
```

Benchmark results (benchstat, 5 runs, p=0.008 for allocs/memory):

| Benchmark | Metric | Before | After | Change | p-value |
|---|---|---|---|---|---|
| SingleConnectionSelect | B/op | 2,452 | 2,199 | **-10.31%** | 0.008 |
| | allocs/op | 28 | 26 | **-7.14%** | 0.008 |
| SingleConnectionInsert | B/op | 2,421 | 2,167 | **-10.49%** | 0.008 |
| | allocs/op | 28 | 26 | **-7.14%** | 0.008 |
| SingleConn (mock) | B/op | 3,127 | 2,896 | **-7.37%** | 0.008 |
| | allocs/op | 36 | 35 | **-2.78%** | 0.008 |

Latency differences are within noise for this benchmark (the allocation savings show up as reduced GC pressure under sustained load rather than single-query latency).

Closes #799