### PR TITLE
Improve timeout observability

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2085,8 +2085,10 @@ func (c *Conn) awaitSchemaAgreement(ctx context.Context) error {
 }
 
 var (
-	ErrQueryArgLength      = errors.New("gocql: query argument length mismatch")
-	ErrTimeoutNoResponse   = errors.New("gocql: no response received from cassandra within timeout period")
+	ErrQueryArgLength    = errors.New("gocql: query argument length mismatch")
+	ErrTimeoutNoResponse = errors.New("gocql: no response received from cassandra within timeout period")
+	// Deprecated: ErrTooManyTimeouts is no longer produced by the library.
+	// It will be removed in a future major release.
 	ErrTooManyTimeouts     = errors.New("gocql: too many query timeouts on the connection")
 	ErrConnectionClosed    = errors.New("gocql: connection closed waiting for response")
 	ErrNoStreams           = errors.New("gocql: no streams available on connection")

--- a/conn.go
+++ b/conn.go
@@ -1464,10 +1464,10 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 		return resp.framer, nil
 	case <-timeoutCh:
 		stopWaiting = true
-		return nil, &QueryError{err: ErrTimeoutNoResponse, potentiallyExecuted: true}
+		return nil, &QueryError{err: ErrTimeoutNoResponse, potentiallyExecuted: true, timeout: requestTimeout, inFlight: c.streams.InUse()}
 	case <-ctxDone:
 		stopWaiting = true
-		return nil, &QueryError{err: ctx.Err(), potentiallyExecuted: true}
+		return nil, &QueryError{err: ctx.Err(), potentiallyExecuted: true, timeout: requestTimeout, inFlight: c.streams.InUse()}
 	case <-c.ctx.Done():
 		stopWaiting = true
 		return nil, &QueryError{err: ErrConnectionClosed, potentiallyExecuted: true}
@@ -2107,6 +2107,8 @@ func (e *ErrSchemaMismatch) Error() string {
 
 type QueryError struct {
 	err                 error
+	timeout             time.Duration
+	inFlight            int
 	potentiallyExecuted bool
 	isIdempotent        bool
 }
@@ -2120,6 +2122,9 @@ func (e *QueryError) PotentiallyExecuted() bool {
 }
 
 func (e *QueryError) Error() string {
+	if e.timeout > 0 {
+		return fmt.Sprintf("%s (timeout: %v, in-flight: %d) (potentially executed: %v)", e.err.Error(), e.timeout, e.inFlight, e.potentiallyExecuted)
+	}
 	return fmt.Sprintf("%s (potentially executed: %v)", e.err.Error(), e.potentiallyExecuted)
 }
 

--- a/conn.go
+++ b/conn.go
@@ -206,7 +206,6 @@ type Conn struct {
 	scyllaSupported      ScyllaConnectionFeatures
 	systemRequestTimeout time.Duration
 	writeTimeout         atomic.Int64
-	timeouts             int64
 	readTimeout          atomic.Int64
 	mu                   sync.Mutex
 	tabletsRoutingV1     int32

--- a/query_error_test.go
+++ b/query_error_test.go
@@ -6,6 +6,7 @@ package gocql
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestQueryError_PotentiallyExecuted(t *testing.T) {
@@ -85,6 +86,8 @@ func TestQueryError_Error(t *testing.T) {
 		name                string
 		err                 error
 		potentiallyExecuted bool
+		timeout             time.Duration
+		inFlight            int
 		expected            string
 	}{
 		{
@@ -99,6 +102,21 @@ func TestQueryError_Error(t *testing.T) {
 			potentiallyExecuted: false,
 			expected:            "syntax error (potentially executed: false)",
 		},
+		{
+			name:                "with timeout",
+			err:                 ErrTimeoutNoResponse,
+			potentiallyExecuted: true,
+			timeout:             11 * time.Second,
+			inFlight:            42,
+			expected:            "gocql: no response received from cassandra within timeout period (timeout: 11s, in-flight: 42) (potentially executed: true)",
+		},
+		{
+			name:                "with zero timeout omits timeout",
+			err:                 errors.New("some error"),
+			potentiallyExecuted: false,
+			timeout:             0,
+			expected:            "some error (potentially executed: false)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -106,6 +124,8 @@ func TestQueryError_Error(t *testing.T) {
 			qErr := &QueryError{
 				err:                 tt.err,
 				potentiallyExecuted: tt.potentiallyExecuted,
+				timeout:             tt.timeout,
+				inFlight:            tt.inFlight,
 			}
 
 			got := qErr.Error()


### PR DESCRIPTION
## Summary

Improve timeout observability by enriching `QueryError` with timeout duration and in-flight request count, adding debug logging for both client-side and server-side timeouts, and cleaning up dead timeout-related code.

## Changes

1. **Remove dead `timeouts` field from `Conn` struct** — the `handleTimeout()` function was removed in fafe6f56 but the field was left behind.

2. **Deprecate `ErrTooManyTimeouts`** — no longer used internally (the timeout-counting logic was removed), but kept as deprecated since it's exported public API in a v1.x module.

3. **Add `timeout` and `inFlight` fields to `QueryError`** — with `Timeout()` and `InFlight()` accessor methods, allowing callers to programmatically inspect timeout details. The `Error()` string only includes these when timeout > 0 to avoid confusion. Set at both timeout return sites in `Conn.exec()`. Unit tests included.

4. **Add debug logging for client-side timeouts** — logs timeout duration, host, keyspace, and in-flight count when `Conn.exec()` hits `ErrTimeoutNoResponse` or context cancellation. Gated behind `gocql_debug` build tag (dead-code eliminated in production).

5. **Add debug logging for server-side read/write timeouts** — logs keyspace, table, consistency, received, blockFor, host, attempt count, and retry type in the retry loop. Also gated behind `gocql_debug` build tag.

FIXES: https://scylladb.atlassian.net/browse/DRIVER-539
AI-assisted: OpenCode / Opus 4.6
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>