### PR TITLE
fix: resolve fieldalignment issues in Iter struct and benchmark

### DIFF
--- a/helpers_bench_test.go
+++ b/helpers_bench_test.go
@@ -203,13 +203,13 @@ func BenchmarkRowDataRepeated(b *testing.B) {
 // BenchmarkRowDataAllocation focuses on allocation patterns
 func BenchmarkRowDataAllocation(b *testing.B) {
 	benchmarks := []struct {
-		name string
 		iter *Iter
+		name string
 	}{
-		{"10cols", createMockIter(10)},
-		{"100cols", createMockIter(100)},
-		{"1000cols", createMockIter(1000)},
-		{"WithTuples", createMockIterWithTuples()},
+		{name: "10cols", iter: createMockIter(10)},
+		{name: "100cols", iter: createMockIter(100)},
+		{name: "1000cols", iter: createMockIter(1000)},
+		{name: "WithTuples", iter: createMockIterWithTuples()},
 	}
 
 	for _, bm := range benchmarks {

--- a/session.go
+++ b/session.go
@@ -1917,26 +1917,24 @@ func (q *Query) GetHostID() string {
 // be used from a single goroutine at a time. While Close() is safe to call multiple
 // times (idempotent), calling Scan(), Next(), or other methods concurrently with
 // Close() or each other will result in undefined behavior.
-//
-//nolint:govet // Keeping iterator lifetime/ownership state together is more important here than field packing.
 type Iter struct {
-	err    error
-	framer framerInterface
-	// allWarnings accumulates warnings across page boundaries.
-	// When a page's framer is released during fetchNextPage(), its warnings
-	// are appended here so they are not lost.
-	allWarnings           []string
+	warningQuery          ExecutableQuery
+	framer                framerInterface
+	err                   error
+	warningHandler        WarningHandler
 	releasedCustomPayload map[string][]byte
 	next                  *nextIter
 	host                  *HostInfo
-	meta                  resultMetadata
-	warningHandler        WarningHandler
-	warningQuery          ExecutableQuery
-	warningQueryOwned     bool
-	pos                   int
-	numRows               int
-	closed                int32
-	warningsHandled       int32
+	// allWarnings accumulates warnings across page boundaries.
+	// When a page's framer is released during fetchNextPage(), its warnings
+	// are appended here so they are not lost.
+	allWarnings       []string
+	meta              resultMetadata
+	pos               int
+	numRows           int
+	closed            int32
+	warningsHandled   int32
+	warningQueryOwned bool
 }
 
 // Host returns the host which the query was sent to.


### PR DESCRIPTION
## Summary

- Reorder fields in the `Iter` struct (`session.go:1922`) to reduce pointer bytes from 184 to 144, saving 40 bytes of padding per iterator instance
- Reorder fields in the anonymous benchmark struct (`helpers_bench_test.go:205`) to reduce pointer bytes from 24 to 16
- Remove the `//nolint:govet` directive that suppressed the `Iter` fieldalignment warning
- Switch from positional to named struct literals in `BenchmarkRowDataAllocation` to prevent breakage from field reordering

Detected by `fieldalignment` (`golang.org/x/tools/go/analysis/passes/fieldalignment`).

## Origin

- The `Iter` struct issue was introduced in commit 3e1e7e4d120acb87a42c8c6a6a4dfc46a54ee012 by Dmitry Kropachev
- The benchmark struct issue was introduced in commit b3f8416a1e24a66d37cbe4e498271e9c69a8678e by Dmitry Kropachev

## Validation

- `go test -tags unit -race -count=1 ./...` — all pass
- `go vet ./...` — clean
- `make check` (goimports) — clean
- `fieldalignment ./...` — clean (0 issues, exit 0)