### PR TITLE
test: fix P1 blockers for parallel test execution

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1940,10 +1940,11 @@ func TestPrepare_PreparedCacheKey(t *testing.T) {
 
 	table := testTableName(t)
 
-	// create a second keyspace
+	// create a second keyspace with a unique name to avoid collisions under parallel execution
+	ks2 := testKeyspaceName(t, "ks2")
 	cluster2 := createCluster()
-	createKeyspace(t, cluster2, "gocql_test2", false)
-	cluster2.Keyspace = "gocql_test2"
+	createKeyspace(t, cluster2, ks2, false)
+	cluster2.Keyspace = ks2
 	session2, err := cluster2.CreateSession()
 	if err != nil {
 		t.Fatal("create session:", err)
@@ -1954,7 +1955,7 @@ func TestPrepare_PreparedCacheKey(t *testing.T) {
 	if err := createTable(session, fmt.Sprintf("CREATE TABLE gocql_test.%s (id varchar primary key, field varchar)", table)); err != nil {
 		t.Fatal("create table:", err)
 	}
-	if err := createTable(session2, fmt.Sprintf("CREATE TABLE gocql_test2.%s (id varchar primary key, field varchar)", table)); err != nil {
+	if err := createTable(session2, fmt.Sprintf("CREATE TABLE %s.%s (id varchar primary key, field varchar)", ks2, table)); err != nil {
 		t.Fatal("create table:", err)
 	}
 

--- a/common_test.go
+++ b/common_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -52,10 +53,22 @@ var (
 	flagCassVersion   cassVersion
 )
 
+// integrationTestSetup is set by an init() in an integration-tagged file to run
+// one-time setup (e.g. tablet probes) before any test executes.
+var integrationTestSetup func()
+
 func init() {
 	flag.Var(&flagCassVersion, "gocql.cversion", "the cassandra version being tested against")
 
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if integrationTestSetup != nil {
+		integrationTestSetup()
+	}
+	os.Exit(m.Run())
 }
 
 func getClusterHosts() []string {
@@ -104,26 +117,23 @@ func (o *OnceManager) GetOnce(key string) *sync.Once {
 var initKeyspaceOnce = NewOnceManager()
 
 var isTabletsSupportedFlag *bool
-var isTabletsSupportedOnce sync.RWMutex
+var isTabletsSupportedOnce sync.Once
 
 func isTabletsSupported() bool {
-	isTabletsSupportedOnce.RLock()
-	if isTabletsSupportedFlag != nil {
-		isTabletsSupportedOnce.RUnlock()
-		return *isTabletsSupportedFlag
+	isTabletsSupportedOnce.Do(probeTabletsSupported)
+	if isTabletsSupportedFlag == nil {
+		return false
 	}
-	isTabletsSupportedOnce.RUnlock()
-	isTabletsSupportedOnce.Lock()
-	defer isTabletsSupportedOnce.Unlock()
-	if isTabletsSupportedFlag != nil {
-		return *isTabletsSupportedFlag
-	}
-	var result bool
+	return *isTabletsSupportedFlag
+}
 
+func probeTabletsSupported() {
 	s, err := createCluster().CreateSession()
 	if err != nil {
 		panic(fmt.Errorf("failed to create session: %v", err))
 	}
+	defer s.Close()
+
 	res := make(map[string]interface{})
 	err = s.Query("select * from system.local").MapScan(res)
 	if err != nil {
@@ -134,36 +144,32 @@ func isTabletsSupported() bool {
 	featuresCasted, _ := features.(string)
 	for _, feature := range strings.Split(featuresCasted, ",") {
 		if feature == "TABLETS" {
-			result = true
+			result := true
 			isTabletsSupportedFlag = &result
-			return true
+			return
 		}
 	}
-	result = false
+	result := false
 	isTabletsSupportedFlag = &result
-	return false
 }
 
 var isTabletsAutoEnabledFlag *bool
-var isTabletsAutoEnabledOnce sync.RWMutex
+var isTabletsAutoEnabledOnce sync.Once
 
 func isTabletsAutoEnabled() bool {
-	isTabletsAutoEnabledOnce.RLock()
-	if isTabletsAutoEnabledFlag != nil {
-		isTabletsAutoEnabledOnce.RUnlock()
-		return *isTabletsAutoEnabledFlag
+	isTabletsAutoEnabledOnce.Do(probeTabletsAutoEnabled)
+	if isTabletsAutoEnabledFlag == nil {
+		return false
 	}
-	isTabletsAutoEnabledOnce.RUnlock()
-	isTabletsAutoEnabledOnce.Lock()
-	defer isTabletsAutoEnabledOnce.Unlock()
-	if isTabletsAutoEnabledFlag != nil {
-		return *isTabletsAutoEnabledFlag
-	}
+	return *isTabletsAutoEnabledFlag
+}
 
+func probeTabletsAutoEnabled() {
 	s, err := createCluster().CreateSession()
 	if err != nil {
 		panic(fmt.Errorf("failed to create session: %v", err))
 	}
+	defer s.Close()
 
 	err = s.Query("DROP KEYSPACE IF EXISTS gocql_check_tablets_enabled").Exec()
 	if err != nil {
@@ -171,20 +177,33 @@ func isTabletsAutoEnabled() bool {
 	}
 	err = s.Query("CREATE KEYSPACE gocql_check_tablets_enabled WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}").Exec()
 	if err != nil {
-		panic(fmt.Errorf("failed to delete keyspace: %v", err))
+		panic(fmt.Errorf("failed to create keyspace: %v", err))
 	}
 
 	res := make(map[string]interface{})
 	err = s.Query("describe keyspace gocql_check_tablets_enabled").MapScan(res)
 	if err != nil {
-		panic(fmt.Errorf("failed to read system.local: %v", err))
+		panic(fmt.Errorf("failed to describe keyspace: %v", err))
+	}
+
+	err = s.Query("DROP KEYSPACE IF EXISTS gocql_check_tablets_enabled").Exec()
+	if err != nil {
+		panic(fmt.Errorf("failed to drop probe keyspace: %v", err))
 	}
 
 	createStmt, _ := res["create_statement"]
 	createStmtCasted, _ := createStmt.(string)
 	result := strings.Contains(strings.ToLower(createStmtCasted), "and tablets")
 	isTabletsAutoEnabledFlag = &result
-	return result
+}
+
+// initTabletProbes runs the tablet-support and tablet-auto-enabled probes eagerly.
+// Called from TestMain before any tests run to avoid races with parallel test startup.
+func initTabletProbes() {
+	probeTabletsSupported()
+	if isTabletsSupportedFlag != nil && *isTabletsSupportedFlag {
+		probeTabletsAutoEnabled()
+	}
 }
 
 func createTable(s *Session, table string) error {

--- a/integration_test.go
+++ b/integration_test.go
@@ -39,6 +39,12 @@ import (
 	"github.com/gocql/gocql/internal/tests"
 )
 
+func init() {
+	// Register integration-only setup that runs before any test (called from TestMain).
+	// This eagerly probes tablet support so parallel tests don't race on lazy init.
+	integrationTestSetup = initTabletProbes
+}
+
 // TestAuthentication verifies that gocql will work with a host configured to only accept authenticated connections
 func TestAuthentication(t *testing.T) {
 

--- a/policies_integration_test.go
+++ b/policies_integration_test.go
@@ -44,7 +44,7 @@ func TestDCValidationRackAware(t *testing.T) {
 
 func TestTokenAwareHostPolicy(t *testing.T) {
 	t.Run("keyspace", func(t *testing.T) {
-		ks := "tokenaware_init_test"
+		ks := testKeyspaceName(t)
 		createKeyspace(t, createCluster(), ks, false)
 
 		policy := TokenAwareHostPolicy(RoundRobinHostPolicy())

--- a/recreate_test.go
+++ b/recreate_test.go
@@ -37,55 +37,55 @@ func TestRecreateSchema(t *testing.T) {
 
 	tcs := []struct {
 		Name            string
-		Keyspace        string
+		FixedKeyspace   string // original keyspace name used in .cql files
 		FailWithTablets bool
 		Input           string
 		Golden          string
 	}{
 		{
-			Name:     "Keyspace",
-			Keyspace: "gocqlx_keyspace",
-			Input:    "testdata/recreate/keyspace.cql",
-			Golden:   "testdata/recreate/keyspace_golden.cql",
+			Name:          "Keyspace",
+			FixedKeyspace: "gocqlx_keyspace",
+			Input:         "testdata/recreate/keyspace.cql",
+			Golden:        "testdata/recreate/keyspace_golden.cql",
 		},
 		{
-			Name:     "Table",
-			Keyspace: "gocqlx_table",
-			Input:    "testdata/recreate/table.cql",
-			Golden:   "testdata/recreate/table_golden.cql",
+			Name:          "Table",
+			FixedKeyspace: "gocqlx_table",
+			Input:         "testdata/recreate/table.cql",
+			Golden:        "testdata/recreate/table_golden.cql",
 		},
 		{
 			Name:            "Materialized Views",
-			Keyspace:        "gocqlx_mv",
+			FixedKeyspace:   "gocqlx_mv",
 			FailWithTablets: failsOnOldScylla,
 			Input:           "testdata/recreate/materialized_views.cql",
 			Golden:          "testdata/recreate/materialized_views_golden.cql",
 		},
 		{
 			Name:            "Index",
-			Keyspace:        "gocqlx_idx",
+			FixedKeyspace:   "gocqlx_idx",
 			FailWithTablets: failsOnOldScylla,
 			Input:           "testdata/recreate/index.cql",
 			Golden:          "testdata/recreate/index_golden.cql",
 		},
 		{
 			Name:            "Secondary Index",
-			Keyspace:        "gocqlx_sec_idx",
+			FixedKeyspace:   "gocqlx_sec_idx",
 			FailWithTablets: failsOnOldScylla,
 			Input:           "testdata/recreate/secondary_index.cql",
 			Golden:          "testdata/recreate/secondary_index_golden.cql",
 		},
 		{
-			Name:     "UDT",
-			Keyspace: "gocqlx_udt",
-			Input:    "testdata/recreate/udt.cql",
-			Golden:   "testdata/recreate/udt_golden.cql",
+			Name:          "UDT",
+			FixedKeyspace: "gocqlx_udt",
+			Input:         "testdata/recreate/udt.cql",
+			Golden:        "testdata/recreate/udt_golden.cql",
 		},
 		{
-			Name:     "Aggregates",
-			Keyspace: "gocqlx_aggregates",
-			Input:    "testdata/recreate/aggregates.cql",
-			Golden:   "testdata/recreate/aggregates_golden.cql",
+			Name:          "Aggregates",
+			FixedKeyspace: "gocqlx_aggregates",
+			Input:         "testdata/recreate/aggregates.cql",
+			Golden:        "testdata/recreate/aggregates_golden.cql",
 		},
 	}
 
@@ -95,14 +95,21 @@ func TestRecreateSchema(t *testing.T) {
 			if test.Name == "UDT" && *flagDistribution == "scylla" && flagCassVersion.Major == 2024 && flagCassVersion.Minor == 1 {
 				t.Skip("Doesn't work properly on Scylla 2024.1 due to https://github.com/scylladb/scylladb/issues/26761")
 			}
-			cleanup(t, session, test.Keyspace)
+
+			// Generate a unique keyspace name to avoid collisions under parallel execution.
+			// Replace the fixed keyspace name in CQL input/golden files with the unique name.
+			ks := testKeyspaceName(t)
+			cleanup(t, session, ks)
 
 			in, err := os.ReadFile(test.Input)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			queries := trimQueries(strings.Split(string(in), ";"))
+			// Substitute the fixed keyspace name in the CQL input with the unique name.
+			inStr := strings.ReplaceAll(string(in), test.FixedKeyspace, ks)
+
+			queries := trimQueries(strings.Split(inStr, ";"))
 			for _, q := range queries {
 				qr := session.Query(q, nil)
 				err = qr.Exec()
@@ -116,7 +123,7 @@ func TestRecreateSchema(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to await for schema agreement", err)
 			}
-			err = session.metadataDescriber.refreshKeyspaceSchema(test.Keyspace)
+			err = session.metadataDescriber.refreshKeyspaceSchema(ks)
 			if err != nil {
 				t.Fatal("failed to read schema for keyspace", err)
 			}
@@ -133,7 +140,7 @@ func TestRecreateSchema(t *testing.T) {
 				t.Fatal("invalid input query", err)
 			}
 
-			km, err := session.KeyspaceMetadata(test.Keyspace)
+			km, err := session.KeyspaceMetadata(ks)
 			if err != nil {
 				t.Fatal("dump schema", err)
 			}
@@ -144,13 +151,18 @@ func TestRecreateSchema(t *testing.T) {
 
 			dump = trimSchema(dump)
 
+			// Normalize the dump back to the fixed keyspace name for comparison with golden files.
+			dump = strings.ReplaceAll(dump, ks, test.FixedKeyspace)
+
 			var golden []byte
 			if getStmtFromCluster {
-				golden, err = getCreateStatements(session, test.Keyspace)
+				golden, err = getCreateStatements(session, ks)
 				if err != nil {
 					t.Fatal(err)
 				}
 				golden = []byte(trimSchema(string(golden)))
+				// Normalize from the cluster's unique keyspace name back to fixed name.
+				golden = []byte(strings.ReplaceAll(string(golden), ks, test.FixedKeyspace))
 			} else {
 				if *updateGolden {
 					if err := os.WriteFile(test.Golden, []byte(dump), 0644); err != nil {
@@ -179,11 +191,12 @@ func TestRecreateSchema(t *testing.T) {
 				}
 			}
 
-			// Exec dumped queries to check if they are CQL-correct
-			cleanup(t, session, test.Keyspace)
-			session.metadataDescriber.invalidateKeyspaceSchema(test.Keyspace)
+			// Exec dumped queries to check if they are CQL-correct.
+			// Substitute the fixed keyspace name back to the unique name for execution.
+			cleanup(t, session, ks)
+			session.metadataDescriber.invalidateKeyspaceSchema(ks)
 
-			for _, q := range trimQueries(strings.Split(dump, ";")) {
+			for _, q := range trimQueries(strings.Split(strings.ReplaceAll(dump, test.FixedKeyspace, ks), ";")) {
 				qr := session.Query(q, nil)
 				if err := qr.Exec(); err != nil {
 					t.Fatal("invalid dump query", q, err)
@@ -196,11 +209,11 @@ func TestRecreateSchema(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to await for schema agreement", err)
 			}
-			err = session.metadataDescriber.refreshKeyspaceSchema(test.Keyspace)
+			err = session.metadataDescriber.refreshKeyspaceSchema(ks)
 			if err != nil {
 				t.Fatal("failed to read schema for keyspace", err)
 			}
-			km, err = session.KeyspaceMetadata(test.Keyspace)
+			km, err = session.KeyspaceMetadata(ks)
 			if err != nil {
 				t.Fatal("dump schema", err)
 			}
@@ -210,6 +223,8 @@ func TestRecreateSchema(t *testing.T) {
 			}
 
 			secondDump = trimSchema(secondDump)
+			// Normalize the second dump back to fixed keyspace name for comparison.
+			secondDump = strings.ReplaceAll(secondDump, ks, test.FixedKeyspace)
 
 			secondDumpQueries := trimQueries(sortQueries(strings.Split(secondDump, ";")))
 


### PR DESCRIPTION
## Summary

Fix three P1 issues from the parallel test enablement meta-issue (#812) that will cause test failures under parallel execution.

## Changes

### 1. Fix UDT cross-test dependency (#802)
Already resolved by PR #813 which added `testTypeName(t)` — each UDT test now creates its own types with unique names. The implicit dependency where `TestUDT_MissingField` relied on a type created by `TestUDT_NullObject` no longer exists.

### 2. Make custom keyspace names unique per test (#805)
- Replace hardcoded `gocql_test2` in `TestPrepare_PreparedCacheKey` with `testKeyspaceName(t, "ks2")`
- Replace hardcoded `tokenaware_init_test` in `TestTokenAwareHostPolicy` with `testKeyspaceName(t)`
- Replace hardcoded `gocqlx_*` keyspace names in `TestRecreateSchema` with `testKeyspaceName(t)`, using string substitution to maintain compatibility with the existing `.cql` test data and golden files

### 3. Move `isTabletsAutoEnabled()` probe to TestMain (#806)
- Replace manual double-checked locking (`sync.RWMutex`) with `sync.Once` for both `isTabletsSupported()` and `isTabletsAutoEnabled()`
- Add `TestMain` in `common_test.go` with an `integrationTestSetup` hook
- Register `initTabletProbes()` via `init()` in `integration_test.go` so the probes run exactly once before any test, eliminating the race with parallel test startup
- Add cleanup (DROP KEYSPACE) for the probe keyspace
- Close sessions that were previously leaked

## Testing
- All unit tests pass (`go test -short ./...`)
- Code compiles with both unit and integration build tags

Fixes #802
Fixes #805
Fixes #806
Ref #812