### PR TITLE
tablets: store TabletInfo and TabletEntry as values

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2145,7 +2145,7 @@ func (e *QueryError) Unwrap() error {
 	return e.err
 }
 
-func unmarshalTabletHint(hint []byte, v uint8, keyspace, table string) (*tablets.TabletInfo, error) {
+func unmarshalTabletHint(hint []byte, v uint8, keyspace, table string) (tablets.TabletInfo, error) {
 	tabletBuilder := tablets.NewTabletInfoBuilder()
 	err := Unmarshal(TupleTypeInfo{
 		NativeType: NativeType{proto: v, typ: TypeTuple},
@@ -2164,7 +2164,7 @@ func unmarshalTabletHint(hint []byte, v uint8, keyspace, table string) (*tablets
 		},
 	}, hint, []any{&tabletBuilder.FirstToken, &tabletBuilder.LastToken, &tabletBuilder.Replicas})
 	if err != nil {
-		return nil, err
+		return tablets.TabletInfo{}, err
 	}
 	tabletBuilder.KeyspaceName = keyspace
 	tabletBuilder.TableName = table

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -655,7 +655,7 @@ func (s *metadataDescriber) forEachTablet(fn func(keyspace, table string, entrie
 	s.metadata.tabletsMetadata.ForEach(fn)
 }
 
-func (s *metadataDescriber) AddTablet(tablet *tablets.TabletInfo) {
+func (s *metadataDescriber) AddTablet(tablet tablets.TabletInfo) {
 	s.metadata.tabletsMetadata.AddTablet(tablet)
 }
 

--- a/tablets/cow_tablet_list_test.go
+++ b/tablets/cow_tablet_list_test.go
@@ -37,7 +37,7 @@ func TestAddTabletToPerTableList(t *testing.T) {
 
 	t.Run("Empty", func(t *testing.T) {
 		tl := TabletEntryList{}
-		tl = tl.addEntry(&TabletEntry{
+		tl = tl.addEntry(TabletEntry{
 			firstToken: -100, lastToken: 100,
 		})
 
@@ -50,7 +50,7 @@ func TestAddTabletToPerTableList(t *testing.T) {
 		tl := TabletEntryList{{
 			firstToken: 100, lastToken: 200,
 		}}
-		tl = tl.addEntry(&TabletEntry{
+		tl = tl.addEntry(TabletEntry{
 			firstToken: -200, lastToken: -100,
 		})
 
@@ -62,7 +62,7 @@ func TestAddTabletToPerTableList(t *testing.T) {
 		tl := TabletEntryList{{
 			firstToken: -200, lastToken: -100,
 		}}
-		tl = tl.addEntry(&TabletEntry{
+		tl = tl.addEntry(TabletEntry{
 			firstToken: 100, lastToken: 200,
 		})
 
@@ -77,7 +77,7 @@ func TestAddTabletToPerTableList(t *testing.T) {
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 0, lastToken: 100},
 		}
-		tl = tl.addEntry(&TabletEntry{
+		tl = tl.addEntry(TabletEntry{
 			firstToken: -150, lastToken: 50,
 		})
 
@@ -89,7 +89,7 @@ func TestAddTabletToPerTableList(t *testing.T) {
 		entries := TabletEntryList{
 			{firstToken: -300, lastToken: 300},
 		}
-		result := entries.addEntry(&TabletEntry{firstToken: -100, lastToken: 100})
+		result := entries.addEntry(TabletEntry{firstToken: -100, lastToken: 100})
 		if len(result) != 1 {
 			t.Errorf("expected 1 tablet after replacement, got %d", len(result))
 		}
@@ -105,7 +105,7 @@ func TestAddTabletToPerTableList(t *testing.T) {
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 0, lastToken: 100},
 		}
-		result := entries.addEntry(&TabletEntry{firstToken: -300, lastToken: 200})
+		result := entries.addEntry(TabletEntry{firstToken: -300, lastToken: 200})
 		if len(result) != 1 {
 			t.Errorf("expected consolidation to 1 tablet, got %d", len(result))
 		}
@@ -121,7 +121,7 @@ func TestAddTabletToPerTableList(t *testing.T) {
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 100, lastToken: 200},
 		}
-		result := entries.addEntry(&TabletEntry{firstToken: -150, lastToken: 150})
+		result := entries.addEntry(TabletEntry{firstToken: -150, lastToken: 150})
 		if len(result) != 2 {
 			t.Errorf("expected 2 tablets after partial overlap, got %d", len(result))
 		}
@@ -139,7 +139,7 @@ func TestBulkAddToPerTableList(t *testing.T) {
 
 	t.Run("Empty", func(t *testing.T) {
 		tl := TabletEntryList{}
-		batch := []*TabletEntry{
+		batch := TabletEntryList{
 			{firstToken: -200, lastToken: -100},
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 0, lastToken: 100},
@@ -157,7 +157,7 @@ func TestBulkAddToPerTableList(t *testing.T) {
 			{firstToken: -200, lastToken: -100},
 			{firstToken: 100, lastToken: 200},
 		}
-		batch := []*TabletEntry{
+		batch := TabletEntryList{
 			{firstToken: -350, lastToken: -250},
 			{firstToken: -250, lastToken: -150},
 		}
@@ -169,7 +169,7 @@ func TestBulkAddToPerTableList(t *testing.T) {
 
 	t.Run("IntraBatchOverlappingPair", func(t *testing.T) {
 		tl := TabletEntryList{}
-		batch := []*TabletEntry{
+		batch := TabletEntryList{
 			{firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{testHostUUID("h1"), 0}}},
 			{firstToken: 50, lastToken: 150, replicas: []ReplicaInfo{{testHostUUID("h2"), 0}}},
 		}
@@ -183,7 +183,7 @@ func TestBulkAddToPerTableList(t *testing.T) {
 
 	t.Run("IntraBatchOverlappingTriple", func(t *testing.T) {
 		tl := TabletEntryList{}
-		batch := []*TabletEntry{
+		batch := TabletEntryList{
 			{firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{testHostUUID("h1"), 0}}},
 			{firstToken: 50, lastToken: 150, replicas: []ReplicaInfo{{testHostUUID("h2"), 0}}},
 			{firstToken: 100, lastToken: 200, replicas: []ReplicaInfo{{testHostUUID("h3"), 0}}},
@@ -200,7 +200,7 @@ func TestBulkAddToPerTableList(t *testing.T) {
 			{firstToken: -500, lastToken: -400},
 			{firstToken: 500, lastToken: 600},
 		}
-		batch := []*TabletEntry{
+		batch := TabletEntryList{
 			{firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{testHostUUID("h1"), 0}}},
 			{firstToken: 50, lastToken: 150, replicas: []ReplicaInfo{{testHostUUID("h2"), 0}}},
 		}
@@ -215,7 +215,7 @@ func TestBulkAddToPerTableList(t *testing.T) {
 
 	t.Run("NonOverlappingBatchStillWorks", func(t *testing.T) {
 		tl := TabletEntryList{}
-		batch := []*TabletEntry{
+		batch := TabletEntryList{
 			{firstToken: 0, lastToken: 100},
 			{firstToken: 100, lastToken: 200},
 			{firstToken: 200, lastToken: 300},
@@ -230,7 +230,7 @@ func TestBulkAddToPerTableList(t *testing.T) {
 		tl := TabletEntryList{
 			{firstToken: 200, lastToken: 300, replicas: []ReplicaInfo{{testHostUUID("existing"), 0}}},
 		}
-		batch := []*TabletEntry{
+		batch := TabletEntryList{
 			{firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{testHostUUID("h1"), 0}}},
 			{firstToken: 500, lastToken: 600, replicas: []ReplicaInfo{{testHostUUID("h2"), 0}}},
 		}
@@ -250,37 +250,37 @@ func TestCowTabletListAddAndFind(t *testing.T) {
 		defer cl.Close()
 
 		host1 := GenerateHostUUIDs(1)[0]
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
 		})
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks1", "tb1", -50)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks1", "tb1", -50)
+		if !ok {
 			t.Fatal("expected tablet for token -50")
 		}
 		tests.AssertEqual(t, "lastToken", int64(0), ti.LastToken())
 
-		ti = cl.FindTabletForToken("ks1", "tb1", 50)
-		if ti == nil {
+		ti, ok = cl.FindTabletForToken("ks1", "tb1", 50)
+		if !ok {
 			t.Fatal("expected tablet for token 50")
 		}
 		tests.AssertEqual(t, "lastToken", int64(100), ti.LastToken())
 
-		ti = cl.FindTabletForToken("ks1", "unknown", 0)
-		if ti != nil {
+		_, ok = cl.FindTabletForToken("ks1", "unknown", 0)
+		if ok {
 			t.Fatal("expected nil for unknown table")
 		}
 
-		ti = cl.FindTabletForToken("unknown", "tb1", 0)
-		if ti != nil {
+		_, ok = cl.FindTabletForToken("unknown", "tb1", 0)
+		if ok {
 			t.Fatal("expected nil for unknown keyspace")
 		}
 	})
@@ -292,7 +292,7 @@ func TestCowTabletListAddAndFind(t *testing.T) {
 		host1 := hosts[0]
 		host2 := hosts[1]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 0}, {host2, 1}},
@@ -315,12 +315,12 @@ func TestCowTabletListAddAndFind(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb1",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb2",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 5}},
@@ -339,12 +339,12 @@ func TestCowTabletListAddAndFind(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks2", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 2}},
@@ -365,20 +365,20 @@ func TestCowTabletListAddAndFind(t *testing.T) {
 		host1 := hosts[0]
 		host2 := hosts[1]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host2, 5}},
 		})
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "tb", 0)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks", "tb", 0)
+		if !ok {
 			t.Fatal("expected tablet")
 		}
 		tests.AssertEqual(t, "updated host", host2.String(), ti.Replicas()[0].HostID())
@@ -392,27 +392,27 @@ func TestCowTabletListAddAndFind(t *testing.T) {
 		host1 := hosts[0]
 		host2 := hosts[1]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: 0, lastToken: 200,
 			replicas: []ReplicaInfo{{host2, 1}},
 		})
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "tb", 50)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks", "tb", 50)
+		if !ok {
 			t.Fatal("expected tablet for token 50")
 		}
 		tests.AssertEqual(t, "replaced host", host2.String(), ti.Replicas()[0].HostID())
 		tests.AssertEqual(t, "replaced lastToken", int64(200), ti.LastToken())
 
-		ti = cl.FindTabletForToken("ks", "tb", 150)
-		if ti == nil {
+		ti, ok = cl.FindTabletForToken("ks", "tb", 150)
+		if !ok {
 			t.Fatal("expected tablet for token 150")
 		}
 		tests.AssertEqual(t, "host at 150", host2.String(), ti.Replicas()[0].HostID())
@@ -427,7 +427,7 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		batch := []*TabletInfo{
+		batch := TabletInfoList{
 			{keyspaceName: "ks", tableName: "tb", firstToken: -300, lastToken: -200, replicas: []ReplicaInfo{{host1, 0}}},
 			{keyspaceName: "ks", tableName: "tb", firstToken: -200, lastToken: -100, replicas: []ReplicaInfo{{host1, 1}}},
 			{keyspaceName: "ks", tableName: "tb", firstToken: -100, lastToken: 0, replicas: []ReplicaInfo{{host1, 2}}},
@@ -435,14 +435,14 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		cl.BulkAddTablets(batch)
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "tb", -250)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks", "tb", -250)
+		if !ok {
 			t.Fatal("expected tablet")
 		}
 		tests.AssertEqual(t, "shard", 0, ti.Replicas()[0].ShardID())
 
-		ti = cl.FindTabletForToken("ks", "tb", -150)
-		if ti == nil {
+		ti, ok = cl.FindTabletForToken("ks", "tb", -150)
+		if !ok {
 			t.Fatal("expected tablet")
 		}
 		tests.AssertEqual(t, "shard", 1, ti.Replicas()[0].ShardID())
@@ -453,7 +453,7 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		batch := []*TabletInfo{
+		batch := TabletInfoList{
 			{keyspaceName: "ks", tableName: "tb1", firstToken: -100, lastToken: 0, replicas: []ReplicaInfo{{host1, 0}}},
 			{keyspaceName: "ks", tableName: "tb1", firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{host1, 1}}},
 			{keyspaceName: "ks", tableName: "tb2", firstToken: -50, lastToken: 50, replicas: []ReplicaInfo{{host1, 2}}},
@@ -461,10 +461,16 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		cl.BulkAddTablets(batch)
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "tb1", -50)
+		ti, ok := cl.FindTabletForToken("ks", "tb1", -50)
+		if !ok {
+			t.Fatal("expected tablet for tb1 token -50")
+		}
 		tests.AssertEqual(t, "tb1 shard", 0, ti.Replicas()[0].ShardID())
 
-		ti = cl.FindTabletForToken("ks", "tb2", 0)
+		ti, ok = cl.FindTabletForToken("ks", "tb2", 0)
+		if !ok {
+			t.Fatal("expected tablet for tb2 token 0")
+		}
 		tests.AssertEqual(t, "tb2 shard", 2, ti.Replicas()[0].ShardID())
 	})
 
@@ -473,7 +479,7 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		batch := []*TabletInfo{
+		batch := TabletInfoList{
 			{keyspaceName: "ks", tableName: "tb1", firstToken: 100, lastToken: 200, replicas: []ReplicaInfo{{host1, 2}}},
 			{keyspaceName: "ks", tableName: "tb2", firstToken: -100, lastToken: 100, replicas: []ReplicaInfo{{host1, 7}}},
 			{keyspaceName: "ks", tableName: "tb1", firstToken: -100, lastToken: 0, replicas: []ReplicaInfo{{host1, 0}}},
@@ -483,40 +489,40 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		cl.BulkAddTablets(batch)
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "tb1", -50)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks", "tb1", -50)
+		if !ok {
 			t.Fatal("expected tablet for tb1 token -50")
 		}
 		tests.AssertEqual(t, "tb1 shard for -50", 0, ti.Replicas()[0].ShardID())
 
-		ti = cl.FindTabletForToken("ks", "tb1", 50)
-		if ti == nil {
+		ti, ok = cl.FindTabletForToken("ks", "tb1", 50)
+		if !ok {
 			t.Fatal("expected tablet for tb1 token 50")
 		}
 		tests.AssertEqual(t, "tb1 shard for 50", 1, ti.Replicas()[0].ShardID())
 
-		ti = cl.FindTabletForToken("ks", "tb1", 150)
-		if ti == nil {
+		ti, ok = cl.FindTabletForToken("ks", "tb1", 150)
+		if !ok {
 			t.Fatal("expected tablet for tb1 token 150")
 		}
 		tests.AssertEqual(t, "tb1 shard for 150", 2, ti.Replicas()[0].ShardID())
 
-		ti = cl.FindTabletForToken("ks", "tb2", 0)
-		if ti == nil {
+		ti, ok = cl.FindTabletForToken("ks", "tb2", 0)
+		if !ok {
 			t.Fatal("expected tablet for tb2 token 0")
 		}
 		tests.AssertEqual(t, "tb2 shard", 7, ti.Replicas()[0].ShardID())
 	})
 
-	t.Run("NilEntries", func(t *testing.T) {
+	t.Run("ZeroValueEntries", func(t *testing.T) {
 		cl := NewCowTabletList()
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.BulkAddTablets([]*TabletInfo{
-			nil,
+		cl.BulkAddTablets(TabletInfoList{
+			{},
 			{keyspaceName: "ks", tableName: "tb", firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{host1, 0}}},
-			nil,
+			{},
 		})
 		cl.Flush()
 
@@ -531,7 +537,7 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.BulkAddTablets([]*TabletInfo{
+		cl.BulkAddTablets(TabletInfoList{
 			{keyspaceName: "", tableName: "tb", firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{host1, 0}}},
 			{keyspaceName: "ks", tableName: "", firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{host1, 1}}},
 			{keyspaceName: "", tableName: "", firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{host1, 2}}},
@@ -552,7 +558,7 @@ func TestCowTabletListBulkAdd(t *testing.T) {
 		cl := NewCowTabletList()
 		defer cl.Close()
 
-		batch := []*TabletInfo{
+		batch := TabletInfoList{
 			{keyspaceName: "ks", tableName: "tb", firstToken: 0, lastToken: 100, replicas: []ReplicaInfo{{testHostUUID("h1"), 0}}},
 			{keyspaceName: "ks", tableName: "tb", firstToken: 50, lastToken: 150, replicas: []ReplicaInfo{{testHostUUID("h2"), 1}}},
 		}
@@ -575,17 +581,17 @@ func TestCowTabletListGet(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb2",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks2", tableName: "tb1",
 			firstToken: 100, lastToken: 200,
 			replicas: []ReplicaInfo{{host1, 2}},
@@ -619,22 +625,22 @@ func TestCowTabletListGetTableTablets(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb2",
 			firstToken: 100, lastToken: 200,
 			replicas: []ReplicaInfo{{host1, 2}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks2", tableName: "tb1",
 			firstToken: 200, lastToken: 300,
 			replicas: []ReplicaInfo{{host1, 3}},
@@ -660,7 +666,7 @@ func TestCowTabletListGetTableTablets(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
@@ -683,12 +689,12 @@ func TestCowTabletListGetTableTablets(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
@@ -698,8 +704,8 @@ func TestCowTabletListGetTableTablets(t *testing.T) {
 		result1 := cl.GetTableTablets("ks", "tb")
 		result2 := cl.GetTableTablets("ks", "tb")
 
-		result1[0] = nil
-		if result2[0] == nil {
+		result1[0] = TabletEntry{}
+		if result2[0].FirstToken() != -100 {
 			t.Fatal("GetTableTablets should return independent copies")
 		}
 	})
@@ -725,17 +731,17 @@ func TestCowTabletListRemove(t *testing.T) {
 		removedHost := hosts[0]
 		keptHost := hosts[1]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb1",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{removedHost, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb1",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{keptHost, 1}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb2",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{removedHost, 2}},
@@ -743,8 +749,8 @@ func TestCowTabletListRemove(t *testing.T) {
 		cl.RemoveTabletsWithHost(removedHost)
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "tb1", 50)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks", "tb1", 50)
+		if !ok {
 			t.Fatal("expected kept tablet in tb1")
 		}
 		tests.AssertEqual(t, "kept shard", 1, ti.Replicas()[0].ShardID())
@@ -764,17 +770,17 @@ func TestCowTabletListRemove(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "removed_ks", tableName: "tb1",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "removed_ks", tableName: "tb2",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "kept_ks", tableName: "tb1",
 			firstToken: 100, lastToken: 200,
 			replicas: []ReplicaInfo{{host1, 2}},
@@ -782,17 +788,17 @@ func TestCowTabletListRemove(t *testing.T) {
 		cl.RemoveTabletsWithKeyspace("removed_ks")
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("removed_ks", "tb1", -50)
-		if ti != nil {
+		_, ok := cl.FindTabletForToken("removed_ks", "tb1", -50)
+		if ok {
 			t.Fatal("expected nil for removed keyspace table tb1")
 		}
-		ti = cl.FindTabletForToken("removed_ks", "tb2", 50)
-		if ti != nil {
+		_, ok = cl.FindTabletForToken("removed_ks", "tb2", 50)
+		if ok {
 			t.Fatal("expected nil for removed keyspace table tb2")
 		}
 
-		ti = cl.FindTabletForToken("kept_ks", "tb1", 150)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("kept_ks", "tb1", 150)
+		if !ok {
 			t.Fatal("expected tablet for kept keyspace")
 		}
 		tests.AssertEqual(t, "kept shard", 2, ti.Replicas()[0].ShardID())
@@ -805,12 +811,12 @@ func TestCowTabletListRemove(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "removed_tb",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "kept_tb",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
@@ -818,13 +824,13 @@ func TestCowTabletListRemove(t *testing.T) {
 		cl.RemoveTabletsWithTable("ks", "removed_tb")
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "removed_tb", -50)
-		if ti != nil {
+		_, ok := cl.FindTabletForToken("ks", "removed_tb", -50)
+		if ok {
 			t.Fatal("expected nil for removed table")
 		}
 
-		ti = cl.FindTabletForToken("ks", "kept_tb", 50)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks", "kept_tb", 50)
+		if !ok {
 			t.Fatal("expected tablet for kept table")
 		}
 		tests.AssertEqual(t, "kept shard", 1, ti.Replicas()[0].ShardID())
@@ -835,7 +841,7 @@ func TestCowTabletListRemove(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 0}},
@@ -857,17 +863,17 @@ func TestCowTabletListForEach(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb1",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks1", tableName: "tb2",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks2", tableName: "tb1",
 			firstToken: 100, lastToken: 200,
 			replicas: []ReplicaInfo{{host1, 2}},
@@ -892,7 +898,7 @@ func TestCowTabletListForEach(t *testing.T) {
 		host1 := GenerateHostUUIDs(1)[0]
 
 		for i := 0; i < 10; i++ {
-			cl.AddTablet(&TabletInfo{
+			cl.AddTablet(TabletInfo{
 				keyspaceName: "ks", tableName: fmt.Sprintf("tb%d", i),
 				firstToken: int64(i * 100), lastToken: int64(i*100 + 99),
 				replicas: []ReplicaInfo{{host1, i}},
@@ -936,12 +942,12 @@ func TestCowTabletListForEach(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
@@ -952,19 +958,19 @@ func TestCowTabletListForEach(t *testing.T) {
 			for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
 				entries[i], entries[j] = entries[j], entries[i]
 			}
-			entries[0] = nil
+			entries[0] = TabletEntry{}
 			return true
 		})
 
-		entry := cl.FindTabletForToken("ks", "tb", 50)
-		if entry == nil {
+		entry, ok := cl.FindTabletForToken("ks", "tb", 50)
+		if !ok {
 			t.Fatal("expected to find tablet for token 50 after ForEach mutation")
 		}
 		tests.AssertEqual(t, "firstToken", int64(0), entry.FirstToken())
 		tests.AssertEqual(t, "lastToken", int64(100), entry.LastToken())
 
-		entry = cl.FindTabletForToken("ks", "tb", -50)
-		if entry == nil {
+		entry, ok = cl.FindTabletForToken("ks", "tb", -50)
+		if !ok {
 			t.Fatal("expected to find tablet for token -50 after ForEach mutation")
 		}
 		tests.AssertEqual(t, "firstToken", int64(-100), entry.FirstToken())
@@ -976,12 +982,12 @@ func TestCowTabletListForEach(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: 0, lastToken: 100,
 			replicas: []ReplicaInfo{{host1, 1}},
@@ -1004,7 +1010,7 @@ func TestCowTabletListForEach(t *testing.T) {
 		cl := NewCowTabletList()
 		defer cl.Close()
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{testHostUUID("host1"), 0}},
@@ -1060,7 +1066,7 @@ func TestCowTabletListLifecycle(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			cl.AddTablet(&TabletInfo{
+			cl.AddTablet(TabletInfo{
 				keyspaceName: "ks", tableName: "tb",
 				firstToken: -100, lastToken: 100,
 				replicas: []ReplicaInfo{{host1, 0}},
@@ -1081,12 +1087,12 @@ func TestCowTabletListLifecycle(t *testing.T) {
 
 		cl.Close()
 		cl.Flush()
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{testHostUUID("host"), 0}},
 		})
-		cl.BulkAddTablets([]*TabletInfo{{
+		cl.BulkAddTablets(TabletInfoList{{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -100, lastToken: 100,
 			replicas: []ReplicaInfo{{testHostUUID("host"), 0}},
@@ -1100,8 +1106,8 @@ func TestCowTabletListLifecycle(t *testing.T) {
 func TestOpQueueRun(t *testing.T) {
 	t.Parallel()
 
-	newTablet := func(first, last int64) *TabletInfo {
-		return &TabletInfo{
+	newTablet := func(first, last int64) TabletInfo {
+		return TabletInfo{
 			keyspaceName: "ks",
 			tableName:    "tb",
 			firstToken:   first,
@@ -1207,7 +1213,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				rnd := getThreadSafeRnd()
 				for j := 0; j < 1000; j++ {
 					token := rnd.Int63()
-					cl.FindTabletForToken("ks", "tb", token)
+					_, _ = cl.FindTabletForToken("ks", "tb", token)
 					cl.FindReplicasUnsafeForToken("ks", "tb", token)
 				}
 			}()
@@ -1229,7 +1235,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				defer wg.Done()
 				rnd := getThreadSafeRnd()
 				for j := 0; j < 1000; j++ {
-					cl.FindTabletForToken("ks", "tb", rnd.Int63())
+					_, _ = cl.FindTabletForToken("ks", "tb", rnd.Int63())
 					cl.Get()
 				}
 			}()
@@ -1242,7 +1248,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				rnd := getThreadSafeRnd()
 				for j := 0; j < 100; j++ {
 					token := rnd.Int63()
-					cl.AddTablet(&TabletInfo{
+					cl.AddTablet(TabletInfo{
 						keyspaceName: "ks", tableName: "tb",
 						firstToken: token - 100, lastToken: token,
 						replicas: repGen.Next(),
@@ -1273,7 +1279,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				rnd := getThreadSafeRnd()
 				tb := tables[idx%len(tables)]
 				for j := 0; j < 500; j++ {
-					cl.FindTabletForToken("ks", tb, rnd.Int63())
+					_, _ = cl.FindTabletForToken("ks", tb, rnd.Int63())
 				}
 			}(i)
 		}
@@ -1287,7 +1293,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				tb := tables[idx%len(tables)]
 				for j := 0; j < 50; j++ {
 					token := rnd.Int63()
-					cl.AddTablet(&TabletInfo{
+					cl.AddTablet(TabletInfo{
 						keyspaceName: "ks", tableName: tb,
 						firstToken: token - 100, lastToken: token,
 						replicas: repGen.Next(),
@@ -1324,8 +1330,8 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				defer wg.Done()
 				rnd := getThreadSafeRnd()
 				for j := 0; j < 500; j++ {
-					cl.FindTabletForToken("ks1", "tb", rnd.Int63())
-					cl.FindTabletForToken("ks2", "tb", rnd.Int63())
+					_, _ = cl.FindTabletForToken("ks1", "tb", rnd.Int63())
+					_, _ = cl.FindTabletForToken("ks2", "tb", rnd.Int63())
 				}
 			}()
 		}
@@ -1339,13 +1345,13 @@ func TestCowTabletListConcurrency(t *testing.T) {
 		wg.Wait()
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks2", "tb", 0)
-		if ti != nil {
+		_, ok := cl.FindTabletForToken("ks2", "tb", 0)
+		if ok {
 			t.Fatal("expected nil for removed keyspace")
 		}
 
-		ti = cl.FindTabletForToken("ks1", "tb", 0)
-		if ti == nil {
+		_, ok = cl.FindTabletForToken("ks1", "tb", 0)
+		if !ok {
 			t.Fatal("expected tablet for ks1")
 		}
 	})
@@ -1361,7 +1367,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				hostID := hostUUIDs[hostIdx]
 				hostIdx++
 				for i := 0; i < 10; i++ {
-					cl.AddTablet(&TabletInfo{
+					cl.AddTablet(TabletInfo{
 						keyspaceName: fmt.Sprintf("ks%d", ks),
 						tableName:    "tb",
 						firstToken:   int64(ks*10000 + host*1000 + i*100),
@@ -1434,14 +1440,14 @@ func TestCowTabletListConcurrency(t *testing.T) {
 	t.Run("CloseRace", func(t *testing.T) {
 		list := NewCowTabletList()
 
-		tablet := &TabletInfo{
+		tablet := TabletInfo{
 			keyspaceName: "ks",
 			tableName:    "tbl",
 			firstToken:   -100,
 			lastToken:    100,
 			replicas:     []ReplicaInfo{{testHostUUID("host1"), 0}},
 		}
-		list.BulkAddTablets([]*TabletInfo{tablet})
+		list.BulkAddTablets(TabletInfoList{tablet})
 		list.Flush()
 
 		ready := make(chan struct{})
@@ -1451,7 +1457,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 				defer func() { done <- true }()
 				ready <- struct{}{}
 				for j := 0; j < 1000; j++ {
-					_ = list.FindTabletForToken("ks", "tbl", 50)
+					_, _ = list.FindTabletForToken("ks", "tbl", 50)
 				}
 			}()
 		}
@@ -1472,7 +1478,7 @@ func TestCowTabletListConcurrency(t *testing.T) {
 
 		uuids := GenerateHostUUIDs(100)
 		for i := 0; i < 100; i++ {
-			cl.AddTablet(&TabletInfo{
+			cl.AddTablet(TabletInfo{
 				keyspaceName: "ks", tableName: "tb",
 				firstToken: int64(i * 100), lastToken: int64(i*100 + 99),
 				replicas: []ReplicaInfo{{uuids[i], 0}},
@@ -1514,32 +1520,32 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 		defer cl.Close()
 		host1 := GenerateHostUUIDs(1)[0]
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: math.MinInt64, lastToken: 0,
 			replicas: []ReplicaInfo{{host1, 0}},
 		})
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: 0, lastToken: math.MaxInt64,
 			replicas: []ReplicaInfo{{host1, 1}},
 		})
 		cl.Flush()
 
-		ti := cl.FindTabletForToken("ks", "tb", math.MinInt64)
-		if ti == nil {
+		ti, ok := cl.FindTabletForToken("ks", "tb", math.MinInt64)
+		if !ok {
 			t.Fatal("expected tablet for math.MinInt64")
 		}
 		tests.AssertEqual(t, "MinInt64 shard", 0, ti.Replicas()[0].ShardID())
 
-		ti = cl.FindTabletForToken("ks", "tb", math.MaxInt64)
-		if ti == nil {
+		ti, ok = cl.FindTabletForToken("ks", "tb", math.MaxInt64)
+		if !ok {
 			t.Fatal("expected tablet for math.MaxInt64")
 		}
 		tests.AssertEqual(t, "MaxInt64 shard", 1, ti.Replicas()[0].ShardID())
 
-		ti = cl.FindTabletForToken("ks", "tb", 0)
-		if ti == nil {
+		_, ok = cl.FindTabletForToken("ks", "tb", 0)
+		if !ok {
 			t.Fatal("expected tablet for token 0")
 		}
 	})
@@ -1548,7 +1554,7 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 		cl := NewCowTabletList()
 		defer cl.Close()
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks",
 			tableName:    "tb",
 			firstToken:   -100,
@@ -1564,8 +1570,8 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 			t.Errorf("expected empty replica set, got %d replicas", len(replicas))
 		}
 
-		tablet := cl.FindTabletForToken("ks", "tb", 0)
-		if tablet == nil {
+		tablet, ok := cl.FindTabletForToken("ks", "tb", 0)
+		if !ok {
 			t.Fatal("expected tablet to exist")
 		}
 		if len(tablet.ReplicasUnsafe()) != 0 {
@@ -1599,7 +1605,7 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 		uuids := GenerateHostUUIDs(operations)
 		go func() {
 			for i := 0; i < operations; i++ {
-				tablet := &TabletInfo{
+				tablet := TabletInfo{
 					keyspaceName: "ks",
 					tableName:    "tb",
 					firstToken:   int64(i * 100),
@@ -1625,7 +1631,7 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 		cl := NewCowTabletList()
 		defer cl.Close()
 
-		cl.AddTablet(&TabletInfo{
+		cl.AddTablet(TabletInfo{
 			keyspaceName: "ks", tableName: "tb",
 			firstToken: -1000, lastToken: -900,
 			replicas: []ReplicaInfo{{GenerateHostUUIDs(1)[0], 0}},
@@ -1640,7 +1646,7 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < writers; i++ {
-				cl.AddTablet(&TabletInfo{
+				cl.AddTablet(TabletInfo{
 					keyspaceName: "ks", tableName: "tb",
 					firstToken: int64(i * 100), lastToken: int64(i*100 + 99),
 					replicas: []ReplicaInfo{{writerUUIDs[i], 0}},
@@ -1654,8 +1660,8 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for i := 0; i < 1000; i++ {
-					entry := cl.FindTabletForToken("ks", "tb", -950)
-					if entry != nil {
+					entry, ok := cl.FindTabletForToken("ks", "tb", -950)
+					if ok {
 						if entry.FirstToken() > entry.LastToken() {
 							t.Errorf("invalid token range: first=%d > last=%d", entry.FirstToken(), entry.LastToken())
 						}
@@ -1667,10 +1673,6 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 
 					entries := cl.GetTableTablets("ks", "tb")
 					for _, e := range entries {
-						if e == nil {
-							t.Error("nil entry in GetTableTablets result")
-							continue
-						}
 						if e.FirstToken() > e.LastToken() {
 							t.Errorf("invalid token range in list: first=%d > last=%d", e.FirstToken(), e.LastToken())
 						}

--- a/tablets/tablet_utils.go
+++ b/tablets/tablet_utils.go
@@ -122,12 +122,12 @@ func GenerateHostUUIDs(count int) []HostUUID {
 // createTablets generates a list of TabletInfo entries for a given keyspace and table.
 // Each tablet is assigned a token range and a set of replica hosts.
 func createTablets(ks, table string, hosts []HostUUID, rf, count int, tokenRangeCount int64) TabletInfoList {
-	out := make([]*TabletInfo, count)
+	out := make(TabletInfoList, count)
 	step := math.MaxUint64 / uint64(tokenRangeCount)
 	repGen := NewReplicaSetGenerator(hosts, rf)
 	firstToken := int64(math.MinInt64)
 	for i := 0; i < count; i++ {
-		out[i] = &TabletInfo{
+		out[i] = TabletInfo{
 			keyspaceName: ks,
 			tableName:    table,
 			firstToken:   firstToken,

--- a/tablets/tablets.go
+++ b/tablets/tablets.go
@@ -107,48 +107,48 @@ type uuidProvider interface {
 	Bytes() []byte
 }
 
-func (b TabletInfoBuilder) Build() (*TabletInfo, error) {
+func (b TabletInfoBuilder) Build() (TabletInfo, error) {
 	if b.FirstToken > b.LastToken {
-		return nil, fmt.Errorf("invalid token range: firstToken (%d) > lastToken (%d)",
+		return TabletInfo{}, fmt.Errorf("invalid token range: firstToken (%d) > lastToken (%d)",
 			b.FirstToken, b.LastToken)
 	}
 
 	tabletReplicas := make([]ReplicaInfo, 0, len(b.Replicas))
 	for _, replica := range b.Replicas {
 		if len(replica) != 2 {
-			return nil, fmt.Errorf("replica info should have exactly two elements, but it has %d: %v", len(replica), replica)
+			return TabletInfo{}, fmt.Errorf("replica info should have exactly two elements, but it has %d: %v", len(replica), replica)
 		}
 		shardId, ok := replica[1].(int)
 		if !ok {
-			return nil, fmt.Errorf("second element (shard) of replica is not int: %v", replica)
+			return TabletInfo{}, fmt.Errorf("second element (shard) of replica is not int: %v", replica)
 		}
 		var hostUUID HostUUID
 		switch v := replica[0].(type) {
 		case uuidProvider:
 			raw := v.Bytes()
 			if len(raw) != 16 {
-				return nil, fmt.Errorf("UUID bytes has wrong length %d, expected 16", len(raw))
+				return TabletInfo{}, fmt.Errorf("UUID bytes has wrong length %d, expected 16", len(raw))
 			}
 			copy(hostUUID[:], raw)
 		case string:
 			parsed, err := ParseHostUUID(v)
 			if err != nil {
-				return nil, fmt.Errorf("first element (hostID) cannot be parsed as UUID: %v: %w", replica, err)
+				return TabletInfo{}, fmt.Errorf("first element (hostID) cannot be parsed as UUID: %v: %w", replica, err)
 			}
 			hostUUID = parsed
 		case toString:
 			parsed, err := ParseHostUUID(v.String())
 			if err != nil {
-				return nil, fmt.Errorf("first element (hostID) cannot be parsed as UUID: %v: %w", replica, err)
+				return TabletInfo{}, fmt.Errorf("first element (hostID) cannot be parsed as UUID: %v: %w", replica, err)
 			}
 			hostUUID = parsed
 		default:
-			return nil, fmt.Errorf("first element (hostID) of replica is not UUID: %v", replica)
+			return TabletInfo{}, fmt.Errorf("first element (hostID) of replica is not UUID: %v", replica)
 		}
 		tabletReplicas = append(tabletReplicas, ReplicaInfo{hostUUID, shardId})
 	}
 
-	return &TabletInfo{
+	return TabletInfo{
 		keyspaceName: b.KeyspaceName,
 		tableName:    b.TableName,
 		firstToken:   b.FirstToken,
@@ -166,34 +166,34 @@ type TabletInfo struct {
 	lastToken    int64
 }
 
-func (t *TabletInfo) KeyspaceName() string {
+func (t TabletInfo) KeyspaceName() string {
 	return t.keyspaceName
 }
 
-func (t *TabletInfo) FirstToken() int64 {
+func (t TabletInfo) FirstToken() int64 {
 	return t.firstToken
 }
 
-func (t *TabletInfo) LastToken() int64 {
+func (t TabletInfo) LastToken() int64 {
 	return t.lastToken
 }
 
-func (t *TabletInfo) TableName() string {
+func (t TabletInfo) TableName() string {
 	return t.tableName
 }
 
-func (t *TabletInfo) Replicas() []ReplicaInfo {
+func (t TabletInfo) Replicas() []ReplicaInfo {
 	result := make([]ReplicaInfo, len(t.replicas))
 	copy(result, t.replicas)
 	return result
 }
 
 // ReplicasUnsafe returns the raw replica slice without copying.
-func (t *TabletInfo) ReplicasUnsafe() []ReplicaInfo {
+func (t TabletInfo) ReplicasUnsafe() []ReplicaInfo {
 	return t.replicas
 }
 
-type TabletInfoList []*TabletInfo
+type TabletInfoList []TabletInfo
 
 // TabletEntry is the per-table representation of a tablet, without keyspace/table names.
 type TabletEntry struct {
@@ -202,25 +202,25 @@ type TabletEntry struct {
 	lastToken  int64
 }
 
-type TabletEntryList []*TabletEntry
+type TabletEntryList []TabletEntry
 
 // Replicas returns a copy of the replica list for this entry.
-func (e *TabletEntry) Replicas() []ReplicaInfo {
+func (e TabletEntry) Replicas() []ReplicaInfo {
 	result := make([]ReplicaInfo, len(e.replicas))
 	copy(result, e.replicas)
 	return result
 }
 
 // ReplicasUnsafe returns the raw replica slice without copying.
-func (e *TabletEntry) ReplicasUnsafe() []ReplicaInfo {
+func (e TabletEntry) ReplicasUnsafe() []ReplicaInfo {
 	return e.replicas
 }
 
-func (e *TabletEntry) FirstToken() int64 {
+func (e TabletEntry) FirstToken() int64 {
 	return e.firstToken
 }
 
-func (e *TabletEntry) LastToken() int64 {
+func (e TabletEntry) LastToken() int64 {
 	return e.lastToken
 }
 
@@ -280,7 +280,7 @@ func (t TabletEntryList) findOverlapRange(firstToken, lastToken int64) (start, t
 
 // addEntry inserts a single entry into the sorted list, replacing any overlapping ranges.
 // Returns a new slice without mutating the original.
-func (t TabletEntryList) addEntry(e *TabletEntry) TabletEntryList {
+func (t TabletEntryList) addEntry(e TabletEntry) TabletEntryList {
 	start, tailStart := t.findOverlapRange(e.firstToken, e.lastToken)
 	result := make(TabletEntryList, 0, start+1+(len(t)-tailStart))
 	result = append(result, t[:start]...)
@@ -295,13 +295,13 @@ func (t TabletEntryList) addEntry(e *TabletEntry) TabletEntryList {
 // gaps between them or overlap each other within the batch; existing entries
 // that fall in gaps between batch entries are preserved. Intra-batch overlaps
 // are resolved by letting later entries replace earlier ones.
-func (t TabletEntryList) bulkAddEntries(entries []*TabletEntry) TabletEntryList {
+func (t TabletEntryList) bulkAddEntries(entries TabletEntryList) TabletEntryList {
 	if len(entries) == 0 {
 		return t
 	}
 
 	// Resolve intra-batch overlaps: later entries replace earlier ones.
-	deduped := make([]*TabletEntry, 0, len(entries))
+	deduped := make(TabletEntryList, 0, len(entries))
 	for _, e := range entries {
 		// Drop any previously added entries that the current one overlaps.
 		for len(deduped) > 0 && deduped[len(deduped)-1].firstToken >= e.firstToken {
@@ -340,13 +340,13 @@ func (t TabletEntryList) bulkAddEntries(entries []*TabletEntry) TabletEntryList 
 }
 
 // findEntryForToken performs a binary search within [l, r) to find the entry
-// covering the given token. Returns nil if no such entry exists.
-func (t TabletEntryList) findEntryForToken(token int64, l int, r int) *TabletEntry {
+// covering the given token. Returns false if no such entry exists.
+func (t TabletEntryList) findEntryForToken(token int64, l int, r int) (TabletEntry, bool) {
 	if l < 0 || r > len(t) || l > r {
-		return nil
+		return TabletEntry{}, false
 	}
 	if l == r {
-		return nil
+		return TabletEntry{}, false
 	}
 
 	for l < r {
@@ -358,12 +358,12 @@ func (t TabletEntryList) findEntryForToken(token int64, l int, r int) *TabletEnt
 		}
 	}
 	if l >= len(t) {
-		return nil
+		return TabletEntry{}, false
 	}
 	if t[l].firstToken > token {
-		return nil
+		return TabletEntry{}, false
 	}
-	return t[l]
+	return t[l], true
 }
 
 // removeEntriesWithHost returns a new list excluding entries with a replica on the given host.
@@ -401,17 +401,17 @@ func (t TabletEntryList) removeEntriesWithHost(hostID HostUUID) TabletEntryList 
 }
 
 // toEntry converts a TabletInfo to a TabletEntry.
-func (t *TabletInfo) toEntry() *TabletEntry {
-	return &TabletEntry{
-		replicas:   t.replicas,
+func (t TabletInfo) toEntry() TabletEntry {
+	return TabletEntry{
+		replicas:   slices.Clone(t.replicas),
 		firstToken: t.firstToken,
 		lastToken:  t.lastToken,
 	}
 }
 
 // toTabletInfo converts a TabletEntry back to a TabletInfo.
-func (e *TabletEntry) toTabletInfo(keyspace, table string) *TabletInfo {
-	return &TabletInfo{
+func (e TabletEntry) toTabletInfo(keyspace, table string) TabletInfo {
+	return TabletInfo{
 		keyspaceName: keyspace,
 		tableName:    table,
 		replicas:     slices.Clone(e.replicas),
@@ -448,13 +448,13 @@ type tabletOp interface {
 }
 
 type opAddTablet struct {
-	tablet *TabletInfo
+	tablet TabletInfo
 }
 
 func (op opAddTablet) execute(c *CowTabletList) { c.doAddTablet(op.tablet) }
 
 type opBulkAddTablets struct {
-	tablets []*TabletInfo
+	tablets TabletInfoList
 }
 
 func (op opBulkAddTablets) execute(c *CowTabletList) { c.doBulkAddTablets(op.tablets) }
@@ -528,10 +528,9 @@ func (q *opQueue) next() tabletOp {
 			return op
 		}
 		bulkOp := opBulkAddTablets{
-			tablets: []*TabletInfo{
-				opAdd.tablet,
-			},
+			tablets: make(TabletInfoList, 0, 1),
 		}
+		bulkOp.tablets = append(bulkOp.tablets, opAdd.tablet)
 		for {
 			select {
 			case op = <-q.ops:
@@ -691,8 +690,8 @@ func (c *CowTabletList) getOrCreateTable(key tableKey) *tableTablets {
 	return tt
 }
 
-func (c *CowTabletList) doAddTablet(tablet *TabletInfo) {
-	if tablet == nil || tablet.keyspaceName == "" || tablet.tableName == "" {
+func (c *CowTabletList) doAddTablet(tablet TabletInfo) {
+	if tablet.keyspaceName == "" || tablet.tableName == "" {
 		return
 	}
 	key := tableKey{tablet.keyspaceName, tablet.tableName}
@@ -700,16 +699,13 @@ func (c *CowTabletList) doAddTablet(tablet *TabletInfo) {
 	tt.store((*tt.list.Load()).addEntry(tablet.toEntry()))
 }
 
-func (c *CowTabletList) doBulkAddTablets(tablets []*TabletInfo) {
+func (c *CowTabletList) doBulkAddTablets(tablets TabletInfoList) {
 	if len(tablets) == 0 {
 		return
 	}
 
-	groups := make(map[tableKey][]*TabletInfo)
+	groups := make(map[tableKey]TabletInfoList)
 	for _, t := range tablets {
-		if t == nil {
-			continue
-		}
 		if t.keyspaceName == "" || t.tableName == "" {
 			continue
 		}
@@ -723,7 +719,7 @@ func (c *CowTabletList) doBulkAddTablets(tablets []*TabletInfo) {
 			}
 			return group[i].LastToken() < group[j].LastToken()
 		})
-		entries := make([]*TabletEntry, len(group))
+		entries := make(TabletEntryList, len(group))
 		for i, t := range group {
 			entries[i] = t.toEntry()
 		}
@@ -850,7 +846,7 @@ func (c *CowTabletList) GetTableTablets(keyspace, table string) TabletEntryList 
 
 // ForEach iterates over all keyspace/table pairs and their tablet entry lists,
 // calling fn for each one. Iteration stops early if fn returns false.
-// The returned TabletEntryList is a shallow copy; do not mutate individual entries.
+// The returned TabletEntryList is a shallow copy; do not mutate entries or their replica slices.
 func (c *CowTabletList) ForEach(fn func(keyspace, table string, entries TabletEntryList) bool) {
 	if c == nil || fn == nil {
 		return
@@ -871,8 +867,8 @@ func (c *CowTabletList) ForEach(fn func(keyspace, table string, entries TabletEn
 
 // FindReplicasForToken returns a copy of the replica set for the given token.
 func (c *CowTabletList) FindReplicasForToken(keyspace, table string, token int64) []ReplicaInfo {
-	tl := c.FindTabletForToken(keyspace, table, token)
-	if tl == nil {
+	tl, ok := c.FindTabletForToken(keyspace, table, token)
+	if !ok {
 		return nil
 	}
 	return tl.Replicas()
@@ -880,25 +876,25 @@ func (c *CowTabletList) FindReplicasForToken(keyspace, table string, token int64
 
 // FindReplicasUnsafeForToken returns the replica set for the given token without copying.
 func (c *CowTabletList) FindReplicasUnsafeForToken(keyspace, table string, token int64) []ReplicaInfo {
-	tl := c.FindTabletForToken(keyspace, table, token)
-	if tl == nil {
+	tl, ok := c.FindTabletForToken(keyspace, table, token)
+	if !ok {
 		return nil
 	}
 	return tl.ReplicasUnsafe()
 }
 
-// FindTabletForToken locates the tablet covering the given token. Returns nil if not found.
-func (c *CowTabletList) FindTabletForToken(keyspace, table string, token int64) *TabletEntry {
+// FindTabletForToken locates the tablet covering the given token. Returns false if not found.
+func (c *CowTabletList) FindTabletForToken(keyspace, table string, token int64) (TabletEntry, bool) {
 	if c == nil {
-		return nil
+		return TabletEntry{}, false
 	}
 	tt := c.getTable(tableKey{keyspace, table})
 	if tt == nil {
-		return nil
+		return TabletEntry{}, false
 	}
 	entries := *tt.list.Load()
 	if len(entries) == 0 {
-		return nil
+		return TabletEntry{}, false
 	}
 	return entries.findEntryForToken(token, 0, len(entries))
 }
@@ -914,12 +910,12 @@ func (c *CowTabletList) sendOp(op tabletOp) {
 }
 
 // AddTablet queues a single tablet addition.
-func (c *CowTabletList) AddTablet(tablet *TabletInfo) {
+func (c *CowTabletList) AddTablet(tablet TabletInfo) {
 	c.sendOp(opAddTablet{tablet: tablet})
 }
 
 // BulkAddTablets queues a batch tablet addition.
-func (c *CowTabletList) BulkAddTablets(tablets []*TabletInfo) {
+func (c *CowTabletList) BulkAddTablets(tablets TabletInfoList) {
 	c.sendOp(opBulkAddTablets{tablets: tablets})
 }
 

--- a/tablets/tablets_bench_test.go
+++ b/tablets/tablets_bench_test.go
@@ -140,12 +140,12 @@ func runSingleCowTabletListTest(b *testing.B, hostsCount, parallelism, rf, total
 		for pb.Next() {
 			id := opID.Add(1)
 			token := rnd.Int63()
-			tablet := tl.FindTabletForToken(targetKS, targetTable, token)
-			if tablet == nil || tablet.lastToken < token || tablet.firstToken > token {
+			tablet, found := tl.FindTabletForToken(targetKS, targetTable, token)
+			if found || tablet.lastToken < token || tablet.firstToken > token {
 				// If there is no tablet for token, emulate update, same way it is usually happening
 				firstToken := (token / tokenRangeCount64) * tokenRangeCount64
 				lastToken := firstToken + tokenRangeCount64
-				tl.AddTablet(&TabletInfo{
+				tl.AddTablet(TabletInfo{
 					keyspaceName: targetKS,
 					tableName:    targetTable,
 					firstToken:   firstToken,

--- a/tablets/tablets_test.go
+++ b/tablets/tablets_test.go
@@ -16,8 +16,8 @@ func TestFindEntryForToken(t *testing.T) {
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 0, lastToken: 100},
 		}
-		entry := entries.findEntryForToken(0, 0, len(entries))
-		if entry == nil {
+		entry, ok := entries.findEntryForToken(0, 0, len(entries))
+		if !ok {
 			t.Fatal("expected entry for token at exact lastToken boundary")
 		}
 		if entry.lastToken != 0 {
@@ -30,8 +30,8 @@ func TestFindEntryForToken(t *testing.T) {
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 0, lastToken: 100},
 		}
-		entry := entries.findEntryForToken(-100, 0, len(entries))
-		if entry == nil {
+		entry, ok := entries.findEntryForToken(-100, 0, len(entries))
+		if !ok {
 			t.Fatal("expected entry for token at exact firstToken boundary")
 		}
 		if entry.firstToken != -100 {
@@ -44,8 +44,8 @@ func TestFindEntryForToken(t *testing.T) {
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 0, lastToken: 100},
 		}
-		entry := entries.findEntryForToken(200, 0, len(entries))
-		if entry != nil {
+		_, ok := entries.findEntryForToken(200, 0, len(entries))
+		if ok {
 			t.Fatal("expected nil for token beyond all tablets")
 		}
 	})
@@ -55,8 +55,8 @@ func TestFindEntryForToken(t *testing.T) {
 			{firstToken: -100, lastToken: 0},
 			{firstToken: 0, lastToken: 100},
 		}
-		entry := entries.findEntryForToken(-200, 0, len(entries))
-		if entry != nil {
+		_, ok := entries.findEntryForToken(-200, 0, len(entries))
+		if ok {
 			t.Fatal("expected nil for token before all tablets")
 		}
 	})
@@ -66,16 +66,16 @@ func TestFindEntryForToken(t *testing.T) {
 			{firstToken: -200, lastToken: -100},
 			{firstToken: 100, lastToken: 200},
 		}
-		entry := entries.findEntryForToken(0, 0, len(entries))
-		if entry != nil {
+		_, ok := entries.findEntryForToken(0, 0, len(entries))
+		if ok {
 			t.Fatal("expected nil for token in gap between non-contiguous tablets")
 		}
 	})
 
 	t.Run("EmptyList", func(t *testing.T) {
 		entries := TabletEntryList{}
-		entry := entries.findEntryForToken(0, 0, 0)
-		if entry != nil {
+		_, ok := entries.findEntryForToken(0, 0, 0)
+		if ok {
 			t.Fatal("expected nil for empty entry list")
 		}
 	})
@@ -85,28 +85,28 @@ func TestFindEntryForToken(t *testing.T) {
 			{firstToken: -50, lastToken: 50},
 		}
 
-		entry := entries.findEntryForToken(0, 0, len(entries))
-		if entry == nil {
+		_, ok := entries.findEntryForToken(0, 0, len(entries))
+		if !ok {
 			t.Fatal("expected entry for token inside single entry")
 		}
 
-		entry = entries.findEntryForToken(-50, 0, len(entries))
-		if entry == nil {
+		_, ok = entries.findEntryForToken(-50, 0, len(entries))
+		if !ok {
 			t.Fatal("expected entry for token at firstToken of single entry")
 		}
 
-		entry = entries.findEntryForToken(50, 0, len(entries))
-		if entry == nil {
+		_, ok = entries.findEntryForToken(50, 0, len(entries))
+		if !ok {
 			t.Fatal("expected entry for token at lastToken of single entry")
 		}
 
-		entry = entries.findEntryForToken(-51, 0, len(entries))
-		if entry != nil {
+		_, ok = entries.findEntryForToken(-51, 0, len(entries))
+		if ok {
 			t.Fatal("expected nil for token before single entry")
 		}
 
-		entry = entries.findEntryForToken(51, 0, len(entries))
-		if entry != nil {
+		_, ok = entries.findEntryForToken(51, 0, len(entries))
+		if ok {
 			t.Fatal("expected nil for token after single entry")
 		}
 	})
@@ -129,8 +129,8 @@ func TestFindEntryForToken(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				result := entries.findEntryForToken(50, tc.l, tc.r)
-				if result != nil {
+				result, ok := entries.findEntryForToken(50, tc.l, tc.r)
+				if ok {
 					t.Errorf("expected nil for invalid bounds l=%d r=%d, got %+v", tc.l, tc.r, result)
 				}
 			})
@@ -144,21 +144,21 @@ func TestFindEntryForToken(t *testing.T) {
 			{firstToken: 100, lastToken: 200},
 		}
 
-		entry := entries.findEntryForToken(42, 0, len(entries))
-		if entry == nil {
+		entry, ok := entries.findEntryForToken(42, 0, len(entries))
+		if !ok {
 			t.Fatal("expected entry for single-token tablet")
 		}
 		if entry.firstToken != 42 || entry.lastToken != 42 {
 			t.Fatalf("expected [42,42], got [%d,%d]", entry.firstToken, entry.lastToken)
 		}
 
-		entry = entries.findEntryForToken(41, 0, len(entries))
-		if entry != nil {
+		_, ok = entries.findEntryForToken(41, 0, len(entries))
+		if ok {
 			t.Fatal("expected nil for token just before single-token tablet")
 		}
 
-		entry = entries.findEntryForToken(43, 0, len(entries))
-		if entry != nil {
+		_, ok = entries.findEntryForToken(43, 0, len(entries))
+		if ok {
 			t.Fatal("expected nil for token just after single-token tablet")
 		}
 	})
@@ -280,7 +280,7 @@ func TestAddEntry(t *testing.T) {
 
 	t.Run("SingleTokenTablet", func(t *testing.T) {
 		tl := TabletEntryList{}
-		tl = tl.addEntry(&TabletEntry{firstToken: 42, lastToken: 42})
+		tl = tl.addEntry(TabletEntry{firstToken: 42, lastToken: 42})
 		if len(tl) != 1 || tl[0].firstToken != 42 || tl[0].lastToken != 42 {
 			t.Fatalf("expected single [42,42] entry, got %v", tl)
 		}
@@ -289,7 +289,7 @@ func TestAddEntry(t *testing.T) {
 			{firstToken: -100, lastToken: -50},
 			{firstToken: 100, lastToken: 200},
 		}
-		tl = tl.addEntry(&TabletEntry{firstToken: 42, lastToken: 42})
+		tl = tl.addEntry(TabletEntry{firstToken: 42, lastToken: 42})
 		if len(tl) != 3 {
 			t.Fatalf("expected 3 entries, got %d", len(tl))
 		}


### PR DESCRIPTION
## Summary
- replace `*TabletInfo` with `TabletInfo` across the tablets code path
- replace `*TabletEntry` with `TabletEntry` across the tablets code path
- update the queue, builders, metadata integration, tests, and benchmarks to use value semantics consistently
- add a GC-focused benchmark for measuring retained heap objects, retained heap bytes, and GC pause on a large long-lived `CowTabletList`

## Verification
- `go test ./...`
- `go test -tags unit ./tablets`

## GC benchmark
Compared `0c623bd` (before) vs `5d43487` (after) with the included benchmark:

```bash
go test -tags unit ./tablets -run '^$' -bench '^BenchmarkCowTabletListGCShape$' -benchmem -benchtime=32x -count 5
```

Results:
- `heap_objects`: `200.6k -> 100.6k` (`-49.88%`, significant)
- `heap_bytes`: `14.09M -> 12.44M` (`-11.74%`, significant)
- `gc_pause_ns`: `164.0k -> 141.0k` (directionally better)
- `sec/op`: `294.7µs -> 235.3µs` (directionally better)
- `gc_cycles`: unchanged (`6 -> 6`)

The GC benchmark is included in this PR as `tablets/gcshape_bench_test.go`.