### PR TITLE
(chore) replace interface{} with any

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Commit that replaced interface{} with any across the codebase.
+# Purely mechanical rename with no behavioral change.
+3ab64422067e24efb0b6b30eea0396d0e9395aee

--- a/cass1batch_test.go
+++ b/cass1batch_test.go
@@ -49,7 +49,7 @@ func TestProto1BatchInsert(t *testing.T) {
 	end := "APPLY BATCH"
 	query := fmt.Sprintf("INSERT INTO %s (id) VALUES (?)", table)
 	fullQuery := strings.Join([]string{begin, query, end}, "\n")
-	args := []interface{}{5}
+	args := []any{5}
 	if err := session.Query(fullQuery, args...).Consistency(Quorum).Exec(); err != nil {
 		t.Fatal(err)
 	}

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -623,7 +623,7 @@ func TestCAS(t *testing.T) {
 
 	successBatch = session.Batch(LoggedBatch)
 	successBatch.Query(fmt.Sprintf("INSERT INTO %s (title, revid, last_modified) VALUES (?, ?, ?) IF NOT EXISTS", table), title+"_foo", revid, modified)
-	casMap := make(map[string]interface{})
+	casMap := make(map[string]any)
 	if applied, _, err := session.MapExecuteBatchCAS(successBatch, casMap); err != nil {
 		t.Fatal("insert:", err)
 	} else if !applied {
@@ -673,7 +673,7 @@ func TestCAS(t *testing.T) {
 		}
 	}
 
-	casMap = make(map[string]interface{})
+	casMap = make(map[string]any)
 	if applied, err := session.Query(fmt.Sprintf(`SELECT revid FROM %s WHERE title = ?`, table),
 		title+"_foo").MapScanCAS(casMap); err != nil {
 		t.Fatal("select:", err)
@@ -688,14 +688,14 @@ func TestCAS(t *testing.T) {
 
 	notCASBatch := session.Batch(LoggedBatch)
 	notCASBatch.Query(fmt.Sprintf("INSERT INTO %s (title, revid, last_modified) VALUES (?, ?, ?)", table), title+"_baz", revid, modified)
-	casMap = make(map[string]interface{})
+	casMap = make(map[string]any)
 	if _, _, err := session.MapExecuteBatchCAS(notCASBatch, casMap); err != ErrNotFound {
 		t.Fatal("insert should have returned not found:", err)
 	}
 
 	notCASBatch = session.Batch(LoggedBatch)
 	notCASBatch.Query(fmt.Sprintf("INSERT INTO %s (title, revid, last_modified) VALUES (?, ?, ?)", table), title+"_baz", revid, modified)
-	casMap = make(map[string]interface{})
+	casMap = make(map[string]any)
 	if _, _, err := session.ExecuteBatchCAS(notCASBatch, &revidCAS); err != ErrNotFound {
 		t.Fatal("insert should have returned not found:", err)
 	}
@@ -706,7 +706,7 @@ func TestCAS(t *testing.T) {
 		t.Fatal("update should have errored")
 	}
 	// make sure MapScanCAS does not panic when MapScan fails
-	casMap = make(map[string]interface{})
+	casMap = make(map[string]any)
 	casMap["last_modified"] = false
 	if _, err := session.Query(fmt.Sprintf(`UPDATE %s SET last_modified = TOTIMESTAMP(NOW()) WHERE title='_foo' AND revid=3e4ad2f1-73a4-11e5-9381-29463d90c3f0 IF last_modified = ?`, table),
 		modified).MapScanCAS(casMap); err == nil {
@@ -716,7 +716,7 @@ func TestCAS(t *testing.T) {
 	// make sure MapExecuteBatchCAS does not panic when MapScan fails
 	failBatch = session.Batch(LoggedBatch)
 	failBatch.Query(fmt.Sprintf("UPDATE %s SET last_modified = TOTIMESTAMP(NOW()) WHERE title='_foo' AND revid=3e4ad2f1-73a4-11e5-9381-29463d90c3f0 IF last_modified = ?", table), modified)
-	casMap = make(map[string]interface{})
+	casMap = make(map[string]any)
 	casMap["last_modified"] = false
 	if _, _, err := session.MapExecuteBatchCAS(failBatch, casMap); err == nil {
 		t.Fatal("update should have errored")
@@ -888,7 +888,7 @@ func TestMapScanCAS(t *testing.T) {
 	}
 
 	title, revid, modified, deleted := "baz", TimeUUID(), time.Now(), false
-	mapCAS := map[string]interface{}{}
+	mapCAS := map[string]any{}
 
 	if applied, err := session.Query(fmt.Sprintf(`INSERT INTO %s (title, revid, last_modified, deleted)
 		VALUES (?, ?, ?, ?) IF NOT EXISTS`, table),
@@ -898,7 +898,7 @@ func TestMapScanCAS(t *testing.T) {
 		t.Fatalf("insert should have been applied: title=%v revID=%v modified=%v", title, revid, modified)
 	}
 
-	mapCAS = map[string]interface{}{}
+	mapCAS = map[string]any{}
 	if applied, err := session.Query(fmt.Sprintf(`INSERT INTO %s (title, revid, last_modified, deleted)
 		VALUES (?, ?, ?, ?) IF NOT EXISTS`, table),
 		title, revid, modified, deleted).MapScanCAS(mapCAS); err != nil {
@@ -1169,7 +1169,7 @@ func TestMapScanWithRefMap(t *testing.T) {
 		)`, table)); err != nil {
 		t.Fatal("create table:", err)
 	}
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m["testtext"] = "testtext"
 	m["testfullname"] = FullName{FirstName: "John", LastName: "Doe"}
 	m["testint"] = 100
@@ -1181,7 +1181,7 @@ func TestMapScanWithRefMap(t *testing.T) {
 
 	var testText string
 	var testFullName FullName
-	ret := map[string]interface{}{
+	ret := map[string]any{
 		"testtext":     &testText,
 		"testfullname": &testFullName,
 		// testint is not set here.
@@ -1210,7 +1210,7 @@ func TestMapScanWithRefMap(t *testing.T) {
 
 	// using MapScan to read a nil int value
 	intp := new(int64)
-	ret = map[string]interface{}{
+	ret = map[string]any{
 		"testint": &intp,
 	}
 	if err := session.Query(fmt.Sprintf("INSERT INTO %s(testtext, testint) VALUES(?, ?)", table), "null-int", nil).Exec(); err != nil {
@@ -1253,7 +1253,7 @@ func TestMapScan(t *testing.T) {
 	iter := session.Query(fmt.Sprintf(`SELECT * FROM %s`, table)).Iter()
 
 	// First iteration
-	row := make(map[string]interface{})
+	row := make(map[string]any)
 	if !iter.MapScan(row) {
 		t.Fatal("select:", iter.Close())
 	}
@@ -1263,7 +1263,7 @@ func TestMapScan(t *testing.T) {
 	tests.AssertDeepEqual(t, "data", []byte(`{"foo": "bar"}`), row["data"])
 
 	// Second iteration using a new map
-	row = make(map[string]interface{})
+	row = make(map[string]any)
 	if !iter.MapScan(row) {
 		t.Fatal("select:", iter.Close())
 	}
@@ -1299,7 +1299,7 @@ func TestSliceMap(t *testing.T) {
 		)`, table)); err != nil {
 		t.Fatal("create table:", err)
 	}
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	bigInt := new(big.Int)
 	if _, ok := bigInt.SetString("830169365738487321165427203929228", 10); !ok {
@@ -1321,7 +1321,7 @@ func TestSliceMap(t *testing.T) {
 	m["testmap"] = map[string]string{"field1": "val1", "field2": "val2", "field3": "val3"}
 	m["testvarint"] = bigInt
 	m["testinet"] = "213.212.2.19"
-	sliceMap := []map[string]interface{}{m}
+	sliceMap := []map[string]any{m}
 	if err := session.Query(fmt.Sprintf(`INSERT INTO %s (testuuid, testtimestamp, testvarchar, testbigint, testblob, testbool, testfloat, testdouble, testint, testdecimal, testlist, testset, testmap, testvarint, testinet) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, table),
 		m["testuuid"], m["testtimestamp"], m["testvarchar"], m["testbigint"], m["testblob"], m["testbool"], m["testfloat"], m["testdouble"], m["testint"], m["testdecimal"], m["testlist"], m["testset"], m["testmap"], m["testvarint"], m["testinet"]).Exec(); err != nil {
 		t.Fatal("insert:", err)
@@ -1334,7 +1334,7 @@ func TestSliceMap(t *testing.T) {
 
 	// Test for Iter.MapScan()
 	{
-		testMap := make(map[string]interface{})
+		testMap := make(map[string]any)
 		if !session.Query(fmt.Sprintf(`SELECT * FROM %s`, table)).Iter().MapScan(testMap) {
 			t.Fatal("MapScan failed to work with one row")
 		}
@@ -1343,14 +1343,14 @@ func TestSliceMap(t *testing.T) {
 
 	// Test for Query.MapScan()
 	{
-		testMap := make(map[string]interface{})
+		testMap := make(map[string]any)
 		if session.Query(fmt.Sprintf(`SELECT * FROM %s`, table)).MapScan(testMap) != nil {
 			t.Fatal("MapScan failed to work with one row")
 		}
 		matchSliceMap(t, sliceMap, testMap)
 	}
 }
-func matchSliceMap(t *testing.T, sliceMap []map[string]interface{}, testMap map[string]interface{}) {
+func matchSliceMap(t *testing.T, sliceMap []map[string]any, testMap map[string]any) {
 	if sliceMap[0]["testuuid"] != testMap["testuuid"] {
 		t.Fatal("returned testuuid did not match")
 	}
@@ -1468,9 +1468,9 @@ func TestSmallInt(t *testing.T) {
 		)`, table)); err != nil {
 		t.Fatal("create table:", err)
 	}
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m["testsmallint"] = int16(2)
-	sliceMap := []map[string]interface{}{m}
+	sliceMap := []map[string]any{m}
 	if err := session.Query(fmt.Sprintf(`INSERT INTO %s (testsmallint) VALUES (?)`, table),
 		m["testsmallint"]).Exec(); err != nil {
 		t.Fatal("insert:", err)
@@ -1628,8 +1628,8 @@ func TestStaticQueryInfo(t *testing.T) {
 		t.Fatalf("insert into static_query_info failed, err '%v'", err)
 	}
 
-	autobinder := func(q *QueryInfo) ([]interface{}, error) {
-		values := make([]interface{}, 1)
+	autobinder := func(q *QueryInfo) ([]any, error) {
+		values := make([]any, 1)
 		values[0] = 113
 		return values, nil
 	}
@@ -1663,8 +1663,8 @@ type ClusteredKeyValue struct {
 	Value   string
 }
 
-func (kv *ClusteredKeyValue) Bind(q *QueryInfo) ([]interface{}, error) {
-	values := make([]interface{}, len(q.Args))
+func (kv *ClusteredKeyValue) Bind(q *QueryInfo) ([]any, error) {
+	values := make([]any, len(q.Args))
 
 	for i, info := range q.Args {
 		fieldName := upcaseInitial(info.Name)
@@ -1738,8 +1738,8 @@ func TestBatchQueryInfo(t *testing.T) {
 		t.Fatalf("failed to create table with error '%v'", err)
 	}
 
-	write := func(q *QueryInfo) ([]interface{}, error) {
-		values := make([]interface{}, 3)
+	write := func(q *QueryInfo) ([]any, error) {
+		values := make([]any, 3)
 		values[0] = 4000
 		values[1] = 5000
 		values[2] = "bar"
@@ -1753,8 +1753,8 @@ func TestBatchQueryInfo(t *testing.T) {
 		t.Fatalf("batch insert into batch_query_info failed, err '%v'", err)
 	}
 
-	read := func(q *QueryInfo) ([]interface{}, error) {
-		values := make([]interface{}, 2)
+	read := func(q *QueryInfo) ([]any, error) {
+		values := make([]any, 2)
 		values[0] = 4000
 		values[1] = 5000
 		return values, nil
@@ -2329,7 +2329,7 @@ func TestBatchObserve(t *testing.T) {
 		observedErr      error
 		observedKeyspace string
 		observedStmts    []string
-		observedValues   [][]interface{}
+		observedValues   [][]any
 	}
 
 	var observedBatch *observation
@@ -2372,7 +2372,7 @@ func TestBatchObserve(t *testing.T) {
 			t.Fatal("unexpected query", stmt)
 		}
 
-		tests.AssertDeepEqual(t, "observed value", []interface{}{i}, observedBatch.observedValues[i])
+		tests.AssertDeepEqual(t, "observed value", []any{i}, observedBatch.observedValues[i])
 	}
 }
 
@@ -3125,8 +3125,8 @@ func TestSessionBindRoutingKey(t *testing.T) {
 		value = 5
 	)
 
-	fn := func(info *QueryInfo) ([]interface{}, error) {
-		return []interface{}{key, value}, nil
+	fn := func(info *QueryInfo) ([]any, error) {
+		return []any{key, value}, nil
 	}
 
 	q := session.Bind(fmt.Sprintf("INSERT INTO %s(key, value) VALUES(?, ?)", table), fn)

--- a/client_routes.go
+++ b/client_routes.go
@@ -715,7 +715,7 @@ func getHostPortMappingFromCluster(c controlConnection, table string, connection
 	var res UnresolvedClientRouteList
 
 	stmt := []string{fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s", table)}
-	var bounds []interface{}
+	var bounds []any
 	if len(connectionIDs) != 0 {
 		var inClause []string
 		for _, connectionID := range connectionIDs {

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -25,17 +25,17 @@ func (f clientRoutesResolverFunc) Resolve(endpoint ResolvedClientRoute) ([]net.I
 
 type fakeControlConn struct {
 	statement string
-	values    []interface{}
+	values    []any
 }
 
 func (f *fakeControlConn) getConn() *connHost          { return nil }
 func (f *fakeControlConn) awaitSchemaAgreement() error { return nil }
-func (f *fakeControlConn) query(statement string, values ...interface{}) *Iter {
+func (f *fakeControlConn) query(statement string, values ...any) *Iter {
 	f.statement = statement
 	f.values = values
 	return &Iter{}
 }
-func (f *fakeControlConn) querySystem(statement string, values ...interface{}) *Iter {
+func (f *fakeControlConn) querySystem(statement string, values ...any) *Iter {
 	return &Iter{}
 }
 func (f *fakeControlConn) discoverProtocol(hosts []*HostInfo) (int, error) { return 0, nil }
@@ -476,7 +476,7 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 		connectionIDs []string
 		hostIDs       []string
 		expectedStmt  string
-		expectedVals  []interface{}
+		expectedVals  []any
 	}{
 		{
 			name:         "all",
@@ -486,20 +486,20 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 			name:          "connections-only",
 			connectionIDs: []string{"c1", "c2"},
 			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in (?,?) allow filtering",
-			expectedVals:  []interface{}{"c1", "c2"},
+			expectedVals:  []any{"c1", "c2"},
 		},
 		{
 			name:         "hosts-only",
 			hostIDs:      []string{"h1"},
 			expectedStmt: "select connection_id, host_id, address, port, tls_port from system.client_routes where host_id in (?) allow filtering",
-			expectedVals: []interface{}{"h1"},
+			expectedVals: []any{"h1"},
 		},
 		{
 			name:          "connections-and-hosts",
 			connectionIDs: []string{"c1"},
 			hostIDs:       []string{"h1", "h2"},
 			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in (?) and host_id in (?,?)",
-			expectedVals:  []interface{}{"c1", "h1", "h2"},
+			expectedVals:  []any{"c1", "h1", "h2"},
 		},
 		{
 			name:          "empty-slices",

--- a/cloud_cluster_test.go
+++ b/cloud_cluster_test.go
@@ -168,7 +168,7 @@ func TestCloudConnection(t *testing.T) {
 	}
 }
 
-func writeYamlToTempFile(obj interface{}) (string, error) {
+func writeYamlToTempFile(obj any) (string, error) {
 	f, err := os.CreateTemp(os.TempDir(), "gocql-cloud")
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)

--- a/common_test.go
+++ b/common_test.go
@@ -135,7 +135,7 @@ func probeTabletsSupported() {
 	}
 	defer s.Close()
 
-	res := make(map[string]interface{})
+	res := make(map[string]any)
 	err = s.Query("select * from system.local").MapScan(res)
 	if err != nil {
 		panic(fmt.Errorf("failed to read system.local: %v", err))
@@ -181,7 +181,7 @@ func probeTabletsAutoEnabled() {
 		panic(fmt.Errorf("failed to create keyspace: %v", err))
 	}
 
-	res := make(map[string]interface{})
+	res := make(map[string]any)
 	err = s.Query("describe keyspace gocql_check_tablets_enabled").MapScan(res)
 	if err != nil {
 		panic(fmt.Errorf("failed to describe keyspace: %v", err))

--- a/conn.go
+++ b/conn.go
@@ -168,7 +168,7 @@ type ConnInterface interface {
 	exec(ctx context.Context, req frameBuilder, tracer Tracer, requestTimeout time.Duration) (*framer, error)
 	awaitSchemaAgreement(ctx context.Context) error
 	executeQuery(ctx context.Context, qry *Query) *Iter
-	querySystem(ctx context.Context, query string, values ...interface{}) *Iter
+	querySystem(ctx context.Context, query string, values ...any) *Iter
 	getIsSchemaV2() bool
 	setSchemaV2(s bool)
 	getScyllaSupported() ScyllaConnectionFeatures
@@ -994,7 +994,7 @@ type callReq struct {
 }
 
 var callReqPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &callReq{
 			resp: make(chan callResp),
 		}
@@ -1606,7 +1606,7 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer,
 	}
 }
 
-func marshalQueryValue(typ TypeInfo, value interface{}, dst *queryValues) error {
+func marshalQueryValue(typ TypeInfo, value any, dst *queryValues) error {
 	if named, ok := value.(*namedValue); ok {
 		dst.name = named.name
 		value = named.value
@@ -1876,7 +1876,7 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 				return &Iter{err: err}
 			}
 
-			var values []interface{}
+			var values []any
 			if entry.binding == nil {
 				values = entry.Args
 			} else {
@@ -1968,7 +1968,7 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 	}
 }
 
-func (c *Conn) querySystem(ctx context.Context, query string, values ...interface{}) *Iter {
+func (c *Conn) querySystem(ctx context.Context, query string, values ...any) *Iter {
 	q := c.session.Query(query+c.usingTimeoutClause, values...).Consistency(One).Trace(nil)
 	q.skipPrepare = true
 	q.disableSkipMetadata = true
@@ -2143,7 +2143,7 @@ func unmarshalTabletHint(hint []byte, v uint8, keyspace, table string) (*tablets
 					}},
 			},
 		},
-	}, hint, []interface{}{&tabletBuilder.FirstToken, &tabletBuilder.LastToken, &tabletBuilder.Replicas})
+	}, hint, []any{&tabletBuilder.FirstToken, &tabletBuilder.LastToken, &tabletBuilder.Replicas})
 	if err != nil {
 		return nil, err
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1862,7 +1862,7 @@ func (srv *TestServer) Stop() {
 	srv.closeLocked()
 }
 
-func (srv *TestServer) errorLocked(err interface{}) {
+func (srv *TestServer) errorLocked(err any) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	if srv.closed {

--- a/control.go
+++ b/control.go
@@ -65,8 +65,8 @@ const (
 type controlConnection interface {
 	getConn() *connHost
 	awaitSchemaAgreement() error
-	query(statement string, values ...interface{}) (iter *Iter)
-	querySystem(statement string, values ...interface{}) (iter *Iter)
+	query(statement string, values ...any) (iter *Iter)
+	querySystem(statement string, values ...any) (iter *Iter)
 	discoverProtocol(hosts []*HostInfo) (int, error)
 	connect(hosts []*HostInfo) error
 	close()
@@ -536,7 +536,7 @@ func (c *controlConn) writeFrame(w frameBuilder) (frame, error) {
 }
 
 // query will return nil if the connection is closed or nil
-func (c *controlConn) querySystem(statement string, values ...interface{}) (iter *Iter) {
+func (c *controlConn) querySystem(statement string, values ...any) (iter *Iter) {
 	conn := c.getConn().conn.(*Conn)
 	return c.runQuery(c.session.Query(statement+conn.usingTimeoutClause, values...).
 		Consistency(One).
@@ -546,7 +546,7 @@ func (c *controlConn) querySystem(statement string, values ...interface{}) (iter
 }
 
 // query will return nil if the connection is closed or nil
-func (c *controlConn) query(statement string, values ...interface{}) (iter *Iter) {
+func (c *controlConn) query(statement string, values ...any) (iter *Iter) {
 	return c.runQuery(c.session.Query(statement, values...).Consistency(One).RoutingKey([]byte{}).Trace(nil))
 }
 

--- a/doc.go
+++ b/doc.go
@@ -386,7 +386,7 @@
 //
 // # User-defined types
 //
-// UDTs can be mapped (un)marshaled from/to map[string]interface{} a Go struct (or a type implementing
+// UDTs can be mapped (un)marshaled from/to map[string]any a Go struct (or a type implementing
 // UDTUnmarshaler, UDTMarshaler, Unmarshaler or Marshaler interfaces).
 //
 // For structs, cql tag can be used to specify the CQL field name to be mapped to a struct field:

--- a/events/event_converter.go
+++ b/events/event_converter.go
@@ -26,7 +26,7 @@ import (
 // This function has access to internal frame types and can perform
 // type-safe conversions.
 // Returns nil if the frame is not an event frame.
-func FrameToEvent(f interface{}) Event {
+func FrameToEvent(f any) Event {
 	if f == nil {
 		return nil
 	}

--- a/events_unit_test.go
+++ b/events_unit_test.go
@@ -101,7 +101,7 @@ var columnMeta = resultMetadata{
 	colCount:       6,
 }
 
-func mustMarshal(info TypeInfo, value interface{}) []byte {
+func mustMarshal(info TypeInfo, value any) []byte {
 	b, err := Marshal(info, value)
 	if err != nil {
 		panic(fmt.Sprintf("mustMarshal(%v, %v): %v", info, value, err))
@@ -109,7 +109,7 @@ func mustMarshal(info TypeInfo, value interface{}) []byte {
 	return b
 }
 
-func marshalRow(meta resultMetadata, values []interface{}) [][]byte {
+func marshalRow(meta resultMetadata, values []any) [][]byte {
 	if len(meta.columns) != len(values) {
 		panic(fmt.Sprintf("marshalRow: column count %d != value count %d", len(meta.columns), len(values)))
 	}
@@ -125,11 +125,11 @@ func makeKeyspaceRow(durableWrites bool) [][]byte {
 		"class":              "org.apache.cassandra.locator.SimpleStrategy",
 		"replication_factor": "1",
 	}
-	return marshalRow(keyspaceMeta, []interface{}{durableWrites, replication})
+	return marshalRow(keyspaceMeta, []any{durableWrites, replication})
 }
 
 func makeTableRow(tableName string) [][]byte {
-	return marshalRow(tableMeta, []interface{}{
+	return marshalRow(tableMeta, []any{
 		tableName,              // table_name
 		float64(0.01),          // bloom_filter_fp_chance
 		map[string]string(nil), // caching
@@ -149,7 +149,7 @@ func makeTableRow(tableName string) [][]byte {
 }
 
 func makeColumnRow(tableName, colName, kind string, position int) [][]byte {
-	return marshalRow(columnMeta, []interface{}{
+	return marshalRow(columnMeta, []any{
 		tableName, // table_name
 		colName,   // column_name
 		"none",    // clustering_order
@@ -204,7 +204,7 @@ func (m *schemaDataMock) awaitSchemaAgreement() error {
 	return nil
 }
 
-func (m *schemaDataMock) query(statement string, values ...interface{}) *Iter {
+func (m *schemaDataMock) query(statement string, values ...any) *Iter {
 	m.mu.Lock()
 	m.queries = append(m.queries, queryRecord{method: "query", stmt: statement})
 	delay := m.queryDelay
@@ -217,7 +217,7 @@ func (m *schemaDataMock) query(statement string, values ...interface{}) *Iter {
 	return &Iter{}
 }
 
-func (m *schemaDataMock) querySystem(statement string, values ...interface{}) *Iter {
+func (m *schemaDataMock) querySystem(statement string, values ...any) *Iter {
 	m.mu.Lock()
 	m.queries = append(m.queries, queryRecord{method: "querySystem", stmt: statement})
 	delay := m.queryDelay

--- a/example_batch_test.go
+++ b/example_batch_test.go
@@ -52,12 +52,12 @@ func Example_batch() {
 	b := session.Batch(gocql.UnloggedBatch).WithContext(ctx)
 	b.Entries = append(b.Entries, gocql.BatchEntry{
 		Stmt:       "INSERT INTO example.batches (pk, ck, description) VALUES (?, ?, ?)",
-		Args:       []interface{}{1, 2, "1.2"},
+		Args:       []any{1, 2, "1.2"},
 		Idempotent: true,
 	})
 	b.Entries = append(b.Entries, gocql.BatchEntry{
 		Stmt:       "INSERT INTO example.batches (pk, ck, description) VALUES (?, ?, ?)",
-		Args:       []interface{}{1, 3, "1.3"},
+		Args:       []any{1, 3, "1.3"},
 		Idempotent: true,
 	})
 

--- a/example_dynamic_columns_test.go
+++ b/example_dynamic_columns_test.go
@@ -55,7 +55,7 @@ func Example_dynamicColumns() {
 	}
 	defer session.Close()
 
-	printQuery := func(ctx context.Context, session *gocql.Session, stmt string, values ...interface{}) error {
+	printQuery := func(ctx context.Context, session *gocql.Session, stmt string, values ...any) error {
 		iter := session.Query(stmt, values...).WithContext(ctx).Iter()
 		fmt.Println(stmt)
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ',

--- a/example_lwt_batch_test.go
+++ b/example_lwt_batch_test.go
@@ -65,23 +65,23 @@ func ExampleSession_MapExecuteBatchCAS() {
 		b := session.Batch(gocql.LoggedBatch)
 		b.Entries = append(b.Entries, gocql.BatchEntry{
 			Stmt: "UPDATE my_lwt_batch_table SET value=? WHERE pk=? AND ck=? IF version=?",
-			Args: []interface{}{"b", "pk1", "ck1", 1},
+			Args: []any{"b", "pk1", "ck1", 1},
 		})
 		b.Entries = append(b.Entries, gocql.BatchEntry{
 			Stmt: "UPDATE my_lwt_batch_table SET value=? WHERE pk=? AND ck=? IF version=?",
-			Args: []interface{}{"B", "pk1", "ck2", ck2Version},
+			Args: []any{"B", "pk1", "ck2", ck2Version},
 		})
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 		applied, iter, err := session.MapExecuteBatchCAS(b.WithContext(ctx), m)
 		if err != nil {
 			log.Fatal(err)
 		}
 		fmt.Println(applied, m)
 
-		m = make(map[string]interface{})
+		m = make(map[string]any)
 		for iter.MapScan(m) {
 			fmt.Println(m)
-			m = make(map[string]interface{})
+			m = make(map[string]any)
 		}
 
 		if err := iter.Close(); err != nil {

--- a/example_lwt_test.go
+++ b/example_lwt_test.go
@@ -54,7 +54,7 @@ func ExampleQuery_MapScanCAS() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	applied, err := session.Query("UPDATE example.my_lwt_table SET value = ? WHERE pk = ? IF version = ?",
 		"b", 1, 0).WithContext(ctx).MapScanCAS(m)
 	if err != nil {
@@ -70,7 +70,7 @@ func ExampleQuery_MapScanCAS() {
 	}
 	fmt.Println(value)
 
-	m = make(map[string]interface{})
+	m = make(map[string]any)
 	applied, err = session.Query("UPDATE example.my_lwt_table SET value = ? WHERE pk = ? IF version = ?",
 		"b", 1, 1).WithContext(ctx).MapScanCAS(m)
 	if err != nil {

--- a/example_udt_map_test.go
+++ b/example_udt_map_test.go
@@ -51,7 +51,7 @@ func Example_userDefinedTypesMap() {
 
 	ctx := context.Background()
 
-	value := map[string]interface{}{
+	value := map[string]any{
 		"field_a": "a value",
 		"field_b": 42,
 	}
@@ -61,7 +61,7 @@ func Example_userDefinedTypesMap() {
 		log.Fatal(err)
 	}
 
-	var readValue map[string]interface{}
+	var readValue map[string]any
 
 	err = session.Query("SELECT value FROM example.my_udt_table WHERE pk = 1").WithContext(ctx).Scan(&readValue)
 	if err != nil {

--- a/exec.go
+++ b/exec.go
@@ -17,13 +17,13 @@ type SingleHostQueryExecutor struct {
 }
 
 // Exec executes the query without returning any rows.
-func (e SingleHostQueryExecutor) Exec(stmt string, values ...interface{}) error {
+func (e SingleHostQueryExecutor) Exec(stmt string, values ...any) error {
 	return e.control.query(stmt, values...).Close()
 }
 
 // Iter executes the query and returns an iterator capable of iterating
 // over all results.
-func (e SingleHostQueryExecutor) Iter(stmt string, values ...interface{}) *Iter {
+func (e SingleHostQueryExecutor) Iter(stmt string, values ...any) *Iter {
 	return e.control.query(stmt, values...)
 }
 

--- a/frame.go
+++ b/frame.go
@@ -52,12 +52,12 @@ type unsetColumn struct{}
 var UnsetValue = unsetColumn{}
 
 type namedValue struct {
-	value interface{}
+	value any
 	name  string
 }
 
 // NamedValue produce a value which will bind to the named parameter in a query
-func NamedValue(name string, value interface{}) interface{} {
+func NamedValue(name string, value any) any {
 	return &namedValue{
 		name:  name,
 		value: value,

--- a/framer.go
+++ b/framer.go
@@ -207,7 +207,7 @@ func (fp *framerPool) init(defaults framerConfig, release func(*framer)) {
 	fp.bufAvgSize.Store(int64(defaultBufSize))
 	fp.enabled.Store(true)
 	fp.pool = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			buf := make([]byte, defaultBufSize)
 			f := &framer{
 				buf:                   buf[:0],

--- a/helpers.go
+++ b/helpers.go
@@ -38,7 +38,7 @@ import (
 
 type RowData struct {
 	Columns []string
-	Values  []interface{}
+	Values  []any
 }
 
 // asVectorType attempts to convert a NativeType(custom) which represents a VectorType
@@ -128,11 +128,11 @@ func goType(t TypeInfo) (reflect.Type, error) {
 	case TypeVarint:
 		return reflect.TypeOf(*new(*big.Int)), nil
 	case TypeTuple:
-		// what can we do here? all there is to do is to make a list of interface{}
+		// what can we do here? all there is to do is to make a list of any
 		tuple := t.(TupleTypeInfo)
-		return reflect.TypeOf(make([]interface{}, len(tuple.Elems))), nil
+		return reflect.TypeOf(make([]any, len(tuple.Elems))), nil
 	case TypeUDT:
-		return reflect.TypeOf(make(map[string]interface{})), nil
+		return reflect.TypeOf(make(map[string]any)), nil
 	case TypeDate:
 		return reflect.TypeOf(*new(time.Time)), nil
 	case TypeDuration:
@@ -156,7 +156,7 @@ func goType(t TypeInfo) (reflect.Type, error) {
 	}
 }
 
-func dereference(i interface{}) interface{} {
+func dereference(i any) any {
 	return reflect.Indirect(reflect.ValueOf(i)).Interface()
 }
 
@@ -341,7 +341,7 @@ func getApacheCassandraType(class string) Type {
 	}
 }
 
-func (r *RowData) rowMap(m map[string]interface{}) {
+func (r *RowData) rowMap(m map[string]any) {
 	for i, column := range r.Columns {
 		val := dereference(r.Values[i])
 		if valVal := reflect.ValueOf(val); valVal.Kind() == reflect.Slice && !valVal.IsNil() {
@@ -371,7 +371,7 @@ func (iter *Iter) RowData() (RowData, error) {
 	// and use direct indexing instead of append for better performance
 	actualSize := iter.meta.actualColCount
 	columns := make([]string, actualSize)
-	values := make([]interface{}, actualSize)
+	values := make([]any, actualSize)
 
 	idx := 0
 	for _, column := range iter.Columns() {
@@ -423,7 +423,7 @@ func (iter *Iter) RowData() (RowData, error) {
 }
 
 // TODO(zariel): is it worth exporting this?
-func (iter *Iter) rowMap() (map[string]interface{}, error) {
+func (iter *Iter) rowMap() (map[string]any, error) {
 	if iter.err != nil {
 		return nil, iter.err
 	}
@@ -433,15 +433,15 @@ func (iter *Iter) rowMap() (map[string]interface{}, error) {
 		return nil, err
 	}
 	iter.Scan(rowData.Values...)
-	m := make(map[string]interface{}, len(rowData.Columns))
+	m := make(map[string]any, len(rowData.Columns))
 	rowData.rowMap(m)
 	return m, nil
 }
 
 // SliceMap is a helper function to make the API easier to use.
 // It consumes the remaining rows, closes the iterator, and returns the data
-// in the form of []map[string]interface{}.
-func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
+// in the form of []map[string]any.
+func (iter *Iter) SliceMap() ([]map[string]any, error) {
 	defer iter.Close()
 
 	if iter.err != nil {
@@ -453,9 +453,9 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	dataToReturn := make([]map[string]interface{}, 0)
+	dataToReturn := make([]map[string]any, 0)
 	for iter.Scan(rowData.Values...) {
-		m := make(map[string]interface{}, len(rowData.Columns))
+		m := make(map[string]any, len(rowData.Columns))
 		rowData.rowMap(m)
 		dataToReturn = append(dataToReturn, m)
 	}
@@ -465,7 +465,7 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 	return dataToReturn, nil
 }
 
-// MapScan takes a map[string]interface{} and populates it with a row
+// MapScan takes a map[string]any and populates it with a row
 // that is returned from cassandra.
 //
 // Each call to MapScan() must be called with a new map object.
@@ -475,7 +475,7 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 //	iter := session.Query(`SELECT * FROM mytable`).Iter()
 //	for {
 //		// New map each iteration
-//		row := make(map[string]interface{})
+//		row := make(map[string]any)
 //		if !iter.MapScan(row) {
 //			break
 //		}
@@ -496,7 +496,7 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 //	iter := session.Query(`SELECT * FROM scan_map_table`).Iter()
 //	for {
 //		// New map each iteration
-//		row := map[string]interface{}{
+//		row := map[string]any{
 //			"fullname": &fullName,
 //			"age":      &age,
 //			"address":  &address,
@@ -509,7 +509,7 @@ func (iter *Iter) SliceMap() ([]map[string]interface{}, error) {
 //	if err := iter.Close(); err != nil {
 //		return err
 //	}
-func (iter *Iter) MapScan(m map[string]interface{}) bool {
+func (iter *Iter) MapScan(m map[string]any) bool {
 	if iter.err != nil {
 		return false
 	}

--- a/host_source.go
+++ b/host_source.go
@@ -638,7 +638,7 @@ func checkSystemSchema(control controlConnection) (bool, error) {
 
 // Given a map that represents a row from either system.local or system.peers
 // return as much information as we can in *HostInfo
-func hostInfoFromMap(row map[string]interface{}, defaultPort int) (*HostInfo, error) {
+func hostInfoFromMap(row map[string]any, defaultPort int) (*HostInfo, error) {
 	const assertErrorMsg = "Assertion failed for %s"
 	var ok bool
 

--- a/host_source_test.go
+++ b/host_source_test.go
@@ -48,15 +48,15 @@ type systemSchemaTestControl struct {
 	iter *Iter
 }
 
-func (*systemSchemaTestControl) getConn() *connHost                                { return nil }
-func (*systemSchemaTestControl) awaitSchemaAgreement() error                       { return nil }
-func (*systemSchemaTestControl) query(string, ...interface{}) (iter *Iter)         { return nil }
-func (c *systemSchemaTestControl) querySystem(string, ...interface{}) (iter *Iter) { return c.iter }
-func (*systemSchemaTestControl) discoverProtocol([]*HostInfo) (int, error)         { return 0, nil }
-func (*systemSchemaTestControl) connect([]*HostInfo) error                         { return nil }
-func (*systemSchemaTestControl) close()                                            {}
-func (*systemSchemaTestControl) getSession() *Session                              { return nil }
-func (*systemSchemaTestControl) reconnect() error                                  { return nil }
+func (*systemSchemaTestControl) getConn() *connHost                        { return nil }
+func (*systemSchemaTestControl) awaitSchemaAgreement() error               { return nil }
+func (*systemSchemaTestControl) query(string, ...any) (iter *Iter)         { return nil }
+func (c *systemSchemaTestControl) querySystem(string, ...any) (iter *Iter) { return c.iter }
+func (*systemSchemaTestControl) discoverProtocol([]*HostInfo) (int, error) { return 0, nil }
+func (*systemSchemaTestControl) connect([]*HostInfo) error                 { return nil }
+func (*systemSchemaTestControl) close()                                    {}
+func (*systemSchemaTestControl) getSession() *Session                      { return nil }
+func (*systemSchemaTestControl) reconnect() error                          { return nil }
 
 func TestUnmarshalCassVersion(t *testing.T) {
 	t.Parallel()
@@ -205,7 +205,7 @@ func TestCheckSystemSchemaClosesIter(t *testing.T) {
 func TestHostInfoFromIterClosesIter(t *testing.T) {
 	t.Parallel()
 
-	row := []interface{}{
+	row := []any{
 		"local",
 		"COMPLETED",
 		net.IPv4(192, 168, 100, 12),

--- a/integration_serialization_scylla_test.go
+++ b/integration_serialization_scylla_test.go
@@ -125,7 +125,7 @@ func checkTypeInsertSelect(t *testing.T, session *Session, insertStmt, selectStm
 			valCaseName := valCase.Name
 
 			for _, langCase := range valCase.LangCases {
-				var insertedValue interface{}
+				var insertedValue any
 				//Check Insert value as values
 				insertedValue = langCase.Value
 				err := session.Query(insertStmt, valCaseName, insertedValue).Exec()
@@ -164,16 +164,16 @@ func checkTypeInsertSelect(t *testing.T, session *Session, insertStmt, selectStm
 }
 
 // newRef returns the nil reference to the input type value (*type)(nil)
-func newRef(in interface{}) interface{} {
+func newRef(in any) any {
 	out := reflect.New(reflect.TypeOf(in)).Interface()
 	return out
 }
 
-func deReference(in interface{}) interface{} {
+func deReference(in any) any {
 	return reflect.Indirect(reflect.ValueOf(in)).Interface()
 }
 
-func equalVals(in1, in2 interface{}) bool {
+func equalVals(in1, in2 any) bool {
 	rin1 := reflect.ValueOf(in1)
 	rin2 := reflect.ValueOf(in2)
 	if rin1.Kind() != rin2.Kind() {
@@ -225,13 +225,13 @@ func equalVals(in1, in2 interface{}) bool {
 // SliceMapTypesTestCase defines a test case for validating SliceMap/MapScan behavior
 type SliceMapTypesTestCase struct {
 	CQLType           string
-	CQLValue          string      // Non-NULL value to insert
-	ExpectedValue     interface{} // Expected value for non-NULL case
-	ExpectedNullValue interface{} // Expected value for NULL
+	CQLValue          string // Non-NULL value to insert
+	ExpectedValue     any    // Expected value for non-NULL case
+	ExpectedNullValue any    // Expected value for NULL
 }
 
 // compareCollectionValues compares collection values (lists, sets, maps) with special handling
-func compareCollectionValues(t *testing.T, cqlType string, expected, actual interface{}) bool {
+func compareCollectionValues(t *testing.T, cqlType string, expected, actual any) bool {
 	switch {
 	case strings.HasPrefix(cqlType, "set<"):
 		// Sets are returned as slices, but order is not guaranteed
@@ -245,12 +245,12 @@ func compareCollectionValues(t *testing.T, cqlType string, expected, actual inte
 		}
 
 		// Convert to maps for unordered comparison
-		expectedSet := make(map[interface{}]bool)
+		expectedSet := make(map[any]bool)
 		for i := 0; i < expectedSlice.Len(); i++ {
 			expectedSet[expectedSlice.Index(i).Interface()] = true
 		}
 
-		actualSet := make(map[interface{}]bool)
+		actualSet := make(map[any]bool)
 		for i := 0; i < actualSlice.Len(); i++ {
 			actualSet[actualSlice.Index(i).Interface()] = true
 		}
@@ -264,7 +264,7 @@ func compareCollectionValues(t *testing.T, cqlType string, expected, actual inte
 }
 
 // compareValues compares expected and actual values with type-specific logic
-func compareValues(t *testing.T, cqlType string, expected, actual interface{}) bool {
+func compareValues(t *testing.T, cqlType string, expected, actual any) bool {
 	switch cqlType {
 	case "varint":
 		// big.Int needs Cmp() for proper comparison, but handle nil pointers safely
@@ -411,7 +411,7 @@ func testSliceMapMapScanSimple(t *testing.T, session *Session, tc SliceMapTypesT
 	})
 }
 
-func queryAndExtractValue(t *testing.T, session *Session, colName string, id int, method string, table string) interface{} {
+func queryAndExtractValue(t *testing.T, session *Session, colName string, id int, method string, table string) any {
 	fmt.Println("queryAndExtractValue")
 	selectQuery := fmt.Sprintf("SELECT %s FROM gocql_test.%s WHERE id = ?", colName, table)
 
@@ -430,7 +430,7 @@ func queryAndExtractValue(t *testing.T, session *Session, colName string, id int
 		return sliceResults[0][colName]
 
 	case "MapScan":
-		mapResult := make(map[string]interface{})
+		mapResult := make(map[string]any)
 		if err := session.Query(selectQuery, id).MapScan(mapResult); err != nil {
 			t.Fatalf("MapScan failed: %v", err)
 		}
@@ -442,7 +442,7 @@ func queryAndExtractValue(t *testing.T, session *Session, colName string, id int
 	}
 }
 
-func validateResult(t *testing.T, cqlType string, expected, actual interface{}, method, valueType string) {
+func validateResult(t *testing.T, cqlType string, expected, actual any, method, valueType string) {
 	if expected != nil && actual != nil {
 		expectedType := reflect.TypeOf(expected)
 		actualType := reflect.TypeOf(actual)
@@ -525,7 +525,7 @@ func TestSliceMapMapScanCounterTypes(t *testing.T) {
 	// Test both SliceMap and MapScan
 	for _, method := range []string{"SliceMap", "MapScan"} {
 		t.Run(method, func(t *testing.T) {
-			var result interface{}
+			var result any
 
 			selectQuery := fmt.Sprintf("SELECT counter_col FROM gocql_test_tablets_disabled.%s WHERE id = ?", table)
 			if method == "SliceMap" {
@@ -540,7 +540,7 @@ func TestSliceMapMapScanCounterTypes(t *testing.T) {
 				}
 				result = sliceResults[0]["counter_col"]
 			} else {
-				mapResult := make(map[string]interface{})
+				mapResult := make(map[string]any)
 				if err := session.Query(selectQuery, testID).MapScan(mapResult); err != nil {
 					t.Fatalf("MapScan failed: %v", err)
 				}
@@ -588,7 +588,7 @@ func TestSliceMapMapScanTupleTypes(t *testing.T) {
 		// Test both SliceMap and MapScan
 		for _, method := range []string{"SliceMap", "MapScan"} {
 			t.Run(method, func(t *testing.T) {
-				var result map[string]interface{}
+				var result map[string]any
 
 				selectQuery := fmt.Sprintf("SELECT tuple_col FROM gocql_test.%s WHERE id = ?", table)
 				if method == "SliceMap" {
@@ -603,7 +603,7 @@ func TestSliceMapMapScanTupleTypes(t *testing.T) {
 					}
 					result = sliceResults[0]
 				} else {
-					result = make(map[string]interface{})
+					result = make(map[string]any)
 					if err := session.Query(selectQuery, testID).MapScan(result); err != nil {
 						t.Fatalf("MapScan failed: %v", err)
 					}
@@ -635,7 +635,7 @@ func TestSliceMapMapScanTupleTypes(t *testing.T) {
 		// Test both SliceMap and MapScan
 		for _, method := range []string{"SliceMap", "MapScan"} {
 			t.Run(method, func(t *testing.T) {
-				var result map[string]interface{}
+				var result map[string]any
 
 				selectQuery := fmt.Sprintf("SELECT tuple_col FROM gocql_test.%s WHERE id = ?", table)
 				if method == "SliceMap" {
@@ -650,7 +650,7 @@ func TestSliceMapMapScanTupleTypes(t *testing.T) {
 					}
 					result = sliceResults[0]
 				} else {
-					result = make(map[string]interface{})
+					result = make(map[string]any)
 					if err := session.Query(selectQuery, testID).MapScan(result); err != nil {
 						t.Fatalf("MapScan failed: %v", err)
 					}
@@ -707,8 +707,8 @@ func TestSliceMapMapScanVectorTypes(t *testing.T) {
 	testCases := []struct {
 		colName       string
 		cqlValue      string
-		expectedValue interface{}
-		expectedNull  interface{}
+		expectedValue any
+		expectedNull  any
 	}{
 		{"vector_float_col", "[1.0, 2.5, -3.0]", []float32{1.0, 2.5, -3.0}, []float32(nil)},
 		{"vector_text_col", "['hello', 'world']", []string{"hello", "world"}, []string(nil)},
@@ -728,7 +728,7 @@ func TestSliceMapMapScanVectorTypes(t *testing.T) {
 				// Test both SliceMap and MapScan
 				for _, method := range []string{"SliceMap", "MapScan"} {
 					t.Run(method, func(t *testing.T) {
-						var result interface{}
+						var result any
 
 						selectQuery := fmt.Sprintf("SELECT %s FROM gocql_test.%s WHERE id = ?", tc.colName, table)
 						if method == "SliceMap" {
@@ -743,7 +743,7 @@ func TestSliceMapMapScanVectorTypes(t *testing.T) {
 							}
 							result = sliceResults[0][tc.colName]
 						} else {
-							mapResult := make(map[string]interface{})
+							mapResult := make(map[string]any)
 							if err := session.Query(selectQuery, testID).MapScan(mapResult); err != nil {
 								t.Fatalf("MapScan failed: %v", err)
 							}
@@ -767,7 +767,7 @@ func TestSliceMapMapScanVectorTypes(t *testing.T) {
 				// Test both SliceMap and MapScan
 				for _, method := range []string{"SliceMap", "MapScan"} {
 					t.Run(method, func(t *testing.T) {
-						var result interface{}
+						var result any
 
 						selectQuery := fmt.Sprintf("SELECT %s FROM gocql_test.%s WHERE id = ?", tc.colName, table)
 						if method == "SliceMap" {
@@ -782,7 +782,7 @@ func TestSliceMapMapScanVectorTypes(t *testing.T) {
 							}
 							result = sliceResults[0][tc.colName]
 						} else {
-							mapResult := make(map[string]interface{})
+							mapResult := make(map[string]any)
 							if err := session.Query(selectQuery, testID).MapScan(mapResult); err != nil {
 								t.Fatalf("MapScan failed: %v", err)
 							}
@@ -827,8 +827,8 @@ func TestSliceMapMapScanCollectionTypes(t *testing.T) {
 	testCases := []struct {
 		colName       string
 		cqlValue      string
-		expectedValue interface{}
-		expectedNull  interface{}
+		expectedValue any
+		expectedNull  any
 	}{
 		{"list_col", "['a', 'b', 'c']", []string{"a", "b", "c"}, []string(nil)},
 		{"set_col", "{1, 2, 3}", []int{1, 2, 3}, []int(nil)},
@@ -849,7 +849,7 @@ func TestSliceMapMapScanCollectionTypes(t *testing.T) {
 				// Test both SliceMap and MapScan
 				for _, method := range []string{"SliceMap", "MapScan"} {
 					t.Run(method, func(t *testing.T) {
-						var result interface{}
+						var result any
 
 						selectQuery := fmt.Sprintf("SELECT %s FROM gocql_test.%s WHERE id = ?", tc.colName, table)
 						if method == "SliceMap" {
@@ -864,7 +864,7 @@ func TestSliceMapMapScanCollectionTypes(t *testing.T) {
 							}
 							result = sliceResults[0][tc.colName]
 						} else {
-							mapResult := make(map[string]interface{})
+							mapResult := make(map[string]any)
 							if err := session.Query(selectQuery, testID).MapScan(mapResult); err != nil {
 								t.Fatalf("MapScan failed: %v", err)
 							}
@@ -895,7 +895,7 @@ func TestSliceMapMapScanCollectionTypes(t *testing.T) {
 				// Test both SliceMap and MapScan
 				for _, method := range []string{"SliceMap", "MapScan"} {
 					t.Run(method, func(t *testing.T) {
-						var result interface{}
+						var result any
 
 						selectQuery := fmt.Sprintf("SELECT %s FROM gocql_test.%s WHERE id = ?", tc.colName, table)
 						if method == "SliceMap" {
@@ -910,7 +910,7 @@ func TestSliceMapMapScanCollectionTypes(t *testing.T) {
 							}
 							result = sliceResults[0][tc.colName]
 						} else {
-							mapResult := make(map[string]interface{})
+							mapResult := make(map[string]any)
 							if err := session.Query(selectQuery, testID).MapScan(mapResult); err != nil {
 								t.Fatalf("MapScan failed: %v", err)
 							}

--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -90,9 +90,9 @@ type EventBus[T any] struct {
 }
 
 type StdLogger interface {
-	Print(v ...interface{})
-	Printf(format string, v ...interface{})
-	Println(v ...interface{})
+	Print(v ...any)
+	Printf(format string, v ...any)
+	Println(v ...any)
 }
 
 type EventBusConfig struct {

--- a/internal/lru/lru.go
+++ b/internal/lru/lru.go
@@ -48,11 +48,11 @@ import "container/list"
 //
 // This cache has been forked from github.com/golang/groupcache/lru and
 // generalized with a comparable type parameter to avoid the allocations
-// caused by wrapping keys in interface{}.
+// caused by wrapping keys in any.
 type Cache[K comparable] struct {
 	// OnEvicted optionally specifies a callback function to be
 	// executed when an entry is purged from the cache.
-	OnEvicted func(key K, value interface{})
+	OnEvicted func(key K, value any)
 	ll        *list.List
 	cache     map[K]*list.Element
 	// MaxEntries is the maximum number of cache entries before
@@ -61,7 +61,7 @@ type Cache[K comparable] struct {
 }
 
 type entry[K comparable] struct {
-	value interface{}
+	value any
 	key   K
 }
 
@@ -77,7 +77,7 @@ func New[K comparable](maxEntries int) *Cache[K] {
 }
 
 // Add adds a value to the cache.
-func (c *Cache[K]) Add(key K, value interface{}) {
+func (c *Cache[K]) Add(key K, value any) {
 	if c.cache == nil {
 		c.cache = make(map[K]*list.Element)
 		c.ll = list.New()
@@ -95,7 +95,7 @@ func (c *Cache[K]) Add(key K, value interface{}) {
 }
 
 // Get looks up a key's value from the cache.
-func (c *Cache[K]) Get(key K) (value interface{}, ok bool) {
+func (c *Cache[K]) Get(key K) (value any, ok bool) {
 	if c.cache == nil {
 		return
 	}

--- a/internal/tests/common.go
+++ b/internal/tests/common.go
@@ -16,21 +16,21 @@ func AssertTrue(t *testing.T, description string, value bool) {
 	}
 }
 
-func AssertEqual(t *testing.T, description string, expected, actual interface{}) {
+func AssertEqual(t *testing.T, description string, expected, actual any) {
 	t.Helper()
 	if expected != actual {
 		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
 	}
 }
 
-func AssertDeepEqual(t *testing.T, description string, expected, actual interface{}) {
+func AssertDeepEqual(t *testing.T, description string, expected, actual any) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("expected %s to be (%+v) but was (%+v) instead", description, expected, actual)
 	}
 }
 
-func AssertNil(t *testing.T, description string, actual interface{}) {
+func AssertNil(t *testing.T, description string, actual any) {
 	t.Helper()
 	if actual != nil {
 		t.Fatalf("expected %s to be (nil) but was (%+v) instead", description, actual)

--- a/internal/tests/serialization/mod/all.go
+++ b/internal/tests/serialization/mod/all.go
@@ -3,12 +3,12 @@ package mod
 var All = []Mod{CustomType, Reference, CustomTypeRef}
 
 // Mod - value modifiers.
-type Mod func(vals ...interface{}) []interface{}
+type Mod func(vals ...any) []any
 
-type Values []interface{}
+type Values []any
 
 func (v Values) AddVariants(mods ...Mod) Values {
-	out := append(make([]interface{}, 0), v...)
+	out := append(make([]any, 0), v...)
 	for _, mod := range mods {
 		out = append(out, mod(v...)...)
 	}

--- a/internal/tests/serialization/mod/custom.go
+++ b/internal/tests/serialization/mod/custom.go
@@ -38,7 +38,7 @@ type (
 	SliceInt32C  []Int32
 	SliceInt32CR []*Int32
 
-	SliceAny []interface{}
+	SliceAny []any
 
 	Arr1Int16   [1]int16
 	Arr1Int16R  [1]*int16
@@ -50,7 +50,7 @@ type (
 	Arr1Int32C  [1]Int32
 	Arr1Int32CR [1]*Int32
 
-	ArrAny [1]interface{}
+	ArrAny [1]any
 
 	MapInt16   map[int16]int16
 	MapInt16R  map[int16]*int16
@@ -62,11 +62,11 @@ type (
 	MapInt32C  map[Int32]Int32
 	MapInt32CR map[Int32]*Int32
 
-	MapUDT map[string]interface{}
+	MapUDT map[string]any
 )
 
-var CustomType Mod = func(vals ...interface{}) []interface{} {
-	out := make([]interface{}, 0)
+var CustomType Mod = func(vals ...any) []any {
+	out := make([]any, 0)
 	for i := range vals {
 		if vals[i] == nil {
 			continue
@@ -79,7 +79,7 @@ var CustomType Mod = func(vals ...interface{}) []interface{} {
 	return out
 }
 
-func customType(i interface{}) interface{} {
+func customType(i any) any {
 	switch v := i.(type) {
 	case bool:
 		return Bool(v)
@@ -171,18 +171,18 @@ func customType(i interface{}) interface{} {
 		return MapInt32C(v)
 	case map[Int32]*Int32:
 		return MapInt32CR(v)
-	case map[string]interface{}:
+	case map[string]any:
 		return MapUDT(v)
-	case []interface{}:
+	case []any:
 		return SliceAny(v)
-	case [1]interface{}:
+	case [1]any:
 		return ArrAny(v)
 	default:
 		return intoCustomR(i)
 	}
 }
 
-func intoCustomR(i interface{}) interface{} {
+func intoCustomR(i any) any {
 	switch v := i.(type) {
 	case *bool:
 		return (*Bool)(v)
@@ -266,11 +266,11 @@ func intoCustomR(i interface{}) interface{} {
 		return (*MapInt32C)(v)
 	case *map[Int32]*Int32:
 		return (*MapInt32CR)(v)
-	case *map[string]interface{}:
+	case *map[string]any:
 		return (*MapUDT)(v)
-	case *[]interface{}:
+	case *[]any:
 		return (*SliceAny)(v)
-	case *[1]interface{}:
+	case *[1]any:
 		return (*ArrAny)(v)
 	default:
 		return nil

--- a/internal/tests/serialization/mod/custom_refs.go
+++ b/internal/tests/serialization/mod/custom_refs.go
@@ -1,5 +1,5 @@
 package mod
 
-var CustomTypeRef Mod = func(vals ...interface{}) []interface{} {
+var CustomTypeRef Mod = func(vals ...any) []any {
 	return Reference(CustomType(vals...)...)
 }

--- a/internal/tests/serialization/mod/refs.go
+++ b/internal/tests/serialization/mod/refs.go
@@ -2,8 +2,8 @@ package mod
 
 import "reflect"
 
-var Reference Mod = func(vals ...interface{}) []interface{} {
-	out := make([]interface{}, 0)
+var Reference Mod = func(vals ...any) []any {
+	out := make([]any, 0)
 	for i := range vals {
 		if vals[i] != nil {
 			out = append(out, reference(vals[i]))
@@ -12,7 +12,7 @@ var Reference Mod = func(vals ...interface{}) []interface{} {
 	return out
 }
 
-func reference(val interface{}) interface{} {
+func reference(val any) any {
 	inV := reflect.ValueOf(val)
 	out := reflect.New(reflect.TypeOf(val))
 	out.Elem().Set(inV)

--- a/internal/tests/serialization/pointers.go
+++ b/internal/tests/serialization/pointers.go
@@ -15,7 +15,7 @@ var errFirstPtrChanged = errors.New("unmarshal function rewrote first pointer")
 // but this is the current implementation `gocql` and changing it can lead to unexpected results in some cases.
 var errSecondPtrNotChanged = errors.New("unmarshal function did not rewrite second pointer")
 
-func getPointers(i interface{}) *pointer {
+func getPointers(i any) *pointer {
 	rv := reflect.ValueOf(i)
 	if rv.Kind() != reflect.Ptr {
 		return nil
@@ -42,7 +42,7 @@ func (p *pointer) NotNil() bool {
 // Valid validates if pointers has been manipulated by unmarshal functions in an expected manner:
 // Fist pointer should not be overwritten,
 // Second pointer, if applicable, should be overwritten.
-func (p *pointer) Valid(v interface{}) error {
+func (p *pointer) Valid(v any) error {
 	p2 := getPointers(v)
 	if p.Fist != p2.Fist {
 		return errFirstPtrChanged

--- a/internal/tests/serialization/set_negative_marshal.go
+++ b/internal/tests/serialization/set_negative_marshal.go
@@ -9,11 +9,11 @@ import (
 
 // NegativeMarshalSet is a tool for marshal funcs testing for cases when the function should an error.
 type NegativeMarshalSet struct {
-	Values      []interface{}
+	Values      []any
 	BrokenTypes []reflect.Type
 }
 
-func (s NegativeMarshalSet) Run(name string, t *testing.T, marshal func(interface{}) ([]byte, error)) {
+func (s NegativeMarshalSet) Run(name string, t *testing.T, marshal func(any) ([]byte, error)) {
 	if name == "" {
 		t.Fatal("name should be provided")
 	}

--- a/internal/tests/serialization/set_negative_unmarshal.go
+++ b/internal/tests/serialization/set_negative_unmarshal.go
@@ -12,11 +12,11 @@ import (
 // NegativeUnmarshalSet is a tool for unmarshal funcs testing for cases when the function should an error.
 type NegativeUnmarshalSet struct {
 	Data        []byte
-	Values      []interface{}
+	Values      []any
 	BrokenTypes []reflect.Type
 }
 
-func (s NegativeUnmarshalSet) Run(name string, t *testing.T, unmarshal func([]byte, interface{}) error) {
+func (s NegativeUnmarshalSet) Run(name string, t *testing.T, unmarshal func([]byte, any) error) {
 	if name == "" {
 		t.Fatal("name should be provided")
 	}
@@ -43,7 +43,7 @@ func (s NegativeUnmarshalSet) Run(name string, t *testing.T, unmarshal func([]by
 	})
 }
 
-func (s NegativeUnmarshalSet) run(name string, t *testing.T, f func([]byte, interface{}) error, val, unmarshalIn interface{}) {
+func (s NegativeUnmarshalSet) run(name string, t *testing.T, f func([]byte, any) error, val, unmarshalIn any) {
 	t.Run(name, func(t *testing.T) {
 		err := func() (err error) {
 			defer func() {

--- a/internal/tests/serialization/set_positive.go
+++ b/internal/tests/serialization/set_positive.go
@@ -14,13 +14,13 @@ import (
 // on unmarshall - unmarshalled value from PositiveSet.Data should be equal with PositiveSet.Values.
 type PositiveSet struct {
 	Data   []byte
-	Values []interface{}
+	Values []any
 
 	BrokenMarshalTypes   []reflect.Type
 	BrokenUnmarshalTypes []reflect.Type
 }
 
-func (s PositiveSet) Run(name string, t *testing.T, marshal func(interface{}) ([]byte, error), unmarshal func([]byte, interface{}) error) {
+func (s PositiveSet) Run(name string, t *testing.T, marshal func(any) ([]byte, error), unmarshal func([]byte, any) error) {
 	if name == "" {
 		t.Fatal("name should be provided")
 	}
@@ -53,7 +53,7 @@ func (s PositiveSet) Run(name string, t *testing.T, marshal func(interface{}) ([
 	})
 }
 
-func (s PositiveSet) runMarshalTest(t *testing.T, f func(interface{}) ([]byte, error), val interface{}) {
+func (s PositiveSet) runMarshalTest(t *testing.T, f func(any) ([]byte, error), val any) {
 	t.Run("marshal", func(t *testing.T) {
 
 		result, err := func() (d []byte, err error) {
@@ -86,7 +86,7 @@ func (s PositiveSet) runMarshalTest(t *testing.T, f func(interface{}) ([]byte, e
 	})
 }
 
-func (s PositiveSet) runUnmarshalTest(name string, t *testing.T, f func([]byte, interface{}) error, expected, result interface{}) {
+func (s PositiveSet) runUnmarshalTest(name string, t *testing.T, f func([]byte, any) error, expected, result any) {
 	t.Run(name, func(t *testing.T) {
 
 		expectedPtr := getPointers(result)

--- a/internal/tests/serialization/utils.go
+++ b/internal/tests/serialization/utils.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func GetTypes(values ...interface{}) []reflect.Type {
+func GetTypes(values ...any) []reflect.Type {
 	types := make([]reflect.Type, len(values))
 	for i, value := range values {
 		types[i] = reflect.TypeOf(value)
@@ -12,7 +12,7 @@ func GetTypes(values ...interface{}) []reflect.Type {
 	return types
 }
 
-func isTypeOf(value interface{}, types []reflect.Type) bool {
+func isTypeOf(value any, types []reflect.Type) bool {
 	valueType := reflect.TypeOf(value)
 	for i := range types {
 		if types[i] == valueType {
@@ -22,6 +22,6 @@ func isTypeOf(value interface{}, types []reflect.Type) bool {
 	return false
 }
 
-func deReference(in interface{}) interface{} {
+func deReference(in any) any {
 	return reflect.Indirect(reflect.ValueOf(in)).Interface()
 }

--- a/internal/tests/serialization/utils_equal.go
+++ b/internal/tests/serialization/utils_equal.go
@@ -19,7 +19,7 @@ func equalData(in1, in2 []byte) bool {
 	return bytes.Equal(in1, in2)
 }
 
-func equalVals(in1, in2 interface{}) bool {
+func equalVals(in1, in2 any) bool {
 	rin1 := reflect.ValueOf(in1)
 	rin2 := reflect.ValueOf(in2)
 	if rin1.Kind() != rin2.Kind() {

--- a/internal/tests/serialization/utils_new.go
+++ b/internal/tests/serialization/utils_new.go
@@ -4,12 +4,12 @@ import (
 	"reflect"
 )
 
-func newRef(in interface{}) interface{} {
+func newRef(in any) any {
 	out := reflect.New(reflect.TypeOf(in)).Interface()
 	return out
 }
 
-func newRefToZero(in interface{}) interface{} {
+func newRefToZero(in any) any {
 	rv := reflect.ValueOf(in)
 	nw := reflect.New(rv.Type().Elem())
 	out := reflect.New(rv.Type())

--- a/internal/tests/serialization/utils_str.go
+++ b/internal/tests/serialization/utils_str.go
@@ -13,7 +13,7 @@ import (
 const printLimit = 100
 
 // stringValue returns (value_type)(value) in the human-readable format.
-func stringValue(in interface{}) string {
+func stringValue(in any) string {
 	valStr := stringVal(in)
 	if len(valStr) > printLimit {
 		return fmt.Sprintf("(%T)", in)
@@ -31,7 +31,7 @@ func stringData(p []byte) string {
 	return fmt.Sprintf("[%x]", p)
 }
 
-func stringVal(in interface{}) string {
+func stringVal(in any) string {
 	switch i := in.(type) {
 	case string:
 		return i

--- a/internal/tests/serialization/valcases/get.go
+++ b/internal/tests/serialization/valcases/get.go
@@ -19,7 +19,7 @@ type SimpleTypeCase struct {
 }
 
 type LangCase struct {
-	Value     interface{}
+	Value     any
 	LangType  string
 	ErrInsert bool
 	ErrSelect bool
@@ -31,7 +31,7 @@ func GetSimple() SimpleTypes {
 	return simpleTypesCases
 }
 
-func nilRef(in interface{}) interface{} {
+func nilRef(in any) any {
 	out := reflect.NewAt(reflect.TypeOf(in), nil).Interface()
 	return out
 }

--- a/logger.go
+++ b/logger.go
@@ -31,30 +31,30 @@ import (
 )
 
 type StdLogger interface {
-	Print(v ...interface{})
-	Printf(format string, v ...interface{})
-	Println(v ...interface{})
+	Print(v ...any)
+	Printf(format string, v ...any)
+	Println(v ...any)
 }
 
 type nopLogger struct{}
 
-func (n nopLogger) Print(_ ...interface{}) {}
+func (n nopLogger) Print(_ ...any) {}
 
-func (n nopLogger) Printf(_ string, _ ...interface{}) {}
+func (n nopLogger) Printf(_ string, _ ...any) {}
 
-func (n nopLogger) Println(_ ...interface{}) {}
+func (n nopLogger) Println(_ ...any) {}
 
 type testLogger struct {
 	capture bytes.Buffer
 }
 
-func (l *testLogger) Print(v ...interface{})                 { fmt.Fprint(&l.capture, v...) }
-func (l *testLogger) Printf(format string, v ...interface{}) { fmt.Fprintf(&l.capture, format, v...) }
-func (l *testLogger) Println(v ...interface{})               { fmt.Fprintln(&l.capture, v...) }
-func (l *testLogger) String() string                         { return l.capture.String() }
+func (l *testLogger) Print(v ...any)                 { fmt.Fprint(&l.capture, v...) }
+func (l *testLogger) Printf(format string, v ...any) { fmt.Fprintf(&l.capture, format, v...) }
+func (l *testLogger) Println(v ...any)               { fmt.Fprintln(&l.capture, v...) }
+func (l *testLogger) String() string                 { return l.capture.String() }
 
 type defaultLogger struct{}
 
-func (l *defaultLogger) Print(v ...interface{})                 { log.Print(v...) }
-func (l *defaultLogger) Printf(format string, v ...interface{}) { log.Printf(format, v...) }
-func (l *defaultLogger) Println(v ...interface{})               { log.Println(v...) }
+func (l *defaultLogger) Print(v ...any)                 { log.Print(v...) }
+func (l *defaultLogger) Printf(format string, v ...any) { log.Printf(format, v...) }
+func (l *defaultLogger) Println(v ...any)               { log.Println(v...) }

--- a/marshal.go
+++ b/marshal.go
@@ -156,7 +156,7 @@ func (d *DirectUnmarshal) UnmarshalCQL(_ TypeInfo, data []byte) error {
 //	tuple                       | slice, array       |
 //	tuple                       | struct             | fields are marshaled in order of declaration
 //	user-defined type           | gocql.UDTMarshaler | MarshalUDT is called
-//	user-defined type           | map[string]interface{} |
+//	user-defined type           | map[string]any         |
 //	user-defined type           | struct             | struct fields' cql tags are used for column names
 //	date                        | int64              | milliseconds since Unix epoch to start of day (in UTC)
 //	date                        | time.Time          | start of day (in UTC)
@@ -168,7 +168,7 @@ func (d *DirectUnmarshal) UnmarshalCQL(_ TypeInfo, data []byte) error {
 //
 // The marshal/unmarshal error provides a list of supported types when an unsupported type is attempted.
 
-func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
+func Marshal(info TypeInfo, value any) ([]byte, error) {
 	if info.Version() < protoVersion1 {
 		panic("protocol version not set")
 	}
@@ -284,12 +284,12 @@ func Marshal(info TypeInfo, value interface{}) ([]byte, error) {
 //	tuple                                   | *slice, *array          |
 //	tuple                                   | *struct                 | struct fields are set in order of declaration
 //	user-defined types                      | gocql.UDTUnmarshaler    | UnmarshalUDT is called
-//	user-defined types                      | *map[string]interface{} |
+//	user-defined types                      | *map[string]any         |
 //	user-defined types                      | *struct                 | cql tag is used to determine field name
 //	date                                    | *time.Time              | time of beginning of the day (in UTC)
 //	date                                    | *string                 | formatted with 2006-01-02 format
 //	duration                                | *gocql.Duration         |
-func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
+func Unmarshal(info TypeInfo, data []byte, value any) error {
 	if v, ok := value.(Unmarshaler); ok {
 		return v.UnmarshalCQL(info, data)
 	}
@@ -359,7 +359,7 @@ func Unmarshal(info TypeInfo, data []byte, value interface{}) error {
 	return fmt.Errorf("can not unmarshal %s into %T", info, value)
 }
 
-func isNullableValue(value interface{}) bool {
+func isNullableValue(value any) bool {
 	v := reflect.ValueOf(value)
 	return v.Kind() == reflect.Ptr && v.Type().Elem().Kind() == reflect.Ptr
 }
@@ -368,7 +368,7 @@ func isNullData(info TypeInfo, data []byte) bool {
 	return data == nil
 }
 
-func unmarshalNullable(info TypeInfo, data []byte, value interface{}) error {
+func unmarshalNullable(info TypeInfo, data []byte, value any) error {
 	valueRef := reflect.ValueOf(value)
 
 	if isNullData(info, data) {
@@ -382,7 +382,7 @@ func unmarshalNullable(info TypeInfo, data []byte, value interface{}) error {
 	return Unmarshal(info, data, newValue.Interface())
 }
 
-func marshalVarchar(value interface{}) ([]byte, error) {
+func marshalVarchar(value any) ([]byte, error) {
 	data, err := varchar.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -390,7 +390,7 @@ func marshalVarchar(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalText(value interface{}) ([]byte, error) {
+func marshalText(value any) ([]byte, error) {
 	data, err := text.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -398,7 +398,7 @@ func marshalText(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalBlob(value interface{}) ([]byte, error) {
+func marshalBlob(value any) ([]byte, error) {
 	data, err := blob.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -406,7 +406,7 @@ func marshalBlob(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalAscii(value interface{}) ([]byte, error) {
+func marshalAscii(value any) ([]byte, error) {
 	data, err := ascii.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -414,7 +414,7 @@ func marshalAscii(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalVarchar(data []byte, value interface{}) error {
+func unmarshalVarchar(data []byte, value any) error {
 	err := varchar.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -422,7 +422,7 @@ func unmarshalVarchar(data []byte, value interface{}) error {
 	return nil
 }
 
-func unmarshalText(data []byte, value interface{}) error {
+func unmarshalText(data []byte, value any) error {
 	err := text.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -430,7 +430,7 @@ func unmarshalText(data []byte, value interface{}) error {
 	return nil
 }
 
-func unmarshalBlob(data []byte, value interface{}) error {
+func unmarshalBlob(data []byte, value any) error {
 	err := blob.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -438,7 +438,7 @@ func unmarshalBlob(data []byte, value interface{}) error {
 	return nil
 }
 
-func unmarshalAscii(data []byte, value interface{}) error {
+func unmarshalAscii(data []byte, value any) error {
 	err := ascii.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -446,7 +446,7 @@ func unmarshalAscii(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalSmallInt(value interface{}) ([]byte, error) {
+func marshalSmallInt(value any) ([]byte, error) {
 	data, err := smallint.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -454,7 +454,7 @@ func marshalSmallInt(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalTinyInt(value interface{}) ([]byte, error) {
+func marshalTinyInt(value any) ([]byte, error) {
 	data, err := tinyint.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -462,7 +462,7 @@ func marshalTinyInt(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalInt(value interface{}) ([]byte, error) {
+func marshalInt(value any) ([]byte, error) {
 	data, err := cqlint.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -470,7 +470,7 @@ func marshalInt(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalBigInt(value interface{}) ([]byte, error) {
+func marshalBigInt(value any) ([]byte, error) {
 	data, err := bigint.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -478,7 +478,7 @@ func marshalBigInt(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalCounter(value interface{}) ([]byte, error) {
+func marshalCounter(value any) ([]byte, error) {
 	data, err := counter.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -486,7 +486,7 @@ func marshalCounter(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalCounter(data []byte, value interface{}) error {
+func unmarshalCounter(data []byte, value any) error {
 	err := counter.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -494,7 +494,7 @@ func unmarshalCounter(data []byte, value interface{}) error {
 	return nil
 }
 
-func unmarshalInt(data []byte, value interface{}) error {
+func unmarshalInt(data []byte, value any) error {
 	err := cqlint.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -502,7 +502,7 @@ func unmarshalInt(data []byte, value interface{}) error {
 	return nil
 }
 
-func unmarshalBigInt(data []byte, value interface{}) error {
+func unmarshalBigInt(data []byte, value any) error {
 	err := bigint.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -510,7 +510,7 @@ func unmarshalBigInt(data []byte, value interface{}) error {
 	return nil
 }
 
-func unmarshalSmallInt(data []byte, value interface{}) error {
+func unmarshalSmallInt(data []byte, value any) error {
 	err := smallint.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -518,21 +518,21 @@ func unmarshalSmallInt(data []byte, value interface{}) error {
 	return nil
 }
 
-func unmarshalTinyInt(data []byte, value interface{}) error {
+func unmarshalTinyInt(data []byte, value any) error {
 	if err := tinyint.Unmarshal(data, value); err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
 	}
 	return nil
 }
 
-func unmarshalVarint(data []byte, value interface{}) error {
+func unmarshalVarint(data []byte, value any) error {
 	if err := varint.Unmarshal(data, value); err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
 	}
 	return nil
 }
 
-func marshalVarint(value interface{}) ([]byte, error) {
+func marshalVarint(value any) ([]byte, error) {
 	data, err := varint.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -540,7 +540,7 @@ func marshalVarint(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func marshalBool(value interface{}) ([]byte, error) {
+func marshalBool(value any) ([]byte, error) {
 	data, err := boolean.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -548,14 +548,14 @@ func marshalBool(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalBool(data []byte, value interface{}) error {
+func unmarshalBool(data []byte, value any) error {
 	if err := boolean.Unmarshal(data, value); err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
 	}
 	return nil
 }
 
-func marshalFloat(value interface{}) ([]byte, error) {
+func marshalFloat(value any) ([]byte, error) {
 	data, err := float.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -563,14 +563,14 @@ func marshalFloat(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalFloat(data []byte, value interface{}) error {
+func unmarshalFloat(data []byte, value any) error {
 	if err := float.Unmarshal(data, value); err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
 	}
 	return nil
 }
 
-func marshalDouble(value interface{}) ([]byte, error) {
+func marshalDouble(value any) ([]byte, error) {
 	data, err := double.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -578,7 +578,7 @@ func marshalDouble(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalDouble(data []byte, value interface{}) error {
+func unmarshalDouble(data []byte, value any) error {
 	err := double.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -586,7 +586,7 @@ func unmarshalDouble(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalDecimal(value interface{}) ([]byte, error) {
+func marshalDecimal(value any) ([]byte, error) {
 	data, err := decimal.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -594,14 +594,14 @@ func marshalDecimal(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalDecimal(data []byte, value interface{}) error {
+func unmarshalDecimal(data []byte, value any) error {
 	if err := decimal.Unmarshal(data, value); err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
 	}
 	return nil
 }
 
-func marshalTime(value interface{}) ([]byte, error) {
+func marshalTime(value any) ([]byte, error) {
 	data, err := cqltime.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -609,7 +609,7 @@ func marshalTime(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalTime(data []byte, value interface{}) error {
+func unmarshalTime(data []byte, value any) error {
 	err := cqltime.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -617,7 +617,7 @@ func unmarshalTime(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalTimestamp(value interface{}) ([]byte, error) {
+func marshalTimestamp(value any) ([]byte, error) {
 	data, err := timestamp.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -625,7 +625,7 @@ func marshalTimestamp(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalTimestamp(data []byte, value interface{}) error {
+func unmarshalTimestamp(data []byte, value any) error {
 	err := timestamp.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -633,7 +633,7 @@ func unmarshalTimestamp(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalDate(value interface{}) ([]byte, error) {
+func marshalDate(value any) ([]byte, error) {
 	data, err := date.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -641,7 +641,7 @@ func marshalDate(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalDate(data []byte, value interface{}) error {
+func unmarshalDate(data []byte, value any) error {
 	err := date.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -649,7 +649,7 @@ func unmarshalDate(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalDuration(value interface{}) ([]byte, error) {
+func marshalDuration(value any) ([]byte, error) {
 	switch uv := value.(type) {
 	case Duration:
 		value = duration.Duration(uv)
@@ -663,7 +663,7 @@ func marshalDuration(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalDuration(data []byte, value interface{}) error {
+func unmarshalDuration(data []byte, value any) error {
 	switch uv := value.(type) {
 	case *Duration:
 		value = (*duration.Duration)(uv)
@@ -694,7 +694,7 @@ func writeCollectionSize(info CollectionType, n int, buf *bytes.Buffer) error {
 	return nil
 }
 
-func marshalList(info TypeInfo, value interface{}) ([]byte, error) {
+func marshalList(info TypeInfo, value any) ([]byte, error) {
 	listInfo, ok := info.(CollectionType)
 	if !ok {
 		return nil, marshalErrorf("marshal: can not marshal non collection type into list")
@@ -742,7 +742,7 @@ func marshalList(info TypeInfo, value interface{}) ([]byte, error) {
 		elem := t.Elem()
 		if elem.Kind() == reflect.Struct && elem.NumField() == 0 {
 			rkeys := rv.MapKeys()
-			keys := make([]interface{}, len(rkeys))
+			keys := make([]any, len(rkeys))
 			for i := 0; i < len(keys); i++ {
 				keys[i] = rkeys[i].Interface()
 			}
@@ -761,7 +761,7 @@ func readCollectionSize(info CollectionType, data []byte) (size, read int, err e
 	return
 }
 
-func unmarshalList(info TypeInfo, data []byte, value interface{}) error {
+func unmarshalList(info TypeInfo, data []byte, value any) error {
 	listInfo, ok := info.(CollectionType)
 	if !ok {
 		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into list")
@@ -775,7 +775,7 @@ func unmarshalList(info TypeInfo, data []byte, value interface{}) error {
 	t := rv.Type()
 	k := t.Kind()
 
-	// Handle *interface{} destination
+	// Handle *any destination
 	if k == reflect.Interface {
 		if t.NumMethod() != 0 {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
@@ -838,10 +838,10 @@ func unmarshalList(info TypeInfo, data []byte, value interface{}) error {
 		}
 		return nil
 	}
-	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *slice, *array, *interface{}.", info, value)
+	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *slice, *array, *any.", info, value)
 }
 
-func marshalVector(info VectorType, value interface{}) ([]byte, error) {
+func marshalVector(info VectorType, value any) ([]byte, error) {
 	if value == nil {
 		return nil, nil
 	} else if _, ok := value.(unsetColumn); ok {
@@ -886,7 +886,7 @@ func marshalVector(info VectorType, value interface{}) ([]byte, error) {
 	return nil, marshalErrorf("can not marshal %T into %s. Accepted types: slice, array.", value, info)
 }
 
-func unmarshalVector(info VectorType, data []byte, value interface{}) error {
+func unmarshalVector(info VectorType, data []byte, value any) error {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -966,7 +966,7 @@ func unmarshalVector(info VectorType, data []byte, value interface{}) error {
 		}
 		return nil
 	}
-	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *slice, *array, *interface{}.", info, value)
+	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *slice, *array, *any.", info, value)
 }
 
 func vectorFixedElemSize(elemType TypeInfo) int {
@@ -1046,7 +1046,7 @@ func computeUnsignedVIntSize(v uint64) int {
 	return (639 - lead0*9) >> 6
 }
 
-func marshalMap(info TypeInfo, value interface{}) ([]byte, error) {
+func marshalMap(info TypeInfo, value any) ([]byte, error) {
 	mapInfo, ok := info.(CollectionType)
 	if !ok {
 		return nil, marshalErrorf("marshal: can not marshal none collection type into map")
@@ -1109,7 +1109,7 @@ func marshalMap(info TypeInfo, value interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
+func unmarshalMap(info TypeInfo, data []byte, value any) error {
 	mapInfo, ok := info.(CollectionType)
 	if !ok {
 		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into map")
@@ -1122,7 +1122,7 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 	rv = rv.Elem()
 	t := rv.Type()
 
-	// Handle *interface{} destination
+	// Handle *any destination
 	if t.Kind() == reflect.Interface {
 		if t.NumMethod() != 0 {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
@@ -1140,7 +1140,7 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 	}
 
 	if t.Kind() != reflect.Map {
-		return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *map, *interface{}.", info, value)
+		return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *map, *any.", info, value)
 	}
 	if data == nil {
 		rv.Set(reflect.Zero(t))
@@ -1204,7 +1204,7 @@ func unmarshalMap(info TypeInfo, data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalUUID(value interface{}) ([]byte, error) {
+func marshalUUID(value any) ([]byte, error) {
 	switch uv := value.(type) {
 	case UUID:
 		value = [16]byte(uv)
@@ -1218,7 +1218,7 @@ func marshalUUID(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalUUID(data []byte, value interface{}) error {
+func unmarshalUUID(data []byte, value any) error {
 	switch uv := value.(type) {
 	case *UUID:
 		value = (*[16]byte)(uv)
@@ -1236,7 +1236,7 @@ func unmarshalUUID(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalTimeUUID(value interface{}) ([]byte, error) {
+func marshalTimeUUID(value any) ([]byte, error) {
 	switch uv := value.(type) {
 	case UUID:
 		value = [16]byte(uv)
@@ -1250,7 +1250,7 @@ func marshalTimeUUID(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalTimeUUID(data []byte, value interface{}) error {
+func unmarshalTimeUUID(data []byte, value any) error {
 	switch uv := value.(type) {
 	case *UUID:
 		value = (*[16]byte)(uv)
@@ -1268,7 +1268,7 @@ func unmarshalTimeUUID(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalInet(value interface{}) ([]byte, error) {
+func marshalInet(value any) ([]byte, error) {
 	data, err := inet.Marshal(value)
 	if err != nil {
 		return nil, wrapMarshalError(err, "marshal error")
@@ -1276,7 +1276,7 @@ func marshalInet(value interface{}) ([]byte, error) {
 	return data, nil
 }
 
-func unmarshalInet(data []byte, value interface{}) error {
+func unmarshalInet(data []byte, value any) error {
 	err := inet.Unmarshal(data, value)
 	if err != nil {
 		return wrapUnmarshalError(err, "unmarshal error")
@@ -1284,12 +1284,12 @@ func unmarshalInet(data []byte, value interface{}) error {
 	return nil
 }
 
-func marshalTuple(info TypeInfo, value interface{}) ([]byte, error) {
+func marshalTuple(info TypeInfo, value any) ([]byte, error) {
 	tuple := info.(TupleTypeInfo)
 	switch v := value.(type) {
 	case unsetColumn:
 		return nil, unmarshalErrorf("Invalid request: UnsetValue is unsupported for tuples")
-	case []interface{}:
+	case []any:
 		if len(v) != len(tuple.Elems) {
 			return nil, unmarshalErrorf("cannont marshal tuple: wrong number of elements")
 		}
@@ -1388,14 +1388,14 @@ func readBytes(p []byte) ([]byte, []byte) {
 // currently only support unmarshal into a list of values, this makes it possible
 // to support tuples without changing the query API. In the future this can be extend
 // to allow unmarshalling into custom tuple types.
-func unmarshalTuple(info TypeInfo, data []byte, value interface{}) error {
+func unmarshalTuple(info TypeInfo, data []byte, value any) error {
 	if v, ok := value.(Unmarshaler); ok {
 		return v.UnmarshalCQL(info, data)
 	}
 
 	tuple := info.(TupleTypeInfo)
 	switch v := value.(type) {
-	case []interface{}:
+	case []any:
 		for i, elem := range tuple.Elems {
 			// each element inside data is a [bytes]
 			var p []byte
@@ -1518,7 +1518,7 @@ type UDTUnmarshaler interface {
 	UnmarshalUDT(name string, info TypeInfo, data []byte) error
 }
 
-func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
+func marshalUDT(info TypeInfo, value any) ([]byte, error) {
 	udt := info.(UDTTypeInfo)
 
 	switch v := value.(type) {
@@ -1538,7 +1538,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 		}
 
 		return buf, nil
-	case map[string]interface{}:
+	case map[string]any:
 		var buf []byte
 		for _, e := range udt.Elements {
 			val, ok := v[e.Name]
@@ -1602,7 +1602,7 @@ func marshalUDT(info TypeInfo, value interface{}) ([]byte, error) {
 	return buf, nil
 }
 
-func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
+func unmarshalUDT(info TypeInfo, data []byte, value any) error {
 	switch v := value.(type) {
 	case Unmarshaler:
 		return v.UnmarshalCQL(info, data)
@@ -1625,7 +1625,7 @@ func unmarshalUDT(info TypeInfo, data []byte, value interface{}) error {
 		}
 
 		return nil
-	case *map[string]interface{}:
+	case *map[string]any:
 		udt := info.(UDTTypeInfo)
 
 		rv := reflect.ValueOf(value)
@@ -1746,7 +1746,7 @@ type TypeInfo interface {
 	// is referenced by the TypeInfo receiver.
 	//
 	// If there is no corresponding Go type for the CQL type, NewWithError returns an error.
-	NewWithError() (interface{}, error)
+	NewWithError() (any, error)
 }
 
 type NativeType struct {
@@ -1764,7 +1764,7 @@ func NewCustomType(proto byte, typ Type, custom string) NativeType {
 	return NativeType{proto: proto, typ: typ, custom: custom}
 }
 
-func (t NativeType) NewWithError() (interface{}, error) {
+func (t NativeType) NewWithError() (any, error) {
 	// Fast path for common types to avoid reflection overhead
 	switch t.typ {
 	case TypeInt:
@@ -1851,7 +1851,7 @@ type VectorType struct {
 }
 
 // Zero returns the zero value for the vector CQL type.
-func (v VectorType) Zero() interface{} {
+func (v VectorType) Zero() any {
 	t, e := v.SubType.NewWithError()
 	if e != nil {
 		return nil
@@ -1859,7 +1859,7 @@ func (v VectorType) Zero() interface{} {
 	return reflect.Zero(reflect.SliceOf(reflect.TypeOf(t))).Interface()
 }
 
-func (t CollectionType) NewWithError() (interface{}, error) {
+func (t CollectionType) NewWithError() (any, error) {
 	// Fast path for common collection patterns
 	switch t.typ {
 	case TypeList, TypeSet:
@@ -1972,9 +1972,9 @@ func (t TupleTypeInfo) String() string {
 	return buf.String()
 }
 
-func (t TupleTypeInfo) NewWithError() (interface{}, error) {
-	// Tuples scan into *[]interface{} — no reflection needed.
-	return new([]interface{}), nil
+func (t TupleTypeInfo) NewWithError() (any, error) {
+	// Tuples scan into *[]any — no reflection needed.
+	return new([]any), nil
 }
 
 type UDTField struct {
@@ -1998,7 +1998,7 @@ type UDTTypeInfo struct {
 	NativeType
 }
 
-func (t UDTTypeInfo) NewWithError() (interface{}, error) {
+func (t UDTTypeInfo) NewWithError() (any, error) {
 	typ, err := goType(t)
 	if err != nil {
 		return nil, err
@@ -2138,7 +2138,7 @@ func (m MarshalError) Unwrap() error {
 	return m.cause
 }
 
-func marshalErrorf(format string, args ...interface{}) MarshalError {
+func marshalErrorf(format string, args ...any) MarshalError {
 	return MarshalError{msg: fmt.Sprintf(format, args...)}
 }
 
@@ -2146,7 +2146,7 @@ func wrapMarshalError(err error, msg string) MarshalError {
 	return MarshalError{msg: msg, cause: err}
 }
 
-func wrapMarshalErrorf(err error, format string, a ...interface{}) MarshalError {
+func wrapMarshalErrorf(err error, format string, a ...any) MarshalError {
 	return MarshalError{msg: fmt.Sprintf(format, a...), cause: err}
 }
 
@@ -2168,7 +2168,7 @@ func (m UnmarshalError) Unwrap() error {
 	return m.cause
 }
 
-func unmarshalErrorf(format string, args ...interface{}) UnmarshalError {
+func unmarshalErrorf(format string, args ...any) UnmarshalError {
 	return UnmarshalError{msg: fmt.Sprintf(format, args...)}
 }
 
@@ -2176,6 +2176,6 @@ func wrapUnmarshalError(err error, msg string) UnmarshalError {
 	return UnmarshalError{msg: msg, cause: err}
 }
 
-func wrapUnmarshalErrorf(err error, format string, a ...interface{}) UnmarshalError {
+func wrapUnmarshalErrorf(err error, format string, a ...any) UnmarshalError {
 	return UnmarshalError{msg: fmt.Sprintf(format, a...), cause: err}
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -51,7 +51,7 @@ type AliasUint64 uint64
 var marshalTests = []struct {
 	Info           TypeInfo
 	Data           []byte
-	Value          interface{}
+	Value          any
 	MarshalError   error
 	UnmarshalError error
 }{
@@ -73,7 +73,7 @@ var marshalTests = []struct {
 var unmarshalTests = []struct {
 	Info           TypeInfo
 	Data           []byte
-	Value          interface{}
+	Value          any
 	UnmarshalError error
 }{
 	{
@@ -224,7 +224,7 @@ func TestMarshalList(t *testing.T) {
 		if unmarshalErr := Unmarshal(testCases[i].typeInfo, listData, &outputList); nil != unmarshalErr {
 			t.Error(unmarshalErr)
 		}
-		resultList := []interface{}{}
+		resultList := []any{}
 		for i := range outputList {
 			if outputList[i] != nil {
 				resultList = append(resultList, *outputList[i])
@@ -333,16 +333,16 @@ func TestMarshalTuple(t *testing.T) {
 	testCases := []struct {
 		name       string
 		expected   []byte
-		value      interface{}
-		checkValue interface{}
-		check      func(*testing.T, interface{})
+		value      any
+		checkValue any
+		check      func(*testing.T, any)
 	}{
 		{
 			name:       "interface-slice:two-strings",
 			expected:   []byte("\x00\x00\x00\x03foo\x00\x00\x00\x03bar"),
-			value:      []interface{}{"foo", "bar"},
-			checkValue: []interface{}{&s1, &s2},
-			check: func(t *testing.T, v interface{}) {
+			value:      []any{"foo", "bar"},
+			checkValue: []any{&s1, &s2},
+			check: func(t *testing.T, v any) {
 				checkString(t, "foo", *s1)
 				checkString(t, "bar", *s2)
 			},
@@ -350,9 +350,9 @@ func TestMarshalTuple(t *testing.T) {
 		{
 			name:       "interface-slice:one-string-one-nil-string",
 			expected:   []byte("\x00\x00\x00\x03foo\xff\xff\xff\xff"),
-			value:      []interface{}{"foo", nil},
-			checkValue: []interface{}{&s1, &s2},
-			check: func(t *testing.T, v interface{}) {
+			value:      []any{"foo", nil},
+			checkValue: []any{&s1, &s2},
+			check: func(t *testing.T, v any) {
 				checkString(t, "foo", *s1)
 				if s2 != nil {
 					t.Errorf("expected string to be nil, got %v", *s2)
@@ -367,7 +367,7 @@ func TestMarshalTuple(t *testing.T) {
 				B: stringToPtr("bar"),
 			},
 			checkValue: &tupleStruct{},
-			check: func(t *testing.T, v interface{}) {
+			check: func(t *testing.T, v any) {
 				got := v.(*tupleStruct)
 				if got.A != "foo" {
 					t.Errorf("expected A string to be %v, got %v", "foo", got.A)
@@ -385,7 +385,7 @@ func TestMarshalTuple(t *testing.T) {
 			expected:   []byte("\x00\x00\x00\x03foo\xff\xff\xff\xff"),
 			value:      tupleStruct{A: "foo", B: nil},
 			checkValue: &tupleStruct{},
-			check: func(t *testing.T, v interface{}) {
+			check: func(t *testing.T, v any) {
 				got := v.(*tupleStruct)
 				if got.A != "foo" {
 					t.Errorf("expected A string to be %v, got %v", "foo", got.A)
@@ -403,7 +403,7 @@ func TestMarshalTuple(t *testing.T) {
 				stringToPtr("bar"),
 			},
 			checkValue: &[2]*string{},
-			check: func(t *testing.T, v interface{}) {
+			check: func(t *testing.T, v any) {
 				got := v.(*[2]*string)
 				checkString(t, "foo", *(got[0]))
 				checkString(t, "bar", *(got[1]))
@@ -417,7 +417,7 @@ func TestMarshalTuple(t *testing.T) {
 				nil,
 			},
 			checkValue: &[2]*string{},
-			check: func(t *testing.T, v interface{}) {
+			check: func(t *testing.T, v any) {
 				got := v.(*[2]*string)
 				checkString(t, "foo", *(got[0]))
 				if got[1] != nil {
@@ -543,7 +543,7 @@ func TestMarshalUDTMap(t *testing.T) {
 	}
 
 	t.Run("partially bound", func(t *testing.T) {
-		value := map[string]interface{}{
+		value := map[string]any{
 			"y": 2,
 			"z": 3,
 		}
@@ -558,7 +558,7 @@ func TestMarshalUDTMap(t *testing.T) {
 		}
 	})
 	t.Run("partially bound from the beginning", func(t *testing.T) {
-		value := map[string]interface{}{
+		value := map[string]any{
 			"x": 1,
 			"y": 2,
 		}
@@ -573,7 +573,7 @@ func TestMarshalUDTMap(t *testing.T) {
 		}
 	})
 	t.Run("fully bound", func(t *testing.T) {
-		value := map[string]interface{}{
+		value := map[string]any{
 			"x": 1,
 			"y": 2,
 			"z": 3,
@@ -857,7 +857,7 @@ func TestUnmarshalUDT(t *testing.T) {
 		bytesWithLength([]byte("Hello")),    // first
 		bytesWithLength([]byte("\x00\x2a")), // second
 	)
-	value := map[string]interface{}{}
+	value := map[string]any{}
 	expectedErr := unmarshalErrorf("can not unmarshal into non-pointer map[string]interface {}")
 
 	if err := Unmarshal(info, data, value); err != expectedErr {
@@ -866,7 +866,7 @@ func TestUnmarshalUDT(t *testing.T) {
 	}
 }
 
-// TestUnmarshalListIntoInterface tests that lists can be unmarshaled into *interface{}
+// TestUnmarshalListIntoInterface tests that lists can be unmarshaled into *any
 // This is used by MapScan and SliceMap functions.
 func TestUnmarshalListIntoInterface(t *testing.T) {
 	t.Parallel()
@@ -887,7 +887,7 @@ func TestUnmarshalListIntoInterface(t *testing.T) {
 		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
 	}
 
-	var result interface{}
+	var result any
 	if err := Unmarshal(info, data, &result); err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -908,7 +908,7 @@ func TestUnmarshalListIntoInterface(t *testing.T) {
 	}
 }
 
-// TestUnmarshalMapIntoInterface tests that maps can be unmarshaled into *interface{}
+// TestUnmarshalMapIntoInterface tests that maps can be unmarshaled into *any
 // This is used by MapScan and SliceMap functions.
 func TestUnmarshalMapIntoInterface(t *testing.T) {
 	t.Parallel()
@@ -933,7 +933,7 @@ func TestUnmarshalMapIntoInterface(t *testing.T) {
 		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
 	}
 
-	var result interface{}
+	var result any
 	if err := Unmarshal(info, data, &result); err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -955,7 +955,7 @@ func TestUnmarshalMapIntoInterface(t *testing.T) {
 }
 
 // TestUnmarshalListWithVectorIntoInterface tests that lists containing vectors
-// can be unmarshaled into *interface{} (issue #692)
+// can be unmarshaled into *any (issue #692)
 func TestUnmarshalListWithVectorIntoInterface(t *testing.T) {
 	t.Parallel()
 
@@ -995,7 +995,7 @@ func TestUnmarshalListWithVectorIntoInterface(t *testing.T) {
 		},
 	}
 
-	var result interface{}
+	var result any
 	if err := Unmarshal(info, data, &result); err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -1093,7 +1093,7 @@ func TestUnmarshalVectorZeroDimensions(t *testing.T) {
 	})
 
 	t.Run("empty_data_into_interface", func(t *testing.T) {
-		var result interface{}
+		var result any
 		if err := unmarshalVector(info, []byte{}, &result); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -22,7 +22,7 @@ import (
 
 // schema metadata for a keyspace
 type KeyspaceMetadata struct {
-	StrategyOptions   map[string]interface{}
+	StrategyOptions   map[string]any
 	Tables            map[string]*TableMetadata
 	Functions         map[string]*FunctionMetadata
 	Aggregates        map[string]*AggregateMetadata
@@ -93,7 +93,7 @@ func (ks *KeyspaceMetadata) removeTable(tableName string) {
 // schema metadata for a table (a.k.a. column family)
 type TableMetadata struct {
 	Columns           map[string]*ColumnMetadata
-	Extensions        map[string]interface{}
+	Extensions        map[string]any
 	Keyspace          string
 	Name              string
 	PartitionKey      []*ColumnMetadata
@@ -158,7 +158,7 @@ func (t *TableMetadataOptions) Equals(other *TableMetadataOptions) bool {
 
 type ViewMetadata struct {
 	Columns                 map[string]*ColumnMetadata
-	Extensions              map[string]interface{}
+	Extensions              map[string]any
 	WhereClause             string
 	BaseTableName           string
 	ID                      string
@@ -328,7 +328,7 @@ func compareStringMaps(a, b map[string]string) bool {
 	return true
 }
 
-func compareInterfaceMaps(a, b map[string]interface{}) bool {
+func compareInterfaceMaps(a, b map[string]any) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -433,7 +433,7 @@ const (
 )
 
 type ColumnIndexMetadata struct {
-	Options map[string]interface{}
+	Options map[string]any
 	Name    string
 	Type    string
 }
@@ -689,7 +689,7 @@ func (s *metadataDescriber) invalidateTableSchema(keyspaceName, tableName string
 // deduplicatedRefreshKeyspace collapses concurrent refreshKeyspaceSchema calls
 // for the same keyspace into a single in-flight operation.
 func (s *metadataDescriber) deduplicatedRefreshKeyspace(keyspaceName string) error {
-	_, err, _ := s.keyspaceGroup.Do(keyspaceName, func() (interface{}, error) {
+	_, err, _ := s.keyspaceGroup.Do(keyspaceName, func() (any, error) {
 		return nil, s.refreshKeyspaceSchema(keyspaceName)
 	})
 	return err
@@ -699,7 +699,7 @@ func (s *metadataDescriber) deduplicatedRefreshKeyspace(keyspaceName string) err
 // for the same keyspace/table into a single in-flight operation.
 func (s *metadataDescriber) deduplicatedRefreshTable(keyspaceName, tableName string) error {
 	key := keyspaceName + "\x00" + tableName
-	_, err, _ := s.tableGroup.Do(key, func() (interface{}, error) {
+	_, err, _ := s.tableGroup.Do(key, func() (any, error) {
 		return nil, s.refreshTableSchema(keyspaceName, tableName)
 	})
 	return err
@@ -1152,7 +1152,7 @@ func getKeyspaceMetadata(session *Session, keyspaceName string) (*KeyspaceMetada
 	keyspace.StrategyClass = replication["class"]
 	delete(replication, "class")
 
-	keyspace.StrategyOptions = make(map[string]interface{}, len(replication))
+	keyspace.StrategyOptions = make(map[string]any, len(replication))
 	for k, v := range replication {
 		keyspace.StrategyOptions[k] = v
 	}
@@ -1172,7 +1172,7 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 
 	var tables []TableMetadata
 	table := TableMetadata{Keyspace: keyspaceName}
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"table_name":                  &table.Name,
 		"bloom_filter_fp_chance":      &table.Options.BloomFilterFpChance,
 		"caching":                     &table.Options.Caching,
@@ -1211,7 +1211,7 @@ func getTableMetadata(session *Session, keyspaceName string) ([]TableMetadata, e
 	scyllaOpts := make(map[string]TableMetadataOptions, len(tables))
 	var opts TableMetadataOptions
 	var tblName string
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"table_name":  &tblName,
 		"cdc":         &opts.CDC,
 		"in_memory":   &opts.InMemory,
@@ -1248,7 +1248,7 @@ func getTableMetadataByName(session *Session, keyspaceName, tableName string) ([
 
 	var tables []TableMetadata
 	table := TableMetadata{Keyspace: keyspaceName}
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"table_name":                  &table.Name,
 		"bloom_filter_fp_chance":      &table.Options.BloomFilterFpChance,
 		"caching":                     &table.Options.Caching,
@@ -1283,7 +1283,7 @@ func getTableMetadataByName(session *Session, keyspaceName, tableName string) ([
 		iter := session.control.querySystem(stmt, keyspaceName, t.Name)
 
 		table := TableMetadata{}
-		if iter.MapScan(map[string]interface{}{
+		if iter.MapScan(map[string]any{
 			"cdc":         &table.Options.CDC,
 			"in_memory":   &table.Options.InMemory,
 			"partitioner": &table.Options.Partitioner,
@@ -1317,7 +1317,7 @@ func getColumnMetadataByTable(session *Session, keyspaceName, tableName string) 
 	iter := session.control.querySystem(stmt, keyspaceName, tableName)
 	column := ColumnMetadata{Keyspace: keyspaceName}
 
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"table_name":       &column.Table,
 		"column_name":      &column.Name,
 		"clustering_order": &column.ClusteringOrder,
@@ -1347,7 +1347,7 @@ func getIndexMetadataByTable(session *Session, keyspaceName, tableName string) (
 	index := IndexMetadata{}
 
 	iter := session.control.querySystem(stmt, keyspaceName, tableName)
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"index_name":    &index.Name,
 		"keyspace_name": &index.KeyspaceName,
 		"table_name":    &index.TableName,
@@ -1377,7 +1377,7 @@ func getViewMetadataByTable(session *Session, keyspaceName, tableName string) ([
 	var views []ViewMetadata
 	view := ViewMetadata{KeyspaceName: keyspaceName}
 
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"id":                          &view.ID,
 		"view_name":                   &view.ViewName,
 		"base_table_id":               &view.BaseTableID,
@@ -1421,7 +1421,7 @@ func getColumnMetadata(session *Session, keyspaceName string) ([]ColumnMetadata,
 	iter := session.control.querySystem(stmt, keyspaceName)
 	column := ColumnMetadata{Keyspace: keyspaceName}
 
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"table_name":       &column.Table,
 		"column_name":      &column.Name,
 		"clustering_order": &column.ClusteringOrder,
@@ -1452,7 +1452,7 @@ func getTypeMetadata(session *Session, keyspaceName string) ([]TypeMetadata, err
 	var types []TypeMetadata
 	tm := TypeMetadata{Keyspace: keyspaceName}
 
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"type_name":   &tm.Name,
 		"field_names": &tm.FieldNames,
 		"field_types": &tm.FieldTypes,
@@ -1479,7 +1479,7 @@ func getFunctionsMetadata(session *Session, keyspaceName string) ([]FunctionMeta
 	function := FunctionMetadata{Keyspace: keyspaceName}
 
 	iter := session.control.querySystem(stmt, keyspaceName)
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"function_name":        &function.Name,
 		"argument_types":       &function.ArgumentTypes,
 		"argument_names":       &function.ArgumentNames,
@@ -1511,7 +1511,7 @@ func getAggregatesMetadata(session *Session, keyspaceName string) ([]AggregateMe
 	aggregate := AggregateMetadata{Keyspace: keyspaceName}
 
 	iter := session.control.querySystem(stmt, keyspaceName)
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"aggregate_name": &aggregate.Name,
 		"argument_types": &aggregate.ArgumentTypes,
 		"final_func":     &aggregate.finalFunc,
@@ -1543,7 +1543,7 @@ func getIndexMetadata(session *Session, keyspaceName string) ([]IndexMetadata, e
 	index := IndexMetadata{}
 
 	iter := session.control.querySystem(stmt, keyspaceName)
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"index_name":    &index.Name,
 		"keyspace_name": &index.KeyspaceName,
 		"table_name":    &index.TableName,
@@ -1603,7 +1603,7 @@ func getViewMetadata(session *Session, keyspaceName string) ([]ViewMetadata, err
 	var views []ViewMetadata
 	view := ViewMetadata{KeyspaceName: keyspaceName}
 
-	for iter.MapScan(map[string]interface{}{
+	for iter.MapScan(map[string]any{
 		"id":                          &view.ID,
 		"view_name":                   &view.ViewName,
 		"base_table_id":               &view.BaseTableID,

--- a/policies_bench_test.go
+++ b/policies_bench_test.go
@@ -31,7 +31,7 @@ func setupTabletAwareBench(b *testing.B, numHosts, numTablets, rf int) (HostSele
 		return &KeyspaceMetadata{
 			Name:          keyspace,
 			StrategyClass: "SimpleStrategy",
-			StrategyOptions: map[string]interface{}{
+			StrategyOptions: map[string]any{
 				"class":              "SimpleStrategy",
 				"replication_factor": rf,
 			},
@@ -70,10 +70,10 @@ func setupTabletAwareBench(b *testing.B, numHosts, numTablets, rf int) (HostSele
 			lastToken = math.MaxInt64
 		}
 
-		reps := make([][]interface{}, rf)
+		reps := make([][]any, rf)
 		for r := 0; r < rf; r++ {
 			hostIdx := (i + r) % numHosts
-			reps[r] = []interface{}{hosts[hostIdx].hostId, 0}
+			reps[r] = []any{hosts[hostIdx].hostId, 0}
 		}
 		ti, err := tablets.TabletInfoBuilder{
 			KeyspaceName: keyspace,

--- a/policies_test.go
+++ b/policies_test.go
@@ -165,7 +165,7 @@ func TestHostPolicy_TokenAware_SimpleStrategy(t *testing.T) {
 		return &KeyspaceMetadata{
 			Name:          keyspace,
 			StrategyClass: "SimpleStrategy",
-			StrategyOptions: map[string]interface{}{
+			StrategyOptions: map[string]any{
 				"class":              "SimpleStrategy",
 				"replication_factor": 2,
 			},
@@ -293,7 +293,7 @@ func createPolicy(keyspace string, shuffle bool) HostSelectionPolicy {
 		return &KeyspaceMetadata{
 			Name:          keyspace,
 			StrategyClass: "SimpleStrategy",
-			StrategyOptions: map[string]interface{}{
+			StrategyOptions: map[string]any{
 				"class":              "SimpleStrategy",
 				"replication_factor": 2,
 			},
@@ -810,7 +810,7 @@ func TestHostPolicy_TokenAware(t *testing.T) {
 		return &KeyspaceMetadata{
 			Name:          keyspace,
 			StrategyClass: "NetworkTopologyStrategy",
-			StrategyOptions: map[string]interface{}{
+			StrategyOptions: map[string]any{
 				"class":   "NetworkTopologyStrategy",
 				"local":   1,
 				"remote1": 1,
@@ -903,7 +903,7 @@ func TestHostPolicy_TokenAware_NetworkStrategy(t *testing.T) {
 		return &KeyspaceMetadata{
 			Name:          keyspace,
 			StrategyClass: "NetworkTopologyStrategy",
-			StrategyOptions: map[string]interface{}{
+			StrategyOptions: map[string]any{
 				"class":   "NetworkTopologyStrategy",
 				"local":   2,
 				"remote1": 2,
@@ -1047,7 +1047,7 @@ func TestHostPolicy_TokenAware_RackAware(t *testing.T) {
 		return &KeyspaceMetadata{
 			Name:          keyspace,
 			StrategyClass: "NetworkTopologyStrategy",
-			StrategyOptions: map[string]interface{}{
+			StrategyOptions: map[string]any{
 				"class":  "NetworkTopologyStrategy",
 				"local":  2,
 				"remote": 2,
@@ -1158,7 +1158,7 @@ func TestHostPolicy_TokenAware_Issue1274(t *testing.T) {
 		return &KeyspaceMetadata{
 			Name:          "myKeyspace",
 			StrategyClass: "NetworkTopologyStrategy",
-			StrategyOptions: map[string]interface{}{
+			StrategyOptions: map[string]any{
 				"class":   "NetworkTopologyStrategy",
 				"local":   1,
 				"remote1": 1,
@@ -1266,7 +1266,7 @@ func TestTokenAwareHostPolicyTabletPath(t *testing.T) {
 			return &KeyspaceMetadata{
 				Name:          keyspace,
 				StrategyClass: "SimpleStrategy",
-				StrategyOptions: map[string]interface{}{
+				StrategyOptions: map[string]any{
 					"class":              "SimpleStrategy",
 					"replication_factor": 1,
 				},
@@ -1285,7 +1285,7 @@ func TestTokenAwareHostPolicyTabletPath(t *testing.T) {
 			TableName:    table,
 			FirstToken:   -9223372036854775808,
 			LastToken:    0,
-			Replicas:     [][]interface{}{{host2.hostId, 0}},
+			Replicas:     [][]any{{host2.hostId, 0}},
 		}.Build()
 		if err != nil {
 			t.Fatal(err)
@@ -1295,7 +1295,7 @@ func TestTokenAwareHostPolicyTabletPath(t *testing.T) {
 			TableName:    table,
 			FirstToken:   0,
 			LastToken:    9223372036854775807,
-			Replicas:     [][]interface{}{{host3.hostId, 0}},
+			Replicas:     [][]any{{host3.hostId, 0}},
 		}.Build()
 		if err != nil {
 			t.Fatal(err)

--- a/recreate.go
+++ b/recreate.go
@@ -87,7 +87,7 @@ func (ks *KeyspaceMetadata) typesSortedTopologically() []*TypeMetadata {
 }
 
 var tableCQLTemplate = template.Must(template.New("table").
-	Funcs(map[string]interface{}{
+	Funcs(map[string]any{
 		"escape":               cqlHelpers.escape,
 		"tableColumnToCQL":     cqlHelpers.tableColumnToCQL,
 		"tablePropertiesToCQL": cqlHelpers.tablePropertiesToCQL,
@@ -99,7 +99,7 @@ CREATE TABLE {{ .KeyspaceName }}.{{ .Tm.Name }} (
 `))
 
 func (ks *KeyspaceMetadata) tableToCQL(w io.Writer, kn string, tm *TableMetadata) error {
-	if err := tableCQLTemplate.Execute(w, map[string]interface{}{
+	if err := tableCQLTemplate.Execute(w, map[string]any{
 		"Tm":           tm,
 		"KeyspaceName": kn,
 	}); err != nil {
@@ -109,7 +109,7 @@ func (ks *KeyspaceMetadata) tableToCQL(w io.Writer, kn string, tm *TableMetadata
 }
 
 var functionTemplate = template.Must(template.New("functions").
-	Funcs(map[string]interface{}{
+	Funcs(map[string]any{
 		"escape":      cqlHelpers.escape,
 		"zip":         cqlHelpers.zip,
 		"stripFrozen": cqlHelpers.stripFrozen,
@@ -128,7 +128,7 @@ CREATE FUNCTION {{ .keyspaceName }}.{{ .fm.Name }} (
 `))
 
 func (ks *KeyspaceMetadata) functionToCQL(w io.Writer, keyspaceName string, fm *FunctionMetadata) error {
-	if err := functionTemplate.Execute(w, map[string]interface{}{
+	if err := functionTemplate.Execute(w, map[string]any{
 		"fm":           fm,
 		"keyspaceName": keyspaceName,
 	}); err != nil {
@@ -138,7 +138,7 @@ func (ks *KeyspaceMetadata) functionToCQL(w io.Writer, keyspaceName string, fm *
 }
 
 var viewTemplate = template.Must(template.New("views").
-	Funcs(map[string]interface{}{
+	Funcs(map[string]any{
 		"zip":                  cqlHelpers.zip,
 		"partitionKeyString":   cqlHelpers.partitionKeyString,
 		"tablePropertiesToCQL": cqlHelpers.tablePropertiesToCQL,
@@ -158,7 +158,7 @@ CREATE MATERIALIZED VIEW {{ .vm.KeyspaceName }}.{{ .vm.ViewName }} AS
 `))
 
 func (ks *KeyspaceMetadata) viewToCQL(w io.Writer, vm *ViewMetadata) error {
-	if err := viewTemplate.Execute(w, map[string]interface{}{
+	if err := viewTemplate.Execute(w, map[string]any{
 		"vm": vm,
 	}); err != nil {
 		return err
@@ -167,7 +167,7 @@ func (ks *KeyspaceMetadata) viewToCQL(w io.Writer, vm *ViewMetadata) error {
 }
 
 var aggregatesTemplate = template.Must(template.New("aggregate").
-	Funcs(map[string]interface{}{
+	Funcs(map[string]any{
 		"stripFrozen": cqlHelpers.stripFrozen,
 	}).
 	Parse(`
@@ -195,7 +195,7 @@ func (ks *KeyspaceMetadata) aggregateToCQL(w io.Writer, am *AggregateMetadata) e
 }
 
 var typeCQLTemplate = template.Must(template.New("types").
-	Funcs(map[string]interface{}{
+	Funcs(map[string]any{
 		"zip": cqlHelpers.zip,
 	}).
 	Parse(`
@@ -249,7 +249,7 @@ func (ks *KeyspaceMetadata) indexToCQL(w io.Writer, im *IndexMetadata) error {
 }
 
 var keyspaceCQLTemplate = template.Must(template.New("keyspace").
-	Funcs(map[string]interface{}{
+	Funcs(map[string]any{
 		"escape":      cqlHelpers.escape,
 		"fixStrategy": cqlHelpers.fixStrategy,
 	}).
@@ -289,7 +289,7 @@ func (h toCQLHelpers) zip(a []string, b []string) [][]string {
 	return m
 }
 
-func (h toCQLHelpers) escape(e interface{}) string {
+func (h toCQLHelpers) escape(e any) string {
 	switch v := e.(type) {
 	case int, float64:
 		return fmt.Sprint(v)
@@ -318,7 +318,7 @@ func (h toCQLHelpers) fixQuote(v string) string {
 }
 
 func (h toCQLHelpers) tableOptionsToCQL(ops TableMetadataOptions) ([]string, error) {
-	opts := map[string]interface{}{
+	opts := map[string]any{
 		"bloom_filter_fp_chance":      ops.BloomFilterFpChance,
 		"comment":                     ops.Comment,
 		"crc_check_chance":            ops.CrcCheckChance,
@@ -368,8 +368,8 @@ func (h toCQLHelpers) tableOptionsToCQL(ops TableMetadataOptions) ([]string, err
 	return out, nil
 }
 
-func (h toCQLHelpers) tableExtensionsToCQL(extensions map[string]interface{}) ([]string, error) {
-	exts := map[string]interface{}{}
+func (h toCQLHelpers) tableExtensionsToCQL(extensions map[string]any) ([]string, error) {
+	exts := map[string]any{}
 
 	if blob, ok := extensions["scylla_encryption_options"]; ok {
 		encOpts := &scyllaEncryptionOptions{}
@@ -395,7 +395,7 @@ func (h toCQLHelpers) tableExtensionsToCQL(extensions map[string]interface{}) ([
 }
 
 func (h toCQLHelpers) tablePropertiesToCQL(cks []*ColumnMetadata, opts TableMetadataOptions,
-	extensions map[string]interface{}) (string, error) {
+	extensions map[string]any) (string, error) {
 	var sb strings.Builder
 
 	var properties []string

--- a/ring_describer.go
+++ b/ring_describer.go
@@ -66,7 +66,7 @@ func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo, c ConnInterface)
 	return getPeersFromQuerySystemPeers(rows, r.cfg.Port, r.logger)
 }
 
-func getPeersFromQuerySystemPeers(querySystemPeerRows []map[string]interface{}, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
+func getPeersFromQuerySystemPeers(querySystemPeerRows []map[string]any, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
 	var peers []*HostInfo
 
 	for _, row := range querySystemPeerRows {

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -20,7 +20,7 @@ func TestGetClusterPeerInfoZeroToken(t *testing.T) {
 
 	schema_version1 := ParseUUIDMust("af810386-a694-11ef-81fa-3aea73156247")
 
-	peersRows := []map[string]interface{}{
+	peersRows := []map[string]any{
 		{
 			"data_center":     "datacenter1",
 			"host_id":         ParseUUIDMust("b2035fd9-e0ca-4857-8c45-e63c00fb7c43"),
@@ -259,10 +259,10 @@ var systemPeersResultMetadata = resultMetadata{
 	}},
 }
 
-func (*mockConnection) querySystem(ctx context.Context, query string, values ...interface{}) *Iter {
-	localData := []interface{}{"local", "COMPLETED", net.IPv4(192, 168, 100, 12), "", "3.3.1", "datacenter1", 1733834239, ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"), net.IPv4(192, 168, 100, 12), "4", "org.apache.cassandra.dht.Murmur3Partitioner", "rack1", "3.0.8", net.IPv4(192, 168, 100, 12), ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"), "", []string{}, map[UUID]byte{}}
-	peerData1 := []interface{}{net.IPv4(192, 168, 100, 13), "datacenter1", ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 13), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{"-1032311531684407545", "-1112089412567859825"}}
-	peerData2 := []interface{}{net.IPv4(192, 168, 100, 14), "datacenter1", ParseUUIDMust("8269e111-ea38-44bd-a73f-9d3d12cfaf78"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 14), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{}}
+func (*mockConnection) querySystem(ctx context.Context, query string, values ...any) *Iter {
+	localData := []any{"local", "COMPLETED", net.IPv4(192, 168, 100, 12), "", "3.3.1", "datacenter1", 1733834239, ParseUUIDMust("045859a7-6b9f-4efd-a5e7-acd64a295e13"), net.IPv4(192, 168, 100, 12), "4", "org.apache.cassandra.dht.Murmur3Partitioner", "rack1", "3.0.8", net.IPv4(192, 168, 100, 12), ParseUUIDMust("daf4df2c-b708-11ef-5c25-3004361afd71"), "", []string{}, map[UUID]byte{}}
+	peerData1 := []any{net.IPv4(192, 168, 100, 13), "datacenter1", ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 13), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{"-1032311531684407545", "-1112089412567859825"}}
+	peerData2 := []any{net.IPv4(192, 168, 100, 14), "datacenter1", ParseUUIDMust("8269e111-ea38-44bd-a73f-9d3d12cfaf78"), net.IP{}, "rack1", "3.0.8", net.IPv4(192, 168, 100, 14), ParseUUIDMust("b6ed5bde-b318-11ef-8f58-aeba19e31273"), "", []string{}}
 
 	if query == "SELECT * FROM system.local WHERE key='local'" {
 		return &Iter{
@@ -290,7 +290,7 @@ func (*mockConnection) getScyllaSupported() ScyllaConnectionFeatures {
 
 type mockControlConn struct{}
 
-func (m *mockControlConn) querySystem(statement string, values ...interface{}) (iter *Iter) {
+func (m *mockControlConn) querySystem(statement string, values ...any) (iter *Iter) {
 	return nil
 }
 
@@ -305,14 +305,14 @@ func (m *mockControlConn) getConn() *connHost {
 	}
 }
 
-func (m *mockControlConn) awaitSchemaAgreement() error                                { return nil }
-func (m *mockControlConn) query(statement string, values ...interface{}) (iter *Iter) { return nil }
-func (m *mockControlConn) discoverProtocol(hosts []*HostInfo) (int, error)            { return 0, nil }
-func (m *mockControlConn) connect(hosts []*HostInfo) error                            { return nil }
-func (m *mockControlConn) close()                                                     {}
-func (m *mockControlConn) getSession() *Session                                       { return nil }
+func (m *mockControlConn) awaitSchemaAgreement() error                        { return nil }
+func (m *mockControlConn) query(statement string, values ...any) (iter *Iter) { return nil }
+func (m *mockControlConn) discoverProtocol(hosts []*HostInfo) (int, error)    { return 0, nil }
+func (m *mockControlConn) connect(hosts []*HostInfo) error                    { return nil }
+func (m *mockControlConn) close()                                             {}
+func (m *mockControlConn) getSession() *Session                               { return nil }
 
-func marshalMetadataMust(metadata resultMetadata, data []interface{}) [][]byte {
+func marshalMetadataMust(metadata resultMetadata, data []any) [][]byte {
 	if len(metadata.columns) != len(data) {
 		panic("metadata length mismatch")
 	}
@@ -339,7 +339,7 @@ func (*trackingRingConnection) exec(context.Context, frameBuilder, Tracer, time.
 }
 func (*trackingRingConnection) awaitSchemaAgreement(context.Context) error { return nil }
 func (*trackingRingConnection) executeQuery(context.Context, *Query) *Iter { return nil }
-func (c *trackingRingConnection) querySystem(context.Context, string, ...interface{}) *Iter {
+func (c *trackingRingConnection) querySystem(context.Context, string, ...any) *Iter {
 	return c.iter
 }
 func (c *trackingRingConnection) getIsSchemaV2() bool { return c.schemaV2 }
@@ -366,7 +366,7 @@ func TestMockGetHostsFromSystem(t *testing.T) {
 func TestRingDescriberGetClusterPeerInfoClosesIter(t *testing.T) {
 	t.Parallel()
 
-	row := []interface{}{
+	row := []any{
 		net.IPv4(192, 168, 100, 13),
 		"datacenter1",
 		ParseUUIDMust("b953309f-6e68-41f2-baf5-0e60da317a9c"),

--- a/scyllacloud/hostdialer_test.go
+++ b/scyllacloud/hostdialer_test.go
@@ -340,7 +340,7 @@ func generateSerialNumber() (*big.Int, error) {
 	return serialNumber, nil
 }
 
-func generateSelfSignedX509Certificate(cn string, extKeyUsage []x509.ExtKeyUsage, dnsNames []string, pub, priv interface{}) (*x509.Certificate, error) {
+func generateSelfSignedX509Certificate(cn string, extKeyUsage []x509.ExtKeyUsage, dnsNames []string, pub, priv any) (*x509.Certificate, error) {
 	now := time.Now()
 
 	serialNumber, err := generateSerialNumber()

--- a/serialization/ascii/marshal.go
+++ b/serialization/ascii/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/ascii/unmarshal.go
+++ b/serialization/ascii/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/ascii/unmarshal_utils.go
+++ b/serialization/ascii/unmarshal_utils.go
@@ -14,7 +14,7 @@ func errInvalidData(p []byte) error {
 	return nil
 }
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal ascii: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/bigint/marshal.go
+++ b/serialization/bigint/marshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/bigint/unmarshal.go
+++ b/serialization/bigint/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/bigint/unmarshal_utils.go
+++ b/serialization/bigint/unmarshal_utils.go
@@ -10,7 +10,7 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal bigint: the length of the data should be 0 or 8")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal bigint: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/blob/marshal.go
+++ b/serialization/blob/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/blob/unmarshal.go
+++ b/serialization/blob/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil
@@ -17,7 +17,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		return DecBytes(data, v)
 	case **[]byte:
 		return DecBytesR(data, v)
-	case *interface{}:
+	case *any:
 		return DecInterface(data, v)
 	default:
 		// Custom types (type MyString string) can be deserialized only via `reflect` package.

--- a/serialization/blob/unmarshal_utils.go
+++ b/serialization/blob/unmarshal_utils.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal blob: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 
@@ -49,7 +49,7 @@ func DecBytesR(p []byte, v **[]byte) error {
 	return nil
 }
 
-func DecInterface(p []byte, v *interface{}) error {
+func DecInterface(p []byte, v *any) error {
 	if v == nil {
 		return errNilReference(v)
 	}

--- a/serialization/boolean/marshal.go
+++ b/serialization/boolean/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/boolean/unmarshal.go
+++ b/serialization/boolean/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/boolean/unmarshal_utils.go
+++ b/serialization/boolean/unmarshal_utils.go
@@ -7,7 +7,7 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal boolean: the length of the data should be 0 or 1")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal boolean: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/counter/marshal.go
+++ b/serialization/counter/marshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/counter/unmarshal.go
+++ b/serialization/counter/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/counter/unmarshal_utils.go
+++ b/serialization/counter/unmarshal_utils.go
@@ -10,7 +10,7 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal counter: the length of the data should be 0 or 8")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal counter: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/cqlint/marshal.go
+++ b/serialization/cqlint/marshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/cqlint/unmarshal.go
+++ b/serialization/cqlint/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/cqlint/unmarshal_utils.go
+++ b/serialization/cqlint/unmarshal_utils.go
@@ -15,7 +15,7 @@ const (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal int: the length of the data should be 0 or 4")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal int: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/cqltime/marshal.go
+++ b/serialization/cqltime/marshal.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/cqltime/unmarshal.go
+++ b/serialization/cqltime/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/cqltime/unmarshal_utils.go
+++ b/serialization/cqltime/unmarshal_utils.go
@@ -12,7 +12,7 @@ var (
 	errDataOutRangeDur   = fmt.Errorf("failed to unmarshal time: (time.Duration) the data should be in the range 0 to 86399999999999")
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal time: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/date/marshal.go
+++ b/serialization/date/marshal.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/date/marshal_utils.go
+++ b/serialization/date/marshal_utils.go
@@ -22,7 +22,7 @@ var (
 	minDate = time.Date(-5877641, 06, 23, 0, 0, 0, 0, time.UTC)
 )
 
-func errWrongStringFormat(v interface{}) error {
+func errWrongStringFormat(v any) error {
 	return fmt.Errorf(`failed to marshal date: the (%T)(%[1]v) should have fromat "2006-01-02"`, v)
 }
 

--- a/serialization/date/unmarshal.go
+++ b/serialization/date/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/date/unmarshal_utils.go
+++ b/serialization/date/unmarshal_utils.go
@@ -15,7 +15,7 @@ const (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal date: the length of the data should be 0 or 4")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal date: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/decimal/marshal.go
+++ b/serialization/decimal/marshal.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/inf.v0"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/decimal/unmarshal.go
+++ b/serialization/decimal/unmarshal.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/inf.v0"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/decimal/unmarshal_utils.go
+++ b/serialization/decimal/unmarshal_utils.go
@@ -19,7 +19,7 @@ func errBrokenData(p []byte) error {
 	return nil
 }
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal decimal: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/double/marshal.go
+++ b/serialization/double/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/double/unmarshal.go
+++ b/serialization/double/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/double/unmarshal_utils.go
+++ b/serialization/double/unmarshal_utils.go
@@ -8,7 +8,7 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal double: the length of the data should be 0 or 8")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal double: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/duration/marshal.go
+++ b/serialization/duration/marshal.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/duration/unmarshal.go
+++ b/serialization/duration/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/duration/unmarshal_utils.go
+++ b/serialization/duration/unmarshal_utils.go
@@ -21,7 +21,7 @@ var (
 	errInvalidSign  = fmt.Errorf("failed to unmarshal duration: the data values of months, days and nanoseconds should have the same sign")
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal duration: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/float/marshal.go
+++ b/serialization/float/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/float/unmarshal.go
+++ b/serialization/float/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/float/unmarshal_utils.go
+++ b/serialization/float/unmarshal_utils.go
@@ -8,7 +8,7 @@ import (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal float: the length of the data should be 0 or 4")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal float: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/inet/marshal.go
+++ b/serialization/inet/marshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/inet/unmarshal.go
+++ b/serialization/inet/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/inet/unmarshal_utils.go
+++ b/serialization/inet/unmarshal_utils.go
@@ -14,7 +14,7 @@ var (
 	digits = getDigits()
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal inet: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/smallint/marshal.go
+++ b/serialization/smallint/marshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/smallint/unmarshal.go
+++ b/serialization/smallint/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/smallint/unmarshal_utils.go
+++ b/serialization/smallint/unmarshal_utils.go
@@ -16,7 +16,7 @@ const (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal smallint: the length of the data should be 0 or 2")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal smallint: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/text/marshal.go
+++ b/serialization/text/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/text/unmarshal.go
+++ b/serialization/text/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil
@@ -17,7 +17,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		return DecBytes(data, v)
 	case **[]byte:
 		return DecBytesR(data, v)
-	case *interface{}:
+	case *any:
 		return DecInterface(data, v)
 	default:
 		// Custom types (type MyString string) can be deserialized only via `reflect` package.

--- a/serialization/text/unmarshal_utils.go
+++ b/serialization/text/unmarshal_utils.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal text: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 
@@ -49,7 +49,7 @@ func DecBytesR(p []byte, v **[]byte) error {
 	return nil
 }
 
-func DecInterface(p []byte, v *interface{}) error {
+func DecInterface(p []byte, v *any) error {
 	if v == nil {
 		return errNilReference(v)
 	}

--- a/serialization/timestamp/marshal.go
+++ b/serialization/timestamp/marshal.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/timestamp/unmarshal.go
+++ b/serialization/timestamp/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/timestamp/unmarshal_utils.go
+++ b/serialization/timestamp/unmarshal_utils.go
@@ -10,7 +10,7 @@ var (
 	errWrongDataLen = fmt.Errorf("failed to unmarshal timestamp: the length of the data should be 0 or 8")
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal timestamp: can not unmarshal into nil reference (%T)(%[1]v))", v)
 }
 

--- a/serialization/timeuuid/marshal.go
+++ b/serialization/timeuuid/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/timeuuid/unmarshal.go
+++ b/serialization/timeuuid/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/timeuuid/unmarshal_utils.go
+++ b/serialization/timeuuid/unmarshal_utils.go
@@ -18,7 +18,7 @@ var (
 	errWrongDataLen = fmt.Errorf("failed to unmarshal timeuuid: the length of the data should be 0 or 16")
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal timeuuid: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/tinyint/marshal.go
+++ b/serialization/tinyint/marshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/tinyint/unmarshal.go
+++ b/serialization/tinyint/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/tinyint/unmarshal_utils.go
+++ b/serialization/tinyint/unmarshal_utils.go
@@ -17,7 +17,7 @@ const (
 
 var errWrongDataLen = fmt.Errorf("failed to unmarshal tinyint: the length of the data should less or equal then 1")
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal tinyint: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/uuid/marshal.go
+++ b/serialization/uuid/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/uuid/unmarshal.go
+++ b/serialization/uuid/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/uuid/unmarshal_utils.go
+++ b/serialization/uuid/unmarshal_utils.go
@@ -12,7 +12,7 @@ var (
 	errWrongDataLen = fmt.Errorf("failed to unmarshal uuid: the length of the data should be 0 or 16")
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal uuid: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 

--- a/serialization/varchar/marshal.go
+++ b/serialization/varchar/marshal.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/varchar/unmarshal.go
+++ b/serialization/varchar/unmarshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil
@@ -17,7 +17,7 @@ func Unmarshal(data []byte, value interface{}) error {
 		return DecBytes(data, v)
 	case **[]byte:
 		return DecBytesR(data, v)
-	case *interface{}:
+	case *any:
 		return DecInterface(data, v)
 	default:
 		// Custom types (type MyString string) can be deserialized only via `reflect` package.

--- a/serialization/varchar/unmarshal_utils.go
+++ b/serialization/varchar/unmarshal_utils.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal varchar: can not unmarshal into nil reference(%T)(%[1]v)", v)
 }
 
@@ -49,7 +49,7 @@ func DecBytesR(p []byte, v **[]byte) error {
 	return nil
 }
 
-func DecInterface(p []byte, v *interface{}) error {
+func DecInterface(p []byte, v *any) error {
 	if v == nil {
 		return errNilReference(v)
 	}

--- a/serialization/varint/marshal.go
+++ b/serialization/varint/marshal.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-func Marshal(value interface{}) ([]byte, error) {
+func Marshal(value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
 		return nil, nil

--- a/serialization/varint/unmarshal.go
+++ b/serialization/varint/unmarshal.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, value interface{}) error {
+func Unmarshal(data []byte, value any) error {
 	switch v := value.(type) {
 	case nil:
 		return nil

--- a/serialization/varint/unmarshal_utils.go
+++ b/serialization/varint/unmarshal_utils.go
@@ -13,7 +13,7 @@ func errBrokenData(p []byte) error {
 	return nil
 }
 
-func errNilReference(v interface{}) error {
+func errNilReference(v any) error {
 	return fmt.Errorf("failed to unmarshal varint: can not unmarshal into nil reference %#v)", v)
 }
 

--- a/session.go
+++ b/session.go
@@ -99,7 +99,7 @@ type Session struct {
 }
 
 var queryPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &Query{
 			routingInfo: &queryRoutingInfo{},
 			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
@@ -544,7 +544,7 @@ func (s *Session) SetTrace(trace Tracer) {
 }
 
 // QueryWithContext same as Query, but adds context to it.
-func (s *Session) QueryWithContext(ctx context.Context, stmt string, values ...interface{}) *Query {
+func (s *Session) QueryWithContext(ctx context.Context, stmt string, values ...any) *Query {
 	q := s.Query(stmt, values...)
 	q.context = ctx
 	return q
@@ -554,7 +554,7 @@ func (s *Session) QueryWithContext(ctx context.Context, stmt string, values ...i
 // Further details of the query may be tweaked using the resulting query
 // value before the query is executed. Query is automatically prepared
 // if it has not previously been executed.
-func (s *Session) Query(stmt string, values ...interface{}) *Query {
+func (s *Session) Query(stmt string, values ...any) *Query {
 	qry := queryPool.Get().(*Query)
 	qry.session = s
 	qry.stmt = stmt
@@ -577,7 +577,7 @@ type QueryInfo struct {
 // values will be marshalled as part of the query execution.
 // During execution, the meta data of the prepared query will be routed to the
 // binding callback, which is responsible for producing the query argument values.
-func (s *Session) Bind(stmt string, b func(q *QueryInfo) ([]interface{}, error)) *Query {
+func (s *Session) Bind(stmt string, b func(q *QueryInfo) ([]any, error)) *Query {
 	qry := queryPool.Get().(*Query)
 	qry.session = s
 	qry.stmt = stmt
@@ -1005,7 +1005,7 @@ func (s *Session) ExecuteBatch(batch *Batch) error {
 // was sent.
 // Further scans on the interator must also remember to include
 // the applied boolean as the first argument to *Iter.Scan
-func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bool, iter *Iter, err error) {
+func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...any) (applied bool, iter *Iter, err error) {
 	iter = s.executeBatch(batch)
 	if err := iter.checkErrAndNotFound(); err != nil {
 		iter.Close()
@@ -1013,7 +1013,7 @@ func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bo
 	}
 
 	if len(iter.Columns()) > 1 {
-		dest = append([]interface{}{&applied}, dest...)
+		dest = append([]any{&applied}, dest...)
 		iter.Scan(dest...)
 	} else {
 		iter.Scan(&applied)
@@ -1025,7 +1025,7 @@ func (s *Session) ExecuteBatchCAS(batch *Batch, dest ...interface{}) (applied bo
 // MapExecuteBatchCAS executes a batch operation much like ExecuteBatchCAS,
 // however it accepts a map rather than a list of arguments for the initial
 // scan.
-func (s *Session) MapExecuteBatchCAS(batch *Batch, dest map[string]interface{}) (applied bool, iter *Iter, err error) {
+func (s *Session) MapExecuteBatchCAS(batch *Batch, dest map[string]any) (applied bool, iter *Iter, err error) {
 	iter = s.executeBatch(batch)
 	if err := iter.checkErrAndNotFound(); err != nil {
 		iter.Close()
@@ -1210,13 +1210,13 @@ type Query struct {
 	getKeyspace func() string
 	// routingInfo is a pointer because Query can be copied and copyable struct can't hold a mutex.
 	routingInfo *queryRoutingInfo
-	binding     func(q *QueryInfo) ([]interface{}, error)
+	binding     func(q *QueryInfo) ([]any, error)
 	// hostID specifies the host on which the query should be executed.
 	// If it is empty, then the host is picked by HostSelectionPolicy
 	hostID     string
 	stmt       string
 	routingKey []byte
-	values     []interface{}
+	values     []any
 	pageState  []byte
 	// requestTimeout is a timeout on waiting for response from server
 	requestTimeout             time.Duration
@@ -1294,7 +1294,7 @@ func (q Query) Statement() string {
 
 // Values returns the values passed in via Bind.
 // This can be used by a wrapper type that needs to access the bound values.
-func (q Query) Values() []interface{} {
+func (q Query) Values() []any {
 	return q.values
 }
 
@@ -1651,7 +1651,7 @@ func (q *Query) Idempotent(value bool) *Query {
 
 // Bind sets query arguments of query. This can also be used to rebind new query arguments
 // to an existing query instance.
-func (q *Query) Bind(v ...interface{}) *Query {
+func (q *Query) Bind(v ...any) *Query {
 	q.values = v
 	q.pageState = nil
 	return q
@@ -1773,7 +1773,7 @@ func (q *Query) executeQuery() *Iter {
 // MapScan executes the query, copies the columns of the first selected
 // row into the map pointed at by m and discards the rest. If no rows
 // were selected, ErrNotFound is returned.
-func (q *Query) MapScan(m map[string]interface{}) error {
+func (q *Query) MapScan(m map[string]any) error {
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
 		iter.Close()
@@ -1786,7 +1786,7 @@ func (q *Query) MapScan(m map[string]interface{}) error {
 // Scan executes the query, copies the columns of the first selected
 // row into the values pointed at by dest and discards the rest. If no rows
 // were selected, ErrNotFound is returned.
-func (q *Query) Scan(dest ...interface{}) error {
+func (q *Query) Scan(dest ...any) error {
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
 		iter.Close()
@@ -1804,7 +1804,7 @@ func (q *Query) Scan(dest ...interface{}) error {
 // As for INSERT .. IF NOT EXISTS, previous values will be returned as if
 // SELECT * FROM. So using ScanCAS with INSERT is inherently prone to
 // column mismatching. Use MapScanCAS to capture them safely.
-func (q *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
+func (q *Query) ScanCAS(dest ...any) (applied bool, err error) {
 	q.disableSkipMetadata = true
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
@@ -1812,7 +1812,7 @@ func (q *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 		return false, err
 	}
 	if len(iter.Columns()) > 1 {
-		dest = append([]interface{}{&applied}, dest...)
+		dest = append([]any{&applied}, dest...)
 		iter.Scan(dest...)
 	} else {
 		iter.Scan(&applied)
@@ -1828,7 +1828,7 @@ func (q *Query) ScanCAS(dest ...interface{}) (applied bool, err error) {
 // As for INSERT .. IF NOT EXISTS, previous values will be returned as if
 // SELECT * FROM. So using ScanCAS with INSERT is inherently prone to
 // column mismatching. MapScanCAS is added to capture them safely.
-func (q *Query) MapScanCAS(dest map[string]interface{}) (applied bool, err error) {
+func (q *Query) MapScanCAS(dest map[string]any) (applied bool, err error) {
 	q.disableSkipMetadata = true
 	iter := q.Iter()
 	if err := iter.checkErrAndNotFound(); err != nil {
@@ -2122,7 +2122,7 @@ type Scanner interface {
 	// when unmarshalling a column into the value in dest an error is returned and the row is invalidated
 	// until the next call to Next.
 	// Next must be called before calling Scan, if it is not an error is returned.
-	Scan(...interface{}) error
+	Scan(...any) error
 
 	// Err returns the if there was one during iteration that resulted in iteration being unable to complete.
 	// Err will also release resources held by the iterator, the Scanner should not used after being called.
@@ -2164,7 +2164,7 @@ func (is *iterScanner) Next() bool {
 	return true
 }
 
-func scanColumn(p []byte, col ColumnInfo, dest []interface{}) (int, error) {
+func scanColumn(p []byte, col ColumnInfo, dest []any) (int, error) {
 	if dest[0] == nil {
 		return 1, nil
 	}
@@ -2188,7 +2188,7 @@ func scanColumn(p []byte, col ColumnInfo, dest []interface{}) (int, error) {
 	}
 }
 
-func (is *iterScanner) Scan(dest ...interface{}) error {
+func (is *iterScanner) Scan(dest ...any) error {
 	if !is.valid {
 		return errors.New("gocql: Scan called without calling Next")
 	}
@@ -2253,7 +2253,7 @@ func (iter *Iter) readColumn() ([]byte, error) {
 // Scan returns true if the row was successfully unmarshaled or false if the
 // end of the result set was reached or if an error occurred. Close should
 // be called afterwards to retrieve any potential errors.
-func (iter *Iter) Scan(dest ...interface{}) bool {
+func (iter *Iter) Scan(dest ...any) bool {
 	if iter.err != nil {
 		iter.finalize(true)
 		return false
@@ -2634,7 +2634,7 @@ func (b *Batch) SpeculativeExecutionPolicy(sp SpeculativeExecutionPolicy) *Batch
 }
 
 // Query adds the query to the batch operation
-func (b *Batch) Query(stmt string, args ...interface{}) *Batch {
+func (b *Batch) Query(stmt string, args ...any) *Batch {
 	b.Entries = append(b.Entries, BatchEntry{Stmt: stmt, Args: args})
 	return b
 }
@@ -2642,7 +2642,7 @@ func (b *Batch) Query(stmt string, args ...interface{}) *Batch {
 // Bind adds the query to the batch operation and correlates it with a binding callback
 // that will be invoked when the batch is executed. The binding callback allows the application
 // to define which query argument values will be marshalled as part of the batch execution.
-func (b *Batch) Bind(stmt string, bind func(q *QueryInfo) ([]interface{}, error)) {
+func (b *Batch) Bind(stmt string, bind func(q *QueryInfo) ([]any, error)) {
 	b.Entries = append(b.Entries, BatchEntry{Stmt: stmt, binding: bind})
 }
 
@@ -2729,7 +2729,7 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 	}
 
 	statements := make([]string, len(b.Entries))
-	values := make([][]interface{}, len(b.Entries))
+	values := make([][]any, len(b.Entries))
 
 	for i, entry := range b.Entries {
 		statements[i] = entry.Stmt
@@ -2792,7 +2792,7 @@ func (b *Batch) SetRequestTimeout(timeout time.Duration) *Batch {
 	return b
 }
 
-func createRoutingKey(routingKeyInfo *routingKeyInfo, values []interface{}) ([]byte, error) {
+func createRoutingKey(routingKeyInfo *routingKeyInfo, values []any) ([]byte, error) {
 	if routingKeyInfo == nil {
 		return nil, nil
 	}
@@ -2868,9 +2868,9 @@ const (
 )
 
 type BatchEntry struct {
-	binding    func(q *QueryInfo) ([]interface{}, error)
+	binding    func(q *QueryInfo) ([]any, error)
 	Stmt       string
-	Args       []interface{}
+	Args       []any
 	Idempotent bool
 }
 
@@ -2923,7 +2923,7 @@ func (r *routingKeyInfoLRU) Max(max int) {
 
 type inflightCachedEntry struct {
 	err   error
-	value interface{}
+	value any
 	wg    sync.WaitGroup
 }
 
@@ -2990,7 +2990,7 @@ type ObservedQuery struct {
 	Statement string
 	// Values holds a slice of bound values for the query.
 	// Do not modify the values here, they are shared with multiple goroutines.
-	Values []interface{}
+	Values []any
 	// Rows is the number of rows in the current iter.
 	// In paginated queries, rows from previous scans are not counted.
 	// Rows is not used in batch queries and remains at the default value
@@ -3025,7 +3025,7 @@ type ObservedBatch struct {
 	// Values holds a slice of bound values for each statement.
 	// Values[i] are bound values passed to Statements[i].
 	// Do not modify the values here, they are shared with multiple goroutines.
-	Values [][]interface{}
+	Values [][]any
 	// Attempt is the index of attempt at executing this query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
@@ -3085,7 +3085,7 @@ var (
 
 type ErrProtocol struct{ error }
 
-func NewErrProtocol(format string, args ...interface{}) error {
+func NewErrProtocol(format string, args ...any) error {
 	return ErrProtocol{error: fmt.Errorf(format, args...)}
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -87,7 +87,7 @@ func TestSessionAPI(t *testing.T) {
 		t.Fatalf("expected qry.stmt to be 'test', got '%v'", qry.stmt)
 	}
 
-	boundQry := s.Bind("test", func(q *QueryInfo) ([]interface{}, error) {
+	boundQry := s.Bind("test", func(q *QueryInfo) ([]any, error) {
 		return nil, nil
 	})
 	if boundQry.binding == nil {
@@ -294,7 +294,7 @@ func TestBatchBasicAPI(t *testing.T) {
 		t.Fatalf("expected batch.Entries[0].Args[0] to be 1, got %v", b.Entries[0].Args[0])
 	}
 
-	b.Bind("test2", func(q *QueryInfo) ([]interface{}, error) {
+	b.Bind("test2", func(q *QueryInfo) ([]any, error) {
 		return nil, nil
 	})
 

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -526,9 +526,9 @@ func (*pagingTestConn) awaitSchemaAgreement(context.Context) error { return nil 
 func (c *pagingTestConn) executeQuery(ctx context.Context, qry *Query) *Iter {
 	return c.executeQueryFunc(ctx, qry)
 }
-func (*pagingTestConn) querySystem(context.Context, string, ...interface{}) *Iter { return nil }
-func (*pagingTestConn) getIsSchemaV2() bool                                       { return false }
-func (*pagingTestConn) setSchemaV2(bool)                                          {}
+func (*pagingTestConn) querySystem(context.Context, string, ...any) *Iter { return nil }
+func (*pagingTestConn) getIsSchemaV2() bool                               { return false }
+func (*pagingTestConn) setSchemaV2(bool)                                  {}
 func (*pagingTestConn) getScyllaSupported() ScyllaConnectionFeatures {
 	return ScyllaConnectionFeatures{}
 }

--- a/tablets/cow_tablet_list_test.go
+++ b/tablets/cow_tablet_list_test.go
@@ -1580,7 +1580,7 @@ func TestCowTabletListEdgeCases(t *testing.T) {
 			TableName:    "tb",
 			FirstToken:   100,
 			LastToken:    -100,
-			Replicas:     [][]interface{}{{hostID.String(), 0}},
+			Replicas:     [][]any{{hostID.String(), 0}},
 		}
 		_, err := builder.Build()
 		if err == nil {

--- a/tablets/tablets.go
+++ b/tablets/tablets.go
@@ -89,7 +89,7 @@ func (r ReplicaInfo) String() string {
 type TabletInfoBuilder struct {
 	KeyspaceName string
 	TableName    string
-	Replicas     [][]interface{}
+	Replicas     [][]any
 	FirstToken   int64
 	LastToken    int64
 }

--- a/tests/serialization/marshal_10_decimal_corrupt_test.go
+++ b/tests/serialization/marshal_10_decimal_corrupt_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestMarshalDecimalCorrupt(t *testing.T) {
 	type testSuite struct {
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 		name      string
 	}
 
@@ -28,10 +28,10 @@ func TestMarshalDecimalCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_10_decimal_test.go
+++ b/tests/serialization/marshal_10_decimal_test.go
@@ -24,8 +24,8 @@ func TestMarshalDecimal(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -36,10 +36,10 @@ func TestMarshalDecimal(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_11_texts_test.go
+++ b/tests/serialization/marshal_11_texts_test.go
@@ -19,8 +19,8 @@ func TestMarshalTexts(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := []testSuite{
@@ -41,28 +41,28 @@ func TestMarshalTexts(t *testing.T) {
 		},
 		{
 			name: "glob.varchar",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(gocql.NewNativeType(4, gocql.TypeVarchar), i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(gocql.NewNativeType(4, gocql.TypeVarchar), bytes, i)
 			},
 		},
 		{
 			name: "glob.text",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(gocql.NewNativeType(4, gocql.TypeText), i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(gocql.NewNativeType(4, gocql.TypeText), bytes, i)
 			},
 		},
 		{
 			name: "glob.blob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(gocql.NewNativeType(4, gocql.TypeBlob), i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(gocql.NewNativeType(4, gocql.TypeBlob), bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_12_ascii_corrupt_test.go
+++ b/tests/serialization/marshal_12_ascii_corrupt_test.go
@@ -19,8 +19,8 @@ func TestMarshalAsciiMustFail(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -31,10 +31,10 @@ func TestMarshalAsciiMustFail(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_12_ascii_test.go
+++ b/tests/serialization/marshal_12_ascii_test.go
@@ -17,8 +17,8 @@ func TestMarshalAscii(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -29,10 +29,10 @@ func TestMarshalAscii(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_13_uuids_corrupt_test.go
+++ b/tests/serialization/marshal_13_uuids_corrupt_test.go
@@ -23,8 +23,8 @@ func TestMarshalUUIDsMustFail(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [4]testSuite{
@@ -35,10 +35,10 @@ func TestMarshalUUIDsMustFail(t *testing.T) {
 		},
 		{
 			name: "glob.uuid",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tTypes[0], i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tTypes[0], bytes, i)
 			},
 		},
@@ -49,8 +49,8 @@ func TestMarshalUUIDsMustFail(t *testing.T) {
 		},
 		{
 			name:      "glob.timeuuid",
-			marshal:   func(i interface{}) ([]byte, error) { return gocql.Marshal(tTypes[1], i) },
-			unmarshal: func(bytes []byte, i interface{}) error { return gocql.Unmarshal(tTypes[1], bytes, i) },
+			marshal:   func(i any) ([]byte, error) { return gocql.Marshal(tTypes[1], i) },
+			unmarshal: func(bytes []byte, i any) error { return gocql.Unmarshal(tTypes[1], bytes, i) },
 		},
 	}
 

--- a/tests/serialization/marshal_13_uuids_test.go
+++ b/tests/serialization/marshal_13_uuids_test.go
@@ -23,8 +23,8 @@ func TestMarshalUUIDs(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [4]testSuite{
@@ -35,10 +35,10 @@ func TestMarshalUUIDs(t *testing.T) {
 		},
 		{
 			name: "glob.uuid",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tTypes[0], i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tTypes[0], bytes, i)
 			},
 		},
@@ -49,8 +49,8 @@ func TestMarshalUUIDs(t *testing.T) {
 		},
 		{
 			name:      "glob.timeuuid",
-			marshal:   func(i interface{}) ([]byte, error) { return gocql.Marshal(tTypes[1], i) },
-			unmarshal: func(bytes []byte, i interface{}) error { return gocql.Unmarshal(tTypes[1], bytes, i) },
+			marshal:   func(i any) ([]byte, error) { return gocql.Marshal(tTypes[1], i) },
+			unmarshal: func(bytes []byte, i any) error { return gocql.Unmarshal(tTypes[1], bytes, i) },
 		},
 	}
 
@@ -128,8 +128,8 @@ func TestMarshalTimeUUID(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [4]testSuite{
@@ -140,8 +140,8 @@ func TestMarshalTimeUUID(t *testing.T) {
 		},
 		{
 			name:      "glob.timeuuid",
-			marshal:   func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) },
-			unmarshal: func(bytes []byte, i interface{}) error { return gocql.Unmarshal(tType, bytes, i) },
+			marshal:   func(i any) ([]byte, error) { return gocql.Marshal(tType, i) },
+			unmarshal: func(bytes []byte, i any) error { return gocql.Unmarshal(tType, bytes, i) },
 		},
 	}
 

--- a/tests/serialization/marshal_14_inet_corrupt_test.go
+++ b/tests/serialization/marshal_14_inet_corrupt_test.go
@@ -20,8 +20,8 @@ func TestMarshalsInetMustFail(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -32,10 +32,10 @@ func TestMarshalsInetMustFail(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_14_inet_test.go
+++ b/tests/serialization/marshal_14_inet_test.go
@@ -20,8 +20,8 @@ func TestMarshalsInet(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -32,10 +32,10 @@ func TestMarshalsInet(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_15_time_corrupt_test.go
+++ b/tests/serialization/marshal_15_time_corrupt_test.go
@@ -21,8 +21,8 @@ func TestMarshalTimeCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -33,10 +33,10 @@ func TestMarshalTimeCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_15_time_test.go
+++ b/tests/serialization/marshal_15_time_test.go
@@ -20,8 +20,8 @@ func TestMarshalsTime(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -32,10 +32,10 @@ func TestMarshalsTime(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_16_timestamp_corrupt_test.go
+++ b/tests/serialization/marshal_16_timestamp_corrupt_test.go
@@ -20,8 +20,8 @@ func TestMarshalTimestampCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -32,10 +32,10 @@ func TestMarshalTimestampCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_16_timestamp_test.go
+++ b/tests/serialization/marshal_16_timestamp_test.go
@@ -21,8 +21,8 @@ func TestMarshalsTimestamp(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -33,10 +33,10 @@ func TestMarshalsTimestamp(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_17_date_corrupt_test.go
+++ b/tests/serialization/marshal_17_date_corrupt_test.go
@@ -20,8 +20,8 @@ func TestMarshalDateCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -32,10 +32,10 @@ func TestMarshalDateCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_17_date_test.go
+++ b/tests/serialization/marshal_17_date_test.go
@@ -21,8 +21,8 @@ func TestMarshalsDate(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -33,10 +33,10 @@ func TestMarshalsDate(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_18_duration_corrupt_test.go
+++ b/tests/serialization/marshal_18_duration_corrupt_test.go
@@ -17,8 +17,8 @@ func TestMarshalDurationCorrupt(t *testing.T) {
 
 	tType := gocql.NewNativeType(4, gocql.TypeDuration)
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
+	marshal := func(i any) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i any) error {
 		return gocql.Unmarshal(tType, bytes, i)
 	}
 

--- a/tests/serialization/marshal_18_duration_test.go
+++ b/tests/serialization/marshal_18_duration_test.go
@@ -18,8 +18,8 @@ func TestMarshalsDuration(t *testing.T) {
 
 	const nanoDay = 24 * 60 * 60 * 1000 * 1000 * 1000
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error { return gocql.Unmarshal(tType, bytes, i) }
+	marshal := func(i any) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i any) error { return gocql.Unmarshal(tType, bytes, i) }
 
 	serialization.PositiveSet{
 		Data: nil,

--- a/tests/serialization/marshal_19_list_set_v3_corrupt_test.go
+++ b/tests/serialization/marshal_19_list_set_v3_corrupt_test.go
@@ -38,8 +38,8 @@ func TestMarshalSetListV3Corrupt(t *testing.T) {
 	refModInt32 := func(v mod.Int32) *mod.Int32 { return &v }
 
 	for _, tType := range tTypes {
-		marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-		unmarshal := func(bytes []byte, i interface{}) error {
+		marshal := func(i any) ([]byte, error) { return gocql.Marshal(tType, i) }
+		unmarshal := func(bytes []byte, i any) error {
 			return gocql.Unmarshal(tType, bytes, i)
 		}
 

--- a/tests/serialization/marshal_19_list_set_v3_test.go
+++ b/tests/serialization/marshal_19_list_set_v3_test.go
@@ -35,8 +35,8 @@ func TestMarshalSetListV3(t *testing.T) {
 	refModInt16 := func(v mod.Int16) *mod.Int16 { return &v }
 
 	for _, tType := range tTypes {
-		marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-		unmarshal := func(bytes []byte, i interface{}) error {
+		marshal := func(i any) ([]byte, error) { return gocql.Marshal(tType, i) }
+		unmarshal := func(bytes []byte, i any) error {
 			return gocql.Unmarshal(tType, bytes, i)
 		}
 

--- a/tests/serialization/marshal_1_boolean_corrupt_test.go
+++ b/tests/serialization/marshal_1_boolean_corrupt_test.go
@@ -20,8 +20,8 @@ func TestMarshalBooleanCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -32,10 +32,10 @@ func TestMarshalBooleanCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_1_boolean_test.go
+++ b/tests/serialization/marshal_1_boolean_test.go
@@ -19,8 +19,8 @@ func TestMarshalBoolean(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	testSuites := [2]testSuite{
@@ -31,10 +31,10 @@ func TestMarshalBoolean(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_20_map_v3_corrupt_test.go
+++ b/tests/serialization/marshal_20_map_v3_corrupt_test.go
@@ -27,8 +27,8 @@ func TestMarshalMapV3Corrupt(t *testing.T) {
 	refInt32 := func(v int32) *int32 { return &v }
 	refModInt32 := func(v mod.Int32) *mod.Int32 { return &v }
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
+	marshal := func(i any) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i any) error {
 		return gocql.Unmarshal(tType, bytes, i)
 	}
 

--- a/tests/serialization/marshal_20_map_v3_test.go
+++ b/tests/serialization/marshal_20_map_v3_test.go
@@ -20,8 +20,8 @@ func TestMarshalMapV3(t *testing.T) {
 	refInt16 := func(v int16) *int16 { return &v }
 	refModInt16 := func(v mod.Int16) *mod.Int16 { return &v }
 
-	marshal := func(i interface{}) ([]byte, error) { return gocql.Marshal(tType, i) }
-	unmarshal := func(bytes []byte, i interface{}) error {
+	marshal := func(i any) ([]byte, error) { return gocql.Marshal(tType, i) }
+	unmarshal := func(bytes []byte, i any) error {
 		return gocql.Unmarshal(tType, bytes, i)
 	}
 

--- a/tests/serialization/marshal_2_tinyint_corrupt_test.go
+++ b/tests/serialization/marshal_2_tinyint_corrupt_test.go
@@ -18,8 +18,8 @@ func TestMarshalTinyintCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeTinyInt)
@@ -32,10 +32,10 @@ func TestMarshalTinyintCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_2_tinyint_test.go
+++ b/tests/serialization/marshal_2_tinyint_test.go
@@ -18,8 +18,8 @@ func TestMarshalTinyint(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeTinyInt)
@@ -32,10 +32,10 @@ func TestMarshalTinyint(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_3_smallint_corrupt_test.go
+++ b/tests/serialization/marshal_3_smallint_corrupt_test.go
@@ -18,8 +18,8 @@ func TestMarshalSmallintCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeSmallInt)
@@ -32,10 +32,10 @@ func TestMarshalSmallintCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_3_smallint_test.go
+++ b/tests/serialization/marshal_3_smallint_test.go
@@ -18,8 +18,8 @@ func TestMarshalSmallint(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeSmallInt)
@@ -32,10 +32,10 @@ func TestMarshalSmallint(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_4_int_corrupt_test.go
+++ b/tests/serialization/marshal_4_int_corrupt_test.go
@@ -18,8 +18,8 @@ func TestMarshalIntCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeInt)
@@ -32,10 +32,10 @@ func TestMarshalIntCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_4_int_test.go
+++ b/tests/serialization/marshal_4_int_test.go
@@ -18,8 +18,8 @@ func TestMarshalInt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeInt)
@@ -32,10 +32,10 @@ func TestMarshalInt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_5_bigint_corrupt_test.go
+++ b/tests/serialization/marshal_5_bigint_corrupt_test.go
@@ -18,8 +18,8 @@ func TestMarshalBigIntCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeBigInt)
@@ -32,10 +32,10 @@ func TestMarshalBigIntCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_5_bigint_test.go
+++ b/tests/serialization/marshal_5_bigint_test.go
@@ -18,8 +18,8 @@ func TestMarshalBigInt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 	tType := gocql.NewNativeType(4, gocql.TypeBigInt)
 
@@ -31,10 +31,10 @@ func TestMarshalBigInt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_6_counter_corrupt_test.go
+++ b/tests/serialization/marshal_6_counter_corrupt_test.go
@@ -18,8 +18,8 @@ func TestMarshalCounterCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeCounter)
@@ -32,10 +32,10 @@ func TestMarshalCounterCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_6_counter_test.go
+++ b/tests/serialization/marshal_6_counter_test.go
@@ -18,8 +18,8 @@ func TestMarshalCounter(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 	tType := gocql.NewNativeType(4, gocql.TypeCounter)
 
@@ -31,10 +31,10 @@ func TestMarshalCounter(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_7_varint_corrupt_test.go
+++ b/tests/serialization/marshal_7_varint_corrupt_test.go
@@ -14,8 +14,8 @@ func TestMarshalVarIntCorrupt(t *testing.T) {
 	t.Parallel()
 
 	type testSuite struct {
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 		name      string
 	}
 
@@ -29,10 +29,10 @@ func TestMarshalVarIntCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_7_varint_test.go
+++ b/tests/serialization/marshal_7_varint_test.go
@@ -18,8 +18,8 @@ func TestMarshalVarIntNew(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeVarint)
@@ -32,10 +32,10 @@ func TestMarshalVarIntNew(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_8_float_corrupt_test.go
+++ b/tests/serialization/marshal_8_float_corrupt_test.go
@@ -17,8 +17,8 @@ func TestMarshalFloatCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeFloat)
@@ -31,10 +31,10 @@ func TestMarshalFloatCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_8_float_test.go
+++ b/tests/serialization/marshal_8_float_test.go
@@ -18,8 +18,8 @@ func TestMarshalFloat(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeFloat)
@@ -32,10 +32,10 @@ func TestMarshalFloat(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_9_double_corrupt_test.go
+++ b/tests/serialization/marshal_9_double_corrupt_test.go
@@ -17,8 +17,8 @@ func TestMarshalDoubleCorrupt(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeDouble)
@@ -31,10 +31,10 @@ func TestMarshalDoubleCorrupt(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/tests/serialization/marshal_9_duble_test.go
+++ b/tests/serialization/marshal_9_duble_test.go
@@ -18,8 +18,8 @@ func TestMarshalDouble(t *testing.T) {
 
 	type testSuite struct {
 		name      string
-		marshal   func(interface{}) ([]byte, error)
-		unmarshal func(bytes []byte, i interface{}) error
+		marshal   func(any) ([]byte, error)
+		unmarshal func(bytes []byte, i any) error
 	}
 
 	tType := gocql.NewNativeType(4, gocql.TypeDouble)
@@ -32,10 +32,10 @@ func TestMarshalDouble(t *testing.T) {
 		},
 		{
 			name: "glob",
-			marshal: func(i interface{}) ([]byte, error) {
+			marshal: func(i any) ([]byte, error) {
 				return gocql.Marshal(tType, i)
 			},
-			unmarshal: func(bytes []byte, i interface{}) error {
+			unmarshal: func(bytes []byte, i any) error {
 				return gocql.Unmarshal(tType, bytes, i)
 			},
 		},

--- a/topology.go
+++ b/topology.go
@@ -70,7 +70,7 @@ type placementStrategy interface {
 	replicationFactor(dc string) int
 }
 
-func getReplicationFactorFromOpts(val interface{}) (int, error) {
+func getReplicationFactorFromOpts(val any) (int, error) {
 	switch v := val.(type) {
 	case int:
 		if v < 0 {

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -192,7 +192,7 @@ func TestTupleMapScan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	err = session.Query(fmt.Sprintf(`SELECT * FROM %s`, table)).MapScan(m)
 	if err != nil {
 		t.Fatal(err)
@@ -225,7 +225,7 @@ func TestTupleMapScanNil(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	err = session.Query(fmt.Sprintf(`SELECT * FROM %s`, table)).MapScan(m)
 	if err != nil {
 		t.Fatal(err)
@@ -258,7 +258,7 @@ func TestTupleMapScanNotSet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	err = session.Query(fmt.Sprintf(`SELECT * FROM %s`, table)).MapScan(m)
 	if err != nil {
 		t.Fatal(err)
@@ -336,10 +336,10 @@ func TestTuple_NestedCollection(t *testing.T) {
 
 	tests := []struct {
 		name string
-		val  interface{}
+		val  any
 	}{
-		{name: "slice", val: [][]interface{}{{1, "2"}, {3, "4"}}},
-		{name: "array", val: [][2]interface{}{{1, "2"}, {3, "4"}}},
+		{name: "slice", val: [][]any{{1, "2"}, {3, "4"}}},
+		{name: "array", val: [][2]any{{1, "2"}, {3, "4"}}},
 		{name: "struct", val: []typ{{1, "2"}, {3, "4"}}},
 	}
 
@@ -395,7 +395,7 @@ func TestTuple_NullableNestedCollection(t *testing.T) {
 
 	tests := []struct {
 		name string
-		val  interface{}
+		val  any
 	}{
 		{name: "slice", val: [][]*string{{ptrStr("1"), nil}, {nil, ptrStr("2")}, {ptrStr("3"), ptrStr("")}}},
 		{name: "array", val: [][2]*string{{ptrStr("1"), nil}, {nil, ptrStr("2")}, {ptrStr("3"), ptrStr("")}}},

--- a/udt_test.go
+++ b/udt_test.go
@@ -277,13 +277,13 @@ func TestMapScanUDT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rawResult := map[string]interface{}{}
+	rawResult := map[string]any{}
 	err = session.Query(fmt.Sprintf(`SELECT * FROM %s WHERE id = ?`, table), id).MapScan(rawResult)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	logEntries, ok := rawResult["log_entries"].([]map[string]interface{})
+	logEntries, ok := rawResult["log_entries"].([]map[string]any)
 	if !ok {
 		t.Fatal("log_entries not in scanned map")
 	}

--- a/vector_test.go
+++ b/vector_test.go
@@ -145,8 +145,8 @@ func TestVector_Types(t *testing.T) {
 	testCases := []struct {
 		name       string
 		cqlType    string
-		value      interface{}
-		comparator func(*testing.T, interface{}, interface{})
+		value      any
+		comparator func(*testing.T, any, any)
 	}{
 		{name: "ascii", cqlType: TypeAscii.String(), value: []string{"a", "1", "Z"}},
 		{name: "bigint", cqlType: TypeBigInt.String(), value: []int64{1, 2, 3}},
@@ -167,7 +167,7 @@ func TestVector_Types(t *testing.T) {
 			name:    "inet",
 			cqlType: TypeInet.String(),
 			value:   []net.IP{net.IPv4(127, 0, 0, 1), net.IPv4(192, 168, 1, 1), net.IPv4(8, 8, 8, 8)},
-			comparator: func(t *testing.T, e interface{}, a interface{}) {
+			comparator: func(t *testing.T, e any, a any) {
 				expected := e.([]net.IP)
 				actual := a.([]net.IP)
 				tests.AssertEqual(t, "vector size", len(expected), len(actual))
@@ -190,7 +190,7 @@ func TestVector_Types(t *testing.T) {
 				{{2, 3}, {2, -1}, {3}, {0}, {-1.3}},
 				{{1, 1000.0}, {0}, {}, {12, 14, 15, 16}, {-1.3}},
 			},
-			comparator: func(t *testing.T, e interface{}, a interface{}) {
+			comparator: func(t *testing.T, e any, a any) {
 				expected := e.([][][]float32)
 				actual := a.([][][]float32)
 				tests.AssertEqual(t, "vector size", len(expected), len(actual))
@@ -208,13 +208,13 @@ func TestVector_Types(t *testing.T) {
 				}
 			},
 		},
-		{name: "vector_tuple_text_int_float", cqlType: "tuple<text, int, float>", value: [][]interface{}{{"a", 1, float32(0.5)}, {"b", 2, float32(-1.2)}, {"c", 3, float32(0)}}},
-		{name: "vector_tuple_text_list_text", cqlType: "tuple<text, list<text>>", value: [][]interface{}{{"a", []string{"b", "c"}}, {"d", []string{"e", "g", "f"}}, {"h", []string{"i"}}}},
+		{name: "vector_tuple_text_int_float", cqlType: "tuple<text, int, float>", value: [][]any{{"a", 1, float32(0.5)}, {"b", 2, float32(-1.2)}, {"c", 3, float32(0)}}},
+		{name: "vector_tuple_text_list_text", cqlType: "tuple<text, list<text>>", value: [][]any{{"a", []string{"b", "c"}}, {"d", []string{"e", "g", "f"}}, {"h", []string{"i"}}}},
 		{
 			name:    "vector_set_text",
 			cqlType: "set<text>",
 			value:   [][]string{{"a", "b"}, {"c", "d"}, {"f", "e"}},
-			comparator: func(t *testing.T, e interface{}, a interface{}) {
+			comparator: func(t *testing.T, e any, a any) {
 				expected := e.([][]string)
 				actual := a.([][]string)
 				tests.AssertEqual(t, "vector size", len(expected), len(actual))


### PR DESCRIPTION
## Motivation

`any` is a built-in type alias for `interface{}` introduced in Go 1.18 (`type any = interface{}`). The project uses Go 1.25, yet the codebase still had ~657 occurrences of the archaic `interface{}` form across 162 files, while some files already used `any` — creating an inconsistency. The Go standard library and ecosystem have fully adopted `any`.

## Change

Mechanical, codebase-wide replacement of `interface{}` with `any`:

- **Code tokens** (function signatures, variable declarations, type assertions): transformed via `gofmt -r 'interface{} -> any'`, which operates at the AST level — safe and precise.
- **Comments, doc strings, and error message strings**: manually updated (~18 occurrences across `marshal.go`, `helpers.go`, `marshal_test.go`, `doc.go`, `internal/lru/lru.go`).
- **`.git-blame-ignore-revs`**: created with the rename commit SHA so `git blame` can skip this mass change.

`any` and `interface{}` are the exact same type per the Go specification. There is zero behavioral, compilation, or API compatibility difference.

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all tests pass
- `rg 'interface{}' --type go` — zero remaining occurrences