### PR TITLE
Improve timeout observability: add timeout/in-flight to QueryError and debug logging

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2085,8 +2085,10 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 }
 
 var (
-	ErrQueryArgLength      = errors.New("gocql: query argument length mismatch")
-	ErrTimeoutNoResponse   = errors.New("gocql: no response received from cassandra within timeout period")
+	ErrQueryArgLength    = errors.New("gocql: query argument length mismatch")
+	ErrTimeoutNoResponse = errors.New("gocql: no response received from cassandra within timeout period")
+	// Deprecated: ErrTooManyTimeouts is no longer produced by the library.
+	// It will be removed in a future major release.
 	ErrTooManyTimeouts     = errors.New("gocql: too many query timeouts on the connection")
 	ErrConnectionClosed    = errors.New("gocql: connection closed waiting for response")
 	ErrNoStreams           = errors.New("gocql: no streams available on connection")

--- a/conn.go
+++ b/conn.go
@@ -1464,10 +1464,10 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 		return resp.framer, nil
 	case <-timeoutCh:
 		stopWaiting = true
-		return nil, &QueryError{err: ErrTimeoutNoResponse, potentiallyExecuted: true}
+		return nil, &QueryError{err: ErrTimeoutNoResponse, potentiallyExecuted: true, timeout: requestTimeout, inFlight: c.streams.InUse()}
 	case <-ctxDone:
 		stopWaiting = true
-		return nil, &QueryError{err: ctx.Err(), potentiallyExecuted: true}
+		return nil, &QueryError{err: ctx.Err(), potentiallyExecuted: true, timeout: requestTimeout, inFlight: c.streams.InUse()}
 	case <-c.ctx.Done():
 		stopWaiting = true
 		return nil, &QueryError{err: ErrConnectionClosed, potentiallyExecuted: true}
@@ -2107,6 +2107,8 @@ func (e *ErrSchemaMismatch) Error() string {
 
 type QueryError struct {
 	err                 error
+	timeout             time.Duration
+	inFlight            int
 	potentiallyExecuted bool
 	isIdempotent        bool
 }
@@ -2119,7 +2121,22 @@ func (e *QueryError) PotentiallyExecuted() bool {
 	return e.potentiallyExecuted
 }
 
+// Timeout returns the configured timeout duration for the query that failed.
+// Returns 0 if the error is not timeout-related.
+func (e *QueryError) Timeout() time.Duration {
+	return e.timeout
+}
+
+// InFlight returns the number of in-flight requests on the connection at the
+// time the error occurred. Returns 0 if not applicable.
+func (e *QueryError) InFlight() int {
+	return e.inFlight
+}
+
 func (e *QueryError) Error() string {
+	if e.timeout > 0 {
+		return fmt.Sprintf("%s (timeout: %v, in-flight: %d) (potentially executed: %v)", e.err.Error(), e.timeout, e.inFlight, e.potentiallyExecuted)
+	}
 	return fmt.Sprintf("%s (potentially executed: %v)", e.err.Error(), e.potentiallyExecuted)
 }
 

--- a/conn.go
+++ b/conn.go
@@ -41,6 +41,7 @@ import (
 	frm "github.com/gocql/gocql/internal/frame"
 	"github.com/gocql/gocql/tablets"
 
+	"github.com/gocql/gocql/internal/debug"
 	"github.com/gocql/gocql/internal/lru"
 	"github.com/gocql/gocql/internal/streams"
 )
@@ -1464,10 +1465,20 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 		return resp.framer, nil
 	case <-timeoutCh:
 		stopWaiting = true
-		return nil, &QueryError{err: ErrTimeoutNoResponse, potentiallyExecuted: true, timeout: requestTimeout, inFlight: c.streams.InUse()}
+		inFlight := c.streams.InUse()
+		if debug.Enabled {
+			c.logger.Printf("gocql: request timeout (timeout: %v, host: %s, keyspace: %s, in-flight: %d)",
+				requestTimeout, c.addr, c.currentKeyspace, inFlight)
+		}
+		return nil, &QueryError{err: ErrTimeoutNoResponse, potentiallyExecuted: true, timeout: requestTimeout, inFlight: inFlight}
 	case <-ctxDone:
 		stopWaiting = true
-		return nil, &QueryError{err: ctx.Err(), potentiallyExecuted: true, timeout: requestTimeout, inFlight: c.streams.InUse()}
+		inFlight := c.streams.InUse()
+		if debug.Enabled {
+			c.logger.Printf("gocql: context done waiting for response (err: %v, timeout: %v, host: %s, keyspace: %s, in-flight: %d)",
+				ctx.Err(), requestTimeout, c.addr, c.currentKeyspace, inFlight)
+		}
+		return nil, &QueryError{err: ctx.Err(), potentiallyExecuted: true, timeout: requestTimeout, inFlight: inFlight}
 	case <-c.ctx.Done():
 		stopWaiting = true
 		return nil, &QueryError{err: ErrConnectionClosed, potentiallyExecuted: true}

--- a/conn.go
+++ b/conn.go
@@ -206,7 +206,6 @@ type Conn struct {
 	scyllaSupported      ScyllaConnectionFeatures
 	systemRequestTimeout time.Duration
 	writeTimeout         atomic.Int64
-	timeouts             int64
 	readTimeout          atomic.Int64
 	mu                   sync.Mutex
 	tabletsRoutingV1     int32

--- a/query_error_test.go
+++ b/query_error_test.go
@@ -6,6 +6,7 @@ package gocql
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestQueryError_PotentiallyExecuted(t *testing.T) {
@@ -85,6 +86,8 @@ func TestQueryError_Error(t *testing.T) {
 		name                string
 		err                 error
 		potentiallyExecuted bool
+		timeout             time.Duration
+		inFlight            int
 		expected            string
 	}{
 		{
@@ -99,6 +102,21 @@ func TestQueryError_Error(t *testing.T) {
 			potentiallyExecuted: false,
 			expected:            "syntax error (potentially executed: false)",
 		},
+		{
+			name:                "with timeout",
+			err:                 ErrTimeoutNoResponse,
+			potentiallyExecuted: true,
+			timeout:             11 * time.Second,
+			inFlight:            42,
+			expected:            "gocql: no response received from cassandra within timeout period (timeout: 11s, in-flight: 42) (potentially executed: true)",
+		},
+		{
+			name:                "with zero timeout omits timeout",
+			err:                 errors.New("some error"),
+			potentiallyExecuted: false,
+			timeout:             0,
+			expected:            "some error (potentially executed: false)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -106,11 +124,83 @@ func TestQueryError_Error(t *testing.T) {
 			qErr := &QueryError{
 				err:                 tt.err,
 				potentiallyExecuted: tt.potentiallyExecuted,
+				timeout:             tt.timeout,
+				inFlight:            tt.inFlight,
 			}
 
 			got := qErr.Error()
 			if got != tt.expected {
 				t.Errorf("QueryError.Error() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestQueryError_Timeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		timeout  time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "with timeout set",
+			timeout:  11 * time.Second,
+			expected: 11 * time.Second,
+		},
+		{
+			name:     "with zero timeout",
+			timeout:  0,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qErr := &QueryError{
+				err:     errors.New("test error"),
+				timeout: tt.timeout,
+			}
+
+			got := qErr.Timeout()
+			if got != tt.expected {
+				t.Errorf("QueryError.Timeout() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestQueryError_InFlight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		inFlight int
+		expected int
+	}{
+		{
+			name:     "with in-flight requests",
+			inFlight: 42,
+			expected: 42,
+		},
+		{
+			name:     "with zero in-flight",
+			inFlight: 0,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qErr := &QueryError{
+				err:      errors.New("test error"),
+				inFlight: tt.inFlight,
+			}
+
+			got := qErr.InFlight()
+			if got != tt.expected {
+				t.Errorf("QueryError.InFlight() = %v, expected %v", got, tt.expected)
 			}
 		})
 	}

--- a/query_executor.go
+++ b/query_executor.go
@@ -30,6 +30,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/gocql/gocql/internal/debug"
 )
 
 type ExecutableQuery interface {
@@ -248,6 +250,20 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 				return iter
 			}
 			retryType = getRetryType(iter.err)
+		}
+
+		if debug.Enabled {
+			if s := qry.GetSession(); s != nil {
+				var rt *RequestErrReadTimeout
+				var wt *RequestErrWriteTimeout
+				if errors.As(iter.err, &rt) {
+					s.logger.Printf("gocql: server read timeout (keyspace: %s, table: %s, consistency: %v, received: %d, blockFor: %d, dataPresent: %v, host: %v, attempt: %d, retryType: %v)",
+						qry.Keyspace(), qry.Table(), rt.Consistency, rt.Received, rt.BlockFor, rt.DataPresent, iter.host, qry.Attempts(), retryType)
+				} else if errors.As(iter.err, &wt) {
+					s.logger.Printf("gocql: server write timeout (keyspace: %s, table: %s, consistency: %v, received: %d, blockFor: %d, writeType: %s, host: %v, attempt: %d, retryType: %v)",
+						qry.Keyspace(), qry.Table(), wt.Consistency, wt.Received, wt.BlockFor, wt.WriteType, iter.host, qry.Attempts(), retryType)
+				}
+			}
 		}
 
 		// If query is unsuccessful, check the error with RetryPolicy to retry


### PR DESCRIPTION
## Summary

- Add `timeout` and `inFlight` fields to `QueryError` with public getters, so callers can inspect timeout configuration and connection load when queries fail
- Add debug logging (gated by `-tags gocql_debug`) for client-side timeouts in `Conn.exec()` and server-side read/write timeouts in the retry loop
- Remove dead `timeouts` field from `Conn` struct (unused since `handleTimeout()` was removed in fafe6f56)
- Deprecate `ErrTooManyTimeouts` (no longer produced, but exported — so deprecate rather than remove)

## Commits

1. **Remove dead timeouts field from Conn struct** — `timeouts int64` has zero references since Sep 2025
2. **Deprecate ErrTooManyTimeouts** — exported sentinel that is no longer produced; mark deprecated for semver safety
3. **Add timeout duration and in-flight count to QueryError** — new fields, getters, `Error()` format includes them when non-zero. Struct is field-aligned. Covers PREPARE, EXECUTE, QUERY, BATCH, OPTIONS, USE
4. **Add debug logging for client-side timeouts in Conn.exec()** — logs timeout, host, keyspace, in-flight count (via lock-free `streams.InUse()`)
5. **Add debug logging for server-side read/write timeouts** — logs keyspace, table, consistency, received/blockFor, host, attempt, retry decision. Note: CQL protocol does not transmit the server-side timeout duration

## Example output

**Error string (non-debug):**
```
gocql: no response received from cassandra within timeout period (timeout: 11s, in-flight: 42) (potentially executed: true)
```

**Debug log (client-side timeout):**
```
gocql: request timeout (timeout: 11s, host: 10.0.0.1:9042, keyspace: mykeyspace, in-flight: 42)
```

**Debug log (server-side read timeout):**
```
gocql: server read timeout (keyspace: mykeyspace, table: mytable, consistency: QUORUM, received: 1, blockFor: 2, dataPresent: 0, host: 10.0.0.1, attempt: 1, retryType: Retry)
```

Refs: CASSGO-304
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
AI-assisted: OpenCode / Opus 4.6