### PR TITLE
test: add t.Parallel() to all safe integration tests

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestBatch_Errors(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -51,6 +53,8 @@ func TestBatch_Errors(t *testing.T) {
 }
 
 func TestBatch_WithTimestamp(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 

--- a/cass1batch_test.go
+++ b/cass1batch_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestProto1BatchInsert(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -54,6 +56,8 @@ func TestProto1BatchInsert(t *testing.T) {
 }
 
 func TestShouldPrepareFunction(t *testing.T) {
+	t.Parallel()
+
 	var shouldPrepareTests = []struct {
 		Stmt   string
 		Result bool

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -51,6 +51,8 @@ import (
 )
 
 func TestEmptyHosts(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.Hosts = nil
 	if session, err := cluster.CreateSession(); err == nil {
@@ -60,6 +62,8 @@ func TestEmptyHosts(t *testing.T) {
 }
 
 func TestInvalidPeerEntry(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("dont mutate system tables, rewrite this to test what we mean to test")
 	session := createSession(t)
 
@@ -97,6 +101,8 @@ func TestInvalidPeerEntry(t *testing.T) {
 
 // TestUseStatementError checks to make sure the correct error is returned when the user tries to execute a use statement.
 func TestUseStatementError(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -111,6 +117,8 @@ func TestUseStatementError(t *testing.T) {
 
 // TestInvalidKeyspace checks that an invalid keyspace will return promptly and without a flood of connections
 func TestInvalidKeyspace(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.Keyspace = "invalidKeyspace"
 	session, err := cluster.CreateSession()
@@ -125,6 +133,8 @@ func TestInvalidKeyspace(t *testing.T) {
 }
 
 func TestTracing(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -168,6 +178,8 @@ func TestTracing(t *testing.T) {
 }
 
 func TestObserve(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -263,6 +275,8 @@ func TestObserve(t *testing.T) {
 }
 
 func TestObserve_Pagination(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -317,6 +331,8 @@ func TestObserve_Pagination(t *testing.T) {
 }
 
 func TestPaging(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -346,6 +362,8 @@ func TestPaging(t *testing.T) {
 }
 
 func TestPagingWithAllowFiltering(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 
 	table := testTableName(t)
@@ -481,6 +499,8 @@ func TestPagingWithAllowFiltering(t *testing.T) {
 }
 
 func TestPagingWithBind(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -523,6 +543,8 @@ func TestPagingWithBind(t *testing.T) {
 }
 
 func TestCAS(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.SerialConsistency = LocalSerial
 	session := createSessionFromClusterTabletsDisabled(cluster, t)
@@ -702,6 +724,8 @@ func TestCAS(t *testing.T) {
 }
 
 func TestConsistencySerial(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -790,6 +814,8 @@ func TestConsistencySerial(t *testing.T) {
 }
 
 func TestDurationType(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -844,6 +870,8 @@ func TestDurationType(t *testing.T) {
 }
 
 func TestMapScanCAS(t *testing.T) {
+	t.Parallel()
+
 	session := createSessionFromClusterTabletsDisabled(createCluster(), t)
 	defer session.Close()
 
@@ -884,6 +912,8 @@ func TestMapScanCAS(t *testing.T) {
 }
 
 func TestBatch(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -911,6 +941,8 @@ func TestBatch(t *testing.T) {
 }
 
 func TestUnpreparedBatch(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("FLAKE skipping")
 	session := createSession(t)
 	defer session.Close()
@@ -948,6 +980,8 @@ func TestUnpreparedBatch(t *testing.T) {
 // TestBatchLimit tests gocql to make sure batch operations larger than the maximum
 // statement limit are not submitted to a cassandra node.
 func TestBatchLimit(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -968,6 +1002,8 @@ func TestBatchLimit(t *testing.T) {
 }
 
 func TestWhereIn(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -996,6 +1032,8 @@ func TestWhereIn(t *testing.T) {
 // TestTooManyQueryArgs tests to make sure the library correctly handles the application level bug
 // whereby too many query arguments are passed to a query
 func TestTooManyQueryArgs(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1026,6 +1064,8 @@ func TestTooManyQueryArgs(t *testing.T) {
 // TestNotEnoughQueryArgs tests to make sure the library correctly handles the application level bug
 // whereby not enough query arguments are passed to a query
 func TestNotEnoughQueryArgs(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1053,6 +1093,8 @@ func TestNotEnoughQueryArgs(t *testing.T) {
 // TestCreateSessionTimeout tests to make sure the CreateSession function timeouts out correctly
 // and prevents an infinite loop of connection retries.
 func TestCreateSessionTimeout(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1114,6 +1156,8 @@ func (n *FullName) UnmarshalCQL(info TypeInfo, data []byte) error {
 }
 
 func TestMapScanWithRefMap(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1182,6 +1226,8 @@ func TestMapScanWithRefMap(t *testing.T) {
 }
 
 func TestMapScan(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1228,6 +1274,8 @@ func TestMapScan(t *testing.T) {
 }
 
 func TestSliceMap(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1371,6 +1419,8 @@ func (*MyRetryPolicy) GetRetryType(err error) RetryType {
 }
 
 func Test_RetryPolicyIdempotence(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1406,6 +1456,8 @@ func Test_RetryPolicyIdempotence(t *testing.T) {
 }
 
 func TestSmallInt(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1433,6 +1485,8 @@ func TestSmallInt(t *testing.T) {
 }
 
 func TestScanWithNilArguments(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1467,6 +1521,8 @@ func TestScanWithNilArguments(t *testing.T) {
 }
 
 func TestScanCASWithNilArguments(t *testing.T) {
+	t.Parallel()
+
 	session := createSessionFromClusterTabletsDisabled(createCluster(), t)
 	defer session.Close()
 
@@ -1513,6 +1569,8 @@ func TestScanCASWithNilArguments(t *testing.T) {
 }
 
 func TestRebindQueryInfo(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1555,6 +1613,8 @@ func TestRebindQueryInfo(t *testing.T) {
 
 // TestStaticQueryInfo makes sure that the application can manually bind query parameters using the simplest possible static binding strategy
 func TestStaticQueryInfo(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1625,6 +1685,7 @@ func upcaseInitial(str string) string {
 
 // TestBoundQueryInfo makes sure that the application can manually bind query parameters using the query meta data supplied at runtime
 func TestBoundQueryInfo(t *testing.T) {
+	t.Parallel()
 
 	session := createSession(t)
 	defer session.Close()
@@ -1666,6 +1727,8 @@ func TestBoundQueryInfo(t *testing.T) {
 
 // TestBatchQueryInfo makes sure that the application can manually bind query parameters when executing in a batch
 func TestBatchQueryInfo(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1764,6 +1827,8 @@ func injectInvalidPreparedStatement(t *testing.T, session *Session, table string
 }
 
 func TestPrepare_MissingSchemaPrepare(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1788,6 +1853,8 @@ func TestPrepare_MissingSchemaPrepare(t *testing.T) {
 }
 
 func TestPrepare_ReprepareStatement(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1804,6 +1871,8 @@ func TestPrepare_ReprepareStatement(t *testing.T) {
 }
 
 func TestPrepare_ReprepareBatch(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1821,6 +1890,8 @@ func TestPrepare_ReprepareBatch(t *testing.T) {
 }
 
 func TestQueryInfo(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1842,6 +1913,8 @@ func TestQueryInfo(t *testing.T) {
 
 // TestPreparedCacheEviction will make sure that the cache size is maintained
 func TestPrepare_PreparedCacheEviction(t *testing.T) {
+	t.Parallel()
+
 	const maxPrepared = 4
 
 	clusterHosts := getClusterHosts()
@@ -1935,6 +2008,8 @@ func TestPrepare_PreparedCacheEviction(t *testing.T) {
 }
 
 func TestPrepare_PreparedCacheKey(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -1986,6 +2061,8 @@ func TestPrepare_PreparedCacheKey(t *testing.T) {
 
 // TestMarshalFloat64Ptr tests to see that a pointer to a float64 is marshalled correctly.
 func TestMarshalFloat64Ptr(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2002,6 +2079,8 @@ func TestMarshalFloat64Ptr(t *testing.T) {
 
 // TestMarshalInet tests to see that a pointer to a float64 is marshalled correctly.
 func TestMarshalInet(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2055,6 +2134,8 @@ func TestMarshalInet(t *testing.T) {
 }
 
 func TestVarint(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2166,6 +2247,8 @@ func TestVarint(t *testing.T) {
 
 // TestQueryStats confirms that the stats are returning valid data. Accuracy may be questionable.
 func TestQueryStats(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 	qry := session.Query("SELECT * FROM system.peers")
@@ -2183,6 +2266,8 @@ func TestQueryStats(t *testing.T) {
 
 // TestIterHosts confirms that host is added to Iter when the query succeeds.
 func TestIterHost(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 	iter := session.Query("SELECT * FROM system.peers").Iter()
@@ -2195,6 +2280,8 @@ func TestIterHost(t *testing.T) {
 
 // TestBatchStats confirms that the stats are returning valid data. Accuracy may be questionable.
 func TestBatchStats(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2227,6 +2314,8 @@ func (f funcBatchObserver) ObserveBatch(ctx context.Context, o ObservedBatch) {
 }
 
 func TestBatchObserve(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2290,6 +2379,8 @@ func TestBatchObserve(t *testing.T) {
 // TestNilInQuery tests to see that a nil value passed to a query is handled by Cassandra
 // TODO validate the nil value by reading back the nil. Need to fix Unmarshalling.
 func TestNilInQuery(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2313,6 +2404,8 @@ func TestNilInQuery(t *testing.T) {
 
 // Don't initialize time.Time bind variable if cassandra timestamp column is empty
 func TestEmptyTimestamp(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 
 	defer session.Close()
@@ -2340,6 +2433,8 @@ func TestEmptyTimestamp(t *testing.T) {
 
 // Integration test of just querying for data from the system.schema_keyspace table where the keyspace DOES exist.
 func TestGetKeyspaceMetadata(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2373,6 +2468,8 @@ func TestGetKeyspaceMetadata(t *testing.T) {
 }
 
 func TestSessionMetadataAPIs(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2728,6 +2825,8 @@ func columnNames(columns map[string]*ColumnMetadata) []string {
 
 // Integration test of just querying for data from the system.schema_keyspace table where the keyspace DOES NOT exist.
 func TestGetKeyspaceMetadataFails(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2740,6 +2839,8 @@ func TestGetKeyspaceMetadataFails(t *testing.T) {
 
 // Integration test of the routing key calculation
 func TestRoutingKey(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2871,6 +2972,8 @@ func TestRoutingKey(t *testing.T) {
 
 // Integration test of the token-aware policy-based connection pool
 func TestTokenAwareConnPool(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
 
@@ -2920,6 +3023,8 @@ func TestTokenAwareConnPool(t *testing.T) {
 }
 
 func TestNegativeStream(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -2940,6 +3045,8 @@ func TestNegativeStream(t *testing.T) {
 }
 
 func TestManualQueryPaging(t *testing.T) {
+	t.Parallel()
+
 	const rowsToInsert = 5
 
 	session := createSession(t)
@@ -2994,6 +3101,8 @@ func TestManualQueryPaging(t *testing.T) {
 
 // Issue 475
 func TestSessionBindRoutingKey(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.PoolConfig.HostSelectionPolicy = TokenAwareHostPolicy(RoundRobinHostPolicy())
 
@@ -3027,6 +3136,8 @@ func TestSessionBindRoutingKey(t *testing.T) {
 }
 
 func TestJSONSupport(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -3073,6 +3184,8 @@ func TestJSONSupport(t *testing.T) {
 }
 
 func TestUnmarshallNestedTypes(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -3108,6 +3221,8 @@ func TestUnmarshallNestedTypes(t *testing.T) {
 }
 
 func TestSchemaReset(t *testing.T) {
+	t.Parallel()
+
 	if flagCassVersion.Major == 0 || flagCassVersion.Before(2, 1, 3) {
 		t.Skipf("skipping TestSchemaReset due to CASSANDRA-7910 in Cassandra <2.1.3 version=%v", flagCassVersion)
 	}
@@ -3166,6 +3281,8 @@ func TestSchemaReset(t *testing.T) {
 }
 
 func TestCreateSession_DontSwallowError(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("This test is bad, and the resultant error from cassandra changes between versions")
 	cluster := createCluster()
 	cluster.ProtoVersion = 0x100
@@ -3190,6 +3307,8 @@ func TestCreateSession_DontSwallowError(t *testing.T) {
 }
 
 func TestControl_DiscoverProtocol(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.ProtoVersion = 0
 
@@ -3206,6 +3325,8 @@ func TestControl_DiscoverProtocol(t *testing.T) {
 
 // TestUnsetCol verify unset column will not replace an existing column
 func TestUnsetCol(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -3237,6 +3358,8 @@ func TestUnsetCol(t *testing.T) {
 
 // TestUnsetColBatch verify unset column will not replace a column in batch
 func TestUnsetColBatch(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -3281,6 +3404,8 @@ func TestUnsetColBatch(t *testing.T) {
 }
 
 func TestQuery_NamedValues(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -13,14 +13,23 @@ import (
 )
 
 func TestGetHostPortMapping(t *testing.T) {
-	session := createSession(t)
-	createKeyspace(t, createCluster(), "gocql_test", true)
+	t.Parallel()
+
+	keyspace := testKeyspaceName(t)
+	cluster := createCluster()
+	createKeyspace(t, cluster, keyspace, true)
+
+	cluster.Keyspace = keyspace
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
 	defer session.Close()
 
 	table := testTableName(t)
-	qualifiedTable := "gocql_test." + table
+	qualifiedTable := keyspace + "." + table
 
-	if err := createTable(session, fmt.Sprintf(`CREATE TABLE gocql_test.%s (
+	if err := createTable(session, fmt.Sprintf(`CREATE TABLE %s.%s (
     connection_id uuid,
     host_id uuid,
     Address text,
@@ -30,7 +39,7 @@ func TestGetHostPortMapping(t *testing.T) {
     alternator_https_port int,
     Datacenter text,
     Rack text,
-    PRIMARY KEY (connection_id, host_id))`, table)); err != nil {
+    PRIMARY KEY (connection_id, host_id))`, keyspace, table)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cloud_cluster_test.go
+++ b/cloud_cluster_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestCloudConnection(t *testing.T) {
+	t.Parallel()
+
 	if !*gocql.FlagRunSslTest {
 		t.Skip("Skipping because SSL is not enabled on cluster")
 	}

--- a/control_integration_test.go
+++ b/control_integration_test.go
@@ -21,6 +21,8 @@ func (d unixSocketDialer) DialContext(_ context.Context, _, _ string) (net.Conn,
 }
 
 func TestUnixSockets(t *testing.T) {
+	t.Parallel()
+
 	socketFiles := getClusterSocketFile()
 	if len(socketFiles) == 0 {
 		t.Skip("this test needs path to socket file provided into -cluster-socket cli option")

--- a/errors_test.go
+++ b/errors_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestErrorsParse(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestSingleHostQueryExecutor(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 
 	e, err := NewSingleHostQueryExecutor(cluster)

--- a/integration_serialization_scylla_test.go
+++ b/integration_serialization_scylla_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestSerializationSimpleTypesCassandra(t *testing.T) {
+	t.Parallel()
+
 	const (
 		pkColumn   = "test_id"
 		testColumn = "test_col"
@@ -306,6 +308,8 @@ func compareValues(t *testing.T, cqlType string, expected, actual interface{}) b
 
 // TestSliceMapMapScanTypes tests SliceMap and MapScan with various CQL types
 func TestSliceMapMapScanTypes(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -488,6 +492,8 @@ func mustCreateDuration(months int32, days int32, timeDuration time.Duration) Du
 // TestSliceMapMapScanCounterTypes tests counter types separately since they have special restrictions
 // (counter columns can't be mixed with other column types in the same table)
 func TestSliceMapMapScanCounterTypes(t *testing.T) {
+	t.Parallel()
+
 	session := createSessionFromClusterTabletsDisabled(createCluster(), t)
 	defer session.Close()
 
@@ -549,6 +555,8 @@ func TestSliceMapMapScanCounterTypes(t *testing.T) {
 // TestSliceMapMapScanTupleTypes tests tuple types separately since they have special handling
 // (tuple elements get split into individual columns)
 func TestSliceMapMapScanTupleTypes(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -666,6 +674,8 @@ func TestSliceMapMapScanTupleTypes(t *testing.T) {
 // TestSliceMapMapScanVectorTypes tests vector types separately since they need Cassandra 5.0+ and special table setup
 // (vectors need separate tables and version checks)
 func TestSliceMapMapScanVectorTypes(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -791,6 +801,8 @@ func TestSliceMapMapScanVectorTypes(t *testing.T) {
 // TestSliceMapMapScanCollectionTypes tests collection types separately since they have special handling
 // (collections should return nil slices/maps for NULL values for consistency with other slice-based types)
 func TestSliceMapMapScanCollectionTypes(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,6 +47,7 @@ func init() {
 
 // TestAuthentication verifies that gocql will work with a host configured to only accept authenticated connections
 func TestAuthentication(t *testing.T) {
+	t.Parallel()
 
 	if !*flagRunAuthTest {
 		t.Skip("Authentication is not configured in the target cluster")
@@ -69,6 +70,8 @@ func TestAuthentication(t *testing.T) {
 }
 
 func TestGetHostsFromSystem(t *testing.T) {
+	t.Parallel()
+
 	clusterHosts := getClusterHosts()
 	cluster := createCluster()
 	session := createSessionFromCluster(cluster, t)
@@ -83,6 +86,8 @@ func TestGetHostsFromSystem(t *testing.T) {
 // TestRingDiscovery makes sure that you can autodiscover other cluster members
 // when you seed a cluster config with just one node
 func TestRingDiscovery(t *testing.T) {
+	t.Parallel()
+
 	clusterHosts := getClusterHosts()
 	cluster := createCluster()
 	cluster.Hosts = clusterHosts[:1]
@@ -110,6 +115,8 @@ func TestRingDiscovery(t *testing.T) {
 
 // TestHostFilterDiscovery ensures that host filtering works even when we discover hosts
 func TestHostFilterDiscovery(t *testing.T) {
+	t.Parallel()
+
 	clusterHosts := getClusterHosts()
 	if len(clusterHosts) < 2 {
 		t.Skip("skipping because we don't have 2 or more hosts")
@@ -135,6 +142,8 @@ func TestHostFilterDiscovery(t *testing.T) {
 // TestHostFilterInitial ensures that host filtering works for the initial
 // connection including the control connection
 func TestHostFilterInitial(t *testing.T) {
+	t.Parallel()
+
 	clusterHosts := getClusterHosts()
 	if len(clusterHosts) < 2 {
 		t.Skip("skipping because we don't have 2 or more hosts")
@@ -157,6 +166,8 @@ func TestHostFilterInitial(t *testing.T) {
 }
 
 func TestApplicationInformation(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	s, err := cluster.CreateSession()
 	if err != nil {
@@ -260,6 +271,8 @@ func TestApplicationInformation(t *testing.T) {
 }
 
 func TestWriteFailure(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("skipped due to unknown purpose")
 	cluster := createCluster()
 	createKeyspace(t, cluster, "test", false)
@@ -302,6 +315,8 @@ func TestWriteFailure(t *testing.T) {
 }
 
 func TestCustomPayloadMessages(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("SKIPPING")
 	cluster := createCluster()
 	session := createSessionFromCluster(cluster, t)
@@ -342,6 +357,8 @@ func TestCustomPayloadMessages(t *testing.T) {
 }
 
 func TestCustomPayloadValues(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("SKIPPING")
 	cluster := createCluster()
 	session := createSessionFromCluster(cluster, t)
@@ -366,6 +383,8 @@ func TestCustomPayloadValues(t *testing.T) {
 }
 
 func TestSessionAwaitSchemaAgreement(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -375,6 +394,8 @@ func TestSessionAwaitSchemaAgreement(t *testing.T) {
 }
 
 func TestSessionAwaitSchemaAgreementSessionClosed(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	session.Close()
 
@@ -385,6 +406,8 @@ func TestSessionAwaitSchemaAgreementSessionClosed(t *testing.T) {
 }
 
 func TestSessionAwaitSchemaAgreementContextCanceled(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -396,6 +419,8 @@ func TestSessionAwaitSchemaAgreementContextCanceled(t *testing.T) {
 }
 
 func TestNewConnectWithLowTimeout(t *testing.T) {
+	t.Parallel()
+
 	// Point of these tests to make sure that with low timeout connection creation will gracefully fail
 
 	type TestExpectation int

--- a/keyspace_table_test.go
+++ b/keyspace_table_test.go
@@ -37,6 +37,8 @@ import (
 
 // Keyspace_table checks if Query.Keyspace() is updated based on prepared statement
 func TestKeyspaceTable(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 
 	fallback := RoundRobinHostPolicy()

--- a/policies_integration_test.go
+++ b/policies_integration_test.go
@@ -11,6 +11,8 @@ import (
 
 // Check if session fail to start if DC name provided in the policy is wrong
 func TestDCValidationTokenAware(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 
 	fallback := DCAwareRoundRobinPolicy("WRONG_DC")
@@ -23,6 +25,8 @@ func TestDCValidationTokenAware(t *testing.T) {
 }
 
 func TestDCValidationDCAware(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.PoolConfig.HostSelectionPolicy = DCAwareRoundRobinPolicy("WRONG_DC")
 
@@ -33,6 +37,8 @@ func TestDCValidationDCAware(t *testing.T) {
 }
 
 func TestDCValidationRackAware(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.PoolConfig.HostSelectionPolicy = RackAwareRoundRobinPolicy("WRONG_DC", "RACK")
 
@@ -43,6 +49,8 @@ func TestDCValidationRackAware(t *testing.T) {
 }
 
 func TestTokenAwareHostPolicy(t *testing.T) {
+	t.Parallel()
+
 	t.Run("keyspace", func(t *testing.T) {
 		ks := testKeyspaceName(t)
 		createKeyspace(t, createCluster(), ks, false)

--- a/recreate_test.go
+++ b/recreate_test.go
@@ -24,6 +24,8 @@ import (
 var updateGolden = flag.Bool("update-golden", false, "update golden files")
 
 func TestRecreateSchema(t *testing.T) {
+	t.Parallel()
+
 	failsOnOldScylla := false
 	if *flagDistribution == "scylla" && flagCassVersion.Before(2024, 0, 0) {
 		failsOnOldScylla = true
@@ -251,6 +253,8 @@ func isDescribeKeyspaceSupported(t *testing.T, s *Session) bool {
 }
 
 func TestScyllaEncryptionOptionsUnmarshaller(t *testing.T) {
+	t.Parallel()
+
 	const (
 		input  = "testdata/recreate/scylla_encryption_options.bin"
 		golden = "testdata/recreate/scylla_encryption_options_golden.json"

--- a/schema_queries_test.go
+++ b/schema_queries_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestSchemaQueries(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 
 	fallback := RoundRobinHostPolicy()

--- a/scylla_shard_aware_port_integration_test.go
+++ b/scylla_shard_aware_port_integration_test.go
@@ -6,6 +6,8 @@ package gocql
 import "testing"
 
 func TestShardAwarePortIntegrationNoReconnections(t *testing.T) {
+	t.Parallel()
+
 	testShardAwarePortNoReconnections(t, func() *ClusterConfig {
 		c := createCluster()
 		c.Port = 9042
@@ -14,6 +16,8 @@ func TestShardAwarePortIntegrationNoReconnections(t *testing.T) {
 }
 
 func TestShardAwarePortIntegrationMaliciousNAT(t *testing.T) {
+	t.Parallel()
+
 	testShardAwarePortMaliciousNAT(t, func() *ClusterConfig {
 		c := createCluster()
 		c.Port = 9042
@@ -22,6 +26,8 @@ func TestShardAwarePortIntegrationMaliciousNAT(t *testing.T) {
 }
 
 func TestShardAwarePortIntegrationUnreachable(t *testing.T) {
+	t.Parallel()
+
 	testShardAwarePortUnreachable(t, func() *ClusterConfig {
 		c := createCluster()
 		c.Port = 9042
@@ -30,6 +36,8 @@ func TestShardAwarePortIntegrationUnreachable(t *testing.T) {
 }
 
 func TestShardAwarePortIntegrationUnusedIfNotEnabled(t *testing.T) {
+	t.Parallel()
+
 	testShardAwarePortUnusedIfNotEnabled(t, func() *ClusterConfig {
 		c := createCluster()
 		c.Port = 9042

--- a/session_event_bus_integration_test.go
+++ b/session_event_bus_integration_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/gocql/gocql/events"
 )
 
+// WARNING: This test must NOT use t.Parallel(). It listens for schema events
+// and concurrent DDL from parallel tests could cause spurious matches.
+//
+//nolint:paralleltest // listens for schema events from the global control connection
 func TestSessionEventBusReceivesSchemaChangeEvent(t *testing.T) {
 	cluster := createCluster()
 	cluster.Events.DisableSchemaEvents = false
@@ -50,6 +54,8 @@ func TestSessionEventBusReceivesSchemaChangeEvent(t *testing.T) {
 }
 
 func TestSessionEventBusReceivesControlReconnectEvent(t *testing.T) {
+	t.Parallel()
+
 	cluster := createCluster()
 	cluster.Events.DisableTopologyEvents = true
 	cluster.Events.DisableNodeStatusEvents = true

--- a/session_test.go
+++ b/session_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestSessionAPI(t *testing.T) {
+	t.Parallel()
+
 	cfg := &ClusterConfig{}
 
 	s := &Session{
@@ -127,6 +129,8 @@ func (f funcQueryObserver) ObserveQuery(ctx context.Context, o ObservedQuery) {
 }
 
 func TestQueryBasicAPI(t *testing.T) {
+	t.Parallel()
+
 	qry := &Query{routingInfo: &queryRoutingInfo{}}
 
 	// Initiate host
@@ -199,6 +203,8 @@ func TestQueryBasicAPI(t *testing.T) {
 }
 
 func TestQueryShouldPrepare(t *testing.T) {
+	t.Parallel()
+
 	toPrepare := []string{"select * ", "INSERT INTO", "update table", "delete from", "begin batch"}
 	cantPrepare := []string{"create table", "USE table", "LIST keyspaces", "alter table", "drop table", "grant user", "revoke user"}
 	q := &Query{routingInfo: &queryRoutingInfo{}}
@@ -219,6 +225,7 @@ func TestQueryShouldPrepare(t *testing.T) {
 }
 
 func TestBatchBasicAPI(t *testing.T) {
+	t.Parallel()
 
 	cfg := &ClusterConfig{RetryPolicy: &SimpleRetryPolicy{NumRetries: 2}}
 
@@ -313,6 +320,8 @@ func TestBatchBasicAPI(t *testing.T) {
 }
 
 func TestConsistencyNames(t *testing.T) {
+	t.Parallel()
+
 	names := map[fmt.Stringer]string{
 		Any:         "ANY",
 		One:         "ONE",
@@ -335,6 +344,8 @@ func TestConsistencyNames(t *testing.T) {
 }
 
 func TestIsUseStatement(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		input string
 		exp   bool
@@ -379,6 +390,8 @@ func (p *simpleTestRetryPolycy) GetRetryType(error) RetryType {
 // - return error is not nil on Rethrow, Ignore
 // - observed error is not nil
 func TestRetryType_IgnoreRethrow(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -485,6 +498,8 @@ func withSessionCache(cache tls.ClientSessionCache) func(config *ClusterConfig) 
 }
 
 func TestTLSTicketResumption(t *testing.T) {
+	t.Parallel()
+
 	t.Skip("TLS ticket resumption is only supported by 2025.2 and later")
 
 	c := newSessionCache()

--- a/tablet_integration_test.go
+++ b/tablet_integration_test.go
@@ -12,6 +12,8 @@ import (
 
 // Check if TokenAwareHostPolicy works correctly when using tablets
 func TestTablets(t *testing.T) {
+	t.Parallel()
+
 	if !isTabletsSupported() {
 		t.Skip("Tablets are not supported by this server")
 	}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestTracingNewAPI(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestTupleSimple(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -77,6 +79,8 @@ func TestTupleSimple(t *testing.T) {
 }
 
 func TestTuple_NullTuple(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -114,6 +118,8 @@ func TestTuple_NullTuple(t *testing.T) {
 }
 
 func TestTuple_TupleNotSet(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -166,6 +172,8 @@ func TestTuple_TupleNotSet(t *testing.T) {
 }
 
 func TestTupleMapScan(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -198,6 +206,8 @@ func TestTupleMapScan(t *testing.T) {
 }
 
 func TestTupleMapScanNil(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -229,6 +239,8 @@ func TestTupleMapScanNil(t *testing.T) {
 }
 
 func TestTupleMapScanNotSet(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -260,6 +272,8 @@ func TestTupleMapScanNotSet(t *testing.T) {
 }
 
 func TestTupleLastFieldEmpty(t *testing.T) {
+	t.Parallel()
+
 	// Regression test - empty value used to be treated as NULL value in the last tuple field
 	session := createSession(t)
 	defer session.Close()
@@ -299,6 +313,8 @@ func TestTupleLastFieldEmpty(t *testing.T) {
 }
 
 func TestTuple_NestedCollection(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -350,6 +366,8 @@ func TestTuple_NestedCollection(t *testing.T) {
 }
 
 func TestTuple_NullableNestedCollection(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 

--- a/udt_test.go
+++ b/udt_test.go
@@ -69,6 +69,8 @@ func (p *position) UnmarshalUDT(name string, info TypeInfo, data []byte) error {
 }
 
 func TestUDT_Marshaler(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -124,6 +126,8 @@ func TestUDT_Marshaler(t *testing.T) {
 }
 
 func TestUDT_Reflect(t *testing.T) {
+	t.Parallel()
+
 	// Uses reflection instead of implementing the marshaling type
 	session := createSession(t)
 	defer session.Close()
@@ -175,6 +179,8 @@ func TestUDT_Reflect(t *testing.T) {
 }
 
 func TestUDT_NullObject(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -228,6 +234,8 @@ func TestUDT_NullObject(t *testing.T) {
 }
 
 func TestMapScanUDT(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -314,6 +322,8 @@ func TestMapScanUDT(t *testing.T) {
 }
 
 func TestUDT_MissingField(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -363,6 +373,8 @@ func TestUDT_MissingField(t *testing.T) {
 }
 
 func TestUDT_EmptyCollections(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -418,6 +430,8 @@ func TestUDT_EmptyCollections(t *testing.T) {
 }
 
 func TestUDT_UpdateField(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -474,6 +488,8 @@ func TestUDT_UpdateField(t *testing.T) {
 }
 
 func TestUDT_ScanNullUDT(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 

--- a/vector_test.go
+++ b/vector_test.go
@@ -52,6 +52,8 @@ func (p person) String() string {
 }
 
 func TestVector_Marshaler(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -103,6 +105,8 @@ func TestVector_Marshaler(t *testing.T) {
 }
 
 func TestVector_Types(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -255,6 +259,8 @@ func TestVector_Types(t *testing.T) {
 }
 
 func TestVector_MarshalerUDT(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -306,6 +312,8 @@ func TestVector_MarshalerUDT(t *testing.T) {
 }
 
 func TestVector_Empty(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -354,6 +362,8 @@ func TestVector_Empty(t *testing.T) {
 }
 
 func TestVector_MissingDimension(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -380,6 +390,7 @@ func TestVector_MissingDimension(t *testing.T) {
 }
 
 func TestVector_SubTypeParsing(t *testing.T) {
+	t.Parallel()
 
 	if *flagDistribution == "scylla" && flagCassVersion.Before(2025, 4, 0) {
 		t.Skip("Vector types are useful in ScyllaDB from 2025.4 and on")

--- a/wiki_test.go
+++ b/wiki_test.go
@@ -149,6 +149,8 @@ func (w *WikiTest) GetPageCount() int {
 }
 
 func TestWikiCreateSchema(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -170,6 +172,8 @@ func BenchmarkWikiCreateSchema(b *testing.B) {
 }
 
 func TestWikiCreatePages(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 
@@ -276,6 +280,8 @@ func BenchmarkWikiSelectPageCount(b *testing.B) {
 }
 
 func TestWikiTypicalCRUD(t *testing.T) {
+	t.Parallel()
+
 	session := createSession(t)
 	defer session.Close()
 


### PR DESCRIPTION
## Summary

Add `t.Parallel()` to all safe integration tests to enable parallel execution, reducing overall CI wall-clock time.

## Context

No integration tests previously called `t.Parallel()`. With all shared-state blockers resolved (#801 -- #806, #808), this is the final mechanical step to enable parallel execution of integration tests.

## Changes

- Added `t.Parallel()` as the first line in 140 integration test functions across 23 files
- 4 tests intentionally remain sequential, each annotated with `//nolint:paralleltest` and an explanatory comment:
  - `TestReconnection` -- mutates shared HostInfo state via `handleNodeDown()`
  - `TestQuery_SetHostID` -- mutates shared HostInfo state via `setState(NodeDown)`
  - `TestNoHangAllHostsDown` -- sets all hosts to NodeDown state
  - `TestSessionEventBusReceivesSchemaChangeEvent` -- listens for schema events from the global control connection

## Testing

```bash
# Linter (passes with 0 issues)
make check

# Unit tests (unaffected, all pass)
make test-unit

# Integration tests require a live cluster
make test-integration-scylla
```

## Links

- Closes #811
- Parent tracking issue: #812
- Prerequisites: #801, #802, #803, #804, #805, #806, #808
