### PR TITLE
perf: optimize collection marshal/unmarshal write path (10's-100's ns improvements - ~14% improvement)

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1109,7 +1109,378 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// readMapEntryData reads a single collection entry (key or value) from data.
+// Returns the entry bytes (nil if the entry is null, i.e. size < 0),
+// the number of bytes consumed from data, and any error.
+func readMapEntryData(data []byte) (entryData []byte, consumed int, err error) {
+	if len(data) < 4 {
+		return nil, 0, unmarshalErrorf("unmarshal map: unexpected eof")
+	}
+	m := int(int32(data[0])<<24 | int32(data[1])<<16 | int32(data[2])<<8 | int32(data[3]))
+	if m < 0 {
+		return nil, 4, nil
+	}
+	if len(data) < 4+m {
+		return nil, 0, unmarshalErrorf("unmarshal map: unexpected eof")
+	}
+	return data[4 : 4+m], 4 + m, nil
+}
+
+// isStringKeyType returns true if the CQL type encodes as raw bytes that
+// should be interpreted as a Go string (text, varchar, ascii).
+func isStringKeyType(t Type) bool {
+	return t == TypeVarchar || t == TypeText || t == TypeAscii
+}
+
+// unmarshalMapFast attempts to unmarshal a map using type-switch fast paths
+// for common concrete map types, avoiding all reflection. Returns (true, err)
+// if the fast path handled the value, or (false, nil) to fall through to the
+// generic reflect-based path.
+func unmarshalMapFast(info CollectionType, data []byte, value any) (bool, error) {
+	keyType := info.Key.Type()
+	elemType := info.Elem.Type()
+
+	// We only fast-path string-keyed maps and int64-keyed maps, which cover
+	// the vast majority of real-world CQL map usage.
+	switch keyType {
+	case TypeVarchar, TypeText, TypeAscii:
+		switch v := value.(type) {
+		case *map[string]string:
+			if !isStringKeyType(elemType) {
+				return false, nil
+			}
+			return true, unmarshalMapStringString(data, v)
+		case *map[string][]byte:
+			if elemType != TypeBlob {
+				return false, nil
+			}
+			return true, unmarshalMapStringBytes(data, v)
+		case *map[string]int64:
+			if elemType != TypeBigInt && elemType != TypeCounter {
+				return false, nil
+			}
+			return true, unmarshalMapStringInt64(data, v)
+		case *map[string]int32:
+			if elemType != TypeInt {
+				return false, nil
+			}
+			return true, unmarshalMapStringInt32(data, v)
+		case *map[string]float64:
+			if elemType != TypeDouble {
+				return false, nil
+			}
+			return true, unmarshalMapStringFloat64(data, v)
+		case *map[string]bool:
+			if elemType != TypeBoolean {
+				return false, nil
+			}
+			return true, unmarshalMapStringBool(data, v)
+		}
+	case TypeBigInt, TypeCounter:
+		switch v := value.(type) {
+		case *map[int64]string:
+			if !isStringKeyType(elemType) {
+				return false, nil
+			}
+			return true, unmarshalMapInt64String(data, v)
+		case *map[int64]int64:
+			if elemType != TypeBigInt && elemType != TypeCounter {
+				return false, nil
+			}
+			return true, unmarshalMapInt64Int64(data, v)
+		}
+	}
+	return false, nil
+}
+
+func unmarshalMapStringString(data []byte, dest *map[string]string) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		m[string(keyData)] = string(valData)
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringBytes(data []byte, dest *map[string][]byte) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string][]byte, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		// Copy the value bytes since the underlying buffer may be reused.
+		var valCopy []byte
+		if valData != nil {
+			valCopy = make([]byte, len(valData))
+			copy(valCopy, valData)
+		}
+		m[string(keyData)] = valCopy
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringInt64(data []byte, dest *map[string]int64) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]int64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int64
+		if err := bigint.DecInt64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringInt32(data []byte, dest *map[string]int32) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]int32, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int32
+		if err := cqlint.DecInt32(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringFloat64(data []byte, dest *map[string]float64) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]float64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v float64
+		if err := double.DecFloat64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringBool(data []byte, dest *map[string]bool) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]bool, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v bool
+		if err := boolean.DecBool(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapInt64String(data []byte, dest *map[int64]string) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[int64]string, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var k int64
+		if err := bigint.DecInt64(keyData, &k); err != nil {
+			return unmarshalErrorf("unmarshal map key: %v", err)
+		}
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		m[k] = string(valData)
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64) error {
+	if data == nil {
+		*dest = nil
+		return nil
+	}
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[int64]int64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var k int64
+		if err := bigint.DecInt64(keyData, &k); err != nil {
+			return unmarshalErrorf("unmarshal map key: %v", err)
+		}
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int64
+		if err := bigint.DecInt64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[k] = v
+	}
+	*dest = m
+	return nil
+}
+
 func unmarshalMap(info CollectionType, data []byte, value any) error {
+	// Try fast path for common concrete map types (no reflection).
+	if handled, err := unmarshalMapFast(info, data, value); handled {
+		return err
+	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)

--- a/marshal.go
+++ b/marshal.go
@@ -219,9 +219,9 @@ func Marshal(info TypeInfo, value any) ([]byte, error) {
 	case TypeTimestamp:
 		return marshalTimestamp(value)
 	case TypeList, TypeSet:
-		return marshalList(info, value)
+		return marshalList(info.(CollectionType), value)
 	case TypeMap:
-		return marshalMap(info, value)
+		return marshalMap(info.(CollectionType), value)
 	case TypeUUID:
 		return marshalUUID(value)
 	case TypeTimeUUID:
@@ -332,9 +332,9 @@ func Unmarshal(info TypeInfo, data []byte, value any) error {
 	case TypeTimestamp:
 		return unmarshalTimestamp(data, value)
 	case TypeList, TypeSet:
-		return unmarshalList(info, data, value)
+		return unmarshalList(info.(CollectionType), data, value)
 	case TypeMap:
-		return unmarshalMap(info, data, value)
+		return unmarshalMap(info.(CollectionType), data, value)
 	case TypeTimeUUID:
 		return unmarshalTimeUUID(data, value)
 	case TypeUUID:
@@ -681,25 +681,18 @@ func unmarshalDuration(data []byte, value any) error {
 	return nil
 }
 
-func writeCollectionSize(info CollectionType, n int, buf *bytes.Buffer) error {
+func writeCollectionSize(n int, buf *bytes.Buffer) error {
 	if n > math.MaxInt32 {
 		return marshalErrorf("marshal: collection too large")
 	}
 
-	buf.WriteByte(byte(n >> 24))
-	buf.WriteByte(byte(n >> 16))
-	buf.WriteByte(byte(n >> 8))
-	buf.WriteByte(byte(n))
+	tmp := [4]byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}
+	buf.Write(tmp[:])
 
 	return nil
 }
 
-func marshalList(info TypeInfo, value any) ([]byte, error) {
-	listInfo, ok := info.(CollectionType)
-	if !ok {
-		return nil, marshalErrorf("marshal: can not marshal non collection type into list")
-	}
-
+func marshalList(info CollectionType, value any) ([]byte, error) {
 	if value == nil {
 		return nil, nil
 	} else if _, ok := value.(unsetColumn); ok {
@@ -718,12 +711,12 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 		buf := &bytes.Buffer{}
 		n := rv.Len()
 
-		if err := writeCollectionSize(listInfo, n, buf); err != nil {
+		if err := writeCollectionSize(n, buf); err != nil {
 			return nil, err
 		}
 
 		for i := 0; i < n; i++ {
-			item, err := Marshal(listInfo.Elem, rv.Index(i).Interface())
+			item, err := Marshal(info.Elem, rv.Index(i).Interface())
 			if err != nil {
 				return nil, err
 			}
@@ -732,7 +725,7 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 			if item == nil {
 				itemLen = -1
 			}
-			if err := writeCollectionSize(listInfo, itemLen, buf); err != nil {
+			if err := writeCollectionSize(itemLen, buf); err != nil {
 				return nil, err
 			}
 			buf.Write(item)
@@ -746,13 +739,13 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 			for i := 0; i < len(keys); i++ {
 				keys[i] = rkeys[i].Interface()
 			}
-			return marshalList(listInfo, keys)
+			return marshalList(info, keys)
 		}
 	}
 	return nil, marshalErrorf("can not marshal %T into %s", value, info)
 }
 
-func readCollectionSize(info CollectionType, data []byte) (size, read int, err error) {
+func readCollectionSize(data []byte) (size, read int, err error) {
 	if len(data) < 4 {
 		return 0, 0, unmarshalErrorf("unmarshal list: unexpected eof")
 	}
@@ -761,12 +754,7 @@ func readCollectionSize(info CollectionType, data []byte) (size, read int, err e
 	return
 }
 
-func unmarshalList(info TypeInfo, data []byte, value any) error {
-	listInfo, ok := info.(CollectionType)
-	if !ok {
-		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into list")
-	}
-
+func unmarshalList(info CollectionType, data []byte, value any) error {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -781,7 +769,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
 		}
 		// Create a properly typed slice based on the element type
-		elemGoType, err := goType(listInfo.Elem)
+		elemGoType, err := goType(info.Elem)
 		if err != nil {
 			return unmarshalErrorf("unmarshal list: cannot determine element type: %v", err)
 		}
@@ -801,7 +789,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			rv.Set(reflect.Zero(t))
 			return nil
 		}
-		n, p, err := readCollectionSize(listInfo, data)
+		n, p, err := readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -818,7 +806,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			}
 		}
 		for i := 0; i < n; i++ {
-			m, p, err := readCollectionSize(listInfo, data)
+			m, p, err := readCollectionSize(data)
 			if err != nil {
 				return err
 			}
@@ -832,7 +820,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 				unmarshalData = data[:m]
 				data = data[m:]
 			}
-			if err := Unmarshal(listInfo.Elem, unmarshalData, rv.Index(i).Addr().Interface()); err != nil {
+			if err := Unmarshal(info.Elem, unmarshalData, rv.Index(i).Addr().Interface()); err != nil {
 				return err
 			}
 		}
@@ -1063,12 +1051,7 @@ func computeUnsignedVIntSize(v uint64) int {
 	return (639 - lead0*9) >> 6
 }
 
-func marshalMap(info TypeInfo, value any) ([]byte, error) {
-	mapInfo, ok := info.(CollectionType)
-	if !ok {
-		return nil, marshalErrorf("marshal: can not marshal none collection type into map")
-	}
-
+func marshalMap(info CollectionType, value any) ([]byte, error) {
 	if value == nil {
 		return nil, nil
 	} else if _, ok := value.(unsetColumn); ok {
@@ -1089,13 +1072,13 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	n := rv.Len()
 
-	if err := writeCollectionSize(mapInfo, n, buf); err != nil {
+	if err := writeCollectionSize(n, buf); err != nil {
 		return nil, err
 	}
 
 	keys := rv.MapKeys()
 	for _, key := range keys {
-		item, err := Marshal(mapInfo.Key, key.Interface())
+		item, err := Marshal(info.Key, key.Interface())
 		if err != nil {
 			return nil, err
 		}
@@ -1104,12 +1087,12 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 		if item == nil {
 			itemLen = -1
 		}
-		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
+		if err := writeCollectionSize(itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
 
-		item, err = Marshal(mapInfo.Elem, rv.MapIndex(key).Interface())
+		item, err = Marshal(info.Elem, rv.MapIndex(key).Interface())
 		if err != nil {
 			return nil, err
 		}
@@ -1118,7 +1101,7 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 		if item == nil {
 			itemLen = -1
 		}
-		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
+		if err := writeCollectionSize(itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
@@ -1126,12 +1109,7 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func unmarshalMap(info TypeInfo, data []byte, value any) error {
-	mapInfo, ok := info.(CollectionType)
-	if !ok {
-		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into map")
-	}
-
+func unmarshalMap(info CollectionType, data []byte, value any) error {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -1145,11 +1123,11 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
 		}
 		// Create a properly typed map based on the key and element types
-		keyGoType, err := goType(mapInfo.Key)
+		keyGoType, err := goType(info.Key)
 		if err != nil {
 			return unmarshalErrorf("unmarshal map: cannot determine key type: %v", err)
 		}
-		elemGoType, err := goType(mapInfo.Elem)
+		elemGoType, err := goType(info.Elem)
 		if err != nil {
 			return unmarshalErrorf("unmarshal map: cannot determine element type: %v", err)
 		}
@@ -1163,7 +1141,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 		rv.Set(reflect.Zero(t))
 		return nil
 	}
-	n, p, err := readCollectionSize(mapInfo, data)
+	n, p, err := readCollectionSize(data)
 	if err != nil {
 		return err
 	}
@@ -1177,7 +1155,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 	}
 	data = data[p:]
 	for i := 0; i < n; i++ {
-		m, p, err := readCollectionSize(mapInfo, data)
+		m, p, err := readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -1192,11 +1170,11 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			unmarshalData = data[:m]
 			data = data[m:]
 		}
-		if err := Unmarshal(mapInfo.Key, unmarshalData, key.Interface()); err != nil {
+		if err := Unmarshal(info.Key, unmarshalData, key.Interface()); err != nil {
 			return err
 		}
 
-		m, p, err = readCollectionSize(mapInfo, data)
+		m, p, err = readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -1212,7 +1190,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			unmarshalData = data[:m]
 			data = data[m:]
 		}
-		if err := Unmarshal(mapInfo.Elem, unmarshalData, val.Interface()); err != nil {
+		if err := Unmarshal(info.Elem, unmarshalData, val.Interface()); err != nil {
 			return err
 		}
 

--- a/marshal.go
+++ b/marshal.go
@@ -1228,7 +1228,359 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// readMapEntryData reads a single collection entry (key or value) from data.
+// Returns the entry bytes (nil if the entry is null, i.e. size < 0),
+// the number of bytes consumed from data, and any error.
+func readMapEntryData(data []byte) (entryData []byte, consumed int, err error) {
+	if len(data) < 4 {
+		return nil, 0, unmarshalErrorf("unmarshal map: unexpected eof")
+	}
+	m := int(int32(data[0])<<24 | int32(data[1])<<16 | int32(data[2])<<8 | int32(data[3]))
+	if m < 0 {
+		return nil, 4, nil
+	}
+	// Compare against len(data)-4 instead of 4+m: on 32-bit targets a large
+	// positive m could overflow 4+m, wrap negative, bypass this guard, and then
+	// panic on the data[4:4+m] slice. len(data) >= 4 and m >= 0 here, so
+	// len(data)-4 is non-negative and the comparison is safe.
+	if m > len(data)-4 {
+		return nil, 0, unmarshalErrorf("unmarshal map: unexpected eof")
+	}
+	return data[4 : 4+m], 4 + m, nil
+}
+
+// isStringKeyType returns true if the CQL type encodes as raw bytes that can be
+// interpreted as a Go string without further validation (text, varchar).
+//
+// TypeAscii is deliberately excluded: the generic path validates ASCII payloads
+// via serialization/ascii.DecString (rejecting bytes > 127), so routing ascii
+// through the raw-string fast path would silently accept invalid data.
+func isStringKeyType(t Type) bool {
+	return t == TypeVarchar || t == TypeText
+}
+
+// unmarshalMapFast attempts to unmarshal a map using type-switch fast paths
+// for common concrete map types, avoiding all reflection. Returns (true, err)
+// if the fast path handled the value, or (false, nil) to fall through to the
+// generic reflect-based path.
+func unmarshalMapFast(info CollectionType, data []byte, value any) (bool, error) {
+	if data == nil {
+		return false, nil
+	}
+
+	keyType := info.Key.Type()
+	elemType := info.Elem.Type()
+
+	// We only fast-path string-keyed maps and int64-keyed maps, which cover
+	// the vast majority of real-world CQL map usage. TypeAscii is excluded so
+	// the generic path can validate ASCII payloads (bytes > 127 are rejected).
+	switch keyType {
+	case TypeVarchar, TypeText:
+		switch v := value.(type) {
+		case *map[string]string:
+			if !isStringKeyType(elemType) {
+				return false, nil
+			}
+			return true, unmarshalMapStringString(data, v)
+		case *map[string][]byte:
+			if elemType != TypeBlob {
+				return false, nil
+			}
+			return true, unmarshalMapStringBytes(data, v)
+		case *map[string]int64:
+			if elemType != TypeBigInt && elemType != TypeCounter {
+				return false, nil
+			}
+			return true, unmarshalMapStringInt64(data, v)
+		case *map[string]int32:
+			if elemType != TypeInt {
+				return false, nil
+			}
+			return true, unmarshalMapStringInt32(data, v)
+		case *map[string]float64:
+			if elemType != TypeDouble {
+				return false, nil
+			}
+			return true, unmarshalMapStringFloat64(data, v)
+		case *map[string]bool:
+			if elemType != TypeBoolean {
+				return false, nil
+			}
+			return true, unmarshalMapStringBool(data, v)
+		}
+	case TypeBigInt, TypeCounter:
+		switch v := value.(type) {
+		case *map[int64]string:
+			if !isStringKeyType(elemType) {
+				return false, nil
+			}
+			return true, unmarshalMapInt64String(data, v)
+		case *map[int64]int64:
+			if elemType != TypeBigInt && elemType != TypeCounter {
+				return false, nil
+			}
+			return true, unmarshalMapInt64Int64(data, v)
+		}
+	}
+	return false, nil
+}
+
+func unmarshalMapStringString(data []byte, dest *map[string]string) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		m[string(keyData)] = string(valData)
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringBytes(data []byte, dest *map[string][]byte) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string][]byte, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		// Copy the value bytes since the underlying buffer may be reused.
+		var valCopy []byte
+		if valData != nil {
+			valCopy = make([]byte, len(valData))
+			copy(valCopy, valData)
+		}
+		m[string(keyData)] = valCopy
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringInt64(data []byte, dest *map[string]int64) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]int64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int64
+		if err := bigint.DecInt64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringInt32(data []byte, dest *map[string]int32) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]int32, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int32
+		if err := cqlint.DecInt32(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringFloat64(data []byte, dest *map[string]float64) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]float64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v float64
+		if err := double.DecFloat64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringBool(data []byte, dest *map[string]bool) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[string]bool, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v bool
+		if err := boolean.DecBool(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapInt64String(data []byte, dest *map[int64]string) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[int64]string, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var k int64
+		if err := bigint.DecInt64(keyData, &k); err != nil {
+			return unmarshalErrorf("unmarshal map key: %v", err)
+		}
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		m[k] = string(valData)
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64) error {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return unmarshalErrorf("negative map size %d", n)
+	}
+	data = data[p:]
+	m := make(map[int64]int64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var k int64
+		if err := bigint.DecInt64(keyData, &k); err != nil {
+			return unmarshalErrorf("unmarshal map key: %v", err)
+		}
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int64
+		if err := bigint.DecInt64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[k] = v
+	}
+	*dest = m
+	return nil
+}
+
 func unmarshalMap(info CollectionType, data []byte, value any) error {
+	// Try fast path for common concrete map types (no reflection).
+	if handled, err := unmarshalMapFast(info, data, value); handled {
+		return err
+	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)

--- a/marshal.go
+++ b/marshal.go
@@ -1316,10 +1316,13 @@ func unmarshalMapFast(info CollectionType, data []byte, value any) (bool, error)
 			}
 			return true, unmarshalMapStringBytes(data, v)
 		case *map[string]int64:
-			if elemType != TypeBigInt && elemType != TypeCounter {
+			decInt64 := bigint.DecInt64
+			if elemType == TypeCounter {
+				decInt64 = counter.DecInt64
+			} else if elemType != TypeBigInt {
 				return false, nil
 			}
-			return true, unmarshalMapStringInt64(data, v)
+			return true, unmarshalMapStringInt64(data, v, decInt64)
 		case *map[string]int32:
 			if elemType != TypeInt {
 				return false, nil
@@ -1342,12 +1345,23 @@ func unmarshalMapFast(info CollectionType, data []byte, value any) (bool, error)
 			if !isStringKeyType(elemType) {
 				return false, nil
 			}
-			return true, unmarshalMapInt64String(data, v)
+			decInt64Key := bigint.DecInt64
+			if keyType == TypeCounter {
+				decInt64Key = counter.DecInt64
+			}
+			return true, unmarshalMapInt64String(data, v, decInt64Key)
 		case *map[int64]int64:
-			if elemType != TypeBigInt && elemType != TypeCounter {
+			decInt64Key := bigint.DecInt64
+			if keyType == TypeCounter {
+				decInt64Key = counter.DecInt64
+			}
+			decInt64Val := bigint.DecInt64
+			if elemType == TypeCounter {
+				decInt64Val = counter.DecInt64
+			} else if elemType != TypeBigInt {
 				return false, nil
 			}
-			return true, unmarshalMapInt64Int64(data, v)
+			return true, unmarshalMapInt64Int64(data, v, decInt64Key, decInt64Val)
 		}
 	}
 	return false, nil
@@ -1413,7 +1427,7 @@ func unmarshalMapStringBytes(data []byte, dest *map[string][]byte) error {
 	return nil
 }
 
-func unmarshalMapStringInt64(data []byte, dest *map[string]int64) error {
+func unmarshalMapStringInt64(data []byte, dest *map[string]int64, decInt64 func([]byte, *int64) error) error {
 	n, p, err := readCollectionSize(data)
 	if err != nil {
 		return err
@@ -1435,8 +1449,8 @@ func unmarshalMapStringInt64(data []byte, dest *map[string]int64) error {
 		}
 		data = data[c:]
 		var v int64
-		if err := bigint.DecInt64(valData, &v); err != nil {
-			return unmarshalErrorf("unmarshal map value: %v", err)
+		if err := decInt64(valData, &v); err != nil {
+			return wrapUnmarshalErrorf(err, "unmarshal map value")
 		}
 		m[string(keyData)] = v
 	}
@@ -1467,7 +1481,7 @@ func unmarshalMapStringInt32(data []byte, dest *map[string]int32) error {
 		data = data[c:]
 		var v int32
 		if err := cqlint.DecInt32(valData, &v); err != nil {
-			return unmarshalErrorf("unmarshal map value: %v", err)
+			return wrapUnmarshalErrorf(err, "unmarshal map value")
 		}
 		m[string(keyData)] = v
 	}
@@ -1498,7 +1512,7 @@ func unmarshalMapStringFloat64(data []byte, dest *map[string]float64) error {
 		data = data[c:]
 		var v float64
 		if err := double.DecFloat64(valData, &v); err != nil {
-			return unmarshalErrorf("unmarshal map value: %v", err)
+			return wrapUnmarshalErrorf(err, "unmarshal map value")
 		}
 		m[string(keyData)] = v
 	}
@@ -1529,7 +1543,7 @@ func unmarshalMapStringBool(data []byte, dest *map[string]bool) error {
 		data = data[c:]
 		var v bool
 		if err := boolean.DecBool(valData, &v); err != nil {
-			return unmarshalErrorf("unmarshal map value: %v", err)
+			return wrapUnmarshalErrorf(err, "unmarshal map value")
 		}
 		m[string(keyData)] = v
 	}
@@ -1537,7 +1551,7 @@ func unmarshalMapStringBool(data []byte, dest *map[string]bool) error {
 	return nil
 }
 
-func unmarshalMapInt64String(data []byte, dest *map[int64]string) error {
+func unmarshalMapInt64String(data []byte, dest *map[int64]string, decInt64Key func([]byte, *int64) error) error {
 	n, p, err := readCollectionSize(data)
 	if err != nil {
 		return err
@@ -1554,8 +1568,8 @@ func unmarshalMapInt64String(data []byte, dest *map[int64]string) error {
 		}
 		data = data[c:]
 		var k int64
-		if err := bigint.DecInt64(keyData, &k); err != nil {
-			return unmarshalErrorf("unmarshal map key: %v", err)
+		if err := decInt64Key(keyData, &k); err != nil {
+			return wrapUnmarshalErrorf(err, "unmarshal map key")
 		}
 		valData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1568,7 +1582,7 @@ func unmarshalMapInt64String(data []byte, dest *map[int64]string) error {
 	return nil
 }
 
-func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64) error {
+func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64, decInt64Key, decInt64Val func([]byte, *int64) error) error {
 	n, p, err := readCollectionSize(data)
 	if err != nil {
 		return err
@@ -1585,8 +1599,8 @@ func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64) error {
 		}
 		data = data[c:]
 		var k int64
-		if err := bigint.DecInt64(keyData, &k); err != nil {
-			return unmarshalErrorf("unmarshal map key: %v", err)
+		if err := decInt64Key(keyData, &k); err != nil {
+			return wrapUnmarshalErrorf(err, "unmarshal map key")
 		}
 		valData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1594,8 +1608,8 @@ func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64) error {
 		}
 		data = data[c:]
 		var v int64
-		if err := bigint.DecInt64(valData, &v); err != nil {
-			return unmarshalErrorf("unmarshal map value: %v", err)
+		if err := decInt64Val(valData, &v); err != nil {
+			return wrapUnmarshalErrorf(err, "unmarshal map value")
 		}
 		m[k] = v
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -224,9 +224,17 @@ func Marshal(info TypeInfo, value any) ([]byte, error) {
 	case TypeTimestamp:
 		return marshalTimestamp(value)
 	case TypeList, TypeSet:
-		return marshalList(info.(CollectionType), value)
+		collection, ok := info.(CollectionType)
+		if !ok {
+			return nil, marshalErrorf("marshal: can not use %T as list/set type", info)
+		}
+		return marshalList(collection, value)
 	case TypeMap:
-		return marshalMap(info.(CollectionType), value)
+		collection, ok := info.(CollectionType)
+		if !ok {
+			return nil, marshalErrorf("marshal: can not use %T as map type", info)
+		}
+		return marshalMap(collection, value)
 	case TypeUUID:
 		return marshalUUID(value)
 	case TypeTimeUUID:
@@ -337,9 +345,17 @@ func Unmarshal(info TypeInfo, data []byte, value any) error {
 	case TypeTimestamp:
 		return unmarshalTimestamp(data, value)
 	case TypeList, TypeSet:
-		return unmarshalList(info.(CollectionType), data, value)
+		collection, ok := info.(CollectionType)
+		if !ok {
+			return unmarshalErrorf("unmarshal: can not use %T as list/set type", info)
+		}
+		return unmarshalList(collection, data, value)
 	case TypeMap:
-		return unmarshalMap(info.(CollectionType), data, value)
+		collection, ok := info.(CollectionType)
+		if !ok {
+			return unmarshalErrorf("unmarshal: can not use %T as map type", info)
+		}
+		return unmarshalMap(collection, data, value)
 	case TypeTimeUUID:
 		return unmarshalTimeUUID(data, value)
 	case TypeUUID:
@@ -1249,6 +1265,18 @@ func readMapEntryData(data []byte) (entryData []byte, consumed int, err error) {
 	return data[4 : 4+m], 4 + m, nil
 }
 
+// mapSizeHint bounds a wire-provided entry count by the remaining payload
+// length before it's used as a map preallocation hint, so a hostile size
+// prefix (e.g. n = MaxInt32 over a few bytes of payload) can't force a huge
+// allocation. Each entry needs at least 8 bytes of framing (4-byte key length
+// + 4-byte value length), so len(data)/8 bounds the hint.
+func mapSizeHint(n int, data []byte) int {
+	if max := len(data) / 8; n > max {
+		return max
+	}
+	return n
+}
+
 // isStringKeyType returns true if the CQL type encodes as raw bytes that can be
 // interpreted as a Go string without further validation (text, varchar).
 //
@@ -1334,7 +1362,7 @@ func unmarshalMapStringString(data []byte, dest *map[string]string) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[string]string, n)
+	m := make(map[string]string, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1361,7 +1389,7 @@ func unmarshalMapStringBytes(data []byte, dest *map[string][]byte) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[string][]byte, n)
+	m := make(map[string][]byte, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1394,7 +1422,7 @@ func unmarshalMapStringInt64(data []byte, dest *map[string]int64) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[string]int64, n)
+	m := make(map[string]int64, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1425,7 +1453,7 @@ func unmarshalMapStringInt32(data []byte, dest *map[string]int32) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[string]int32, n)
+	m := make(map[string]int32, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1456,7 +1484,7 @@ func unmarshalMapStringFloat64(data []byte, dest *map[string]float64) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[string]float64, n)
+	m := make(map[string]float64, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1487,7 +1515,7 @@ func unmarshalMapStringBool(data []byte, dest *map[string]bool) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[string]bool, n)
+	m := make(map[string]bool, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1518,7 +1546,7 @@ func unmarshalMapInt64String(data []byte, dest *map[int64]string) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[int64]string, n)
+	m := make(map[int64]string, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1549,7 +1577,7 @@ func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64) error {
 		return unmarshalErrorf("negative map size %d", n)
 	}
 	data = data[p:]
-	m := make(map[int64]int64, n)
+	m := make(map[int64]int64, mapSizeHint(n, data))
 	for i := 0; i < n; i++ {
 		keyData, c, err := readMapEntryData(data)
 		if err != nil {
@@ -1622,12 +1650,12 @@ func unmarshalMap(info CollectionType, data []byte, value any) error {
 	if n > (len(data)-p)/8 {
 		return unmarshalErrorf("unmarshal map: invalid size %d", n)
 	}
-	rv.Set(reflect.MakeMapWithSize(t, n))
+	data = data[p:]
+	rv.Set(reflect.MakeMapWithSize(t, mapSizeHint(n, data)))
 	// If rv was an interface, get the underlying map
 	if rv.Kind() == reflect.Interface {
 		rv = rv.Elem()
 	}
-	data = data[p:]
 	for i := 0; i < n; i++ {
 		m, p, err := readCollectionSize(data)
 		if err != nil {

--- a/marshal.go
+++ b/marshal.go
@@ -174,6 +174,10 @@ func Marshal(info TypeInfo, value any) ([]byte, error) {
 		panic("protocol version not set")
 	}
 
+	if value == nil {
+		return nil, nil
+	}
+
 	if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
 		if valueRef.IsNil() {
 			return nil, nil
@@ -220,9 +224,9 @@ func Marshal(info TypeInfo, value any) ([]byte, error) {
 	case TypeTimestamp:
 		return marshalTimestamp(value)
 	case TypeList, TypeSet:
-		return marshalList(info, value)
+		return marshalList(info.(CollectionType), value)
 	case TypeMap:
-		return marshalMap(info, value)
+		return marshalMap(info.(CollectionType), value)
 	case TypeUUID:
 		return marshalUUID(value)
 	case TypeTimeUUID:
@@ -333,9 +337,9 @@ func Unmarshal(info TypeInfo, data []byte, value any) error {
 	case TypeTimestamp:
 		return unmarshalTimestamp(data, value)
 	case TypeList, TypeSet:
-		return unmarshalList(info, data, value)
+		return unmarshalList(info.(CollectionType), data, value)
 	case TypeMap:
-		return unmarshalMap(info, data, value)
+		return unmarshalMap(info.(CollectionType), data, value)
 	case TypeTimeUUID:
 		return unmarshalTimeUUID(data, value)
 	case TypeUUID:
@@ -695,28 +699,19 @@ func unmarshalDuration(data []byte, value any) error {
 	return nil
 }
 
-func writeCollectionSize(info CollectionType, n int, buf *bytes.Buffer) error {
+func writeCollectionSize(n int, buf *bytes.Buffer) error {
 	if n > math.MaxInt32 {
 		return marshalErrorf("marshal: collection too large")
 	}
 
-	buf.WriteByte(byte(n >> 24))
-	buf.WriteByte(byte(n >> 16))
-	buf.WriteByte(byte(n >> 8))
-	buf.WriteByte(byte(n))
+	tmp := [4]byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}
+	buf.Write(tmp[:])
 
 	return nil
 }
 
-func marshalList(info TypeInfo, value any) ([]byte, error) {
-	listInfo, ok := info.(CollectionType)
-	if !ok {
-		return nil, marshalErrorf("marshal: can not marshal non collection type into list")
-	}
-
-	if value == nil {
-		return nil, nil
-	} else if _, ok := value.(unsetColumn); ok {
+func marshalList(info CollectionType, value any) ([]byte, error) {
+	if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -732,12 +727,12 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 		buf := &bytes.Buffer{}
 		n := rv.Len()
 
-		if err := writeCollectionSize(listInfo, n, buf); err != nil {
+		if err := writeCollectionSize(n, buf); err != nil {
 			return nil, err
 		}
 
 		for i := 0; i < n; i++ {
-			item, err := Marshal(listInfo.Elem, rv.Index(i).Interface())
+			item, err := Marshal(info.Elem, rv.Index(i).Interface())
 			if err != nil {
 				return nil, err
 			}
@@ -746,7 +741,7 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 			if item == nil {
 				itemLen = -1
 			}
-			if err := writeCollectionSize(listInfo, itemLen, buf); err != nil {
+			if err := writeCollectionSize(itemLen, buf); err != nil {
 				return nil, err
 			}
 			buf.Write(item)
@@ -760,13 +755,13 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 			for i := 0; i < len(keys); i++ {
 				keys[i] = rkeys[i].Interface()
 			}
-			return marshalList(listInfo, keys)
+			return marshalList(info, keys)
 		}
 	}
 	return nil, marshalErrorf("can not marshal %T into %s", value, info)
 }
 
-func readCollectionSize(info CollectionType, data []byte) (size, read int, err error) {
+func readCollectionSize(data []byte) (size, read int, err error) {
 	if len(data) < 4 {
 		return 0, 0, unmarshalErrorf("unmarshal list: unexpected eof")
 	}
@@ -775,12 +770,7 @@ func readCollectionSize(info CollectionType, data []byte) (size, read int, err e
 	return
 }
 
-func unmarshalList(info TypeInfo, data []byte, value any) error {
-	listInfo, ok := info.(CollectionType)
-	if !ok {
-		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into list")
-	}
-
+func unmarshalList(info CollectionType, data []byte, value any) error {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -795,7 +785,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
 		}
 		// Create a properly typed slice based on the element type
-		elemGoType, err := goType(listInfo.Elem)
+		elemGoType, err := goType(info.Elem)
 		if err != nil {
 			return unmarshalErrorf("unmarshal list: cannot determine element type: %v", err)
 		}
@@ -815,7 +805,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			rv.Set(reflect.Zero(t))
 			return nil
 		}
-		n, p, err := readCollectionSize(listInfo, data)
+		n, p, err := readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -838,7 +828,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			}
 		}
 		for i := 0; i < n; i++ {
-			m, p, err := readCollectionSize(listInfo, data)
+			m, p, err := readCollectionSize(data)
 			if err != nil {
 				return err
 			}
@@ -852,7 +842,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 				unmarshalData = data[:m]
 				data = data[m:]
 			}
-			if err := Unmarshal(listInfo.Elem, unmarshalData, rv.Index(i).Addr().Interface()); err != nil {
+			if err := Unmarshal(info.Elem, unmarshalData, rv.Index(i).Addr().Interface()); err != nil {
 				return err
 			}
 		}
@@ -862,9 +852,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 }
 
 func marshalVector(info VectorType, value any) ([]byte, error) {
-	if value == nil {
-		return nil, nil
-	} else if _, ok := value.(unsetColumn); ok {
+	if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -1184,15 +1172,8 @@ func computeUnsignedVIntSize(v uint64) int {
 	return (639 - lead0*9) >> 6
 }
 
-func marshalMap(info TypeInfo, value any) ([]byte, error) {
-	mapInfo, ok := info.(CollectionType)
-	if !ok {
-		return nil, marshalErrorf("marshal: can not marshal none collection type into map")
-	}
-
-	if value == nil {
-		return nil, nil
-	} else if _, ok := value.(unsetColumn); ok {
+func marshalMap(info CollectionType, value any) ([]byte, error) {
+	if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -1210,13 +1191,13 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	n := rv.Len()
 
-	if err := writeCollectionSize(mapInfo, n, buf); err != nil {
+	if err := writeCollectionSize(n, buf); err != nil {
 		return nil, err
 	}
 
 	keys := rv.MapKeys()
 	for _, key := range keys {
-		item, err := Marshal(mapInfo.Key, key.Interface())
+		item, err := Marshal(info.Key, key.Interface())
 		if err != nil {
 			return nil, err
 		}
@@ -1225,12 +1206,12 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 		if item == nil {
 			itemLen = -1
 		}
-		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
+		if err := writeCollectionSize(itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
 
-		item, err = Marshal(mapInfo.Elem, rv.MapIndex(key).Interface())
+		item, err = Marshal(info.Elem, rv.MapIndex(key).Interface())
 		if err != nil {
 			return nil, err
 		}
@@ -1239,7 +1220,7 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 		if item == nil {
 			itemLen = -1
 		}
-		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
+		if err := writeCollectionSize(itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
@@ -1247,12 +1228,7 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func unmarshalMap(info TypeInfo, data []byte, value any) error {
-	mapInfo, ok := info.(CollectionType)
-	if !ok {
-		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into map")
-	}
-
+func unmarshalMap(info CollectionType, data []byte, value any) error {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -1266,11 +1242,11 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
 		}
 		// Create a properly typed map based on the key and element types
-		keyGoType, err := goType(mapInfo.Key)
+		keyGoType, err := goType(info.Key)
 		if err != nil {
 			return unmarshalErrorf("unmarshal map: cannot determine key type: %v", err)
 		}
-		elemGoType, err := goType(mapInfo.Elem)
+		elemGoType, err := goType(info.Elem)
 		if err != nil {
 			return unmarshalErrorf("unmarshal map: cannot determine element type: %v", err)
 		}
@@ -1284,7 +1260,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 		rv.Set(reflect.Zero(t))
 		return nil
 	}
-	n, p, err := readCollectionSize(mapInfo, data)
+	n, p, err := readCollectionSize(data)
 	if err != nil {
 		return err
 	}
@@ -1301,7 +1277,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 	}
 	data = data[p:]
 	for i := 0; i < n; i++ {
-		m, p, err := readCollectionSize(mapInfo, data)
+		m, p, err := readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -1316,11 +1292,11 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			unmarshalData = data[:m]
 			data = data[m:]
 		}
-		if err := Unmarshal(mapInfo.Key, unmarshalData, key.Interface()); err != nil {
+		if err := Unmarshal(info.Key, unmarshalData, key.Interface()); err != nil {
 			return err
 		}
 
-		m, p, err = readCollectionSize(mapInfo, data)
+		m, p, err = readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -1336,7 +1312,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			unmarshalData = data[:m]
 			data = data[m:]
 		}
-		if err := Unmarshal(mapInfo.Elem, unmarshalData, val.Interface()); err != nil {
+		if err := Unmarshal(info.Elem, unmarshalData, val.Interface()); err != nil {
 			return err
 		}
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -774,7 +774,7 @@ func TestReadCollectionSize(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			size, _, err := readCollectionSize(test.info, test.data)
+			size, _, err := readCollectionSize(test.data)
 			if test.isError {
 				if err == nil {
 					t.Fatal("Expected error, but it was nil")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1300,3 +1300,262 @@ func TestCollectionNewWithErrorConsistentWithGoType(t *testing.T) {
 		}
 	}
 }
+
+// buildMapBytes builds the CQL binary wire format for a map with n entries.
+// keyFn and valFn produce the raw bytes for each key and value given the entry index.
+func buildMapBytes(n int, keyFn, valFn func(i int) []byte) []byte {
+	// 4 bytes for the entry count
+	size := 4
+	for i := 0; i < n; i++ {
+		size += 4 + len(keyFn(i)) + 4 + len(valFn(i))
+	}
+	buf := make([]byte, 0, size)
+	buf = append(buf, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	for i := 0; i < n; i++ {
+		k := keyFn(i)
+		buf = append(buf, byte(len(k)>>24), byte(len(k)>>16), byte(len(k)>>8), byte(len(k)))
+		buf = append(buf, k...)
+		v := valFn(i)
+		buf = append(buf, byte(len(v)>>24), byte(len(v)>>16), byte(len(v)>>8), byte(len(v)))
+		buf = append(buf, v...)
+	}
+	return buf
+}
+
+func int64Bytes(v int64) []byte {
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32),
+		byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+func TestUnmarshalMapFastPath(t *testing.T) {
+	t.Parallel()
+
+	infoSS := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	infoSI := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+	infoII := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+
+	t.Run("nil data sets nil map", func(t *testing.T) {
+		var m map[string]string
+		if err := unmarshalMap(infoSS, nil, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m != nil {
+			t.Fatalf("expected nil map, got %v", m)
+		}
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		data := buildMapBytes(0, nil, nil)
+		var m map[string]string
+		if err := unmarshalMap(infoSS, data, &m); err != nil {
+			t.Fatal(err)
+		}
+		if len(m) != 0 {
+			t.Fatalf("expected empty map, got %v", m)
+		}
+	})
+
+	t.Run("map[string]string correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return []byte(fmt.Sprintf("k%d", i)) },
+			func(i int) []byte { return []byte(fmt.Sprintf("v%d", i)) },
+		)
+		var fast map[string]string
+		if err := unmarshalMap(infoSS, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("map[string]int64 correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return []byte(fmt.Sprintf("k%d", i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 10)) },
+		)
+		var fast map[string]int64
+		if err := unmarshalMap(infoSI, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[string]int64{"k0": 0, "k1": 10, "k2": 20}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("map[int64]int64 correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return int64Bytes(int64(i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 100)) },
+		)
+		var fast map[int64]int64
+		if err := unmarshalMap(infoII, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[int64]int64{0: 0, 1: 100, 2: 200}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("null value decoded as zero", func(t *testing.T) {
+		// Build a map with one entry where value is null (size = -1)
+		buf := []byte{
+			0, 0, 0, 1, // n=1
+			0, 0, 0, 3, 'k', 'e', 'y', // key = "key"
+			0xff, 0xff, 0xff, 0xff, // value size = -1 (null)
+		}
+		var m map[string]int64
+		if err := unmarshalMap(infoSI, buf, &m); err != nil {
+			t.Fatal(err)
+		}
+		if v, ok := m["key"]; !ok || v != 0 {
+			t.Fatalf("expected key→0, got key→%d (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("truncated data returns error", func(t *testing.T) {
+		buf := []byte{0, 0, 0, 1, 0, 0} // n=1 but truncated key
+		var m map[string]string
+		err := unmarshalMap(infoSS, buf, &m)
+		if err == nil {
+			t.Fatal("expected error on truncated data")
+		}
+	})
+
+	t.Run("fallthrough to reflect for mismatched types", func(t *testing.T) {
+		// *map[string]string with TypeBigInt elem should fall through to reflect
+		data := buildMapBytes(1,
+			func(i int) []byte { return []byte("key") },
+			func(i int) []byte { return int64Bytes(42) },
+		)
+		infoMismatch := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+		// This should NOT use the string-string fast path (elem is BigInt, not text)
+		// and should fall through to reflect, which will unmarshal int64 into string via format
+		var m map[string]string
+		err := unmarshalMap(infoMismatch, data, &m)
+		// The reflect path may succeed or fail depending on type compatibility
+		// The key point is it doesn't panic and doesn't use the wrong fast path
+		_ = err
+	})
+}
+
+func BenchmarkUnmarshalMapStringString(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return []byte(fmt.Sprintf("key-%04d", i)) },
+			func(i int) []byte { return []byte(fmt.Sprintf("value-%04d", i)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[string]string
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalMapStringInt64(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return []byte(fmt.Sprintf("key-%04d", i)) },
+			func(i int) []byte { return int64Bytes(int64(i)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[string]int64
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalMapInt64Int64(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return int64Bytes(int64(i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 100)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[int64]int64
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -699,6 +699,22 @@ func TestMarshalNil(t *testing.T) {
 			t.Errorf("expected to get nil byte for nil %v got % X", typ, data)
 		}
 	}
+
+	// Collection types also need nil coverage.
+	collectionTypes := []Type{TypeList, TypeSet, TypeMap}
+	for _, typ := range collectionTypes {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion3, typ: typ},
+			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion3, typ: TypeVarchar},
+		}
+		data, err := Marshal(info, nil)
+		if err != nil {
+			t.Errorf("unable to marshal nil %v: %v\n", typ, err)
+		} else if data != nil {
+			t.Errorf("expected nil bytes for nil %v, got % X", typ, data)
+		}
+	}
 }
 
 func TestUnmarshalInetCopyBytes(t *testing.T) {
@@ -778,7 +794,7 @@ func TestReadCollectionSize(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			size, _, err := readCollectionSize(test.info, test.data)
+			size, _, err := readCollectionSize(test.data)
 			if test.isError {
 				if err == nil {
 					t.Fatal("Expected error, but it was nil")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1405,3 +1405,295 @@ func TestUnmarshalMapReflect_OversizedCount_RejectedBeforeAlloc(t *testing.T) {
 		t.Fatalf("expected dst to remain nil, got %#v", dst)
 	}
 }
+
+// buildMapBytes builds the CQL binary wire format for a map with n entries.
+// keyFn and valFn produce the raw bytes for each key and value given the entry index.
+func buildMapBytes(n int, keyFn, valFn func(i int) []byte) []byte {
+	// 4 bytes for the entry count
+	size := 4
+	for i := 0; i < n; i++ {
+		size += 4 + len(keyFn(i)) + 4 + len(valFn(i))
+	}
+	buf := make([]byte, 0, size)
+	buf = append(buf, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	for i := 0; i < n; i++ {
+		k := keyFn(i)
+		buf = append(buf, byte(len(k)>>24), byte(len(k)>>16), byte(len(k)>>8), byte(len(k)))
+		buf = append(buf, k...)
+		v := valFn(i)
+		buf = append(buf, byte(len(v)>>24), byte(len(v)>>16), byte(len(v)>>8), byte(len(v)))
+		buf = append(buf, v...)
+	}
+	return buf
+}
+
+func int64Bytes(v int64) []byte {
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32),
+		byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+func TestUnmarshalMapFastPath(t *testing.T) {
+	t.Parallel()
+
+	infoSS := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	infoSI := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+	infoII := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+
+	t.Run("nil data sets nil map", func(t *testing.T) {
+		var m map[string]string
+		if err := unmarshalMap(infoSS, nil, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m != nil {
+			t.Fatalf("expected nil map, got %v", m)
+		}
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		data := buildMapBytes(0, nil, nil)
+		var m map[string]string
+		if err := unmarshalMap(infoSS, data, &m); err != nil {
+			t.Fatal(err)
+		}
+		if len(m) != 0 {
+			t.Fatalf("expected empty map, got %v", m)
+		}
+	})
+
+	t.Run("map[string]string correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return []byte(fmt.Sprintf("k%d", i)) },
+			func(i int) []byte { return []byte(fmt.Sprintf("v%d", i)) },
+		)
+		var fast map[string]string
+		if err := unmarshalMap(infoSS, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("map[string]int64 correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return []byte(fmt.Sprintf("k%d", i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 10)) },
+		)
+		var fast map[string]int64
+		if err := unmarshalMap(infoSI, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[string]int64{"k0": 0, "k1": 10, "k2": 20}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("map[int64]int64 correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return int64Bytes(int64(i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 100)) },
+		)
+		var fast map[int64]int64
+		if err := unmarshalMap(infoII, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[int64]int64{0: 0, 1: 100, 2: 200}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("null value decoded as zero", func(t *testing.T) {
+		// Build a map with one entry where value is null (size = -1)
+		buf := []byte{
+			0, 0, 0, 1, // n=1
+			0, 0, 0, 3, 'k', 'e', 'y', // key = "key"
+			0xff, 0xff, 0xff, 0xff, // value size = -1 (null)
+		}
+		var m map[string]int64
+		if err := unmarshalMap(infoSI, buf, &m); err != nil {
+			t.Fatal(err)
+		}
+		if v, ok := m["key"]; !ok || v != 0 {
+			t.Fatalf("expected key→0, got key→%d (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("truncated data returns error", func(t *testing.T) {
+		buf := []byte{0, 0, 0, 1, 0, 0} // n=1 but truncated key
+		var m map[string]string
+		err := unmarshalMap(infoSS, buf, &m)
+		if err == nil {
+			t.Fatal("expected error on truncated data")
+		}
+	})
+
+	t.Run("fallthrough to reflect for mismatched types", func(t *testing.T) {
+		// *map[string]string with TypeBigInt elem should fall through to reflect
+		data := buildMapBytes(1,
+			func(i int) []byte { return []byte("key") },
+			func(i int) []byte { return int64Bytes(42) },
+		)
+		infoMismatch := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+		// The fast path must NOT claim this mismatched elem type (BigInt, not a
+		// string), so it has to report handled == false and let the generic
+		// reflect path take over. Asserting this protects the dispatch logic.
+		var m map[string]string
+		handled, err := unmarshalMapFast(infoMismatch, data, &m)
+		if err != nil {
+			t.Fatalf("unexpected fast-path error: %v", err)
+		}
+		if handled {
+			t.Fatal("expected mismatched elem type to skip the fast path")
+		}
+
+		_ = unmarshalMap(infoMismatch, data, &m) // keep the panic-smoke test
+	})
+
+	t.Run("ascii map keys/values are validated via generic path", func(t *testing.T) {
+		// A byte > 127 is invalid ASCII. With TypeAscii excluded from the
+		// raw-string fast path, this must be rejected by serialization/ascii
+		// instead of being silently accepted.
+		data := buildMapBytes(1,
+			func(i int) []byte { return []byte{0x80} }, // invalid ascii key
+			func(i int) []byte { return []byte("v") },
+		)
+		infoAscii := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeAscii},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeAscii},
+		}
+
+		// Fast path must not claim ascii-typed maps.
+		var fm map[string]string
+		if handled, _ := unmarshalMapFast(infoAscii, data, &fm); handled {
+			t.Fatal("expected ascii map to skip the raw-string fast path")
+		}
+
+		// Full Unmarshal (generic path) must reject the invalid byte.
+		var m map[string]string
+		if err := Unmarshal(infoAscii, data, &m); err == nil {
+			t.Fatal("expected error unmarshaling invalid ascii, got nil")
+		}
+	})
+}
+
+func BenchmarkUnmarshalMapStringString(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return []byte(fmt.Sprintf("key-%04d", i)) },
+			func(i int) []byte { return []byte(fmt.Sprintf("value-%04d", i)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[string]string
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalMapStringInt64(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return []byte(fmt.Sprintf("key-%04d", i)) },
+			func(i int) []byte { return int64Bytes(int64(i)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[string]int64
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalMapInt64Int64(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return int64Bytes(int64(i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 100)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[int64]int64
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1596,6 +1596,146 @@ func TestUnmarshalMapFastPath(t *testing.T) {
 	})
 }
 
+// namedStrStrMap is a named map type. Because Go type switches match concrete
+// types exactly, unmarshalMapFast does NOT recognise it, so unmarshaling into
+// it exercises the generic reflect path. This lets us assert that the fast
+// path and the generic path agree byte-for-byte on identical wire data.
+type namedStrStrMap map[string]string
+type namedStrI64Map map[string]int64
+type namedI64I64Map map[int64]int64
+
+// TestUnmarshalMapFastVsReflect is a differential test: for the same wire
+// bytes it unmarshals via the fast path (concrete map type) and via the
+// generic reflect path (named map type) and requires identical results.
+func TestUnmarshalMapFastVsReflect(t *testing.T) {
+	t.Parallel()
+
+	infoSS := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	infoSI := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+	infoII := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+
+	// nullVal returns a -1 (null) length prefix.
+	nullPrefix := []byte{0xff, 0xff, 0xff, 0xff}
+	withLen := func(b []byte) []byte {
+		out := []byte{byte(len(b) >> 24), byte(len(b) >> 16), byte(len(b) >> 8), byte(len(b))}
+		return append(out, b...)
+	}
+	count := func(n int) []byte {
+		return []byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}
+	}
+
+	t.Run("string/string with null key and null value", func(t *testing.T) {
+		// entry0: key "" (len 0), value null
+		// entry1: key null, value "v"
+		var data []byte
+		data = append(data, count(2)...)
+		data = append(data, withLen([]byte{})...) // key ""
+		data = append(data, nullPrefix...)        // value null
+		data = append(data, nullPrefix...)        // key null
+		data = append(data, withLen([]byte("v"))...)
+
+		var fast map[string]string
+		if err := unmarshalMap(infoSS, data, &fast); err != nil {
+			t.Fatalf("fast path: %v", err)
+		}
+		var slow namedStrStrMap
+		if err := unmarshalMap(infoSS, data, &slow); err != nil {
+			t.Fatalf("reflect path: %v", err)
+		}
+		if !reflect.DeepEqual(map[string]string(fast), map[string]string(slow)) {
+			t.Fatalf("fast=%v reflect=%v differ", fast, slow)
+		}
+	})
+
+	t.Run("string/int64 with null value vs reflect", func(t *testing.T) {
+		var data []byte
+		data = append(data, count(2)...)
+		data = append(data, withLen([]byte("a"))...)
+		data = append(data, nullPrefix...) // null int64 value
+		data = append(data, withLen([]byte("b"))...)
+		data = append(data, withLen(int64Bytes(7))...)
+
+		var fast map[string]int64
+		if err := unmarshalMap(infoSI, data, &fast); err != nil {
+			t.Fatalf("fast: %v", err)
+		}
+		var slow namedStrI64Map
+		if err := unmarshalMap(infoSI, data, &slow); err != nil {
+			t.Fatalf("reflect: %v", err)
+		}
+		if !reflect.DeepEqual(map[string]int64(fast), map[string]int64(slow)) {
+			t.Fatalf("fast=%v reflect=%v differ", fast, slow)
+		}
+	})
+
+	t.Run("int64/int64 duplicate keys keep last vs reflect", func(t *testing.T) {
+		// Duplicate key 5 appears twice; map semantics keep the last write.
+		var data []byte
+		data = append(data, count(2)...)
+		data = append(data, withLen(int64Bytes(5))...)
+		data = append(data, withLen(int64Bytes(1))...)
+		data = append(data, withLen(int64Bytes(5))...)
+		data = append(data, withLen(int64Bytes(2))...)
+
+		var fast map[int64]int64
+		if err := unmarshalMap(infoII, data, &fast); err != nil {
+			t.Fatalf("fast: %v", err)
+		}
+		var slow namedI64I64Map
+		if err := unmarshalMap(infoII, data, &slow); err != nil {
+			t.Fatalf("reflect: %v", err)
+		}
+		if !reflect.DeepEqual(map[int64]int64(fast), map[int64]int64(slow)) {
+			t.Fatalf("fast=%v reflect=%v differ", fast, slow)
+		}
+		if fast[5] != 2 {
+			t.Fatalf("expected last-write-wins key 5 -> 2, got %d", fast[5])
+		}
+	})
+
+	t.Run("nil data agrees", func(t *testing.T) {
+		var fast map[string]string
+		var slow namedStrStrMap
+		if err := unmarshalMap(infoSS, nil, &fast); err != nil {
+			t.Fatal(err)
+		}
+		if err := unmarshalMap(infoSS, nil, &slow); err != nil {
+			t.Fatal(err)
+		}
+		if (fast == nil) != (slow == nil) {
+			t.Fatalf("nil disagreement: fast nil=%v reflect nil=%v", fast == nil, slow == nil)
+		}
+	})
+
+	t.Run("wrong fixed-width value length errors like reflect", func(t *testing.T) {
+		// int64 value with 4 bytes (invalid: must be 0 or 8).
+		var data []byte
+		data = append(data, count(1)...)
+		data = append(data, withLen([]byte("k"))...)
+		data = append(data, withLen([]byte{0, 0, 0, 1})...) // 4-byte int64 -> invalid
+
+		var fast map[string]int64
+		errFast := unmarshalMap(infoSI, data, &fast)
+		var slow namedStrI64Map
+		errSlow := unmarshalMap(infoSI, data, &slow)
+		if (errFast == nil) != (errSlow == nil) {
+			t.Fatalf("error disagreement: fast=%v reflect=%v", errFast, errSlow)
+		}
+	})
+}
+
 func BenchmarkUnmarshalMapStringString(b *testing.B) {
 	for _, n := range []int{10, 100} {
 		data := buildMapBytes(n,

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -30,6 +30,7 @@ package gocql
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -1638,6 +1639,82 @@ func TestUnmarshalMapFastPath(t *testing.T) {
 		var m map[string]string
 		if err := Unmarshal(infoAscii, data, &m); err == nil {
 			t.Fatal("expected error unmarshaling invalid ascii, got nil")
+		}
+	})
+
+	t.Run("counter-typed value uses the counter decoder, not bigint", func(t *testing.T) {
+		infoSCounter := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeCounter},
+		}
+		// Correctness: counter values decode the same 8-byte big-endian layout as bigint.
+		data := buildMapBytes(1,
+			func(i int) []byte { return []byte("c") },
+			func(i int) []byte { return int64Bytes(42) },
+		)
+		var m map[string]int64
+		if err := unmarshalMap(infoSCounter, data, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m["c"] != 42 {
+			t.Fatalf("got %v, want map[c:42]", m)
+		}
+
+		// Error message should identify the actual (counter) type, not bigint,
+		// so the fast path must dispatch to counter.DecInt64.
+		badData := buildMapBytes(1,
+			func(i int) []byte { return []byte("c") },
+			func(i int) []byte { return []byte{1, 2, 3, 4} }, // invalid length for int64
+		)
+		err := unmarshalMap(infoSCounter, badData, &m)
+		if err == nil {
+			t.Fatal("expected error for malformed counter value")
+		}
+		if strings.Contains(err.Error(), "bigint") || !strings.Contains(err.Error(), "counter") {
+			t.Fatalf("expected counter-specific error, got: %v", err)
+		}
+	})
+
+	t.Run("counter-typed key uses the counter decoder, not bigint", func(t *testing.T) {
+		infoCounterKey := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeCounter},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeCounter},
+		}
+		badData := buildMapBytes(1,
+			func(i int) []byte { return []byte{1, 2, 3, 4} }, // invalid length for int64
+			func(i int) []byte { return int64Bytes(1) },
+		)
+		var m map[int64]int64
+		err := unmarshalMap(infoCounterKey, badData, &m)
+		if err == nil {
+			t.Fatal("expected error for malformed counter key")
+		}
+		if strings.Contains(err.Error(), "bigint") || !strings.Contains(err.Error(), "counter") {
+			t.Fatalf("expected counter-specific error, got: %v", err)
+		}
+	})
+
+	t.Run("fast-path decode error preserves the underlying cause", func(t *testing.T) {
+		data := buildMapBytes(1,
+			func(i int) []byte { return []byte("key") },
+			func(i int) []byte { return []byte{1, 2, 3, 4} }, // invalid length for int64
+		)
+		var m map[string]int64
+		err := unmarshalMap(infoSI, data, &m)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		ue, ok := err.(UnmarshalError)
+		if !ok {
+			t.Fatalf("expected UnmarshalError, got %T", err)
+		}
+		if ue.Cause() == nil {
+			t.Fatal("expected Cause() to preserve the underlying decode error, got nil")
+		}
+		if errors.Unwrap(err) == nil {
+			t.Fatal("expected errors.Unwrap to reach the underlying decode error, got nil")
 		}
 	})
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1432,6 +1432,52 @@ func int64Bytes(v int64) []byte {
 		byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
 }
 
+func TestMarshalUnmarshalCollectionTypeAssertion(t *testing.T) {
+	t.Parallel()
+
+	// NativeType reports TypeMap/TypeList/TypeSet but is not a CollectionType.
+	// Marshal/Unmarshal dispatch must return an error instead of panicking on
+	// the type assertion.
+	notCollection := []Type{TypeMap, TypeList, TypeSet}
+	for _, typ := range notCollection {
+		typ := typ
+		t.Run(typ.String(), func(t *testing.T) {
+			info := NativeType{proto: protoVersion4, typ: typ}
+
+			if _, err := Marshal(info, []string{"a"}); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var dest any
+			if err := Unmarshal(info, []byte{0, 0, 0, 0}, &dest); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestMapSizeHint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		n    int
+		data []byte
+		want int
+	}{
+		{"fits within payload", 2, make([]byte, 16), 2},
+		{"hostile huge count clamped", 2147483647, make([]byte, 8), 1},
+		{"empty payload clamps to zero", 5, nil, 0},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			if got := mapSizeHint(c.n, c.data); got != c.want {
+				t.Fatalf("mapSizeHint(%d, %d bytes) = %d, want %d", c.n, len(c.data), got, c.want)
+			}
+		})
+	}
+}
+
 func TestUnmarshalMapFastPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Replace 4 individual `WriteByte()` calls in `writeCollectionSize` with a single `Write()` using a stack-allocated `[4]byte` array, reducing function call overhead and buffer capacity checks from 4 to 1 per call
- Remove unused `CollectionType` parameter from `writeCollectionSize` and `readCollectionSize` — neither function referenced the parameter
- Change `marshalList`, `marshalMap`, `unmarshalList`, `unmarshalMap` signatures from `TypeInfo` to `CollectionType`, eliminating redundant type assertions on every call (all callers already know the concrete type from the type switch in `Marshal()`/`Unmarshal()`)
- Add collection marshal benchmarks (`BenchmarkMarshalListInt32`, `BenchmarkMarshalMapStringInt32`, `BenchmarkWriteCollectionSize`)
- **NEW:** Add `unmarshalMap` type-switch fast paths for 8 common concrete map types, eliminating all reflection (`reflect.New`, `reflect.SetMapIndex`, interface boxing) from the unmarshal hot path — **2.6–3.0x faster**

## Benchmarks — Commit 1: marshal/write path

10 runs, `benchstat` comparison (Before = master, After = this PR):

| Benchmark | Before (ns/op) | After (ns/op) | Delta | p-value |
|---|---|---|---|---|
| WriteCollectionSize | 8.91 | 5.72 | **-35.72%** | p=0.000 |
| MarshalListInt32/elems=10 | 616.6 | 559.3 | **-9.29%** | p=0.000 |
| MarshalListInt32/elems=100 | 5336 | 4515 | **-15.39%** | p=0.000 |
| MarshalListInt32/elems=1000 | 47120 | 43370 | **-7.96%** | p=0.000 |
| MarshalMapStringInt32/elems=10 | 1671 | 1585 | **-5.15%** | p=0.000 |
| MarshalMapStringInt32/elems=100 | 14470 | 13630 | **-5.79%** | p=0.000 |
| **geomean** | **1794** | **1544** | **-13.96%** | |

Memory and allocations unchanged (this is purely CPU work reduction).

## Benchmarks — Commit 2: unmarshalMap fast paths (NEW)

5 runs, `-benchmem`, fast path vs reflect path:

| Benchmark | Fast (ns/op) | Reflect (ns/op) | Speedup | Fast allocs | Reflect allocs |
|---|---|---|---|---|---|
| map[string]string/10 | 593 | 1,611 | **2.7x** | 25 / 912B | 45 / 1,240B |
| map[string]string/100 | 4,775 | 14,522 | **3.0x** | 205 / 7,360B | 405 / 10,568B |
| map[string]int64/10 | 527 | 1,395 | **2.6x** | 25 / 672B | 35 / 840B |
| map[string]int64/100 | 4,040 | 12,099 | **3.0x** | 205 / 5,152B | 305 / 6,760B |
| map[int64]int64/10 | 487 | 1,254 | **2.6x** | 25 / 544B | 25 / 552B |
| map[int64]int64/100 | 3,592 | 10,636 | **3.0x** | 205 / 4,000B | 205 / 4,008B |

Fast-pathed types: `*map[string]string`, `*map[string][]byte`, `*map[string]int64`, `*map[string]int32`, `*map[string]float64`, `*map[string]bool`, `*map[int64]string`, `*map[int64]int64`. Unmatched types fall through to the existing reflect-based path unchanged.

## Details

`writeCollectionSize` is called during list, set, and map marshaling:
- **Lists/Sets**: `1 + N` calls per marshal (once for collection count + once per element length)
- **Maps**: `1 + 2*N` calls per marshal (once for count + twice per entry for key and value lengths)

The `writeCollectionSize` optimization replaces 4 `WriteByte()` method calls (each with its own bounds check and potential buffer growth) with a single `Write()` of a 4-byte stack-allocated array. The `[4]byte` does not escape to heap.

The type assertion elimination removes redundant `info.(CollectionType)` checks from `marshalList`, `marshalMap`, `unmarshalList`, and `unmarshalMap`. These functions are only ever called from the `Marshal()`/`Unmarshal()` type switches where the concrete type is already known to be `CollectionType`.

The `unmarshalMap` fast paths use a type-switch on the concrete `value` parameter to dispatch directly to specialized functions per map type. Each specialized function reads keys/values directly from the wire bytes and calls the serialization package's `Dec*` functions (e.g., `bigint.DecInt64`, `double.DecFloat64`) without any reflection. This eliminates per-entry `reflect.New` (2 per entry), `reflect.SetMapIndex`, and interface boxing that the generic path requires.

Complementary to PR #779 (which optimizes the read/scan path via reflection elimination); this PR optimizes both the collection write/marshal path and the map unmarshal/read path.