### PR TITLE
client_routes: simplify concurrency, fix stale entries, add sticky routing

### DIFF
--- a/client_routes.go
+++ b/client_routes.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gocql/gocql/events"
@@ -60,11 +59,14 @@ func (l *ClientRoutesEndpointList) Validate() error {
 }
 
 type ClientRoutesConfig struct {
-	TableName                    string
-	Endpoints                    ClientRoutesEndpointList
+	TableName string
+	Endpoints ClientRoutesEndpointList
+	// Deprecated:
 	ResolveHealthyEndpointPeriod time.Duration
-	ResolverCacheDuration        time.Duration
-	MaxResolverConcurrency       int
+	// Deprecated:
+	ResolverCacheDuration time.Duration
+	// Deprecated:
+	MaxResolverConcurrency int
 
 	// Deprecated: BlockUnknownEndpoints no longer has any effect. Unknown
 	// endpoints are always blocked. This field will be removed in a future
@@ -101,16 +103,10 @@ func (cfg *ClientRoutesConfig) Validate() error {
 	if err := cfg.Endpoints.Validate(); err != nil {
 		return fmt.Errorf("failed to validate endpoints: %w", err)
 	}
-	if cfg.ResolveHealthyEndpointPeriod < 0 {
-		return errors.New("resolve healthy endpoint period must be >= 0")
-	}
-	if cfg.MaxResolverConcurrency <= 0 {
-		return errors.New("max resolver concurrency must be > 0")
-	}
 	return nil
 }
 
-type UnresolvedClientRoute struct {
+type clientRoute struct {
 	ConnectionID  string
 	HostID        string
 	Address       string
@@ -119,18 +115,18 @@ type UnresolvedClientRoute struct {
 }
 
 // Similar returns true if both records targets same host and connection id
-func (r UnresolvedClientRoute) Similar(o UnresolvedClientRoute) bool {
+func (r clientRoute) Similar(o clientRoute) bool {
 	return r.ConnectionID == o.ConnectionID && r.HostID == o.HostID
 }
 
 // Equal returns true if both records are exactly the same
-func (r UnresolvedClientRoute) Equal(o UnresolvedClientRoute) bool {
+func (r clientRoute) Equal(o clientRoute) bool {
 	return r == o
 }
 
-func (r UnresolvedClientRoute) String() string {
+func (r clientRoute) String() string {
 	return fmt.Sprintf(
-		"UnresolvedClientRoute{ConnectionID=%s, HostID=%s, Address=%s, CQLPort=%d, SecureCQLPort=%d}",
+		"clientRoute{ConnectionID=%s, HostID=%s, Address=%s, CQLPort=%d, SecureCQLPort=%d}",
 		r.ConnectionID,
 		r.HostID,
 		r.Address,
@@ -139,149 +135,34 @@ func (r UnresolvedClientRoute) String() string {
 	)
 }
 
-type UnresolvedClientRouteList []UnresolvedClientRoute
+type clientRouteList []clientRoute
 
-func (l *UnresolvedClientRouteList) Len() int {
+func (l *clientRouteList) Len() int {
 	return len(*l)
 }
 
-type ResolvedClientRoute struct {
-	updateTime time.Time
-	UnresolvedClientRoute
-	allKnownIPs   []net.IP
-	currentIP     net.IP
-	forcedResolve bool
-}
-
-func (r ResolvedClientRoute) String() string {
-	var ip string
-	if r.currentIP == nil {
-		ip = "<nil>"
-	} else {
-		ip = r.currentIP.String()
-	}
-
-	return fmt.Sprintf(
-		"ResolvedClientRoute{ConnectionID=%s, HostID=%s, Address=%s, CQLPort=%d, SecureCQLPort=%d, CurrentIP=%s}",
-		r.ConnectionID,
-		r.HostID,
-		r.Address,
-		r.CQLPort,
-		r.SecureCQLPort,
-		ip,
-	)
-}
-
-func (r ResolvedClientRoute) Clone() ResolvedClientRoute {
-	res := r
-	if res.allKnownIPs != nil {
-		res.allKnownIPs = make([]net.IP, 0, len(r.allKnownIPs))
-		for _, ip := range r.allKnownIPs {
-			res.allKnownIPs = append(res.allKnownIPs, slices.Clone(ip))
-		}
-	}
-	if len(res.currentIP) != 0 {
-		copy(res.currentIP, r.currentIP)
-		res.currentIP = slices.Clone(res.currentIP)
-	}
-	return res
-}
-
-// Newer returns true if o is newer than r
-func (r ResolvedClientRoute) Newer(o ResolvedClientRoute) bool {
-	if len(r.currentIP) == 0 && len(o.currentIP) != 0 {
-		return true
-	}
-	if len(r.allKnownIPs) == 0 && len(o.allKnownIPs) != 0 {
-		return true
-	}
-	return r.updateTime.Compare(o.updateTime) == -1
-}
-
-// Similar returns true if both records targets same host and connection id
-func (r ResolvedClientRoute) Similar(o ResolvedClientRoute) bool {
-	return r.ConnectionID == o.ConnectionID && r.HostID == o.HostID
-}
-
-func (r ResolvedClientRoute) NeedsUpdate() bool {
-	return r.currentIP == nil || len(r.allKnownIPs) == 0 || r.forcedResolve
-}
-
-func (r ResolvedClientRoute) GetCQLPort() uint16 {
-	if r.SecureCQLPort != 0 {
-		return r.SecureCQLPort
-	}
-	return r.CQLPort
-}
-
-type ResolvedClientRouteList []ResolvedClientRoute
-
-func (l *ResolvedClientRouteList) Len() int {
-	return len(*l)
-}
-
-func (l *ResolvedClientRouteList) MergeWithUnresolved(unresolved UnresolvedClientRouteList) {
-	for _, unres := range unresolved {
+// Merge upserts entries from incoming into the list.
+// Existing entries matching by (ConnectionID, HostID) are updated in place;
+// new entries are appended.
+func (l *clientRouteList) Merge(incoming clientRouteList) {
+	for _, inc := range incoming {
 		found := false
-		for id, res := range *l {
-			if res.UnresolvedClientRoute.Similar(unres) {
+		for id, existing := range *l {
+			if existing.Similar(inc) {
 				found = true
-				if res.Equal(unres) {
-					// Records are the same, no information has changed
-					break
-				}
-				// Records are not the same, add unresolved record
-				// It will be picked up by resolver on very next iteration
-				(*l)[id] = ResolvedClientRoute{
-					UnresolvedClientRoute: unres,
-					forcedResolve:         true,
+				if !existing.Equal(inc) {
+					(*l)[id] = inc
 				}
 				break
 			}
 		}
 		if !found {
-			*l = append(*l, ResolvedClientRoute{
-				UnresolvedClientRoute: unres,
-				forcedResolve:         true,
-			})
+			*l = append(*l, inc)
 		}
 	}
 }
 
-func (l *ResolvedClientRouteList) MergeWithResolved(o *ResolvedClientRouteList) {
-	for id, rec := range *l {
-		for _, otherRec := range *o {
-			if rec.Similar(otherRec) {
-				if rec.Newer(otherRec) {
-					(*l)[id] = otherRec
-				}
-				break
-			}
-		}
-	}
-
-	for _, otherRec := range *o {
-		if !slices.ContainsFunc(*l, otherRec.Similar) {
-			*l = append(*l, otherRec)
-		}
-	}
-}
-
-func (l *ResolvedClientRouteList) UpdateIfNewer(route ResolvedClientRoute) bool {
-	for id, r := range *l {
-		if r.Similar(route) {
-			if !r.Newer(route) {
-				return false
-			}
-			(*l)[id] = route
-			return true
-		}
-	}
-	*l = append(*l, route)
-	return true
-}
-
-func (l *ResolvedClientRouteList) FindByHostID(hostID string) *ResolvedClientRoute {
+func (l *clientRouteList) FindByHostID(hostID string) *clientRoute {
 	for i := range *l {
 		if (*l)[i].HostID == hostID {
 			return &(*l)[i]
@@ -290,107 +171,18 @@ func (l *ResolvedClientRouteList) FindByHostID(hostID string) *ResolvedClientRou
 	return nil
 }
 
-func (l *ResolvedClientRouteList) Clone() ResolvedClientRouteList {
-	if len(*l) == 0 {
-		return make(ResolvedClientRouteList, 0)
-	}
-	cpy := make(ResolvedClientRouteList, len(*l))
-	copy(cpy, *l)
-	return cpy
-}
-
-type ResolvedEndpoint struct {
-	updateTime    time.Time
-	connectionID  string
-	dc            string
-	rack          string
-	address       string
-	allKnown      []net.IP
-	currentIP     net.IP
-	forcedResolve bool
-}
-
-type ClientRoutesResolver interface {
-	Resolve(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error)
-}
-
-type resolvedCacheRecord struct {
-	lastTimeResolved time.Time
-	lastResult       []net.IP
-}
-
-func (r resolvedCacheRecord) WasResolvedLessThan(cachingTime time.Duration) bool {
-	return time.Now().UTC().Sub(r.lastTimeResolved) < cachingTime
-}
-
-// simpleClientRoutesResolver resolves endpoints using the provided lookup function while enforcing
-// a minimal period between successive resolutions of the same address.
-type simpleClientRoutesResolver struct {
-	resolver    DNSResolver
-	cache       map[string]resolvedCacheRecord
-	cachingTime time.Duration
-	mu          sync.RWMutex
-}
-
-func newSimpleClientRoutesResolver(cachingTime time.Duration, resolver DNSResolver) *simpleClientRoutesResolver {
-	if resolver == nil {
-		resolver = defaultDnsResolver
-	}
-	return &simpleClientRoutesResolver{
-		resolver:    resolver,
-		cachingTime: cachingTime,
-		cache:       make(map[string]resolvedCacheRecord),
-	}
-}
-
-func (r *simpleClientRoutesResolver) Resolve(endpoint ResolvedClientRoute) (allKnown []net.IP, current net.IP, err error) {
-	r.mu.RLock()
-	cache, ok := r.cache[endpoint.Address]
-	r.mu.RUnlock()
-	if ok && cache.WasResolvedLessThan(r.cachingTime) {
-		allKnown = cache.lastResult
-	}
-
-	if len(allKnown) == 0 {
-		allKnown, err = r.resolver.LookupIP(endpoint.Address)
-		if err != nil {
-			return endpoint.allKnownIPs, endpoint.currentIP, err
-		}
-		if len(allKnown) == 0 {
-			return endpoint.allKnownIPs, endpoint.currentIP, fmt.Errorf("no addresses returned for %s", endpoint.Address)
-		}
-	}
-
-	for _, addr := range allKnown {
-		if endpoint.currentIP != nil && endpoint.currentIP.Equal(addr) {
-			current = addr
-			break
-		}
-	}
-	if current == nil {
-		current = allKnown[0]
-	}
-
-	r.mu.Lock()
-	r.cache[endpoint.Address] = resolvedCacheRecord{
-		lastTimeResolved: time.Now().UTC(),
-		lastResult:       allKnown,
-	}
-	r.mu.Unlock()
-	return allKnown, current, nil
-}
-
 type ClientRoutesHandler struct {
-	log               StdLogger
-	c                 controlConnection
-	resolver          ClientRoutesResolver
-	sub               *eventbus.Subscriber[events.Event]
-	resolvedEndpoints atomic.Pointer[ResolvedClientRouteList]
-	updateTasks       chan updateTask
-	closeChan         chan struct{}
-	cfg               ClientRoutesConfig
-	pickTLSPorts      bool
-	initialized       bool
+	log         StdLogger
+	c           controlConnection
+	resolver    DNSResolver
+	sub         *eventbus.Subscriber[events.Event]
+	routes      clientRouteList
+	updateTasks chan updateTask
+	closeChan   chan struct{}
+	cfg         ClientRoutesConfig
+	mu          sync.RWMutex
+	pickTLSPorts bool
+	initialized  bool
 }
 
 var _ AddressTranslatorV2 = (*ClientRoutesHandler)(nil)
@@ -401,76 +193,49 @@ func (p *ClientRoutesHandler) Translate(addr net.IP, port int) (net.IP, int) {
 	panic("should never be called")
 }
 
-func pickProperPort(pickTLSPorts bool, rec *ResolvedClientRoute) uint16 {
+func pickProperPort(pickTLSPorts bool, rec *clientRoute) uint16 {
 	if pickTLSPorts {
 		return rec.SecureCQLPort
 	}
 	return rec.CQLPort
 }
 
-// TranslateWithHost implements AddressTranslatorV2 interface
+// TranslateHost implements AddressTranslatorV2 interface.
+// It resolves DNS on every call rather than caching resolved addresses.
 func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) (AddressPort, error) {
 	hostID := host.HostID()
 	if hostID == "" {
 		return addr, nil
 	}
 
-	current := p.resolvedEndpoints.Load()
-	rec := current.FindByHostID(hostID)
-	if rec == nil {
+	p.mu.RLock()
+	rec := p.routes.FindByHostID(hostID)
+	var route clientRoute
+	found := rec != nil
+	if found {
+		route = *rec
+	}
+	p.mu.RUnlock()
+
+	if !found {
 		return addr, fmt.Errorf("no address found for host %s", hostID)
 	}
 
-	if rec.currentIP != nil {
-		port := pickProperPort(p.pickTLSPorts, rec)
-		if port == 0 {
-			return addr, fmt.Errorf("record %s/%s has target port empty", rec.HostID, rec.ConnectionID)
-		}
-		return AddressPort{
-			Address: rec.currentIP,
-			Port:    port,
-		}, nil
-	}
-
-	all, currentIP, err := p.resolver.Resolve(*rec)
+	ips, err := p.resolver.LookupIP(route.Address)
 	if err != nil {
-		return addr, fmt.Errorf("failed to resolve DNS resolver for host %s: %v", hostID, err)
+		return addr, fmt.Errorf("failed to resolve address for host %s: %v", hostID, err)
 	}
-	rec.allKnownIPs = all
-	rec.currentIP = currentIP
-
-	for {
-		updated := current.Clone()
-		if updated.UpdateIfNewer(*rec) {
-			if p.resolvedEndpoints.CompareAndSwap(current, &updated) {
-				port := pickProperPort(p.pickTLSPorts, rec)
-				if port == 0 {
-					return addr, fmt.Errorf("record %s/%s has target port empty", rec.HostID, rec.ConnectionID)
-				}
-				return AddressPort{
-					Address: rec.currentIP,
-					Port:    port,
-				}, nil
-			}
-			continue
-		}
-
-		rec = current.FindByHostID(hostID)
-		if rec == nil {
-			return addr, fmt.Errorf("no address found for host %s", hostID)
-		}
-		port := pickProperPort(p.pickTLSPorts, rec)
-		if port == 0 {
-			return addr, fmt.Errorf("record %s/%s has target port empty", rec.HostID, rec.ConnectionID)
-		}
-		return AddressPort{
-			Address: rec.currentIP,
-			Port:    port,
-		}, nil
+	if len(ips) == 0 {
+		return addr, fmt.Errorf("no addresses returned for host %s (address=%s)", hostID, route.Address)
 	}
+
+	port := pickProperPort(p.pickTLSPorts, &route)
+	if port == 0 {
+		return addr, fmt.Errorf("record %s/%s has target port empty", route.HostID, route.ConnectionID)
+	}
+
+	return AddressPort{Address: ips[0], Port: port}, nil
 }
-
-var never = time.Unix(1<<63-1, 0)
 
 type updateTask struct {
 	result        chan error
@@ -516,75 +281,6 @@ func (p *ClientRoutesHandler) Stop() {
 	if p.sub != nil {
 		p.sub.Stop()
 	}
-}
-
-// resolveAndUpdateInPlace updates provided list of resolved endpoint in place
-// If it can't resolve it keeps old record as is.
-// Logic to pick a single address from all available addresses is delegated to ClientRoutesResolver at p.endpointResolver
-// It does not resolve everything, it picks endpoints that are:
-// 1. Marked via forcedResolve=true,
-// 2. Have not resolved previously and have no ip address information
-// 3. Was resolved more than cfg.ResolveHealthyEndpointPeriod ago.
-func (p *ClientRoutesHandler) resolveAndUpdateInPlace(records ResolvedClientRouteList) error {
-	if len(records) == 0 {
-		return nil
-	}
-
-	errs := make([]error, len(records))
-	tasks := make(chan int, len(records))
-
-	var cutoffTimeForHealthy time.Time
-	if p.cfg.ResolveHealthyEndpointPeriod == 0 {
-		cutoffTimeForHealthy = never
-	} else {
-		cutoffTimeForHealthy = time.Now().UTC().Add(-p.cfg.ResolveHealthyEndpointPeriod)
-	}
-
-	scheduled := false
-	for id, endpoint := range records {
-		if endpoint.currentIP == nil || len(endpoint.allKnownIPs) == 0 || endpoint.forcedResolve {
-			scheduled = true
-			tasks <- id
-		} else if endpoint.updateTime.Before(cutoffTimeForHealthy) {
-			scheduled = true
-			tasks <- id
-		}
-	}
-
-	if !scheduled {
-		return nil
-	}
-
-	var wg sync.WaitGroup
-	for i := 0; i < p.cfg.MaxResolverConcurrency; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			for id := range tasks {
-				all, currentIP, err := p.resolver.Resolve(records[id])
-				records[id].updateTime = time.Now().UTC()
-				if err != nil {
-					errs[id] = fmt.Errorf("resolve %s failed: %w", records[id].currentIP, err)
-					continue
-				} else if len(all) == 0 {
-					errs[id] = fmt.Errorf("resolve %s: no addresses returned", records[id].currentIP)
-				} else if currentIP == nil {
-					errs[id] = fmt.Errorf("resolve %s: no current addres has been set, should not happen, please report a bug", records[id].currentIP)
-				} else {
-					// Reset forcedResolve is it was resolved successfully
-					records[id].forcedResolve = false
-				}
-				records[id].allKnownIPs = all
-				records[id].currentIP = currentIP
-			}
-		}()
-	}
-
-	close(tasks)
-	wg.Wait()
-
-	return errors.Join(errs...)
 }
 
 func (p *ClientRoutesHandler) updateHostPortMappingAsync(connectionIDs []string, hostIDs []string) {
@@ -660,30 +356,14 @@ func (p *ClientRoutesHandler) startUpdateWorker() {
 }
 
 func (p *ClientRoutesHandler) updateHostPortMapping(connectionIDs []string, hostIDs []string) error {
-	unresolved, err := getHostPortMappingFromCluster(p.c, p.cfg.TableName, connectionIDs, hostIDs)
+	incoming, err := getHostPortMappingFromCluster(p.c, p.cfg.TableName, connectionIDs, hostIDs)
 	if err != nil {
 		return err
 	}
-	current := p.resolvedEndpoints.Load()
-	updated := slices.Clone(*current)
-	updated.MergeWithUnresolved(unresolved)
-	err = p.resolveAndUpdateInPlace(updated)
-	if err != nil {
-		p.log.Printf("failed to resolve endpoints: %v", err)
-		// Despite an error it is better to save results, it should not corrupt existing and resolved records
-	}
 
-	// Try to update until it successes
-	// 10 times is more than enough, if it fails
-	for range 10 {
-		if p.resolvedEndpoints.CompareAndSwap(current, &updated) {
-			return nil
-		}
-
-		current = p.resolvedEndpoints.Load()
-		updated.MergeWithResolved(current)
-	}
-	p.log.Printf("failed to update host port mapping due to collisions")
+	p.mu.Lock()
+	p.routes.Merge(incoming)
+	p.mu.Unlock()
 
 	return nil
 }
@@ -694,22 +374,24 @@ func NewClientRoutesAddressTranslator(
 	pickTLSPorts bool,
 	log StdLogger,
 ) *ClientRoutesHandler {
-	res := &ClientRoutesHandler{
+	if resolver == nil {
+		resolver = defaultDnsResolver
+	}
+	return &ClientRoutesHandler{
 		cfg:          cfg,
 		log:          log,
 		pickTLSPorts: pickTLSPorts,
 		closeChan:    make(chan struct{}),
 		updateTasks:  make(chan updateTask, 1024),
-		resolver:     newSimpleClientRoutesResolver(cfg.ResolverCacheDuration, resolver),
+		resolver:     resolver,
+		routes:       make(clientRouteList, 0),
 	}
-	res.resolvedEndpoints.Store(&ResolvedClientRouteList{})
-	return res
 }
 
 var _ AddressTranslator = &ClientRoutesHandler{}
 
-func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string) (UnresolvedClientRouteList, error) {
-	var res UnresolvedClientRouteList
+func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string) (clientRouteList, error) {
+	var res clientRouteList
 
 	stmt := []string{fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s", table)}
 	var bounds []any
@@ -745,7 +427,7 @@ func getHostPortMappingFromCluster(c controlConnection, table string, connection
 	}
 
 	iter := c.query(strings.Join(stmt, " "), bounds...)
-	var rec UnresolvedClientRoute
+	var rec clientRoute
 	for iter.Scan(&rec.ConnectionID, &rec.HostID, &rec.Address, &rec.CQLPort, &rec.SecureCQLPort) {
 		res = append(res, rec)
 	}

--- a/client_routes.go
+++ b/client_routes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -380,10 +379,16 @@ func (p *ClientRoutesHandler) startUpdateWorker() {
 }
 
 func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
+	var incoming []clientRoute
+	var err error
 	var connectionIDs, hostIDs []string
 
 	switch {
 	case task.pairs != nil:
+		incoming, err = getHostPortMappingForPairs(p.c, p.cfg.TableName, task.pairs, p.pickTLSPorts)
+		if err != nil {
+			return err
+		}
 		connectionIDs = make([]string, len(task.pairs))
 		hostIDs = make([]string, len(task.pairs))
 		for i, p := range task.pairs {
@@ -391,14 +396,13 @@ func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
 			hostIDs[i] = p.hostID
 		}
 	case task.connectionIDs != nil:
+		incoming, err = getHostPortMappingForConnectionIDs(p.c, p.cfg.TableName, task.connectionIDs, p.pickTLSPorts)
+		if err != nil {
+			return err
+		}
 		connectionIDs = task.connectionIDs
 	default:
 		return errors.New("updateTask has neither pairs nor connectionIDs")
-	}
-
-	incoming, err := getHostPortMappingFromCluster(p.c, p.cfg.TableName, connectionIDs, hostIDs, p.pickTLSPorts)
-	if err != nil {
-		return err
 	}
 
 	p.mu.Lock()
@@ -438,43 +442,33 @@ func NewClientRoutesAddressTranslator(
 
 var _ AddressTranslator = &ClientRoutesHandler{}
 
-func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string, pickTLSPorts bool) ([]clientRoute, error) {
-	var res []clientRoute
-
-	stmt := []string{fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s", table)}
-	var bounds []any
-	if len(connectionIDs) != 0 {
-		var inClause []string
-		for _, connectionID := range connectionIDs {
-			bounds = append(bounds, connectionID)
-			inClause = append(inClause, "?")
-		}
-		if len(stmt) == 1 {
-			stmt = append(stmt, "where")
-		}
-		stmt = append(stmt, fmt.Sprintf("connection_id in (%s)", strings.Join(inClause, ",")))
+func getHostPortMappingForConnectionIDs(c controlConnection, table string, connIDs []string, pickTLSPorts bool) ([]clientRoute, error) {
+	if len(connIDs) == 0 {
+		return nil, errors.New("connIDs cannot be empty")
 	}
 
-	if len(hostIDs) != 0 {
-		var inClause []string
-		for _, hostID := range hostIDs {
-			bounds = append(bounds, hostID)
-			inClause = append(inClause, "?")
-		}
-		if len(stmt) == 1 {
-			stmt = append(stmt, "where")
-		} else {
-			stmt = append(stmt, "and")
-		}
-		stmt = append(stmt, fmt.Sprintf("host_id in (%s)", strings.Join(inClause, ",")))
+	stmt := fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s where connection_id in ?", table)
+	return readClientRoutesTable(c, table, stmt, []any{connIDs}, pickTLSPorts)
+}
+
+func getHostPortMappingForPairs(c controlConnection, table string, pairs []pair, pickTLSPorts bool) ([]clientRoute, error) {
+	if len(pairs) == 0 {
+		return nil, errors.New("pairs cannot be empty")
 	}
 
-	isFullScan := len(hostIDs) == 0 || len(connectionIDs) == 0
-	if isFullScan {
-		stmt = append(stmt, "allow filtering")
+	connIDs := make([]string, len(pairs))
+	hostIDs := make([]string, len(pairs))
+	for i, p := range pairs {
+		connIDs[i] = p.connectionID
+		hostIDs[i] = p.hostID
 	}
 
-	iter := c.query(strings.Join(stmt, " "), bounds...)
+	stmt := fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s where connection_id in ? and host_id in ?", table)
+	return readClientRoutesTable(c, table, stmt, []any{connIDs, hostIDs}, pickTLSPorts)
+}
+
+func readClientRoutesTable(c controlConnection, table, stmt string, bounds []any, pickTLSPorts bool) ([]clientRoute, error) {
+	iter := c.query(stmt, bounds...)
 	var (
 		connectionID  string
 		hostID        string
@@ -482,6 +476,7 @@ func getHostPortMappingFromCluster(c controlConnection, table string, connection
 		cqlPort       uint16
 		secureCQLPort uint16
 	)
+	var res []clientRoute
 	for iter.Scan(&connectionID, &hostID, &address, &cqlPort, &secureCQLPort) {
 		port := cqlPort
 		if pickTLSPorts {

--- a/client_routes.go
+++ b/client_routes.go
@@ -358,6 +358,7 @@ func (p *ClientRoutesHandler) Initialize(s *Session) error {
 	if p.initialized {
 		return errors.New("already initialized")
 	}
+	p.initialized = true
 	connectionIDs := p.cfg.Endpoints.GetAllConnectionIDs()
 	p.c = s.control
 	p.sub = s.eventBus.Subscribe("port-mux", 1024, func(event events.Event) bool {

--- a/client_routes.go
+++ b/client_routes.go
@@ -31,16 +31,16 @@ func (e ClientRoutesEndpoint) Validate() error {
 
 type ClientRoutesEndpointList []ClientRoutesEndpoint
 
-func (l *ClientRoutesEndpointList) GetAllConnectionIDs() []string {
-	var ids []string
-	for _, endpoint := range *l {
+func (l ClientRoutesEndpointList) GetAllConnectionIDs() []string {
+	ids := make([]string, 0, len(l))
+	for _, endpoint := range l {
 		ids = append(ids, endpoint.ConnectionID)
 	}
 	return ids
 }
 
-func (l *ClientRoutesEndpointList) Validate() error {
-	for id, endpoint := range *l {
+func (l ClientRoutesEndpointList) Validate() error {
+	for id, endpoint := range l {
 		if err := endpoint.Validate(); err != nil {
 			return fmt.Errorf("endpoint #%d is invalid: %w", id, err)
 		}
@@ -113,88 +113,171 @@ func (r clientRoute) String() string {
 	)
 }
 
-// clientRouteMap groups routes by hostID → connectionID → clientRoute.
-// The outer key is the host, the inner key is the connection.
-// This layout matches the AddressTranslator lookup pattern: find routes for a
-// host first, then pick the right connection.
-type clientRouteMap map[string]map[string]clientRoute
+type clientRouteCacheEntry struct {
+	current   *clientRoute
+	allRoutes []clientRoute
+}
+
+func (r *clientRouteCacheEntry) routeIndex(connectionID string) int {
+	return slices.IndexFunc(r.allRoutes, func(route clientRoute) bool {
+		return route.connectionID == connectionID
+	})
+}
+
+func (r *clientRouteCacheEntry) CurrentConnectionID() string {
+	if r.current == nil {
+		return ""
+	}
+	return r.current.connectionID
+}
+
+func (r *clientRouteCacheEntry) BindCurrent(connectionID string) {
+	if idx := r.routeIndex(connectionID); idx >= 0 {
+		r.current = &r.allRoutes[idx]
+		return
+	}
+	r.current = nil
+}
+
+func (r *clientRouteCacheEntry) DeleteByConnectionID(connectionID string) {
+	r.allRoutes = slices.DeleteFunc(r.allRoutes, func(route clientRoute) bool {
+		return route.connectionID == connectionID
+	})
+}
+
+func (r *clientRouteCacheEntry) Upsert(route clientRoute) {
+	if idx := r.routeIndex(route.connectionID); idx >= 0 {
+		r.allRoutes[idx] = route
+	} else {
+		r.allRoutes = append(r.allRoutes, route)
+	}
+}
+
+func (r *clientRouteCacheEntry) preferredRoute() (clientRoute, bool) {
+	if r.current != nil {
+		return *r.current, true
+	}
+
+	if len(r.allRoutes) == 0 {
+		return clientRoute{}, false
+	}
+
+	r.current = &r.allRoutes[0]
+	return *r.current, true
+}
+
+// clientRouteCache groups routes by hostID and owns synchronization for route selection and updates.
+type clientRouteCache struct {
+	routes map[string]clientRouteCacheEntry
+	mu     sync.Mutex
+}
+
+func newClientRouteCache() clientRouteCache {
+	return clientRouteCache{routes: make(map[string]clientRouteCacheEntry)}
+}
 
 // deleteByPairs removes entries identified by (connectionID, hostID) pairs.
-func (m clientRouteMap) deleteByPairs(pairs []pair) {
+func (c *clientRouteCache) deleteByPairsLocked(pairs []pair) {
 	for _, p := range pairs {
-		conns := m[p.hostID]
-		if conns == nil {
+		entry, ok := c.routes[p.hostID]
+		if !ok {
 			continue
 		}
-		delete(conns, p.connectionID)
-		if len(conns) == 0 {
-			delete(m, p.hostID)
+		entry.DeleteByConnectionID(p.connectionID)
+		if len(entry.allRoutes) == 0 {
+			delete(c.routes, p.hostID)
+			continue
 		}
+		c.routes[p.hostID] = entry
 	}
 }
 
 // deleteByConnectionIDs removes all entries for the given connectionIDs across all hosts.
-func (m clientRouteMap) deleteByConnectionIDs(connectionIDs []string) {
-	for hostID, conns := range m {
+func (c *clientRouteCache) deleteByConnectionIDsLocked(connectionIDs []string) {
+	for hostID, entry := range c.routes {
 		for _, connID := range connectionIDs {
-			delete(conns, connID)
+			entry.DeleteByConnectionID(connID)
 		}
-		if len(conns) == 0 {
-			delete(m, hostID)
+		if len(entry.allRoutes) == 0 {
+			delete(c.routes, hostID)
+			continue
 		}
+		c.routes[hostID] = entry
 	}
 }
 
-func (m clientRouteMap) populateRecords(incoming []clientRoute) {
+func (c *clientRouteCache) upsertRecordsLocked(incoming []clientRoute) {
 	for _, inc := range incoming {
-		conns := m[inc.hostID]
-		if conns == nil {
-			conns = make(map[string]clientRoute)
-			m[inc.hostID] = conns
+		entry := c.routes[inc.hostID]
+		entry.Upsert(inc)
+		c.routes[inc.hostID] = entry
+	}
+}
+
+// preferredRoute returns the current route for hostID if one exists and is still valid,
+// otherwise picks the first available route and records it as current.
+func (c *clientRouteCache) preferredRouteLocked(hostID string) (clientRoute, bool) {
+	entry, ok := c.routes[hostID]
+	if !ok {
+		return clientRoute{}, false
+	}
+
+	route, ok := entry.preferredRoute()
+	if !ok {
+		delete(c.routes, hostID)
+		return clientRoute{}, false
+	}
+	c.routes[hostID] = entry
+	return route, true
+}
+
+func (c *clientRouteCache) snapshotCurrentConnectionIDsLocked() map[string]string {
+	currentIDs := make(map[string]string, len(c.routes))
+	for hostID, entry := range c.routes {
+		if currentID := entry.CurrentConnectionID(); currentID != "" {
+			currentIDs[hostID] = currentID
 		}
-		conns[inc.connectionID] = inc
 	}
+	return currentIDs
 }
 
-// clientRouteTable is the single source of truth for route data.
-// It owns both the full route index and the per-host sticky selection so that
-// all consistency-maintaining logic lives in one place.
-type clientRouteTable struct {
-	routes      clientRouteMap         // hostID → connectionID → clientRoute
-	stickyRoute map[string]clientRoute // hostID → preferred route
-}
-
-func newClientRouteTable() clientRouteTable {
-	return clientRouteTable{
-		routes:      make(clientRouteMap),
-		stickyRoute: make(map[string]clientRoute),
-	}
-}
-
-// pruneStickyRoutes removes sticky entries whose route is no longer present in routes.
-func (t *clientRouteTable) pruneStickyRoutes() {
-	for hostID, route := range t.stickyRoute {
-		if _, ok := t.routes[hostID][route.connectionID]; !ok {
-			delete(t.stickyRoute, hostID)
+func (c *clientRouteCache) rebindCurrentConnectionIDsLocked(currentIDs map[string]string) {
+	for hostID, currentID := range currentIDs {
+		entry, ok := c.routes[hostID]
+		if !ok {
+			continue
 		}
+		entry.BindCurrent(currentID)
+		if len(entry.allRoutes) == 0 {
+			delete(c.routes, hostID)
+			continue
+		}
+		c.routes[hostID] = entry
 	}
 }
 
-// preferred returns the sticky route for hostID if one exists and is still valid,
-// otherwise picks an arbitrary route and records it as the new sticky entry.
-func (t *clientRouteTable) preferred(hostID string) (clientRoute, bool) {
-	if route, ok := t.stickyRoute[hostID]; ok {
-		if _, exists := t.routes[hostID][route.connectionID]; exists {
-			return route, true
-		}
-		// Stale sticky entry; clear it and fall back to a live route.
-		delete(t.stickyRoute, hostID)
-	}
-	for _, route := range t.routes[hostID] {
-		t.stickyRoute[hostID] = route
-		return route, true
-	}
-	return clientRoute{}, false
+func (c *clientRouteCache) PreferredRoute(hostID string) (clientRoute, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.preferredRouteLocked(hostID)
+}
+
+func (c *clientRouteCache) ReplaceByPairs(pairs []pair, incoming []clientRoute) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	currentIDs := c.snapshotCurrentConnectionIDsLocked()
+	c.deleteByPairsLocked(pairs)
+	c.upsertRecordsLocked(incoming)
+	c.rebindCurrentConnectionIDsLocked(currentIDs)
+}
+
+func (c *clientRouteCache) ReplaceByConnectionIDs(connectionIDs []string, incoming []clientRoute) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	currentIDs := c.snapshotCurrentConnectionIDsLocked()
+	c.deleteByConnectionIDsLocked(connectionIDs)
+	c.upsertRecordsLocked(incoming)
+	c.rebindCurrentConnectionIDsLocked(currentIDs)
 }
 
 type ClientRoutesHandler struct {
@@ -202,12 +285,11 @@ type ClientRoutesHandler struct {
 	c             controlConnection
 	resolver      DNSResolver
 	sub           *eventbus.Subscriber[events.Event]
-	routeTable    clientRouteTable
+	routeCache    clientRouteCache
 	addrOverrides map[string]string // connectionID → user-supplied ConnectionAddr
 	updateTasks   chan updateTask
 	closeChan     chan struct{}
 	cfg           ClientRoutesConfig
-	mu            sync.Mutex
 	pickTLSPorts  bool
 	initialized   bool
 }
@@ -230,9 +312,7 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 		return addr, nil
 	}
 
-	p.mu.Lock()
-	route, found := p.routeTable.preferred(hostID)
-	p.mu.Unlock()
+	route, found := p.routeCache.PreferredRoute(hostID)
 
 	if !found {
 		return addr, fmt.Errorf("no address found for host %s", hostID)
@@ -278,12 +358,7 @@ func (p *ClientRoutesHandler) Initialize(s *Session) error {
 	if p.initialized {
 		return errors.New("already initialized")
 	}
-	connectionIDs := make([]string, 0, len(p.cfg.Endpoints))
-	for _, ep := range p.cfg.Endpoints {
-		if ep.ConnectionID != "" {
-			connectionIDs = append(connectionIDs, ep.ConnectionID)
-		}
-	}
+	connectionIDs := p.cfg.Endpoints.GetAllConnectionIDs()
 	p.c = s.control
 	p.sub = s.eventBus.Subscribe("port-mux", 1024, func(event events.Event) bool {
 		switch event.Type() {
@@ -294,7 +369,7 @@ func (p *ClientRoutesHandler) Initialize(s *Session) error {
 		}
 	})
 	p.startUpdateWorker()
-	p.startReadingEvents()
+	p.startReadingEvents(connectionIDs)
 	err := p.updateHostPortMappingSync(updateTask{connectionIDs: connectionIDs})
 	if err != nil {
 		p.log.Printf("error updating host ports: %v\n", err)
@@ -332,9 +407,7 @@ func (p *ClientRoutesHandler) updateHostPortMappingSync(task updateTask) error {
 	return <-task.result
 }
 
-func (p *ClientRoutesHandler) startReadingEvents() {
-	connectionIDs := p.cfg.Endpoints.GetAllConnectionIDs()
-
+func (p *ClientRoutesHandler) startReadingEvents(connectionIDs []string) {
 	go func() {
 		for event := range p.sub.Events() {
 			switch evt := event.(type) {
@@ -346,10 +419,17 @@ func (p *ClientRoutesHandler) startReadingEvents() {
 					}
 					if len(evt.HostIDs) == 0 {
 						p.log.Printf("got CLIENT_ROUTES_CHANGE event with no host IDs")
-						continue
 					}
 				}
-				pairs := getPairsFromEvent(evt, connectionIDs)
+				filteredConnectionIDs := filterAllowedConnectionIDs(evt.ConnectionIDs, connectionIDs)
+				if len(filteredConnectionIDs) == 0 {
+					continue
+				}
+				if len(evt.HostIDs) == 0 {
+					p.updateHostPortMappingAsync(updateTask{connectionIDs: filteredConnectionIDs})
+					continue
+				}
+				pairs := getPairsFromEvent(filteredConnectionIDs, evt.HostIDs)
 				if len(pairs) != 0 {
 					p.updateHostPortMappingAsync(updateTask{pairs: pairs})
 				}
@@ -360,20 +440,33 @@ func (p *ClientRoutesHandler) startReadingEvents() {
 	}()
 }
 
-func getPairsFromEvent(evt *events.ClientRoutesChangedEvent, allowedConnectionIDs []string) (pairs []pair) {
-	if len(evt.ConnectionIDs) != len(evt.HostIDs) {
+func getPairsFromEvent(connectionIDs, hostIDs []string) (pairs []pair) {
+	if len(connectionIDs) == 0 || len(hostIDs) == 0 {
 		return nil
 	}
-	for n, connID := range evt.ConnectionIDs {
-		if !slices.Contains(allowedConnectionIDs, connID) {
-			continue
+	pairs = make([]pair, 0, len(connectionIDs)*len(hostIDs))
+	for _, connID := range connectionIDs {
+		for _, hostID := range hostIDs {
+			pairs = append(pairs, pair{
+				connectionID: connID,
+				hostID:       hostID,
+			})
 		}
-		pairs = append(pairs, pair{
-			connectionID: connID,
-			hostID:       evt.HostIDs[n],
-		})
 	}
 	return pairs
+}
+
+func filterAllowedConnectionIDs(connectionIDs, allowedConnectionIDs []string) []string {
+	filtered := make([]string, 0, len(connectionIDs))
+	for _, connID := range connectionIDs {
+		if connID == "" {
+			continue
+		}
+		if slices.Contains(allowedConnectionIDs, connID) {
+			filtered = append(filtered, connID)
+		}
+	}
+	return filtered
 }
 
 func (p *ClientRoutesHandler) startUpdateWorker() {
@@ -408,22 +501,16 @@ func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
 		if err != nil {
 			return err
 		}
-		p.mu.Lock()
-		p.routeTable.routes.deleteByPairs(task.pairs)
+		p.routeCache.ReplaceByPairs(task.pairs, incoming)
 	case task.connectionIDs != nil:
 		incoming, err = getHostPortMappingForConnectionIDs(p.c, p.cfg.TableName, task.connectionIDs, p.pickTLSPorts)
 		if err != nil {
 			return err
 		}
-		p.mu.Lock()
-		p.routeTable.routes.deleteByConnectionIDs(task.connectionIDs)
+		p.routeCache.ReplaceByConnectionIDs(task.connectionIDs, incoming)
 	default:
 		return errors.New("updateTask has neither pairs nor connectionIDs")
 	}
-
-	p.routeTable.routes.populateRecords(incoming)
-	p.routeTable.pruneStickyRoutes()
-	p.mu.Unlock()
 
 	return nil
 }
@@ -450,7 +537,7 @@ func NewClientRoutesAddressTranslator(
 		closeChan:     make(chan struct{}),
 		updateTasks:   make(chan updateTask, 1024),
 		resolver:      resolver,
-		routeTable:    newClientRouteTable(),
+		routeCache:    newClientRouteCache(),
 		addrOverrides: overrides,
 	}
 }
@@ -479,7 +566,17 @@ func getHostPortMappingForPairs(c controlConnection, table string, pairs []pair,
 	}
 
 	stmt := fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s where connection_id in ? and host_id in ?", table)
-	return readClientRoutesTable(c, table, stmt, []any{connIDs, hostIDs}, pickTLSPorts)
+	routes, err := readClientRoutesTable(c, table, stmt, []any{connIDs, hostIDs}, pickTLSPorts)
+	if err != nil {
+		return nil, err
+	}
+
+	// The IN query returns the cartesian product of the requested connectionIDs
+	// and hostIDs, so keep only the exact pairs the caller asked for.
+	routes = slices.DeleteFunc(routes, func(route clientRoute) bool {
+		return !slices.Contains(pairs, pair{connectionID: route.connectionID, hostID: route.hostID})
+	})
+	return routes, nil
 }
 
 func readClientRoutesTable(c controlConnection, table, stmt string, bounds []any, pickTLSPorts bool) ([]clientRoute, error) {

--- a/client_routes.go
+++ b/client_routes.go
@@ -156,17 +156,58 @@ func (m clientRouteMap) populateRecords(incoming []clientRoute) {
 	}
 }
 
+// clientRouteTable is the single source of truth for route data.
+// It owns both the full route index and the per-host sticky selection so that
+// all consistency-maintaining logic lives in one place.
+type clientRouteTable struct {
+	routes      clientRouteMap         // hostID → connectionID → clientRoute
+	stickyRoute map[string]clientRoute // hostID → preferred route
+}
+
+func newClientRouteTable() clientRouteTable {
+	return clientRouteTable{
+		routes:      make(clientRouteMap),
+		stickyRoute: make(map[string]clientRoute),
+	}
+}
+
+// pruneStickyRoutes removes sticky entries whose route is no longer present in routes.
+func (t *clientRouteTable) pruneStickyRoutes() {
+	for hostID, route := range t.stickyRoute {
+		if _, ok := t.routes[hostID][route.connectionID]; !ok {
+			delete(t.stickyRoute, hostID)
+		}
+	}
+}
+
+// preferred returns the sticky route for hostID if one exists and is still valid,
+// otherwise picks an arbitrary route and records it as the new sticky entry.
+func (t *clientRouteTable) preferred(hostID string) (clientRoute, bool) {
+	if route, ok := t.stickyRoute[hostID]; ok {
+		if _, exists := t.routes[hostID][route.connectionID]; exists {
+			return route, true
+		}
+		// Stale sticky entry; clear it and fall back to a live route.
+		delete(t.stickyRoute, hostID)
+	}
+	for _, route := range t.routes[hostID] {
+		t.stickyRoute[hostID] = route
+		return route, true
+	}
+	return clientRoute{}, false
+}
+
 type ClientRoutesHandler struct {
 	log           StdLogger
 	c             controlConnection
 	resolver      DNSResolver
 	sub           *eventbus.Subscriber[events.Event]
-	routes        clientRouteMap
+	routeTable    clientRouteTable
 	addrOverrides map[string]string // connectionID → user-supplied ConnectionAddr
 	updateTasks   chan updateTask
 	closeChan     chan struct{}
 	cfg           ClientRoutesConfig
-	mu            sync.RWMutex
+	mu            sync.Mutex
 	pickTLSPorts  bool
 	initialized   bool
 }
@@ -189,15 +230,9 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 		return addr, nil
 	}
 
-	p.mu.RLock()
-	var route clientRoute
-	var found bool
-	for _, r := range p.routes[hostID] {
-		route = r
-		found = true
-		break
-	}
-	p.mu.RUnlock()
+	p.mu.Lock()
+	route, found := p.routeTable.preferred(hostID)
+	p.mu.Unlock()
 
 	if !found {
 		return addr, fmt.Errorf("no address found for host %s", hostID)
@@ -218,10 +253,6 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 	}
 	if len(ips) == 0 {
 		return addr, fmt.Errorf("no addresses returned for host %s (address=%s)", hostID, resolveAddr)
-	}
-
-	if route.port == 0 {
-		return addr, fmt.Errorf("record %s/%s has target port empty", route.hostID, route.connectionID)
 	}
 
 	return AddressPort{Address: ips[0], Port: route.port}, nil
@@ -378,19 +409,20 @@ func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
 			return err
 		}
 		p.mu.Lock()
-		p.routes.deleteByPairs(task.pairs)
+		p.routeTable.routes.deleteByPairs(task.pairs)
 	case task.connectionIDs != nil:
 		incoming, err = getHostPortMappingForConnectionIDs(p.c, p.cfg.TableName, task.connectionIDs, p.pickTLSPorts)
 		if err != nil {
 			return err
 		}
 		p.mu.Lock()
-		p.routes.deleteByConnectionIDs(task.connectionIDs)
+		p.routeTable.routes.deleteByConnectionIDs(task.connectionIDs)
 	default:
 		return errors.New("updateTask has neither pairs nor connectionIDs")
 	}
 
-	p.routes.populateRecords(incoming)
+	p.routeTable.routes.populateRecords(incoming)
+	p.routeTable.pruneStickyRoutes()
 	p.mu.Unlock()
 
 	return nil
@@ -418,7 +450,7 @@ func NewClientRoutesAddressTranslator(
 		closeChan:     make(chan struct{}),
 		updateTasks:   make(chan updateTask, 1024),
 		resolver:      resolver,
-		routes:        make(clientRouteMap),
+		routeTable:    newClientRouteTable(),
 		addrOverrides: overrides,
 	}
 }

--- a/client_routes.go
+++ b/client_routes.go
@@ -107,21 +107,21 @@ func (cfg *ClientRoutesConfig) Validate() error {
 }
 
 type clientRoute struct {
-	ConnectionID  string
-	HostID        string
-	Address       string
-	CQLPort       uint16
-	SecureCQLPort uint16
+	connectionID  string
+	hostID        string
+	address       string
+	cqlPort       uint16
+	secureCQLPort uint16
 }
 
 func (r clientRoute) String() string {
 	return fmt.Sprintf(
-		"clientRoute{ConnectionID=%s, HostID=%s, Address=%s, CQLPort=%d, SecureCQLPort=%d}",
-		r.ConnectionID,
-		r.HostID,
-		r.Address,
-		r.CQLPort,
-		r.SecureCQLPort,
+		"clientRoute{connectionID=%s, hostID=%s, address=%s, cqlPort=%d, secureCQLPort=%d}",
+		r.connectionID,
+		r.hostID,
+		r.address,
+		r.cqlPort,
+		r.secureCQLPort,
 	)
 }
 
@@ -131,16 +131,16 @@ func (r clientRoute) String() string {
 // host first, then pick the right connection.
 type clientRouteMap map[string]map[string]clientRoute
 
-// Merge upserts entries from incoming into the map.
+// merge upserts entries from incoming into the map.
 // Before upserting it prunes stale entries within the query scope defined by
 // scopeConnectionIDs and scopeHostIDs:
 //   - Both non-empty (partial update): prune entries matching BOTH lists.
 //   - Only scopeConnectionIDs (full refresh): prune all entries for those connections.
 //
 // scopeConnectionIDs must not be empty.
-func (m clientRouteMap) Merge(incoming []clientRoute, scopeConnectionIDs, scopeHostIDs []string) {
+func (m clientRouteMap) merge(incoming []clientRoute, scopeConnectionIDs, scopeHostIDs []string) {
 	if len(scopeConnectionIDs) == 0 {
-		panic("clientRouteMap.Merge: scopeConnectionIDs must not be empty")
+		panic("clientRouteMap.merge: scopeConnectionIDs must not be empty")
 	}
 
 	if len(scopeHostIDs) > 0 {
@@ -170,12 +170,12 @@ func (m clientRouteMap) Merge(incoming []clientRoute, scopeConnectionIDs, scopeH
 	}
 
 	for _, inc := range incoming {
-		conns := m[inc.HostID]
+		conns := m[inc.hostID]
 		if conns == nil {
 			conns = make(map[string]clientRoute)
-			m[inc.HostID] = conns
+			m[inc.hostID] = conns
 		}
-		conns[inc.ConnectionID] = inc
+		conns[inc.connectionID] = inc
 	}
 }
 
@@ -203,9 +203,9 @@ func (p *ClientRoutesHandler) Translate(addr net.IP, port int) (net.IP, int) {
 
 func pickProperPort(pickTLSPorts bool, rec *clientRoute) uint16 {
 	if pickTLSPorts {
-		return rec.SecureCQLPort
+		return rec.secureCQLPort
 	}
-	return rec.CQLPort
+	return rec.cqlPort
 }
 
 
@@ -231,17 +231,17 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 		return addr, fmt.Errorf("no address found for host %s", hostID)
 	}
 
-	ips, err := p.resolver.LookupIP(route.Address)
+	ips, err := p.resolver.LookupIP(route.address)
 	if err != nil {
 		return addr, fmt.Errorf("failed to resolve address for host %s: %v", hostID, err)
 	}
 	if len(ips) == 0 {
-		return addr, fmt.Errorf("no addresses returned for host %s (address=%s)", hostID, route.Address)
+		return addr, fmt.Errorf("no addresses returned for host %s (address=%s)", hostID, route.address)
 	}
 
 	port := pickProperPort(p.pickTLSPorts, &route)
 	if port == 0 {
-		return addr, fmt.Errorf("record %s/%s has target port empty", route.HostID, route.ConnectionID)
+		return addr, fmt.Errorf("record %s/%s has target port empty", route.hostID, route.connectionID)
 	}
 
 	return AddressPort{Address: ips[0], Port: port}, nil
@@ -372,7 +372,7 @@ func (p *ClientRoutesHandler) updateHostPortMapping(connectionIDs []string, host
 	}
 
 	p.mu.Lock()
-	p.routes.Merge(incoming, connectionIDs, hostIDs)
+	p.routes.merge(incoming, connectionIDs, hostIDs)
 	p.mu.Unlock()
 
 	return nil
@@ -439,7 +439,7 @@ func getHostPortMappingFromCluster(c controlConnection, table string, connection
 
 	iter := c.query(strings.Join(stmt, " "), bounds...)
 	var rec clientRoute
-	for iter.Scan(&rec.ConnectionID, &rec.HostID, &rec.Address, &rec.CQLPort, &rec.SecureCQLPort) {
+	for iter.Scan(&rec.connectionID, &rec.hostID, &rec.address, &rec.cqlPort, &rec.secureCQLPort) {
 		res = append(res, rec)
 	}
 	if err := iter.Close(); err != nil {

--- a/client_routes.go
+++ b/client_routes.go
@@ -239,10 +239,20 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 	return AddressPort{Address: ips[0], Port: route.port}, nil
 }
 
+type pair struct {
+	connectionID string
+	hostID       string
+}
+
 type updateTask struct {
-	result        chan error
+	result chan error
+	// Exactly one of pairs or connectionIDs must be set.
+	// pairs: scoped update — delete and re-query specific (connectionID, hostID) pairs.
+	// connectionIDs: full refresh — delete all entries for these connections and re-query.
+	// If both are nil, updateHostPortMapping returns an error.
+	// If both are set, pairs takes precedence.
+	pairs         []pair
 	connectionIDs []string
-	hostIDs       []string
 }
 
 func (p *ClientRoutesHandler) Initialize(s *Session) error {
@@ -266,7 +276,7 @@ func (p *ClientRoutesHandler) Initialize(s *Session) error {
 	})
 	p.startUpdateWorker()
 	p.startReadingEvents()
-	err := p.updateHostPortMappingSync(connectionIDs, nil)
+	err := p.updateHostPortMappingSync(updateTask{connectionIDs: connectionIDs})
 	if err != nil {
 		p.log.Printf("error updating host ports: %v\n", err)
 	}
@@ -285,29 +295,22 @@ func (p *ClientRoutesHandler) Stop() {
 	// and concurrent sends to it.
 }
 
-func (p *ClientRoutesHandler) updateHostPortMappingAsync(connectionIDs []string, hostIDs []string) {
+func (p *ClientRoutesHandler) updateHostPortMappingAsync(task updateTask) {
 	select {
-	case p.updateTasks <- updateTask{
-		connectionIDs: connectionIDs,
-		hostIDs:       hostIDs,
-	}:
+	case p.updateTasks <- task:
 	case <-p.closeChan:
 		// Stop() was called; drop the update safely.
 	}
 }
 
-func (p *ClientRoutesHandler) updateHostPortMappingSync(connectionIDs []string, hostIDs []string) error {
-	result := make(chan error, 1)
+func (p *ClientRoutesHandler) updateHostPortMappingSync(task updateTask) error {
+	task.result = make(chan error, 1)
 	select {
-	case p.updateTasks <- updateTask{
-		connectionIDs: connectionIDs,
-		hostIDs:       hostIDs,
-		result:        result,
-	}:
+	case p.updateTasks <- task:
 	case <-p.closeChan:
 		return errors.New("client routes handler stopped")
 	}
-	return <-result
+	return <-task.result
 }
 
 func (p *ClientRoutesHandler) startReadingEvents() {
@@ -327,25 +330,31 @@ func (p *ClientRoutesHandler) startReadingEvents() {
 						continue
 					}
 				}
-				var newConnectionIDs []string
-				for _, connectionID := range evt.ConnectionIDs {
-					if connectionID == "" {
-						continue
-					}
-					if slices.ContainsFunc(p.cfg.Endpoints, func(ep ClientRoutesEndpoint) bool {
-						return ep.ConnectionID == connectionID
-					}) {
-						newConnectionIDs = append(newConnectionIDs, connectionID)
-					}
-				}
-				if len(newConnectionIDs) != 0 {
-					p.updateHostPortMappingAsync(newConnectionIDs, evt.HostIDs)
+				pairs := getPairsFromEvent(evt, connectionIDs)
+				if len(pairs) != 0 {
+					p.updateHostPortMappingAsync(updateTask{pairs: pairs})
 				}
 			case *events.ControlConnectionRecreatedEvent:
-				p.updateHostPortMappingAsync(connectionIDs, nil)
+				p.updateHostPortMappingAsync(updateTask{connectionIDs: connectionIDs})
 			}
 		}
 	}()
+}
+
+func getPairsFromEvent(evt *events.ClientRoutesChangedEvent, allowedConnectionIDs []string) (pairs []pair) {
+	if len(evt.ConnectionIDs) != len(evt.HostIDs) {
+		return nil
+	}
+	for n, connID := range evt.ConnectionIDs {
+		if !slices.Contains(allowedConnectionIDs, connID) {
+			continue
+		}
+		pairs = append(pairs, pair{
+			connectionID: connID,
+			hostID:       evt.HostIDs[n],
+		})
+	}
+	return pairs
 }
 
 func (p *ClientRoutesHandler) startUpdateWorker() {
@@ -353,7 +362,7 @@ func (p *ClientRoutesHandler) startUpdateWorker() {
 		for {
 			select {
 			case task := <-p.updateTasks:
-				err := p.updateHostPortMapping(task.connectionIDs, task.hostIDs)
+				err := p.updateHostPortMapping(task)
 				if err != nil {
 					if debug.Enabled {
 						p.log.Printf("failed to update host port mapping: %v", err)
@@ -370,7 +379,23 @@ func (p *ClientRoutesHandler) startUpdateWorker() {
 	}()
 }
 
-func (p *ClientRoutesHandler) updateHostPortMapping(connectionIDs []string, hostIDs []string) error {
+func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
+	var connectionIDs, hostIDs []string
+
+	switch {
+	case task.pairs != nil:
+		connectionIDs = make([]string, len(task.pairs))
+		hostIDs = make([]string, len(task.pairs))
+		for i, p := range task.pairs {
+			connectionIDs[i] = p.connectionID
+			hostIDs[i] = p.hostID
+		}
+	case task.connectionIDs != nil:
+		connectionIDs = task.connectionIDs
+	default:
+		return errors.New("updateTask has neither pairs nor connectionIDs")
+	}
+
 	incoming, err := getHostPortMappingFromCluster(p.c, p.cfg.TableName, connectionIDs, hostIDs, p.pickTLSPorts)
 	if err != nil {
 		return err

--- a/client_routes.go
+++ b/client_routes.go
@@ -98,21 +98,19 @@ func (cfg *ClientRoutesConfig) Validate() error {
 }
 
 type clientRoute struct {
-	connectionID  string
-	hostID        string
-	address       string
-	cqlPort       uint16
-	secureCQLPort uint16
+	connectionID string
+	hostID       string
+	address      string
+	port         uint16
 }
 
 func (r clientRoute) String() string {
 	return fmt.Sprintf(
-		"clientRoute{connectionID=%s, hostID=%s, address=%s, cqlPort=%d, secureCQLPort=%d}",
+		"clientRoute{connectionID=%s, hostID=%s, address=%s, port=%d}",
 		r.connectionID,
 		r.hostID,
 		r.address,
-		r.cqlPort,
-		r.secureCQLPort,
+		r.port,
 	)
 }
 
@@ -193,14 +191,6 @@ func (p *ClientRoutesHandler) Translate(addr net.IP, port int) (net.IP, int) {
 	panic("should never be called")
 }
 
-func pickProperPort(pickTLSPorts bool, rec *clientRoute) uint16 {
-	if pickTLSPorts {
-		return rec.secureCQLPort
-	}
-	return rec.cqlPort
-}
-
-
 // TranslateHost implements AddressTranslatorV2 interface.
 // It resolves DNS on every call rather than caching resolved addresses.
 // If the user provided a ConnectionAddr for the route's connectionID,
@@ -230,6 +220,10 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 		resolveAddr = override
 	}
 
+	if route.port == 0 {
+		return addr, fmt.Errorf("record %s/%s has target port empty", route.hostID, route.connectionID)
+	}
+
 	ips, err := p.resolver.LookupIP(resolveAddr)
 	if err != nil {
 		return addr, fmt.Errorf("failed to resolve address for host %s: %v", hostID, err)
@@ -238,12 +232,11 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 		return addr, fmt.Errorf("no addresses returned for host %s (address=%s)", hostID, resolveAddr)
 	}
 
-	port := pickProperPort(p.pickTLSPorts, &route)
-	if port == 0 {
+	if route.port == 0 {
 		return addr, fmt.Errorf("record %s/%s has target port empty", route.hostID, route.connectionID)
 	}
 
-	return AddressPort{Address: ips[0], Port: port}, nil
+	return AddressPort{Address: ips[0], Port: route.port}, nil
 }
 
 type updateTask struct {
@@ -365,7 +358,7 @@ func (p *ClientRoutesHandler) startUpdateWorker() {
 }
 
 func (p *ClientRoutesHandler) updateHostPortMapping(connectionIDs []string, hostIDs []string) error {
-	incoming, err := getHostPortMappingFromCluster(p.c, p.cfg.TableName, connectionIDs, hostIDs)
+	incoming, err := getHostPortMappingFromCluster(p.c, p.cfg.TableName, connectionIDs, hostIDs, p.pickTLSPorts)
 	if err != nil {
 		return err
 	}
@@ -407,7 +400,7 @@ func NewClientRoutesAddressTranslator(
 
 var _ AddressTranslator = &ClientRoutesHandler{}
 
-func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string) ([]clientRoute, error) {
+func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string, pickTLSPorts bool) ([]clientRoute, error) {
 	var res []clientRoute
 
 	stmt := []string{fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s", table)}
@@ -444,9 +437,24 @@ func getHostPortMappingFromCluster(c controlConnection, table string, connection
 	}
 
 	iter := c.query(strings.Join(stmt, " "), bounds...)
-	var rec clientRoute
-	for iter.Scan(&rec.connectionID, &rec.hostID, &rec.address, &rec.cqlPort, &rec.secureCQLPort) {
-		res = append(res, rec)
+	var (
+		connectionID  string
+		hostID        string
+		address       string
+		cqlPort       uint16
+		secureCQLPort uint16
+	)
+	for iter.Scan(&connectionID, &hostID, &address, &cqlPort, &secureCQLPort) {
+		port := cqlPort
+		if pickTLSPorts {
+			port = secureCQLPort
+		}
+		res = append(res, clientRoute{
+			connectionID: connectionID,
+			hostID:       hostID,
+			address:      address,
+			port:         port,
+		})
 	}
 	if err := iter.Close(); err != nil {
 		return nil, fmt.Errorf("error reading %s table: %v", table, err)

--- a/client_routes.go
+++ b/client_routes.go
@@ -142,9 +142,28 @@ func (l *clientRouteList) Len() int {
 }
 
 // Merge upserts entries from incoming into the list.
-// Existing entries matching by (ConnectionID, HostID) are updated in place;
-// new entries are appended.
-func (l *clientRouteList) Merge(incoming clientRouteList) {
+// Before upserting it prunes stale entries within the query scope defined by
+// scopeConnectionIDs and scopeHostIDs:
+//   - Both non-empty (partial update): prune entries matching BOTH lists.
+//   - Only scopeConnectionIDs (full refresh): prune all entries for those connections.
+//
+// scopeConnectionIDs must not be empty.
+func (l *clientRouteList) Merge(incoming clientRouteList, scopeConnectionIDs, scopeHostIDs []string) {
+	if len(scopeConnectionIDs) == 0 {
+		panic("clientRouteList.Merge: scopeConnectionIDs must not be empty")
+	}
+
+	if len(scopeHostIDs) > 0 {
+		*l = slices.DeleteFunc(*l, func(r clientRoute) bool {
+			return slices.Contains(scopeConnectionIDs, r.ConnectionID) &&
+				slices.Contains(scopeHostIDs, r.HostID)
+		})
+	} else {
+		*l = slices.DeleteFunc(*l, func(r clientRoute) bool {
+			return slices.Contains(scopeConnectionIDs, r.ConnectionID)
+		})
+	}
+
 	for _, inc := range incoming {
 		found := false
 		for id, existing := range *l {
@@ -362,7 +381,7 @@ func (p *ClientRoutesHandler) updateHostPortMapping(connectionIDs []string, host
 	}
 
 	p.mu.Lock()
-	p.routes.Merge(incoming)
+	p.routes.Merge(incoming, connectionIDs, hostIDs)
 	p.mu.Unlock()
 
 	return nil

--- a/client_routes.go
+++ b/client_routes.go
@@ -114,16 +114,6 @@ type clientRoute struct {
 	SecureCQLPort uint16
 }
 
-// Similar returns true if both records targets same host and connection id
-func (r clientRoute) Similar(o clientRoute) bool {
-	return r.ConnectionID == o.ConnectionID && r.HostID == o.HostID
-}
-
-// Equal returns true if both records are exactly the same
-func (r clientRoute) Equal(o clientRoute) bool {
-	return r == o
-}
-
 func (r clientRoute) String() string {
 	return fmt.Sprintf(
 		"clientRoute{ConnectionID=%s, HostID=%s, Address=%s, CQLPort=%d, SecureCQLPort=%d}",
@@ -135,71 +125,70 @@ func (r clientRoute) String() string {
 	)
 }
 
-type clientRouteList []clientRoute
+// clientRouteMap groups routes by hostID → connectionID → clientRoute.
+// The outer key is the host, the inner key is the connection.
+// This layout matches the AddressTranslator lookup pattern: find routes for a
+// host first, then pick the right connection.
+type clientRouteMap map[string]map[string]clientRoute
 
-func (l *clientRouteList) Len() int {
-	return len(*l)
-}
-
-// Merge upserts entries from incoming into the list.
+// Merge upserts entries from incoming into the map.
 // Before upserting it prunes stale entries within the query scope defined by
 // scopeConnectionIDs and scopeHostIDs:
 //   - Both non-empty (partial update): prune entries matching BOTH lists.
 //   - Only scopeConnectionIDs (full refresh): prune all entries for those connections.
 //
 // scopeConnectionIDs must not be empty.
-func (l *clientRouteList) Merge(incoming clientRouteList, scopeConnectionIDs, scopeHostIDs []string) {
+func (m clientRouteMap) Merge(incoming []clientRoute, scopeConnectionIDs, scopeHostIDs []string) {
 	if len(scopeConnectionIDs) == 0 {
-		panic("clientRouteList.Merge: scopeConnectionIDs must not be empty")
+		panic("clientRouteMap.Merge: scopeConnectionIDs must not be empty")
 	}
 
 	if len(scopeHostIDs) > 0 {
-		*l = slices.DeleteFunc(*l, func(r clientRoute) bool {
-			return slices.Contains(scopeConnectionIDs, r.ConnectionID) &&
-				slices.Contains(scopeHostIDs, r.HostID)
-		})
+		// Partial update: prune entries matching BOTH connection and host.
+		for _, hostID := range scopeHostIDs {
+			conns := m[hostID]
+			if conns == nil {
+				continue
+			}
+			for _, connID := range scopeConnectionIDs {
+				delete(conns, connID)
+			}
+			if len(conns) == 0 {
+				delete(m, hostID)
+			}
+		}
 	} else {
-		*l = slices.DeleteFunc(*l, func(r clientRoute) bool {
-			return slices.Contains(scopeConnectionIDs, r.ConnectionID)
-		})
+		// Full refresh: prune all entries for the given connections.
+		for hostID, conns := range m {
+			for _, connID := range scopeConnectionIDs {
+				delete(conns, connID)
+			}
+			if len(conns) == 0 {
+				delete(m, hostID)
+			}
+		}
 	}
 
 	for _, inc := range incoming {
-		found := false
-		for id, existing := range *l {
-			if existing.Similar(inc) {
-				found = true
-				if !existing.Equal(inc) {
-					(*l)[id] = inc
-				}
-				break
-			}
+		conns := m[inc.HostID]
+		if conns == nil {
+			conns = make(map[string]clientRoute)
+			m[inc.HostID] = conns
 		}
-		if !found {
-			*l = append(*l, inc)
-		}
+		conns[inc.ConnectionID] = inc
 	}
-}
-
-func (l *clientRouteList) FindByHostID(hostID string) *clientRoute {
-	for i := range *l {
-		if (*l)[i].HostID == hostID {
-			return &(*l)[i]
-		}
-	}
-	return nil
 }
 
 type ClientRoutesHandler struct {
-	log         StdLogger
-	c           controlConnection
-	resolver    DNSResolver
-	sub         *eventbus.Subscriber[events.Event]
-	routes      clientRouteList
-	updateTasks chan updateTask
-	closeChan   chan struct{}
-	cfg         ClientRoutesConfig
-	mu          sync.RWMutex
+	log          StdLogger
+	c            controlConnection
+	resolver     DNSResolver
+	sub          *eventbus.Subscriber[events.Event]
+	routes       clientRouteMap
+	updateTasks  chan updateTask
+	closeChan    chan struct{}
+	cfg          ClientRoutesConfig
+	mu           sync.RWMutex
 	pickTLSPorts bool
 	initialized  bool
 }
@@ -219,6 +208,7 @@ func pickProperPort(pickTLSPorts bool, rec *clientRoute) uint16 {
 	return rec.CQLPort
 }
 
+
 // TranslateHost implements AddressTranslatorV2 interface.
 // It resolves DNS on every call rather than caching resolved addresses.
 func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) (AddressPort, error) {
@@ -228,11 +218,12 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 	}
 
 	p.mu.RLock()
-	rec := p.routes.FindByHostID(hostID)
 	var route clientRoute
-	found := rec != nil
-	if found {
-		route = *rec
+	var found bool
+	for _, r := range p.routes[hostID] {
+		route = r
+		found = true
+		break
 	}
 	p.mu.RUnlock()
 
@@ -387,6 +378,7 @@ func (p *ClientRoutesHandler) updateHostPortMapping(connectionIDs []string, host
 	return nil
 }
 
+
 func NewClientRoutesAddressTranslator(
 	cfg ClientRoutesConfig,
 	resolver DNSResolver,
@@ -403,14 +395,14 @@ func NewClientRoutesAddressTranslator(
 		closeChan:    make(chan struct{}),
 		updateTasks:  make(chan updateTask, 1024),
 		resolver:     resolver,
-		routes:       make(clientRouteList, 0),
+			routes:       make(clientRouteMap),
 	}
 }
 
 var _ AddressTranslator = &ClientRoutesHandler{}
 
-func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string) (clientRouteList, error) {
-	var res clientRouteList
+func getHostPortMappingFromCluster(c controlConnection, table string, connectionIDs []string, hostIDs []string) ([]clientRoute, error) {
+	var res []clientRoute
 
 	stmt := []string{fmt.Sprintf("select connection_id, host_id, address, port, tls_port from %s", table)}
 	var bounds []any

--- a/client_routes.go
+++ b/client_routes.go
@@ -119,44 +119,33 @@ func (r clientRoute) String() string {
 // host first, then pick the right connection.
 type clientRouteMap map[string]map[string]clientRoute
 
-// merge upserts entries from incoming into the map.
-// Before upserting it prunes stale entries within the query scope defined by
-// scopeConnectionIDs and scopeHostIDs:
-//   - Both non-empty (partial update): prune entries matching BOTH lists.
-//   - Only scopeConnectionIDs (full refresh): prune all entries for those connections.
-//
-// scopeConnectionIDs must not be empty.
-func (m clientRouteMap) merge(incoming []clientRoute, scopeConnectionIDs, scopeHostIDs []string) {
-	if len(scopeConnectionIDs) == 0 {
-		panic("clientRouteMap.merge: scopeConnectionIDs must not be empty")
-	}
-
-	if len(scopeHostIDs) > 0 {
-		// Partial update: prune entries matching BOTH connection and host.
-		for _, hostID := range scopeHostIDs {
-			conns := m[hostID]
-			if conns == nil {
-				continue
-			}
-			for _, connID := range scopeConnectionIDs {
-				delete(conns, connID)
-			}
-			if len(conns) == 0 {
-				delete(m, hostID)
-			}
+// deleteByPairs removes entries identified by (connectionID, hostID) pairs.
+func (m clientRouteMap) deleteByPairs(pairs []pair) {
+	for _, p := range pairs {
+		conns := m[p.hostID]
+		if conns == nil {
+			continue
 		}
-	} else {
-		// Full refresh: prune all entries for the given connections.
-		for hostID, conns := range m {
-			for _, connID := range scopeConnectionIDs {
-				delete(conns, connID)
-			}
-			if len(conns) == 0 {
-				delete(m, hostID)
-			}
+		delete(conns, p.connectionID)
+		if len(conns) == 0 {
+			delete(m, p.hostID)
 		}
 	}
+}
 
+// deleteByConnectionIDs removes all entries for the given connectionIDs across all hosts.
+func (m clientRouteMap) deleteByConnectionIDs(connectionIDs []string) {
+	for hostID, conns := range m {
+		for _, connID := range connectionIDs {
+			delete(conns, connID)
+		}
+		if len(conns) == 0 {
+			delete(m, hostID)
+		}
+	}
+}
+
+func (m clientRouteMap) populateRecords(incoming []clientRoute) {
 	for _, inc := range incoming {
 		conns := m[inc.hostID]
 		if conns == nil {
@@ -381,7 +370,6 @@ func (p *ClientRoutesHandler) startUpdateWorker() {
 func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
 	var incoming []clientRoute
 	var err error
-	var connectionIDs, hostIDs []string
 
 	switch {
 	case task.pairs != nil:
@@ -389,29 +377,24 @@ func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
 		if err != nil {
 			return err
 		}
-		connectionIDs = make([]string, len(task.pairs))
-		hostIDs = make([]string, len(task.pairs))
-		for i, p := range task.pairs {
-			connectionIDs[i] = p.connectionID
-			hostIDs[i] = p.hostID
-		}
+		p.mu.Lock()
+		p.routes.deleteByPairs(task.pairs)
 	case task.connectionIDs != nil:
 		incoming, err = getHostPortMappingForConnectionIDs(p.c, p.cfg.TableName, task.connectionIDs, p.pickTLSPorts)
 		if err != nil {
 			return err
 		}
-		connectionIDs = task.connectionIDs
+		p.mu.Lock()
+		p.routes.deleteByConnectionIDs(task.connectionIDs)
 	default:
 		return errors.New("updateTask has neither pairs nor connectionIDs")
 	}
 
-	p.mu.Lock()
-	p.routes.merge(incoming, connectionIDs, hostIDs)
+	p.routes.populateRecords(incoming)
 	p.mu.Unlock()
 
 	return nil
 }
-
 
 func NewClientRoutesAddressTranslator(
 	cfg ClientRoutesConfig,

--- a/client_routes.go
+++ b/client_routes.go
@@ -274,30 +274,38 @@ func (p *ClientRoutesHandler) Initialize(s *Session) error {
 }
 
 func (p *ClientRoutesHandler) Stop() {
-	if p.updateTasks != nil {
-		close(p.updateTasks)
-	}
 	if p.closeChan != nil {
 		close(p.closeChan)
 	}
 	if p.sub != nil {
 		p.sub.Stop()
 	}
+	// updateTasks is intentionally NOT closed here; the worker goroutine exits
+	// by selecting on closeChan, which avoids the race between close(updateTasks)
+	// and concurrent sends to it.
 }
 
 func (p *ClientRoutesHandler) updateHostPortMappingAsync(connectionIDs []string, hostIDs []string) {
-	p.updateTasks <- updateTask{
+	select {
+	case p.updateTasks <- updateTask{
 		connectionIDs: connectionIDs,
 		hostIDs:       hostIDs,
+	}:
+	case <-p.closeChan:
+		// Stop() was called; drop the update safely.
 	}
 }
 
 func (p *ClientRoutesHandler) updateHostPortMappingSync(connectionIDs []string, hostIDs []string) error {
 	result := make(chan error, 1)
-	p.updateTasks <- updateTask{
+	select {
+	case p.updateTasks <- updateTask{
 		connectionIDs: connectionIDs,
 		hostIDs:       hostIDs,
 		result:        result,
+	}:
+	case <-p.closeChan:
+		return errors.New("client routes handler stopped")
 	}
 	return <-result
 }
@@ -342,16 +350,21 @@ func (p *ClientRoutesHandler) startReadingEvents() {
 
 func (p *ClientRoutesHandler) startUpdateWorker() {
 	go func() {
-		for task := range p.updateTasks {
-			err := p.updateHostPortMapping(task.connectionIDs, task.hostIDs)
-			if err != nil {
-				if debug.Enabled {
-					p.log.Printf("failed to update host port mapping: %v", err)
+		for {
+			select {
+			case task := <-p.updateTasks:
+				err := p.updateHostPortMapping(task.connectionIDs, task.hostIDs)
+				if err != nil {
+					if debug.Enabled {
+						p.log.Printf("failed to update host port mapping: %v", err)
+					}
 				}
-			}
-			if task.result != nil {
-				task.result <- err
-				close(task.result)
+				if task.result != nil {
+					task.result <- err
+					close(task.result)
+				}
+			case <-p.closeChan:
+				return
 			}
 		}
 	}()

--- a/client_routes.go
+++ b/client_routes.go
@@ -40,15 +40,6 @@ func (l *ClientRoutesEndpointList) GetAllConnectionIDs() []string {
 	return ids
 }
 
-func (l *ClientRoutesEndpointList) GetConnectionAddr(connectionID string) string {
-	for _, endpoint := range *l {
-		if endpoint.ConnectionID == connectionID {
-			return endpoint.ConnectionAddr
-		}
-	}
-	return ""
-}
-
 func (l *ClientRoutesEndpointList) Validate() error {
 	for id, endpoint := range *l {
 		if err := endpoint.Validate(); err != nil {
@@ -180,17 +171,18 @@ func (m clientRouteMap) merge(incoming []clientRoute, scopeConnectionIDs, scopeH
 }
 
 type ClientRoutesHandler struct {
-	log          StdLogger
-	c            controlConnection
-	resolver     DNSResolver
-	sub          *eventbus.Subscriber[events.Event]
-	routes       clientRouteMap
-	updateTasks  chan updateTask
-	closeChan    chan struct{}
-	cfg          ClientRoutesConfig
-	mu           sync.RWMutex
-	pickTLSPorts bool
-	initialized  bool
+	log           StdLogger
+	c             controlConnection
+	resolver      DNSResolver
+	sub           *eventbus.Subscriber[events.Event]
+	routes        clientRouteMap
+	addrOverrides map[string]string // connectionID → user-supplied ConnectionAddr
+	updateTasks   chan updateTask
+	closeChan     chan struct{}
+	cfg           ClientRoutesConfig
+	mu            sync.RWMutex
+	pickTLSPorts  bool
+	initialized   bool
 }
 
 var _ AddressTranslatorV2 = (*ClientRoutesHandler)(nil)
@@ -211,6 +203,8 @@ func pickProperPort(pickTLSPorts bool, rec *clientRoute) uint16 {
 
 // TranslateHost implements AddressTranslatorV2 interface.
 // It resolves DNS on every call rather than caching resolved addresses.
+// If the user provided a ConnectionAddr for the route's connectionID,
+// that address is used instead of the one from the system.client_routes table.
 func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr AddressPort) (AddressPort, error) {
 	hostID := host.HostID()
 	if hostID == "" {
@@ -231,12 +225,17 @@ func (p *ClientRoutesHandler) TranslateHost(host AddressTranslatorHostInfo, addr
 		return addr, fmt.Errorf("no address found for host %s", hostID)
 	}
 
-	ips, err := p.resolver.LookupIP(route.address)
+	resolveAddr := route.address
+	if override, ok := p.addrOverrides[route.connectionID]; ok {
+		resolveAddr = override
+	}
+
+	ips, err := p.resolver.LookupIP(resolveAddr)
 	if err != nil {
 		return addr, fmt.Errorf("failed to resolve address for host %s: %v", hostID, err)
 	}
 	if len(ips) == 0 {
-		return addr, fmt.Errorf("no addresses returned for host %s (address=%s)", hostID, route.address)
+		return addr, fmt.Errorf("no addresses returned for host %s (address=%s)", hostID, resolveAddr)
 	}
 
 	port := pickProperPort(p.pickTLSPorts, &route)
@@ -388,14 +387,21 @@ func NewClientRoutesAddressTranslator(
 	if resolver == nil {
 		resolver = defaultDnsResolver
 	}
+	overrides := make(map[string]string, len(cfg.Endpoints))
+	for _, ep := range cfg.Endpoints {
+		if ep.ConnectionAddr != "" {
+			overrides[ep.ConnectionID] = ep.ConnectionAddr
+		}
+	}
 	return &ClientRoutesHandler{
-		cfg:          cfg,
-		log:          log,
-		pickTLSPorts: pickTLSPorts,
-		closeChan:    make(chan struct{}),
-		updateTasks:  make(chan updateTask, 1024),
-		resolver:     resolver,
-			routes:       make(clientRouteMap),
+		cfg:           cfg,
+		log:           log,
+		pickTLSPorts:  pickTLSPorts,
+		closeChan:     make(chan struct{}),
+		updateTasks:   make(chan updateTask, 1024),
+		resolver:      resolver,
+		routes:        make(clientRouteMap),
+		addrOverrides: overrides,
 	}
 }
 

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -53,7 +53,7 @@ func TestGetHostPortMapping(t *testing.T) {
 	}
 
 	racks := []string{"rack1", "rack2", "rack3"}
-	expected := []UnresolvedClientRoute{}
+	expected := []clientRoute{}
 	for id, hostID := range hostIDs {
 		rack := racks[id]
 		ip := net.ParseIP(fmt.Sprintf("127.0.0.%d", id+1))
@@ -67,7 +67,7 @@ func TestGetHostPortMapping(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to insert connection metadata: %s", err.Error())
 			}
-			expected = append(expected, UnresolvedClientRoute{
+			expected = append(expected, clientRoute{
 				ConnectionID:  connectionID,
 				HostID:        hostID,
 				Address:       ip.String(),
@@ -77,44 +77,44 @@ func TestGetHostPortMapping(t *testing.T) {
 		}
 	}
 
-	sortUnresolvedHostPorts(expected)
+	sortClientRoutes(expected)
 
 	tcases := []struct {
 		name     string
-		method   func(controlConnection) ([]UnresolvedClientRoute, error)
-		expected []UnresolvedClientRoute
+		method   func(controlConnection) ([]clientRoute, error)
+		expected []clientRoute
 	}{
 		{
 			name: "get-all",
-			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+			method: func(controlConnection) ([]clientRoute, error) {
 				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, nil)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-all-hosts",
-			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+			method: func(controlConnection) ([]clientRoute, error) {
 				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, nil)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-all-connections",
-			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+			method: func(controlConnection) ([]clientRoute, error) {
 				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, hostIDs)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-concrete",
-			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+			method: func(controlConnection) ([]clientRoute, error) {
 				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-concrete-host",
-			method: func(controlConnection) ([]UnresolvedClientRoute, error) {
+			method: func(controlConnection) ([]clientRoute, error) {
 				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs)
 			},
 			expected: expected,
@@ -128,7 +128,7 @@ func TestGetHostPortMapping(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			sortUnresolvedHostPorts(got)
+			sortClientRoutes(got)
 
 			if diff := cmp.Diff(got, tc.expected); diff != "" {
 				t.Errorf("got unexpected result: %s", diff)
@@ -137,7 +137,7 @@ func TestGetHostPortMapping(t *testing.T) {
 	}
 }
 
-func sortUnresolvedHostPorts(xs []UnresolvedClientRoute) {
+func sortClientRoutes(xs []clientRoute) {
 	sort.Slice(xs, func(i, j int) bool {
 		a, b := xs[i], xs[j]
 

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -61,7 +61,7 @@ func TestGetHostPortMapping(t *testing.T) {
 		for _, connectionID := range connectionIDs {
 			err := session.Query(
 				fmt.Sprintf(`INSERT INTO %s (
-                                            connection_id, host_id, Address, port, tls_port, alternator_port, alternator_https_port, Datacenter, Rack) 
+                                            connection_id, host_id, Address, port, tls_port, alternator_port, alternator_https_port, Datacenter, Rack)
 						VALUES (?, ?, ?, 9042, 9142, 0, 0, 'dc1', ?);`, qualifiedTable),
 				connectionID, hostID, ip.String(), rack,
 			).Exec()

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -53,7 +53,8 @@ func TestGetHostPortMapping(t *testing.T) {
 	}
 
 	racks := []string{"rack1", "rack2", "rack3"}
-	expected := []clientRoute{}
+	var expected []clientRoute
+	var expectedTLS []clientRoute
 	for id, hostID := range hostIDs {
 		rack := racks[id]
 		ip := net.ParseIP(fmt.Sprintf("127.0.0.%d", id+1))
@@ -68,16 +69,22 @@ func TestGetHostPortMapping(t *testing.T) {
 				t.Fatalf("unable to insert connection metadata: %s", err.Error())
 			}
 			expected = append(expected, clientRoute{
-				connectionID:  connectionID,
-				hostID:        hostID,
-				address:       ip.String(),
-				cqlPort:       9042,
-				secureCQLPort: 9142,
+				connectionID: connectionID,
+				hostID:       hostID,
+				address:      ip.String(),
+				port:         9042,
+			})
+			expectedTLS = append(expectedTLS, clientRoute{
+				connectionID: connectionID,
+				hostID:       hostID,
+				address:      ip.String(),
+				port:         9142,
 			})
 		}
 	}
 
 	sortClientRoutes(expected)
+	sortClientRoutes(expectedTLS)
 
 	tcases := []struct {
 		name     string
@@ -87,37 +94,44 @@ func TestGetHostPortMapping(t *testing.T) {
 		{
 			name: "get-all",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, nil)
+				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, nil, false)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-all-hosts",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, nil)
+				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, nil, false)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-all-connections",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, hostIDs)
+				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, hostIDs, false)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-concrete",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs)
+				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs, false)
 			},
 			expected: expected,
 		},
 		{
 			name: "get-concrete-host",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs)
+				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs, false)
 			},
 			expected: expected,
+		},
+		{
+			name: "get-all-tls",
+			method: func(controlConnection) ([]clientRoute, error) {
+				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, nil, true)
+			},
+			expected: expectedTLS,
 		},
 	}
 

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -85,6 +85,7 @@ func TestGetHostPortMapping(t *testing.T) {
 
 	sortClientRoutes(expected)
 	sortClientRoutes(expectedTLS)
+	expectedFirstHost := filterClientRoutesByHostID(expected, hostIDs[0])
 
 	tcases := []struct {
 		name     string
@@ -92,44 +93,30 @@ func TestGetHostPortMapping(t *testing.T) {
 		expected []clientRoute
 	}{
 		{
-			name: "get-all",
+			name: "get-for-connection-ids",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, nil, false)
+				return getHostPortMappingForConnectionIDs(session.control, qualifiedTable, connectionIDs, false)
 			},
 			expected: expected,
 		},
 		{
-			name: "get-all-hosts",
+			name: "get-for-pairs",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, nil, false)
+				return getHostPortMappingForPairs(session.control, qualifiedTable, makeClientRoutePairs(connectionIDs, hostIDs), false)
 			},
 			expected: expected,
 		},
 		{
-			name: "get-all-connections",
+			name: "get-for-single-host-pairs",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, hostIDs, false)
+				return getHostPortMappingForPairs(session.control, qualifiedTable, makeClientRoutePairs(connectionIDs, hostIDs[:1]), false)
 			},
-			expected: expected,
+			expected: expectedFirstHost,
 		},
 		{
-			name: "get-concrete",
+			name: "get-for-connection-ids-tls",
 			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs, false)
-			},
-			expected: expected,
-		},
-		{
-			name: "get-concrete-host",
-			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, connectionIDs, hostIDs, false)
-			},
-			expected: expected,
-		},
-		{
-			name: "get-all-tls",
-			method: func(controlConnection) ([]clientRoute, error) {
-				return getHostPortMappingFromCluster(session.control, qualifiedTable, nil, nil, true)
+				return getHostPortMappingForConnectionIDs(session.control, qualifiedTable, connectionIDs, true)
 			},
 			expected: expectedTLS,
 		},
@@ -149,6 +136,26 @@ func TestGetHostPortMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeClientRoutePairs(connectionIDs, hostIDs []string) []pair {
+	pairs := make([]pair, 0, len(connectionIDs)*len(hostIDs))
+	for _, connectionID := range connectionIDs {
+		for _, hostID := range hostIDs {
+			pairs = append(pairs, pair{connectionID: connectionID, hostID: hostID})
+		}
+	}
+	return pairs
+}
+
+func filterClientRoutesByHostID(routes []clientRoute, hostID string) []clientRoute {
+	var filtered []clientRoute
+	for _, route := range routes {
+		if route.hostID == hostID {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
 }
 
 func sortClientRoutes(xs []clientRoute) {

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -60,7 +60,7 @@ func TestGetHostPortMapping(t *testing.T) {
 		for _, connectionID := range connectionIDs {
 			err := session.Query(
 				fmt.Sprintf(`INSERT INTO %s (
-                                            connection_id, host_id, Address, port, tls_port, alternator_port, alternator_https_port, Datacenter, Rack) 
+                                            connection_id, host_id, Address, port, tls_port, alternator_port, alternator_https_port, Datacenter, Rack)
 						VALUES (?, ?, ?, 9042, 9142, 0, 0, 'dc1', ?);`, qualifiedTable),
 				connectionID, hostID, ip.String(), rack,
 			).Exec()

--- a/client_routes_test.go
+++ b/client_routes_test.go
@@ -60,7 +60,7 @@ func TestGetHostPortMapping(t *testing.T) {
 		for _, connectionID := range connectionIDs {
 			err := session.Query(
 				fmt.Sprintf(`INSERT INTO %s (
-                                            connection_id, host_id, Address, port, tls_port, alternator_port, alternator_https_port, Datacenter, Rack)
+                                            connection_id, host_id, Address, port, tls_port, alternator_port, alternator_https_port, Datacenter, Rack) 
 						VALUES (?, ?, ?, 9042, 9142, 0, 0, 'dc1', ?);`, qualifiedTable),
 				connectionID, hostID, ip.String(), rack,
 			).Exec()
@@ -68,11 +68,11 @@ func TestGetHostPortMapping(t *testing.T) {
 				t.Fatalf("unable to insert connection metadata: %s", err.Error())
 			}
 			expected = append(expected, clientRoute{
-				ConnectionID:  connectionID,
-				HostID:        hostID,
-				Address:       ip.String(),
-				CQLPort:       9042,
-				SecureCQLPort: 9142,
+				connectionID:  connectionID,
+				hostID:        hostID,
+				address:       ip.String(),
+				cqlPort:       9042,
+				secureCQLPort: 9142,
 			})
 		}
 	}
@@ -130,7 +130,7 @@ func TestGetHostPortMapping(t *testing.T) {
 
 			sortClientRoutes(got)
 
-			if diff := cmp.Diff(got, tc.expected); diff != "" {
+			if diff := cmp.Diff(got, tc.expected, cmp.AllowUnexported(clientRoute{})); diff != "" {
 				t.Errorf("got unexpected result: %s", diff)
 			}
 		})
@@ -141,9 +141,9 @@ func sortClientRoutes(xs []clientRoute) {
 	sort.Slice(xs, func(i, j int) bool {
 		a, b := xs[i], xs[j]
 
-		if a.ConnectionID != b.ConnectionID {
-			return a.ConnectionID < b.ConnectionID // or bytes.Compare if raw [16]byte
+		if a.connectionID != b.connectionID {
+			return a.connectionID < b.connectionID // or bytes.Compare if raw [16]byte
 		}
-		return a.HostID < b.HostID
+		return a.hostID < b.hostID
 	})
 }

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -7,20 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"sync/atomic"
 	"testing"
-	"time"
 )
 
-type dnsResolverFunc func(string) ([]net.IP, error)
+// dnsResolverFunc adapts a function to the DNSResolver interface.
+type dnsResolverFunc func(host string) ([]net.IP, error)
 
-// LookupIP implements DNSResolver for dnsResolverFunc.
-func (f dnsResolverFunc) LookupIP(host string) ([]net.IP, error) { return f(host) }
-
-type clientRoutesResolverFunc func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error)
-
-func (f clientRoutesResolverFunc) Resolve(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
-	return f(endpoint)
+func (f dnsResolverFunc) LookupIP(host string) ([]net.IP, error) {
+	return f(host)
 }
 
 type fakeControlConn struct {
@@ -64,151 +58,41 @@ func (t testHostInfo) ScyllaShardAwarePort() uint16       { return 0 }
 func (t testHostInfo) ScyllaShardAwarePortTLS() uint16    { return 0 }
 func (t testHostInfo) ScyllaShardCount() int              { return 0 }
 
-func TestResolvedClientRouteCloneNewerNeedsUpdate(t *testing.T) {
-	ip1 := net.ParseIP("127.0.0.1")
-	ip2 := net.ParseIP("127.0.0.2")
-	base := ResolvedClientRoute{
-		UnresolvedClientRoute: UnresolvedClientRoute{
-			ConnectionID: "c1",
-			HostID:       "h1",
-			Address:      "host",
-			CQLPort:      9042,
-		},
-		allKnownIPs: []net.IP{ip1},
-		currentIP:   ip1,
-		updateTime:  time.Unix(10, 0),
+func TestMerge(t *testing.T) {
+	list := clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
 	}
 
-	clone := base.Clone()
-	clone.allKnownIPs[0][0] = 8
-	clone.currentIP[0] = 9
-
-	if base.allKnownIPs[0][0] == 8 {
-		t.Fatalf("Clone should not share allKnownIPs slices")
-	}
-	if base.currentIP[0] == 9 {
-		t.Fatalf("Clone should not share currentIP slices")
-	}
-
-	newerIP := ResolvedClientRoute{currentIP: ip2}
-	if !(ResolvedClientRoute{}).Newer(newerIP) {
-		t.Fatalf("expected Newer to prefer non-nil currentIP")
-	}
-
-	newerTime := ResolvedClientRoute{updateTime: time.Unix(20, 0)}
-	if !base.Newer(newerTime) {
-		t.Fatalf("expected Newer to prefer newer updateTime")
-	}
-
-	if !(ResolvedClientRoute{currentIP: nil}).NeedsUpdate() {
-		t.Fatalf("expected NeedsUpdate for missing currentIP")
-	}
-	if !(ResolvedClientRoute{currentIP: ip1}).NeedsUpdate() {
-		t.Fatalf("expected NeedsUpdate for missing allKnownIPs")
-	}
-	if !(ResolvedClientRoute{currentIP: ip1, allKnownIPs: []net.IP{ip1}, forcedResolve: true}).NeedsUpdate() {
-		t.Fatalf("expected NeedsUpdate when forcedResolve is set")
-	}
-	if (ResolvedClientRoute{currentIP: ip1, allKnownIPs: []net.IP{ip1}}).NeedsUpdate() {
-		t.Fatalf("did not expect NeedsUpdate for fully resolved route")
-	}
-}
-
-func TestResolvedClientRouteListMergeWithUnresolved(t *testing.T) {
-	list := ResolvedClientRouteList{
-		{
-			UnresolvedClientRoute: UnresolvedClientRoute{
-				ConnectionID: "c1",
-				HostID:       "h1",
-				Address:      "a1",
-				CQLPort:      9042,
-			},
-			forcedResolve: false,
-		},
-	}
-
-	list.MergeWithUnresolved(UnresolvedClientRouteList{
-		{
-			ConnectionID: "c1",
-			HostID:       "h1",
-			Address:      "a1",
-			CQLPort:      9042,
-		},
+	// Same record: no change expected.
+	list.Merge(clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
 	})
-	if len(list) != 1 || list[0].forcedResolve {
-		t.Fatalf("expected unchanged record when unresolved is equal")
+	if len(list) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(list))
 	}
 
-	list.MergeWithUnresolved(UnresolvedClientRouteList{
-		{
-			ConnectionID: "c1",
-			HostID:       "h1",
-			Address:      "a2",
-			CQLPort:      9043,
-		},
+	// Updated address: record should be replaced.
+	list.Merge(clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a2", CQLPort: 9043},
 	})
-	if list[0].Address != "a2" || list[0].CQLPort != 9043 || !list[0].forcedResolve {
-		t.Fatalf("expected record to update and force resolve")
+	if list[0].Address != "a2" || list[0].CQLPort != 9043 {
+		t.Fatalf("expected record to update")
 	}
 
-	list = ResolvedClientRouteList{}
-	list.MergeWithUnresolved(UnresolvedClientRouteList{
-		{
-			ConnectionID: "c2",
-			HostID:       "h2",
-			Address:      "a3",
-			CQLPort:      9044,
-		},
+	// New record: should be appended.
+	list = clientRouteList{}
+	list.Merge(clientRouteList{
+		{ConnectionID: "c2", HostID: "h2", Address: "a3", CQLPort: 9044},
 	})
-	if len(list) != 1 || !list[0].forcedResolve {
-		t.Fatalf("expected new record to be appended with forcedResolve")
-	}
-}
-
-func TestResolvedClientRouteListMergeWithResolved(t *testing.T) {
-	older := ResolvedClientRoute{
-		UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"},
-		updateTime:            time.Unix(10, 0),
-	}
-	newer := ResolvedClientRoute{
-		UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"},
-		updateTime:            time.Unix(20, 0),
-		currentIP:             net.ParseIP("10.0.0.1"),
-	}
-
-	list := ResolvedClientRouteList{older}
-	other := ResolvedClientRouteList{newer, {UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c2", HostID: "h2"}}}
-	list.MergeWithResolved(&other)
-
-	if list[0].updateTime != newer.updateTime || list[0].currentIP == nil {
-		t.Fatalf("expected newer record to replace older one")
-	}
-	if len(list) != 2 {
+	if len(list) != 1 {
 		t.Fatalf("expected new record to be appended")
 	}
-
-	list = ResolvedClientRouteList{newer}
-	stale := ResolvedClientRouteList{older}
-	list.MergeWithResolved(&stale)
-	if list[0].updateTime != newer.updateTime {
-		t.Fatalf("expected newer record to be preserved when other is stale")
-	}
 }
 
-func TestResolvedClientRouteListUpdateIfNewerAndFindByHostID(t *testing.T) {
-	list := ResolvedClientRouteList{{
-		UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"},
-		updateTime:            time.Unix(10, 0),
-	}}
-
-	older := ResolvedClientRoute{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"}, updateTime: time.Unix(5, 0)}
-	if list.UpdateIfNewer(older) {
-		t.Fatalf("expected UpdateIfNewer to ignore older record")
-	}
-
-	newer := ResolvedClientRoute{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1"}, updateTime: time.Unix(15, 0)}
-	if !list.UpdateIfNewer(newer) {
-		t.Fatalf("expected UpdateIfNewer to accept newer record")
+func TestFindByHostID(t *testing.T) {
+	list := clientRouteList{
+		{ConnectionID: "c1", HostID: "h1"},
+		{ConnectionID: "c1", HostID: "h2"},
 	}
 
 	rec := list.FindByHostID("h1")
@@ -219,64 +103,9 @@ func TestResolvedClientRouteListUpdateIfNewerAndFindByHostID(t *testing.T) {
 	if list[0].ConnectionID != "updated" {
 		t.Fatalf("expected FindByHostID to return pointer to list element")
 	}
-}
 
-func TestSimpleClientRoutesResolverResolve(t *testing.T) {
-	calls := 0
-	resolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
-		calls++
-		return []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2")}, nil
-	})
-
-	res := newSimpleClientRoutesResolver(time.Hour, resolver)
-	endpoint := ResolvedClientRoute{
-		UnresolvedClientRoute: UnresolvedClientRoute{Address: "example"},
-		currentIP:             net.ParseIP("10.0.0.2"),
-	}
-
-	all, current, err := res.Resolve(endpoint)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("expected resolver to be called once, got %d", calls)
-	}
-	if current == nil || !current.Equal(endpoint.currentIP) {
-		t.Fatalf("expected currentIP to be preserved when present")
-	}
-	if len(all) != 2 {
-		t.Fatalf("expected allKnownIPs to be returned")
-	}
-
-	_, _, err = res.Resolve(endpoint)
-	if err != nil {
-		t.Fatalf("unexpected error from cached resolve: %v", err)
-	}
-	if calls != 1 {
-		t.Fatalf("expected cached resolve to avoid LookupIP, got %d", calls)
-	}
-
-	resolveErr := errors.New("resolve failed")
-	errorResolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
-		return nil, resolveErr
-	})
-	errorRes := newSimpleClientRoutesResolver(0, errorResolver)
-	endpoint.allKnownIPs = []net.IP{net.ParseIP("10.0.0.9")}
-	all, current, err = errorRes.Resolve(endpoint)
-	if !errors.Is(err, resolveErr) {
-		t.Fatalf("expected resolver error to propagate")
-	}
-	if len(all) != 1 || current == nil || !current.Equal(endpoint.currentIP) {
-		t.Fatalf("expected existing values to be returned on error")
-	}
-
-	emptyResolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
-		return []net.IP{}, nil
-	})
-	emptyRes := newSimpleClientRoutesResolver(0, emptyResolver)
-	_, _, err = emptyRes.Resolve(ResolvedClientRoute{UnresolvedClientRoute: UnresolvedClientRoute{Address: "example"}})
-	if err == nil {
-		t.Fatalf("expected error when resolver returns empty list")
+	if list.FindByHostID("h3") != nil {
+		t.Fatalf("expected nil for missing host")
 	}
 }
 
@@ -285,8 +114,14 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 	noHost := testHostInfo{hostID: ""}
 	missingHost := testHostInfo{hostID: "missing"}
 
-	handler := &ClientRoutesHandler{}
-	handler.resolvedEndpoints.Store(&ResolvedClientRouteList{})
+	resolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.0.0.1")}, nil
+	})
+
+	handler := &ClientRoutesHandler{
+		resolver: resolver,
+		routes:   make(clientRouteList, 0),
+	}
 
 	res, err := handler.TranslateHost(noHost, addr)
 	if err != nil {
@@ -301,15 +136,11 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		t.Fatalf("expected error for missing host entry")
 	}
 
-	resolvedList := ResolvedClientRouteList{
-		{
-			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1", CQLPort: 9042, SecureCQLPort: 9142},
-			currentIP:             net.ParseIP("10.0.0.1"),
-		},
+	handler.routes = clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", CQLPort: 9042, SecureCQLPort: 9142},
 	}
 
 	handler.pickTLSPorts = false
-	handler.resolvedEndpoints.Store(&resolvedList)
 	res, err = handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -328,145 +159,14 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 	}
 
 	errorHandler := &ClientRoutesHandler{
-		resolver: clientRoutesResolverFunc(func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
-			return nil, nil, errors.New("lookup failed")
+		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
+			return nil, errors.New("lookup failed")
 		}),
+		routes: clientRouteList{{ConnectionID: "c2", HostID: "h2", Address: "host", CQLPort: 9042}},
 	}
-	errorList := ResolvedClientRouteList{{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c2", HostID: "h2", Address: "host"}}}
-	errorHandler.resolvedEndpoints.Store(&errorList)
 	_, err = errorHandler.TranslateHost(testHostInfo{hostID: "h2"}, addr)
 	if err == nil {
 		t.Fatalf("expected resolver error to bubble up")
-	}
-}
-
-func TestClientRoutesHandlerTranslateHost_CASCollision(t *testing.T) {
-	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
-	resolverStarted := make(chan struct{})
-	releaseResolver := make(chan struct{})
-	resolver := clientRoutesResolverFunc(func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
-		close(resolverStarted)
-		<-releaseResolver
-		ip := net.ParseIP("10.0.0.1")
-		return []net.IP{ip}, ip, nil
-	})
-
-	handler := &ClientRoutesHandler{resolver: resolver, pickTLSPorts: false}
-	origList := ResolvedClientRouteList{{UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1", Address: "host", CQLPort: 9042}}}
-	handler.resolvedEndpoints.Store(&origList)
-
-	done := make(chan error, 1)
-	go func() {
-		_, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
-		done <- err
-	}()
-
-	<-resolverStarted
-	altList := ResolvedClientRouteList{}
-	handler.resolvedEndpoints.Store(&altList)
-	close(releaseResolver)
-	time.Sleep(10 * time.Millisecond)
-	handler.resolvedEndpoints.Store(&origList)
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("unexpected error after CAS collision: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("TranslateHost timed out after CAS collision")
-	}
-}
-
-func TestClientRoutesHandlerResolveAndUpdateInPlace(t *testing.T) {
-	var inFlight int32
-	var maxInFlight int32
-	called := make(chan string, 4)
-	resolveErr := errors.New("resolve error")
-
-	resolver := clientRoutesResolverFunc(func(endpoint ResolvedClientRoute) ([]net.IP, net.IP, error) {
-		curr := atomic.AddInt32(&inFlight, 1)
-		for {
-			prev := atomic.LoadInt32(&maxInFlight)
-			if curr > prev && atomic.CompareAndSwapInt32(&maxInFlight, prev, curr) {
-				break
-			}
-			if curr <= prev {
-				break
-			}
-		}
-		defer atomic.AddInt32(&inFlight, -1)
-
-		called <- endpoint.Address
-		time.Sleep(10 * time.Millisecond)
-		if endpoint.Address == "err" {
-			return nil, nil, resolveErr
-		}
-		ip := net.ParseIP("10.0.0.1")
-		return []net.IP{ip}, ip, nil
-	})
-
-	handler := &ClientRoutesHandler{
-		resolver: resolver,
-		cfg: ClientRoutesConfig{
-			MaxResolverConcurrency:       2,
-			ResolveHealthyEndpointPeriod: time.Hour,
-		},
-	}
-
-	now := time.Now().UTC()
-	ip := net.ParseIP("10.0.0.2")
-	records := ResolvedClientRouteList{
-		{
-			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c1", HostID: "h1", Address: "healthy"},
-			currentIP:             ip,
-			allKnownIPs:           []net.IP{ip},
-			updateTime:            now,
-		},
-		{
-			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c2", HostID: "h2", Address: "forced"},
-			forcedResolve:         true,
-		},
-		{
-			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c3", HostID: "h3", Address: "empty"},
-		},
-		{
-			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c4", HostID: "h4", Address: "stale"},
-			currentIP:             ip,
-			allKnownIPs:           []net.IP{ip},
-			updateTime:            now.Add(-2 * time.Hour),
-		},
-		{
-			UnresolvedClientRoute: UnresolvedClientRoute{ConnectionID: "c5", HostID: "h5", Address: "err"},
-		},
-	}
-
-	err := handler.resolveAndUpdateInPlace(records)
-	if err == nil || !errors.Is(err, resolveErr) {
-		t.Fatalf("expected aggregated error to include resolver error")
-	}
-	close(called)
-
-	calledMap := map[string]bool{}
-	for addr := range called {
-		calledMap[addr] = true
-	}
-
-	if calledMap["healthy"] {
-		t.Fatalf("did not expect healthy endpoint to be resolved")
-	}
-	for _, addr := range []string{"forced", "empty", "stale", "err"} {
-		if !calledMap[addr] {
-			t.Fatalf("expected resolver to be called for %s", addr)
-		}
-	}
-
-	if atomic.LoadInt32(&maxInFlight) > int32(handler.cfg.MaxResolverConcurrency) {
-		t.Fatalf("expected max concurrency <= %d, got %d", handler.cfg.MaxResolverConcurrency, maxInFlight)
-	}
-
-	if records[1].currentIP == nil || len(records[1].allKnownIPs) == 0 || records[1].forcedResolve {
-		t.Fatalf("expected forced endpoint to be resolved and forcedResolve cleared")
 	}
 }
 
@@ -525,3 +225,7 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries simulates the same
+// sequence of operations that updateHostPortMapping performs (lock → Merge → unlock)
+// to verify that a full refresh correctly prunes a host that disappeared.

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -60,30 +60,30 @@ func (t testHostInfo) ScyllaShardCount() int              { return 0 }
 
 func TestMerge(t *testing.T) {
 	m := clientRouteMap{
-		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
 	}
 
 	// Same record: no change expected.
-	m.Merge([]clientRoute{
-		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
+	m.merge([]clientRoute{
+		{connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042},
 	}, []string{"c1"}, nil)
 	if len(m) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(m))
 	}
 
 	// Updated address: record should be replaced.
-	m.Merge([]clientRoute{
-		{ConnectionID: "c1", HostID: "h1", Address: "a2", CQLPort: 9043},
+	m.merge([]clientRoute{
+		{connectionID: "c1", hostID: "h1", address: "a2", cqlPort: 9043},
 	}, []string{"c1"}, nil)
 	rec := m["h1"]["c1"]
-	if rec.Address != "a2" || rec.CQLPort != 9043 {
+	if rec.address != "a2" || rec.cqlPort != 9043 {
 		t.Fatalf("expected record to update")
 	}
 
 	// New record: should be added.
 	m = make(clientRouteMap)
-	m.Merge([]clientRoute{
-		{ConnectionID: "c2", HostID: "h2", Address: "a3", CQLPort: 9044},
+	m.merge([]clientRoute{
+		{connectionID: "c2", hostID: "h2", address: "a3", cqlPort: 9044},
 	}, []string{"c2"}, nil)
 	if len(m) != 1 {
 		t.Fatalf("expected new record to be added")
@@ -118,7 +118,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 	}
 
 	handler.routes = clientRouteMap{
-		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", CQLPort: 9042, SecureCQLPort: 9142}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", cqlPort: 9042, secureCQLPort: 9142}},
 	}
 
 	handler.pickTLSPorts = false
@@ -143,7 +143,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
 			return nil, errors.New("lookup failed")
 		}),
-			routes: clientRouteMap{"h2": {"c2": {ConnectionID: "c2", HostID: "h2", Address: "host", CQLPort: 9042}}},
+			routes: clientRouteMap{"h2": {"c2": {connectionID: "c2", hostID: "h2", address: "host", cqlPort: 9042}}},
 	}
 	_, err = errorHandler.TranslateHost(testHostInfo{hostID: "h2"}, addr)
 	if err == nil {
@@ -209,12 +209,12 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 
 func TestMerge_DeletedHost(t *testing.T) {
 	m := clientRouteMap{
-		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
-		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042}},
 	}
 
 	// Simulate event for (c1, h1) where query returned nothing → (c1,h1) should be removed.
-	m.Merge(nil, []string{"c1"}, []string{"h1"})
+	m.merge(nil, []string{"c1"}, []string{"h1"})
 
 	if len(m) != 1 {
 		t.Fatalf("expected 1 entry after pruning deleted host, got %d", len(m))
@@ -227,43 +227,43 @@ func TestMerge_DeletedHost(t *testing.T) {
 func TestMerge_UpdatedHost(t *testing.T) {
 	m := clientRouteMap{
 		"h1": {
-			"c1": {ConnectionID: "c1", HostID: "h1", Address: "old-addr", CQLPort: 9042},
-			"c2": {ConnectionID: "c2", HostID: "h1", Address: "old-addr2", CQLPort: 9042},
+			"c1": {connectionID: "c1", hostID: "h1", address: "old-addr", cqlPort: 9042},
+			"c2": {connectionID: "c2", hostID: "h1", address: "old-addr2", cqlPort: 9042},
 		},
-		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "keep", CQLPort: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "keep", cqlPort: 9042}},
 	}
 
 	// h1 address changed; fresh query returns new data for h1. h2 is not affected.
-	m.Merge([]clientRoute{
-		{ConnectionID: "c1", HostID: "h1", Address: "new-addr", CQLPort: 9043},
-		{ConnectionID: "c2", HostID: "h1", Address: "new-addr2", CQLPort: 9043},
+	m.merge([]clientRoute{
+		{connectionID: "c1", hostID: "h1", address: "new-addr", cqlPort: 9043},
+		{connectionID: "c2", hostID: "h1", address: "new-addr2", cqlPort: 9043},
 	}, []string{"c1", "c2"}, []string{"h1"})
 
 	if len(m) != 2 || len(m["h1"]) != 2 {
 		t.Fatalf("expected 2 hosts with h1 having 2 connections, got %d hosts", len(m))
 	}
-	if r := m["h1"]["c1"]; r.Address != "new-addr" {
-		t.Fatalf("expected c1/h1 to have new address, got %s", r.Address)
+	if r := m["h1"]["c1"]; r.address != "new-addr" {
+		t.Fatalf("expected c1/h1 to have new address, got %s", r.address)
 	}
-	if r := m["h1"]["c2"]; r.Address != "new-addr2" {
-		t.Fatalf("expected c2/h1 to have new address, got %s", r.Address)
+	if r := m["h1"]["c2"]; r.address != "new-addr2" {
+		t.Fatalf("expected c2/h1 to have new address, got %s", r.address)
 	}
-	if r := m["h2"]["c1"]; r.Address != "keep" {
+	if r := m["h2"]["c1"]; r.address != "keep" {
 		t.Fatalf("expected h2 entry to be preserved unchanged")
 	}
 }
 
 func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
 	m := clientRouteMap{
-		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
-		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042}},
-		"h3": {"c1": {ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042}},
+		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", cqlPort: 9042}},
 	}
 
 	// Full refresh for connection c1: all entries for c1 are pruned, only h1 and h2 returned.
-	m.Merge([]clientRoute{
-		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+	m.merge([]clientRoute{
+		{connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042},
+		{connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042},
 	}, []string{"c1"}, nil)
 
 	if len(m) != 2 {
@@ -280,18 +280,18 @@ func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
 func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
 	// Existing routes: h1, h2, h3.
 	routes := clientRouteMap{
-		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
-		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042}},
-		"h3": {"c1": {ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042}},
+		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", cqlPort: 9042}},
 	}
 
 	// Cluster now returns only h1 and h2 (h3 was decommissioned).
 	incoming := []clientRoute{
-		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+		{connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042},
+		{connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042},
 	}
 
-	routes.Merge(incoming, []string{"c1"}, nil)
+	routes.merge(incoming, []string{"c1"}, nil)
 
 	if len(routes) != 2 {
 		t.Fatalf("expected 2 entries after full-refresh prune, got %d", len(routes))

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -630,6 +630,37 @@ func TestStartReadingEventsUsesCartesianPairs(t *testing.T) {
 	}
 }
 
+func TestClientRoutesHandlerInitializeIsIdempotent(t *testing.T) {
+	s := &Session{
+		control: &fakeControlConn{},
+		eventBus: eventbus.New[events.Event](eventbus.EventBusConfig{
+			InputEventsQueueSize: 1,
+		}, nil),
+		logger: &nopLogger{},
+	}
+	if err := s.eventBus.Start(); err != nil {
+		t.Fatalf("starting event bus: %v", err)
+	}
+	defer s.eventBus.Stop()
+
+	h := NewClientRoutesAddressTranslator(ClientRoutesConfig{
+		TableName: "system.client_routes",
+		Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
+	}, nil, false, &nopLogger{})
+	defer h.Stop()
+
+	if err := h.Initialize(s); err != nil {
+		t.Fatalf("first Initialize call failed: %v", err)
+	}
+	if !h.initialized {
+		t.Fatal("expected handler to be marked initialized")
+	}
+
+	if err := h.Initialize(s); err == nil {
+		t.Fatal("expected second Initialize call to fail")
+	}
+}
+
 func TestClientRoutesHandlerTranslateHost_RetainsCurrentRouteAfterQueryError(t *testing.T) {
 	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
 	resolvedIPs := map[string]net.IP{

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 )
 
 // dnsResolverFunc adapts a function to the DNSResolver interface.
@@ -21,6 +22,7 @@ func (f dnsResolverFunc) LookupIP(host string) ([]net.IP, error) {
 type fakeControlConn struct {
 	statement string
 	values    []any
+	iter      *Iter
 }
 
 func (f *fakeControlConn) getConn() *connHost          { return nil }
@@ -28,6 +30,9 @@ func (f *fakeControlConn) awaitSchemaAgreement() error { return nil }
 func (f *fakeControlConn) query(statement string, values ...any) *Iter {
 	f.statement = statement
 	f.values = values
+	if f.iter != nil {
+		return f.iter
+	}
 	return &Iter{}
 }
 func (f *fakeControlConn) querySystem(statement string, values ...any) *Iter {
@@ -101,8 +106,8 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 	})
 
 	handler := &ClientRoutesHandler{
-		resolver: resolver,
-		routes:   make(clientRouteMap),
+		resolver:   resolver,
+		routeTable: newClientRouteTable(),
 	}
 
 	res, err := handler.TranslateHost(noHost, addr)
@@ -118,7 +123,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		t.Fatalf("expected error for missing host entry")
 	}
 
-	handler.routes = clientRouteMap{
+	handler.routeTable.routes = clientRouteMap{
 		"h1": {"c1": {connectionID: "c1", hostID: "h1", port: 9042}},
 	}
 
@@ -137,7 +142,10 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
 			return nil, errors.New("lookup failed")
 		}),
-			routes: clientRouteMap{"h2": {"c2": {connectionID: "c2", hostID: "h2", address: "host", port: 9042}}},
+		routeTable: clientRouteTable{
+			routes:      clientRouteMap{"h2": {"c2": {connectionID: "c2", hostID: "h2", address: "host", port: 9042}}},
+			stickyRoute: make(map[string]clientRoute),
+		},
 	}
 	_, err = errorHandler.TranslateHost(testHostInfo{hostID: "h2"}, addr)
 	if err == nil {
@@ -150,11 +158,81 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 			t.Fatal("DNS should not be called when port is 0")
 			return nil, nil
 		}),
-			routes: clientRouteMap{"h3": {"c3": {connectionID: "c3", hostID: "h3", address: "host", port: 0}}},
+		routeTable: clientRouteTable{
+			routes:      clientRouteMap{"h3": {"c3": {connectionID: "c3", hostID: "h3", address: "host", port: 0}}},
+			stickyRoute: make(map[string]clientRoute),
+		},
 	}
 	_, err = zeroPortHandler.TranslateHost(testHostInfo{hostID: "h3"}, addr)
 	if err == nil {
 		t.Fatalf("expected error for zero port")
+	}
+}
+
+func TestTranslateHost_StickyRoute(t *testing.T) {
+	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
+	resolvedIPs := map[string]net.IP{
+		"addr-c1": net.ParseIP("10.0.0.1"),
+		"addr-c2": net.ParseIP("10.0.0.2"),
+	}
+	handler := &ClientRoutesHandler{
+		pickTLSPorts: false,
+		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
+			if ip, ok := resolvedIPs[host]; ok {
+				return []net.IP{ip}, nil
+			}
+			return nil, fmt.Errorf("unknown host %s", host)
+		}),
+		routeTable: clientRouteTable{
+			routes: clientRouteMap{
+				"h1": {
+					"c1": {connectionID: "c1", hostID: "h1", address: "addr-c1", port: 9042},
+					"c2": {connectionID: "c2", hostID: "h1", address: "addr-c2", port: 9042},
+				},
+			},
+			stickyRoute: make(map[string]clientRoute),
+		},
+	}
+
+	// First call picks an arbitrary route and records it as sticky.
+	res1, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	firstIP := res1.Address
+
+	// Determine which connection was picked so we can verify stickiness.
+	var pickedConn, otherConn string
+	var otherIP net.IP
+	if firstIP.Equal(resolvedIPs["addr-c1"]) {
+		pickedConn, otherConn, otherIP = "c1", "c2", resolvedIPs["addr-c2"]
+	} else if firstIP.Equal(resolvedIPs["addr-c2"]) {
+		pickedConn, otherConn, otherIP = "c2", "c1", resolvedIPs["addr-c1"]
+	} else {
+		t.Fatalf("unexpected IP %v", firstIP)
+	}
+	_ = otherConn // used implicitly via otherIP
+
+	// Second call should stick to the same connection.
+	res2, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res2.Address.Equal(firstIP) {
+		t.Fatalf("expected sticky route IP %v, got %v", firstIP, res2.Address)
+	}
+
+	// Remove the picked route; sticky route should fall back to the other.
+	handler.mu.Lock()
+	delete(handler.routeTable.routes["h1"], pickedConn)
+	handler.mu.Unlock()
+
+	res3, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res3.Address.Equal(otherIP) {
+		t.Fatalf("expected fallback IP %v, got %v", otherIP, res3.Address)
 	}
 }
 
@@ -333,6 +411,32 @@ func TestClientRouteMapDeleteByConnectionIDs_FullRefreshPrunesAllStale(t *testin
 	}
 }
 
+func TestPruneStickyRoutes(t *testing.T) {
+	table := clientRouteTable{
+		stickyRoute: map[string]clientRoute{
+			"h1": {connectionID: "c1"},
+			"h2": {connectionID: "c1"},
+			"h3": {connectionID: "c1"},
+		},
+		routes: clientRouteMap{
+			"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
+			"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
+		},
+	}
+
+	table.pruneStickyRoutes()
+
+	if _, ok := table.stickyRoute["h1"]; !ok {
+		t.Fatalf("expected h1 to remain in stickyRoute")
+	}
+	if _, ok := table.stickyRoute["h2"]; !ok {
+		t.Fatalf("expected h2 to remain in stickyRoute")
+	}
+	if _, ok := table.stickyRoute["h3"]; ok {
+		t.Fatalf("expected h3 to be pruned from stickyRoute")
+	}
+}
+
 func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
 
@@ -346,15 +450,16 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 		}
 		return nil, fmt.Errorf("unknown host %s", host)
 	})
-	routes := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "route-addr", port: 9042}},
+	routes := clientRouteTable{
+		routes:      clientRouteMap{"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "route-addr", port: 9042}}},
+		stickyRoute: make(map[string]clientRoute),
 	}
 
 	t.Run("no override uses route address", func(t *testing.T) {
 		handler := &ClientRoutesHandler{
 			addrOverrides: map[string]string{},
 			resolver:      resolver,
-			routes:        routes,
+			routeTable:    routes,
 		}
 
 		res, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
@@ -370,7 +475,7 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 		handler := &ClientRoutesHandler{
 			addrOverrides: map[string]string{"c1": "override-addr"},
 			resolver:      resolver,
-			routes:        routes,
+			routeTable:    routes,
 		}
 
 		res, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
@@ -417,7 +522,7 @@ func TestStop_DoesNotPanicWithConcurrentAsyncSends(t *testing.T) {
 		c:           &fakeControlConn{},
 		closeChan:   make(chan struct{}),
 		updateTasks: make(chan updateTask, 1024),
-		routes:      make(clientRouteMap),
+		routeTable:  newClientRouteTable(),
 		cfg: ClientRoutesConfig{
 			TableName: "system.client_routes",
 			Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
@@ -439,4 +544,69 @@ func TestStop_DoesNotPanicWithConcurrentAsyncSends(t *testing.T) {
 	close(start) // release all goroutines simultaneously
 	h.Stop()     // race against the concurrent sends — must not panic
 	wg.Wait()
+}
+
+func TestUpdateHostPortMappingSyncCompletes(t *testing.T) {
+	h := &ClientRoutesHandler{
+		log:         &defaultLogger{},
+		c:           &fakeControlConn{},
+		closeChan:   make(chan struct{}),
+		updateTasks: make(chan updateTask, 1024),
+		routeTable:  newClientRouteTable(),
+		cfg: ClientRoutesConfig{
+			TableName: "system.client_routes",
+			Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
+		},
+	}
+	h.startUpdateWorker()
+	defer h.Stop()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.updateHostPortMappingSync(updateTask{connectionIDs: []string{"c1"}})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for synchronous update")
+	}
+}
+
+func TestUpdateWorkerDoesNotMutateRoutesOnQueryError(t *testing.T) {
+	h := &ClientRoutesHandler{
+		log:         &defaultLogger{},
+		c:           &fakeControlConn{iter: &Iter{err: errors.New("query failed")}},
+		closeChan:   make(chan struct{}),
+		updateTasks: make(chan updateTask, 1024),
+		routeTable: clientRouteTable{
+			routes: clientRouteMap{
+				"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
+			},
+			stickyRoute: map[string]clientRoute{
+				"h1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
+			},
+		},
+		cfg: ClientRoutesConfig{
+			TableName: "system.client_routes",
+			Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
+		},
+	}
+	h.startUpdateWorker()
+	defer h.Stop()
+
+	err := h.updateHostPortMappingSync(updateTask{connectionIDs: []string{"c1"}})
+	if err == nil {
+		t.Fatal("expected query error")
+	}
+
+	if _, ok := h.routeTable.routes["h1"]["c1"]; !ok {
+		t.Fatal("expected existing route to remain after query error")
+	}
+	if _, ok := h.routeTable.stickyRoute["h1"]; !ok {
+		t.Fatal("expected sticky route to remain after query error")
+	}
 }

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -10,6 +10,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gocql/gocql/events"
+	"github.com/gocql/gocql/internal/eventbus"
 )
 
 // dnsResolverFunc adapts a function to the DNSResolver interface.
@@ -44,6 +47,30 @@ func (f *fakeControlConn) close()                                          {}
 func (f *fakeControlConn) getSession() *Session                            { return nil }
 func (f *fakeControlConn) reconnect() error                                { return nil }
 
+func newClientRoutesEventHarness(t *testing.T, allowedConnectionIDs []string) (*ClientRoutesHandler, *eventbus.EventBus[events.Event]) {
+	t.Helper()
+
+	bus := eventbus.New[events.Event](eventbus.EventBusConfig{InputEventsQueueSize: 1}, nil)
+	if err := bus.Start(); err != nil {
+		t.Fatalf("starting event bus: %v", err)
+	}
+
+	h := &ClientRoutesHandler{
+		sub:         bus.Subscribe("port-mux", 1, nil),
+		updateTasks: make(chan updateTask, 1),
+		closeChan:   make(chan struct{}),
+	}
+	h.startReadingEvents(allowedConnectionIDs)
+
+	t.Cleanup(func() {
+		if err := bus.Stop(); err != nil {
+			t.Fatalf("stopping event bus: %v", err)
+		}
+	})
+
+	return h, bus
+}
+
 type testHostInfo struct {
 	hostID string
 }
@@ -64,36 +91,18 @@ func (t testHostInfo) ScyllaShardAwarePort() uint16       { return 0 }
 func (t testHostInfo) ScyllaShardAwarePortTLS() uint16    { return 0 }
 func (t testHostInfo) ScyllaShardCount() int              { return 0 }
 
-func TestClientRouteMapPopulateRecords(t *testing.T) {
-	m := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
-	}
+func newCacheEntry(routes ...clientRoute) clientRouteCacheEntry {
+	return clientRouteCacheEntry{allRoutes: routes}
+}
 
-	// Same record: no change expected.
-	m.populateRecords([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
-	})
-	if len(m) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(m))
-	}
+func newCache(routes map[string]clientRouteCacheEntry) clientRouteCache {
+	return clientRouteCache{routes: routes}
+}
 
-	// Updated address: record should be replaced.
-	m.populateRecords([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a2", port: 9043},
-	})
-	rec := m["h1"]["c1"]
-	if rec.address != "a2" || rec.port != 9043 {
-		t.Fatalf("expected record to update")
-	}
-
-	// New record: should be added.
-	m = make(clientRouteMap)
-	m.populateRecords([]clientRoute{
-		{connectionID: "c2", hostID: "h2", address: "a3", port: 9044},
-	})
-	if len(m) != 1 {
-		t.Fatalf("expected new record to be added")
-	}
+func newCacheEntryWithCurrent(current clientRoute, routes ...clientRoute) clientRouteCacheEntry {
+	entry := clientRouteCacheEntry{allRoutes: routes}
+	entry.BindCurrent(current.connectionID)
+	return entry
 }
 
 func TestClientRoutesHandlerTranslateHost(t *testing.T) {
@@ -107,7 +116,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 
 	handler := &ClientRoutesHandler{
 		resolver:   resolver,
-		routeTable: newClientRouteTable(),
+		routeCache: newClientRouteCache(),
 	}
 
 	res, err := handler.TranslateHost(noHost, addr)
@@ -123,9 +132,9 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		t.Fatalf("expected error for missing host entry")
 	}
 
-	handler.routeTable.routes = clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", port: 9042}},
-	}
+	handler.routeCache = newCache(map[string]clientRouteCacheEntry{
+		"h1": newCacheEntry(clientRoute{connectionID: "c1", hostID: "h1", port: 9042}),
+	})
 
 	res, err = handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
 	if err != nil {
@@ -142,10 +151,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
 			return nil, errors.New("lookup failed")
 		}),
-		routeTable: clientRouteTable{
-			routes:      clientRouteMap{"h2": {"c2": {connectionID: "c2", hostID: "h2", address: "host", port: 9042}}},
-			stickyRoute: make(map[string]clientRoute),
-		},
+		routeCache: newCache(map[string]clientRouteCacheEntry{"h2": newCacheEntry(clientRoute{connectionID: "c2", hostID: "h2", address: "host", port: 9042})}),
 	}
 	_, err = errorHandler.TranslateHost(testHostInfo{hostID: "h2"}, addr)
 	if err == nil {
@@ -158,10 +164,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 			t.Fatal("DNS should not be called when port is 0")
 			return nil, nil
 		}),
-		routeTable: clientRouteTable{
-			routes:      clientRouteMap{"h3": {"c3": {connectionID: "c3", hostID: "h3", address: "host", port: 0}}},
-			stickyRoute: make(map[string]clientRoute),
-		},
+		routeCache: newCache(map[string]clientRouteCacheEntry{"h3": newCacheEntry(clientRoute{connectionID: "c3", hostID: "h3", address: "host", port: 0})}),
 	}
 	_, err = zeroPortHandler.TranslateHost(testHostInfo{hostID: "h3"}, addr)
 	if err == nil {
@@ -169,7 +172,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 	}
 }
 
-func TestTranslateHost_StickyRoute(t *testing.T) {
+func TestClientRoutesHandlerTranslateHost_CurrentRoute(t *testing.T) {
 	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
 	resolvedIPs := map[string]net.IP{
 		"addr-c1": net.ParseIP("10.0.0.1"),
@@ -183,56 +186,136 @@ func TestTranslateHost_StickyRoute(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unknown host %s", host)
 		}),
-		routeTable: clientRouteTable{
-			routes: clientRouteMap{
-				"h1": {
-					"c1": {connectionID: "c1", hostID: "h1", address: "addr-c1", port: 9042},
-					"c2": {connectionID: "c2", hostID: "h1", address: "addr-c2", port: 9042},
-				},
-			},
-			stickyRoute: make(map[string]clientRoute),
-		},
+		routeCache: newCache(map[string]clientRouteCacheEntry{
+			"h1": newCacheEntry(
+				clientRoute{connectionID: "c1", hostID: "h1", address: "addr-c1", port: 9042},
+				clientRoute{connectionID: "c2", hostID: "h1", address: "addr-c2", port: 9042},
+			),
+		}),
 	}
 
-	// First call picks an arbitrary route and records it as sticky.
+	// First call picks the first route in the record.
 	res1, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	firstIP := res1.Address
-
-	// Determine which connection was picked so we can verify stickiness.
-	var pickedConn, otherConn string
-	var otherIP net.IP
-	if firstIP.Equal(resolvedIPs["addr-c1"]) {
-		pickedConn, otherConn, otherIP = "c1", "c2", resolvedIPs["addr-c2"]
-	} else if firstIP.Equal(resolvedIPs["addr-c2"]) {
-		pickedConn, otherConn, otherIP = "c2", "c1", resolvedIPs["addr-c1"]
-	} else {
-		t.Fatalf("unexpected IP %v", firstIP)
+	if !res1.Address.Equal(resolvedIPs["addr-c1"]) {
+		t.Fatalf("expected first route to resolve addr-c1, got %v", res1.Address)
 	}
-	_ = otherConn // used implicitly via otherIP
 
-	// Second call should stick to the same connection.
+	// Refresh the host and replace c1 with c2. The next call should fall back to
+	// the remaining route.
+	handler.routeCache.ReplaceByConnectionIDs([]string{"c1"}, []clientRoute{
+		{connectionID: "c2", hostID: "h1", address: "addr-c2", port: 9042},
+	})
+
 	res2, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !res2.Address.Equal(firstIP) {
-		t.Fatalf("expected sticky route IP %v, got %v", firstIP, res2.Address)
+	if !res2.Address.Equal(resolvedIPs["addr-c2"]) {
+		t.Fatalf("expected fallback route to resolve addr-c2, got %v", res2.Address)
+	}
+}
+
+func TestClientRoutesHandlerTranslateHost_PreservesCurrentAcrossRefresh(t *testing.T) {
+	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
+	resolvedIPs := map[string]net.IP{
+		"addr-c1-old": net.ParseIP("10.0.0.1"),
+		"addr-c1-new": net.ParseIP("10.0.0.2"),
+		"addr-c2":     net.ParseIP("10.0.0.3"),
+	}
+	resolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
+		if ip, ok := resolvedIPs[host]; ok {
+			return []net.IP{ip}, nil
+		}
+		return nil, fmt.Errorf("unknown host %s", host)
+	})
+
+	newHandler := func() *ClientRoutesHandler {
+		return &ClientRoutesHandler{
+			resolver: resolver,
+			routeCache: newCache(map[string]clientRouteCacheEntry{
+				"h1": newCacheEntryWithCurrent(
+					clientRoute{connectionID: "c1", hostID: "h1", address: "addr-c1-old", port: 9042},
+					clientRoute{connectionID: "c1", hostID: "h1", address: "addr-c1-old", port: 9042},
+					clientRoute{connectionID: "c2", hostID: "h1", address: "addr-c2", port: 9042},
+				),
+			}),
+		}
 	}
 
-	// Remove the picked route; sticky route should fall back to the other.
-	handler.mu.Lock()
-	delete(handler.routeTable.routes["h1"], pickedConn)
-	handler.mu.Unlock()
+	for _, tc := range []struct {
+		name    string
+		replace func(*clientRouteCache)
+	}{
+		{
+			name: "connection-ids",
+			replace: func(c *clientRouteCache) {
+				c.ReplaceByConnectionIDs([]string{"c1"}, []clientRoute{
+					{connectionID: "c1", hostID: "h1", address: "addr-c1-new", port: 9042},
+				})
+			},
+		},
+		{
+			name: "pairs",
+			replace: func(c *clientRouteCache) {
+				c.ReplaceByPairs([]pair{{connectionID: "c1", hostID: "h1"}}, []clientRoute{
+					{connectionID: "c1", hostID: "h1", address: "addr-c1-new", port: 9042},
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newHandler()
+			tc.replace(&handler.routeCache)
 
-	res3, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+			res, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !res.Address.Equal(resolvedIPs["addr-c1-new"]) {
+				t.Fatalf("expected preferred route to stay on c1 with updated address, got %v", res.Address)
+			}
+		})
 	}
-	if !res3.Address.Equal(otherIP) {
-		t.Fatalf("expected fallback IP %v, got %v", otherIP, res3.Address)
+}
+
+func TestClientRoutesHandlerTranslateHost_PrunesMissingHostAcrossRefresh(t *testing.T) {
+	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
+	resolvedIPs := map[string]net.IP{
+		"addr-h1": net.ParseIP("10.0.1.1"),
+		"addr-h2": net.ParseIP("10.0.1.2"),
+		"addr-h3": net.ParseIP("10.0.1.3"),
+	}
+	handler := &ClientRoutesHandler{
+		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
+			if ip, ok := resolvedIPs[host]; ok {
+				return []net.IP{ip}, nil
+			}
+			return nil, fmt.Errorf("unknown host %s", host)
+		}),
+		routeCache: newCache(map[string]clientRouteCacheEntry{
+			"h1": newCacheEntryWithCurrent(
+				clientRoute{connectionID: "c1", hostID: "h1", address: "addr-h1", port: 9042},
+				clientRoute{connectionID: "c1", hostID: "h1", address: "addr-h1", port: 9042},
+			),
+			"h2": newCacheEntry(clientRoute{connectionID: "c1", hostID: "h2", address: "addr-h2", port: 9042}),
+			"h3": newCacheEntry(clientRoute{connectionID: "c1", hostID: "h3", address: "addr-h3", port: 9042}),
+		}),
+	}
+
+	if _, err := handler.TranslateHost(testHostInfo{hostID: "h3"}, addr); err != nil {
+		t.Fatalf("unexpected error before refresh: %v", err)
+	}
+
+	handler.routeCache.ReplaceByConnectionIDs([]string{"c1"}, []clientRoute{
+		{connectionID: "c1", hostID: "h1", address: "addr-h1-new", port: 9042},
+		{connectionID: "c1", hostID: "h2", address: "addr-h2", port: 9042},
+	})
+
+	if _, err := handler.TranslateHost(testHostInfo{hostID: "h3"}, addr); err == nil {
+		t.Fatal("expected h3 to be pruned after refresh")
 	}
 }
 
@@ -339,101 +422,47 @@ func TestGetHostPortMappingForPairsQuery(t *testing.T) {
 	}
 }
 
-func TestClientRouteMapDeleteByPairs_DeletedHost(t *testing.T) {
-	m := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
-	}
-
-	// Simulate event for (c1, h1) where query returned nothing → (c1,h1) should be removed.
-	m.deleteByPairs([]pair{{connectionID: "c1", hostID: "h1"}})
-
-	if len(m) != 1 {
-		t.Fatalf("expected 1 entry after pruning deleted host, got %d", len(m))
-	}
-	if _, ok := m["h2"]; !ok {
-		t.Fatalf("expected h2 to survive")
-	}
-}
-
-func TestClientRouteMapDeleteByPairs_UpdatedHost(t *testing.T) {
-	m := clientRouteMap{
-		"h1": {
-			"c1": {connectionID: "c1", hostID: "h1", address: "old-addr", port: 9042},
-			"c2": {connectionID: "c2", hostID: "h1", address: "old-addr2", port: 9042},
+func TestGetHostPortMappingForPairsFiltersCrossProductRows(t *testing.T) {
+	meta := resultMetadata{
+		columns: []ColumnInfo{
+			{Name: "connection_id", TypeInfo: typeVarchar},
+			{Name: "host_id", TypeInfo: typeVarchar},
+			{Name: "address", TypeInfo: typeVarchar},
+			{Name: "port", TypeInfo: typeInt},
+			{Name: "tls_port", TypeInfo: typeInt},
 		},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "keep", port: 9042}},
+		actualColCount: 5,
+		colCount:       5,
 	}
 
-	// h1 address changed; delete old pairs, then populate with new data.
-	m.deleteByPairs([]pair{
+	ctrl := &fakeControlConn{
+		iter: makeIter(meta,
+			marshalRow(meta, []any{"c1", "h1", "10.0.0.1", 9042, 9142}),
+			marshalRow(meta, []any{"c1", "h2", "10.0.0.2", 9043, 9143}),
+			marshalRow(meta, []any{"c2", "h1", "10.0.0.3", 9044, 9144}),
+			marshalRow(meta, []any{"c2", "h2", "10.0.0.4", 9045, 9145}),
+		),
+	}
+
+	got, err := getHostPortMappingForPairs(ctrl, "system.client_routes", []pair{
 		{connectionID: "c1", hostID: "h1"},
-		{connectionID: "c2", hostID: "h1"},
-	})
-	m.populateRecords([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "new-addr", port: 9043},
-		{connectionID: "c2", hostID: "h1", address: "new-addr2", port: 9043},
-	})
-
-	if len(m) != 2 || len(m["h1"]) != 2 {
-		t.Fatalf("expected 2 hosts with h1 having 2 connections, got %d hosts", len(m))
-	}
-	if r := m["h1"]["c1"]; r.address != "new-addr" {
-		t.Fatalf("expected c1/h1 to have new address, got %s", r.address)
-	}
-	if r := m["h1"]["c2"]; r.address != "new-addr2" {
-		t.Fatalf("expected c2/h1 to have new address, got %s", r.address)
-	}
-	if r := m["h2"]["c1"]; r.address != "keep" {
-		t.Fatalf("expected h2 entry to be preserved unchanged")
-	}
-}
-
-func TestClientRouteMapDeleteByConnectionIDs_FullRefreshPrunesAllStale(t *testing.T) {
-	m := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
-		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", port: 9042}},
+		{connectionID: "c2", hostID: "h2"},
+	}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Full refresh for connection c1: all entries for c1 are pruned, only h1 and h2 returned.
-	m.deleteByConnectionIDs([]string{"c1"})
-	m.populateRecords([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
-		{connectionID: "c1", hostID: "h2", address: "a2", port: 9042},
-	})
-
-	if len(m) != 2 {
-		t.Fatalf("expected 2 entries after full refresh prune, got %d", len(m))
+	want := []clientRoute{
+		{connectionID: "c1", hostID: "h1", address: "10.0.0.1", port: 9042},
+		{connectionID: "c2", hostID: "h2", address: "10.0.0.4", port: 9045},
 	}
-	if _, ok := m["h3"]; ok {
-		t.Fatalf("expected h3 to be pruned")
+	if len(got) != len(want) {
+		t.Fatalf("unexpected row count: got %d want %d", len(got), len(want))
 	}
-}
-
-func TestPruneStickyRoutes(t *testing.T) {
-	table := clientRouteTable{
-		stickyRoute: map[string]clientRoute{
-			"h1": {connectionID: "c1"},
-			"h2": {connectionID: "c1"},
-			"h3": {connectionID: "c1"},
-		},
-		routes: clientRouteMap{
-			"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
-			"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
-		},
-	}
-
-	table.pruneStickyRoutes()
-
-	if _, ok := table.stickyRoute["h1"]; !ok {
-		t.Fatalf("expected h1 to remain in stickyRoute")
-	}
-	if _, ok := table.stickyRoute["h2"]; !ok {
-		t.Fatalf("expected h2 to remain in stickyRoute")
-	}
-	if _, ok := table.stickyRoute["h3"]; ok {
-		t.Fatalf("expected h3 to be pruned from stickyRoute")
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row #%d = %+v, want %+v", i, got[i], want[i])
+		}
 	}
 }
 
@@ -450,16 +479,15 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 		}
 		return nil, fmt.Errorf("unknown host %s", host)
 	})
-	routes := clientRouteTable{
-		routes:      clientRouteMap{"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "route-addr", port: 9042}}},
-		stickyRoute: make(map[string]clientRoute),
+	newRoutes := func() clientRouteCache {
+		return newCache(map[string]clientRouteCacheEntry{"h1": newCacheEntry(clientRoute{connectionID: "c1", hostID: "h1", address: "route-addr", port: 9042})})
 	}
 
 	t.Run("no override uses route address", func(t *testing.T) {
 		handler := &ClientRoutesHandler{
 			addrOverrides: map[string]string{},
 			resolver:      resolver,
-			routeTable:    routes,
+			routeCache:    newRoutes(),
 		}
 
 		res, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
@@ -475,7 +503,7 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 		handler := &ClientRoutesHandler{
 			addrOverrides: map[string]string{"c1": "override-addr"},
 			resolver:      resolver,
-			routeTable:    routes,
+			routeCache:    newRoutes(),
 		}
 
 		res, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
@@ -487,42 +515,13 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 		}
 	})
 }
-
-// TestClientRouteMapFullRefresh_PrunesStaleEntries simulates the same
-// sequence of operations that updateHostPortMapping performs (lock → delete → populate → unlock)
-// to verify that a full refresh correctly prunes a host that disappeared.
-func TestClientRouteMapFullRefresh_PrunesStaleEntries(t *testing.T) {
-	// Existing routes: h1, h2, h3.
-	routes := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
-		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", port: 9042}},
-	}
-
-	// Cluster now returns only h1 and h2 (h3 was decommissioned).
-	incoming := []clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
-		{connectionID: "c1", hostID: "h2", address: "a2", port: 9042},
-	}
-
-	routes.deleteByConnectionIDs([]string{"c1"})
-	routes.populateRecords(incoming)
-
-	if len(routes) != 2 {
-		t.Fatalf("expected 2 entries after full-refresh prune, got %d", len(routes))
-	}
-	if _, ok := routes["h3"]; ok {
-		t.Fatalf("h3 should have been pruned by full refresh")
-	}
-}
-
 func TestStop_DoesNotPanicWithConcurrentAsyncSends(t *testing.T) {
 	h := &ClientRoutesHandler{
 		log:         &defaultLogger{},
 		c:           &fakeControlConn{},
 		closeChan:   make(chan struct{}),
 		updateTasks: make(chan updateTask, 1024),
-		routeTable:  newClientRouteTable(),
+		routeCache:  newClientRouteCache(),
 		cfg: ClientRoutesConfig{
 			TableName: "system.client_routes",
 			Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
@@ -552,7 +551,7 @@ func TestUpdateHostPortMappingSyncCompletes(t *testing.T) {
 		c:           &fakeControlConn{},
 		closeChan:   make(chan struct{}),
 		updateTasks: make(chan updateTask, 1024),
-		routeTable:  newClientRouteTable(),
+		routeCache:  newClientRouteCache(),
 		cfg: ClientRoutesConfig{
 			TableName: "system.client_routes",
 			Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
@@ -576,20 +575,83 @@ func TestUpdateHostPortMappingSyncCompletes(t *testing.T) {
 	}
 }
 
-func TestUpdateWorkerDoesNotMutateRoutesOnQueryError(t *testing.T) {
+func TestStartReadingEventsConnectionIDsOnlySchedulesRefresh(t *testing.T) {
+	h, bus := newClientRoutesEventHarness(t, []string{"c1"})
+
+	bus.PublishEventBlocking(&events.ClientRoutesChangedEvent{
+		ChangeType:    "UPDATED",
+		ConnectionIDs: []string{"c1"},
+		HostIDs:       []string{},
+	})
+
+	select {
+	case task := <-h.updateTasks:
+		if len(task.connectionIDs) != 1 || task.connectionIDs[0] != "c1" {
+			t.Fatalf("unexpected connection IDs: %v", task.connectionIDs)
+		}
+		if task.pairs != nil {
+			t.Fatalf("expected connectionIDs-only refresh, got pairs: %v", task.pairs)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for refresh task")
+	}
+}
+
+func TestStartReadingEventsUsesCartesianPairs(t *testing.T) {
+	h, bus := newClientRoutesEventHarness(t, []string{"c1", "c2"})
+
+	bus.PublishEventBlocking(&events.ClientRoutesChangedEvent{
+		ChangeType:    "UPDATED",
+		ConnectionIDs: []string{"c1", "c2"},
+		HostIDs:       []string{"h1", "h2"},
+	})
+
+	select {
+	case task := <-h.updateTasks:
+		want := []pair{
+			{connectionID: "c1", hostID: "h1"},
+			{connectionID: "c1", hostID: "h2"},
+			{connectionID: "c2", hostID: "h1"},
+			{connectionID: "c2", hostID: "h2"},
+		}
+		if len(task.pairs) != len(want) {
+			t.Fatalf("unexpected pair count: got %d want %d", len(task.pairs), len(want))
+		}
+		for i := range want {
+			if task.pairs[i] != want[i] {
+				t.Fatalf("pair #%d = %+v, want %+v", i, task.pairs[i], want[i])
+			}
+		}
+		if task.connectionIDs != nil {
+			t.Fatalf("expected pairs-only refresh, got connection IDs: %v", task.connectionIDs)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for refresh task")
+	}
+}
+
+func TestClientRoutesHandlerTranslateHost_RetainsCurrentRouteAfterQueryError(t *testing.T) {
+	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
+	resolvedIPs := map[string]net.IP{
+		"a1": net.ParseIP("10.0.0.1"),
+	}
 	h := &ClientRoutesHandler{
 		log:         &defaultLogger{},
 		c:           &fakeControlConn{iter: &Iter{err: errors.New("query failed")}},
 		closeChan:   make(chan struct{}),
 		updateTasks: make(chan updateTask, 1024),
-		routeTable: clientRouteTable{
-			routes: clientRouteMap{
-				"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
-			},
-			stickyRoute: map[string]clientRoute{
-				"h1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
-			},
-		},
+		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
+			if ip, ok := resolvedIPs[host]; ok {
+				return []net.IP{ip}, nil
+			}
+			return nil, fmt.Errorf("unknown host %s", host)
+		}),
+		routeCache: newCache(map[string]clientRouteCacheEntry{
+			"h1": newCacheEntryWithCurrent(
+				clientRoute{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
+				clientRoute{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
+			),
+		}),
 		cfg: ClientRoutesConfig{
 			TableName: "system.client_routes",
 			Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
@@ -598,15 +660,21 @@ func TestUpdateWorkerDoesNotMutateRoutesOnQueryError(t *testing.T) {
 	h.startUpdateWorker()
 	defer h.Stop()
 
-	err := h.updateHostPortMappingSync(updateTask{connectionIDs: []string{"c1"}})
+	before, err := h.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+	if err != nil {
+		t.Fatalf("unexpected error before query failure: %v", err)
+	}
+
+	err = h.updateHostPortMappingSync(updateTask{connectionIDs: []string{"c1"}})
 	if err == nil {
 		t.Fatal("expected query error")
 	}
 
-	if _, ok := h.routeTable.routes["h1"]["c1"]; !ok {
-		t.Fatal("expected existing route to remain after query error")
+	after, err := h.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+	if err != nil {
+		t.Fatalf("unexpected error after query failure: %v", err)
 	}
-	if _, ok := h.routeTable.stickyRoute["h1"]; !ok {
-		t.Fatal("expected sticky route to remain after query error")
+	if !after.Equal(before) {
+		t.Fatalf("expected route to remain stable after query failure, got %v want %v", after, before)
 	}
 }

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 )
 
@@ -356,4 +357,34 @@ func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
 	if _, ok := routes["h3"]; ok {
 		t.Fatalf("h3 should have been pruned by full refresh")
 	}
+}
+
+func TestStop_DoesNotPanicWithConcurrentAsyncSends(t *testing.T) {
+	h := &ClientRoutesHandler{
+		log:         &defaultLogger{},
+		c:           &fakeControlConn{},
+		closeChan:   make(chan struct{}),
+		updateTasks: make(chan updateTask, 1024),
+		routes:      make(clientRouteMap),
+		cfg: ClientRoutesConfig{
+			TableName: "system.client_routes",
+			Endpoints: ClientRoutesEndpointList{{ConnectionID: "c1"}},
+		},
+	}
+	h.startUpdateWorker()
+
+	const goroutines = 200
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			h.updateHostPortMappingAsync([]string{"c1"}, nil)
+		}()
+	}
+	close(start) // release all goroutines simultaneously
+	h.Stop()     // race against the concurrent sends — must not panic
+	wg.Wait()
 }

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -381,7 +381,7 @@ func TestStop_DoesNotPanicWithConcurrentAsyncSends(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			h.updateHostPortMappingAsync([]string{"c1"}, nil)
+			h.updateHostPortMappingAsync(updateTask{connectionIDs: []string{"c1"}})
 		}()
 	}
 	close(start) // release all goroutines simultaneously

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -60,12 +60,12 @@ func (t testHostInfo) ScyllaShardCount() int              { return 0 }
 
 func TestMerge(t *testing.T) {
 	m := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
 	}
 
 	// Same record: no change expected.
 	m.merge([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042},
+		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
 	}, []string{"c1"}, nil)
 	if len(m) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(m))
@@ -73,17 +73,17 @@ func TestMerge(t *testing.T) {
 
 	// Updated address: record should be replaced.
 	m.merge([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a2", cqlPort: 9043},
+		{connectionID: "c1", hostID: "h1", address: "a2", port: 9043},
 	}, []string{"c1"}, nil)
 	rec := m["h1"]["c1"]
-	if rec.address != "a2" || rec.cqlPort != 9043 {
+	if rec.address != "a2" || rec.port != 9043 {
 		t.Fatalf("expected record to update")
 	}
 
 	// New record: should be added.
 	m = make(clientRouteMap)
 	m.merge([]clientRoute{
-		{connectionID: "c2", hostID: "h2", address: "a3", cqlPort: 9044},
+		{connectionID: "c2", hostID: "h2", address: "a3", port: 9044},
 	}, []string{"c2"}, nil)
 	if len(m) != 1 {
 		t.Fatalf("expected new record to be added")
@@ -118,36 +118,42 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 	}
 
 	handler.routes = clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", cqlPort: 9042, secureCQLPort: 9142}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", port: 9042}},
 	}
 
-	handler.pickTLSPorts = false
 	res, err = handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Address.Equal(net.ParseIP("10.0.0.1")) {
+		t.Fatalf("expected resolved IP 10.0.0.1, got %v", res.Address)
 	}
 	if res.Port != 9042 {
-		t.Fatalf("expected non-TLS port, got %d", res.Port)
-	}
-
-	handler.pickTLSPorts = true
-	res, err = handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if res.Port != 9142 {
-		t.Fatalf("expected TLS port, got %d", res.Port)
+		t.Fatalf("expected port 9042, got %d", res.Port)
 	}
 
 	errorHandler := &ClientRoutesHandler{
 		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
 			return nil, errors.New("lookup failed")
 		}),
-			routes: clientRouteMap{"h2": {"c2": {connectionID: "c2", hostID: "h2", address: "host", cqlPort: 9042}}},
+			routes: clientRouteMap{"h2": {"c2": {connectionID: "c2", hostID: "h2", address: "host", port: 9042}}},
 	}
 	_, err = errorHandler.TranslateHost(testHostInfo{hostID: "h2"}, addr)
 	if err == nil {
 		t.Fatalf("expected resolver error to bubble up")
+	}
+
+	// Route with port 0 should return an error before attempting DNS.
+	zeroPortHandler := &ClientRoutesHandler{
+		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
+			t.Fatal("DNS should not be called when port is 0")
+			return nil, nil
+		}),
+			routes: clientRouteMap{"h3": {"c3": {connectionID: "c3", hostID: "h3", address: "host", port: 0}}},
+	}
+	_, err = zeroPortHandler.TranslateHost(testHostInfo{hostID: "h3"}, addr)
+	if err == nil {
+		t.Fatalf("expected error for zero port")
 	}
 }
 
@@ -193,7 +199,7 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := &fakeControlConn{}
-			_, err := getHostPortMappingFromCluster(ctrl, "system.client_routes", tc.connectionIDs, tc.hostIDs)
+			_, err := getHostPortMappingFromCluster(ctrl, "system.client_routes", tc.connectionIDs, tc.hostIDs, false)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -209,8 +215,8 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 
 func TestMerge_DeletedHost(t *testing.T) {
 	m := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
 	}
 
 	// Simulate event for (c1, h1) where query returned nothing → (c1,h1) should be removed.
@@ -227,16 +233,16 @@ func TestMerge_DeletedHost(t *testing.T) {
 func TestMerge_UpdatedHost(t *testing.T) {
 	m := clientRouteMap{
 		"h1": {
-			"c1": {connectionID: "c1", hostID: "h1", address: "old-addr", cqlPort: 9042},
-			"c2": {connectionID: "c2", hostID: "h1", address: "old-addr2", cqlPort: 9042},
+			"c1": {connectionID: "c1", hostID: "h1", address: "old-addr", port: 9042},
+			"c2": {connectionID: "c2", hostID: "h1", address: "old-addr2", port: 9042},
 		},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "keep", cqlPort: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "keep", port: 9042}},
 	}
 
 	// h1 address changed; fresh query returns new data for h1. h2 is not affected.
 	m.merge([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "new-addr", cqlPort: 9043},
-		{connectionID: "c2", hostID: "h1", address: "new-addr2", cqlPort: 9043},
+		{connectionID: "c1", hostID: "h1", address: "new-addr", port: 9043},
+		{connectionID: "c2", hostID: "h1", address: "new-addr2", port: 9043},
 	}, []string{"c1", "c2"}, []string{"h1"})
 
 	if len(m) != 2 || len(m["h1"]) != 2 {
@@ -255,15 +261,15 @@ func TestMerge_UpdatedHost(t *testing.T) {
 
 func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
 	m := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042}},
-		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", cqlPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
+		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", port: 9042}},
 	}
 
 	// Full refresh for connection c1: all entries for c1 are pruned, only h1 and h2 returned.
 	m.merge([]clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042},
-		{connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042},
+		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
+		{connectionID: "c1", hostID: "h2", address: "a2", port: 9042},
 	}, []string{"c1"}, nil)
 
 	if len(m) != 2 {
@@ -272,6 +278,7 @@ func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
 	if _, ok := m["h3"]; ok {
 		t.Fatalf("expected h3 to be pruned")
 }
+
 }
 
 func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
@@ -288,7 +295,7 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 		return nil, fmt.Errorf("unknown host %s", host)
 	})
 	routes := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "route-addr", cqlPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "route-addr", port: 9042}},
 	}
 
 	t.Run("no override uses route address", func(t *testing.T) {
@@ -330,15 +337,15 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
 	// Existing routes: h1, h2, h3.
 	routes := clientRouteMap{
-		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042}},
-		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042}},
-		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", cqlPort: 9042}},
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
+		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
+		"h3": {"c1": {connectionID: "c1", hostID: "h3", address: "a3", port: 9042}},
 	}
 
 	// Cluster now returns only h1 and h2 (h3 was decommissioned).
 	incoming := []clientRoute{
-		{connectionID: "c1", hostID: "h1", address: "a1", cqlPort: 9042},
-		{connectionID: "c1", hostID: "h2", address: "a2", cqlPort: 9042},
+		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
+		{connectionID: "c1", hostID: "h2", address: "a2", port: 9042},
 	}
 
 	routes.merge(incoming, []string{"c1"}, nil)

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -59,23 +59,23 @@ func (t testHostInfo) ScyllaShardAwarePort() uint16       { return 0 }
 func (t testHostInfo) ScyllaShardAwarePortTLS() uint16    { return 0 }
 func (t testHostInfo) ScyllaShardCount() int              { return 0 }
 
-func TestMerge(t *testing.T) {
+func TestClientRouteMapPopulateRecords(t *testing.T) {
 	m := clientRouteMap{
 		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
 	}
 
 	// Same record: no change expected.
-	m.merge([]clientRoute{
+	m.populateRecords([]clientRoute{
 		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
-	}, []string{"c1"}, nil)
+	})
 	if len(m) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(m))
 	}
 
 	// Updated address: record should be replaced.
-	m.merge([]clientRoute{
+	m.populateRecords([]clientRoute{
 		{connectionID: "c1", hostID: "h1", address: "a2", port: 9043},
-	}, []string{"c1"}, nil)
+	})
 	rec := m["h1"]["c1"]
 	if rec.address != "a2" || rec.port != 9043 {
 		t.Fatalf("expected record to update")
@@ -83,9 +83,9 @@ func TestMerge(t *testing.T) {
 
 	// New record: should be added.
 	m = make(clientRouteMap)
-	m.merge([]clientRoute{
+	m.populateRecords([]clientRoute{
 		{connectionID: "c2", hostID: "h2", address: "a3", port: 9044},
-	}, []string{"c2"}, nil)
+	})
 	if len(m) != 1 {
 		t.Fatalf("expected new record to be added")
 	}
@@ -261,14 +261,14 @@ func TestGetHostPortMappingForPairsQuery(t *testing.T) {
 	}
 }
 
-func TestMerge_DeletedHost(t *testing.T) {
+func TestClientRouteMapDeleteByPairs_DeletedHost(t *testing.T) {
 	m := clientRouteMap{
 		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
 		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
 	}
 
 	// Simulate event for (c1, h1) where query returned nothing → (c1,h1) should be removed.
-	m.merge(nil, []string{"c1"}, []string{"h1"})
+	m.deleteByPairs([]pair{{connectionID: "c1", hostID: "h1"}})
 
 	if len(m) != 1 {
 		t.Fatalf("expected 1 entry after pruning deleted host, got %d", len(m))
@@ -278,7 +278,7 @@ func TestMerge_DeletedHost(t *testing.T) {
 	}
 }
 
-func TestMerge_UpdatedHost(t *testing.T) {
+func TestClientRouteMapDeleteByPairs_UpdatedHost(t *testing.T) {
 	m := clientRouteMap{
 		"h1": {
 			"c1": {connectionID: "c1", hostID: "h1", address: "old-addr", port: 9042},
@@ -287,11 +287,15 @@ func TestMerge_UpdatedHost(t *testing.T) {
 		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "keep", port: 9042}},
 	}
 
-	// h1 address changed; fresh query returns new data for h1. h2 is not affected.
-	m.merge([]clientRoute{
+	// h1 address changed; delete old pairs, then populate with new data.
+	m.deleteByPairs([]pair{
+		{connectionID: "c1", hostID: "h1"},
+		{connectionID: "c2", hostID: "h1"},
+	})
+	m.populateRecords([]clientRoute{
 		{connectionID: "c1", hostID: "h1", address: "new-addr", port: 9043},
 		{connectionID: "c2", hostID: "h1", address: "new-addr2", port: 9043},
-	}, []string{"c1", "c2"}, []string{"h1"})
+	})
 
 	if len(m) != 2 || len(m["h1"]) != 2 {
 		t.Fatalf("expected 2 hosts with h1 having 2 connections, got %d hosts", len(m))
@@ -307,7 +311,7 @@ func TestMerge_UpdatedHost(t *testing.T) {
 	}
 }
 
-func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
+func TestClientRouteMapDeleteByConnectionIDs_FullRefreshPrunesAllStale(t *testing.T) {
 	m := clientRouteMap{
 		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
 		"h2": {"c1": {connectionID: "c1", hostID: "h2", address: "a2", port: 9042}},
@@ -315,18 +319,18 @@ func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
 	}
 
 	// Full refresh for connection c1: all entries for c1 are pruned, only h1 and h2 returned.
-	m.merge([]clientRoute{
+	m.deleteByConnectionIDs([]string{"c1"})
+	m.populateRecords([]clientRoute{
 		{connectionID: "c1", hostID: "h1", address: "a1", port: 9042},
 		{connectionID: "c1", hostID: "h2", address: "a2", port: 9042},
-	}, []string{"c1"}, nil)
+	})
 
 	if len(m) != 2 {
 		t.Fatalf("expected 2 entries after full refresh prune, got %d", len(m))
 	}
 	if _, ok := m["h3"]; ok {
 		t.Fatalf("expected h3 to be pruned")
-}
-
+	}
 }
 
 func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
@@ -379,10 +383,10 @@ func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
 	})
 }
 
-// TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries simulates the same
-// sequence of operations that updateHostPortMapping performs (lock → Merge → unlock)
+// TestClientRouteMapFullRefresh_PrunesStaleEntries simulates the same
+// sequence of operations that updateHostPortMapping performs (lock → delete → populate → unlock)
 // to verify that a full refresh correctly prunes a host that disappeared.
-func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
+func TestClientRouteMapFullRefresh_PrunesStaleEntries(t *testing.T) {
 	// Existing routes: h1, h2, h3.
 	routes := clientRouteMap{
 		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "a1", port: 9042}},
@@ -396,7 +400,8 @@ func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
 		{connectionID: "c1", hostID: "h2", address: "a2", port: 9042},
 	}
 
-	routes.merge(incoming, []string{"c1"}, nil)
+	routes.deleteByConnectionIDs([]string{"c1"})
+	routes.populateRecords(incoming)
 
 	if len(routes) != 2 {
 		t.Fatalf("expected 2 entries after full-refresh prune, got %d", len(routes))

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -59,53 +59,34 @@ func (t testHostInfo) ScyllaShardAwarePortTLS() uint16    { return 0 }
 func (t testHostInfo) ScyllaShardCount() int              { return 0 }
 
 func TestMerge(t *testing.T) {
-	list := clientRouteList{
-		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
+	m := clientRouteMap{
+		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
 	}
 
 	// Same record: no change expected.
-	list.Merge(clientRouteList{
+	m.Merge([]clientRoute{
 		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
 	}, []string{"c1"}, nil)
-	if len(list) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(list))
+	if len(m) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(m))
 	}
 
 	// Updated address: record should be replaced.
-	list.Merge(clientRouteList{
+	m.Merge([]clientRoute{
 		{ConnectionID: "c1", HostID: "h1", Address: "a2", CQLPort: 9043},
 	}, []string{"c1"}, nil)
-	if list[0].Address != "a2" || list[0].CQLPort != 9043 {
+	rec := m["h1"]["c1"]
+	if rec.Address != "a2" || rec.CQLPort != 9043 {
 		t.Fatalf("expected record to update")
 	}
 
-	// New record: should be appended.
-	list = clientRouteList{}
-	list.Merge(clientRouteList{
+	// New record: should be added.
+	m = make(clientRouteMap)
+	m.Merge([]clientRoute{
 		{ConnectionID: "c2", HostID: "h2", Address: "a3", CQLPort: 9044},
 	}, []string{"c2"}, nil)
-	if len(list) != 1 {
-		t.Fatalf("expected new record to be appended")
-	}
-}
-
-func TestFindByHostID(t *testing.T) {
-	list := clientRouteList{
-		{ConnectionID: "c1", HostID: "h1"},
-		{ConnectionID: "c1", HostID: "h2"},
-	}
-
-	rec := list.FindByHostID("h1")
-	if rec == nil {
-		t.Fatalf("expected FindByHostID to locate record")
-	}
-	rec.ConnectionID = "updated"
-	if list[0].ConnectionID != "updated" {
-		t.Fatalf("expected FindByHostID to return pointer to list element")
-	}
-
-	if list.FindByHostID("h3") != nil {
-		t.Fatalf("expected nil for missing host")
+	if len(m) != 1 {
+		t.Fatalf("expected new record to be added")
 	}
 }
 
@@ -120,7 +101,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 
 	handler := &ClientRoutesHandler{
 		resolver: resolver,
-		routes:   make(clientRouteList, 0),
+		routes:   make(clientRouteMap),
 	}
 
 	res, err := handler.TranslateHost(noHost, addr)
@@ -136,8 +117,8 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		t.Fatalf("expected error for missing host entry")
 	}
 
-	handler.routes = clientRouteList{
-		{ConnectionID: "c1", HostID: "h1", CQLPort: 9042, SecureCQLPort: 9142},
+	handler.routes = clientRouteMap{
+		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", CQLPort: 9042, SecureCQLPort: 9142}},
 	}
 
 	handler.pickTLSPorts = false
@@ -162,7 +143,7 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 		resolver: dnsResolverFunc(func(host string) ([]net.IP, error) {
 			return nil, errors.New("lookup failed")
 		}),
-		routes: clientRouteList{{ConnectionID: "c2", HostID: "h2", Address: "host", CQLPort: 9042}},
+			routes: clientRouteMap{"h2": {"c2": {ConnectionID: "c2", HostID: "h2", Address: "host", CQLPort: 9042}}},
 	}
 	_, err = errorHandler.TranslateHost(testHostInfo{hostID: "h2"}, addr)
 	if err == nil {
@@ -227,70 +208,69 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 }
 
 func TestMerge_DeletedHost(t *testing.T) {
-	list := clientRouteList{
-		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+	m := clientRouteMap{
+		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
+		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042}},
 	}
 
 	// Simulate event for (c1, h1) where query returned nothing → (c1,h1) should be removed.
-	list.Merge(nil, []string{"c1"}, []string{"h1"})
+	m.Merge(nil, []string{"c1"}, []string{"h1"})
 
-	if len(list) != 1 {
-		t.Fatalf("expected 1 entry after pruning deleted host, got %d", len(list))
+	if len(m) != 1 {
+		t.Fatalf("expected 1 entry after pruning deleted host, got %d", len(m))
 	}
-	if list[0].HostID != "h2" {
-		t.Fatalf("expected h2 to survive, got %s", list[0].HostID)
+	if _, ok := m["h2"]; !ok {
+		t.Fatalf("expected h2 to survive")
 	}
 }
 
 func TestMerge_UpdatedHost(t *testing.T) {
-	list := clientRouteList{
-		{ConnectionID: "c1", HostID: "h1", Address: "old-addr", CQLPort: 9042},
-		{ConnectionID: "c2", HostID: "h1", Address: "old-addr2", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h2", Address: "keep", CQLPort: 9042},
+	m := clientRouteMap{
+		"h1": {
+			"c1": {ConnectionID: "c1", HostID: "h1", Address: "old-addr", CQLPort: 9042},
+			"c2": {ConnectionID: "c2", HostID: "h1", Address: "old-addr2", CQLPort: 9042},
+		},
+		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "keep", CQLPort: 9042}},
 	}
 
 	// h1 address changed; fresh query returns new data for h1. h2 is not affected.
-	list.Merge(clientRouteList{
+	m.Merge([]clientRoute{
 		{ConnectionID: "c1", HostID: "h1", Address: "new-addr", CQLPort: 9043},
 		{ConnectionID: "c2", HostID: "h1", Address: "new-addr2", CQLPort: 9043},
 	}, []string{"c1", "c2"}, []string{"h1"})
 
-	if len(list) != 3 {
-		t.Fatalf("expected 3 entries, got %d", len(list))
+	if len(m) != 2 || len(m["h1"]) != 2 {
+		t.Fatalf("expected 2 hosts with h1 having 2 connections, got %d hosts", len(m))
 	}
-	for _, r := range list {
-		if r.HostID == "h1" {
-			if r.Address != "new-addr" && r.Address != "new-addr2" {
-				t.Fatalf("expected h1 entries to have new addresses, got %s", r.Address)
-			}
-		}
-		if r.HostID == "h2" && r.Address != "keep" {
-			t.Fatalf("expected h2 entry to be preserved unchanged")
-		}
+	if r := m["h1"]["c1"]; r.Address != "new-addr" {
+		t.Fatalf("expected c1/h1 to have new address, got %s", r.Address)
+	}
+	if r := m["h1"]["c2"]; r.Address != "new-addr2" {
+		t.Fatalf("expected c2/h1 to have new address, got %s", r.Address)
+	}
+	if r := m["h2"]["c1"]; r.Address != "keep" {
+		t.Fatalf("expected h2 entry to be preserved unchanged")
 	}
 }
 
 func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
-	list := clientRouteList{
-		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042},
+	m := clientRouteMap{
+		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
+		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042}},
+		"h3": {"c1": {ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042}},
 	}
 
 	// Full refresh for connection c1: all entries for c1 are pruned, only h1 and h2 returned.
-	list.Merge(clientRouteList{
+	m.Merge([]clientRoute{
 		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
 		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
 	}, []string{"c1"}, nil)
 
-	if len(list) != 2 {
-		t.Fatalf("expected 2 entries after full refresh prune, got %d", len(list))
+	if len(m) != 2 {
+		t.Fatalf("expected 2 entries after full refresh prune, got %d", len(m))
 	}
-	for _, r := range list {
-		if r.HostID == "h3" {
-			t.Fatalf("expected h3 to be pruned")
-		}
+	if _, ok := m["h3"]; ok {
+		t.Fatalf("expected h3 to be pruned")
 	}
 }
 
@@ -299,14 +279,14 @@ func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
 // to verify that a full refresh correctly prunes a host that disappeared.
 func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
 	// Existing routes: h1, h2, h3.
-	routes := clientRouteList{
-		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
-		{ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042},
+	routes := clientRouteMap{
+		"h1": {"c1": {ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042}},
+		"h2": {"c1": {ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042}},
+		"h3": {"c1": {ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042}},
 	}
 
 	// Cluster now returns only h1 and h2 (h3 was decommissioned).
-	incoming := clientRouteList{
+	incoming := []clientRoute{
 		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
 		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
 	}
@@ -316,9 +296,7 @@ func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
 	if len(routes) != 2 {
 		t.Fatalf("expected 2 entries after full-refresh prune, got %d", len(routes))
 	}
-	for _, r := range routes {
-		if r.HostID == "h3" {
-			t.Fatalf("h3 should have been pruned by full refresh")
-		}
+	if _, ok := routes["h3"]; ok {
+		t.Fatalf("h3 should have been pruned by full refresh")
 	}
 }

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -66,7 +66,7 @@ func TestMerge(t *testing.T) {
 	// Same record: no change expected.
 	list.Merge(clientRouteList{
 		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
-	})
+	}, []string{"c1"}, nil)
 	if len(list) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(list))
 	}
@@ -74,7 +74,7 @@ func TestMerge(t *testing.T) {
 	// Updated address: record should be replaced.
 	list.Merge(clientRouteList{
 		{ConnectionID: "c1", HostID: "h1", Address: "a2", CQLPort: 9043},
-	})
+	}, []string{"c1"}, nil)
 	if list[0].Address != "a2" || list[0].CQLPort != 9043 {
 		t.Fatalf("expected record to update")
 	}
@@ -83,7 +83,7 @@ func TestMerge(t *testing.T) {
 	list = clientRouteList{}
 	list.Merge(clientRouteList{
 		{ConnectionID: "c2", HostID: "h2", Address: "a3", CQLPort: 9044},
-	})
+	}, []string{"c2"}, nil)
 	if len(list) != 1 {
 		t.Fatalf("expected new record to be appended")
 	}
@@ -226,6 +226,99 @@ func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
 	}
 }
 
+func TestMerge_DeletedHost(t *testing.T) {
+	list := clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+	}
+
+	// Simulate event for (c1, h1) where query returned nothing → (c1,h1) should be removed.
+	list.Merge(nil, []string{"c1"}, []string{"h1"})
+
+	if len(list) != 1 {
+		t.Fatalf("expected 1 entry after pruning deleted host, got %d", len(list))
+	}
+	if list[0].HostID != "h2" {
+		t.Fatalf("expected h2 to survive, got %s", list[0].HostID)
+	}
+}
+
+func TestMerge_UpdatedHost(t *testing.T) {
+	list := clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "old-addr", CQLPort: 9042},
+		{ConnectionID: "c2", HostID: "h1", Address: "old-addr2", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h2", Address: "keep", CQLPort: 9042},
+	}
+
+	// h1 address changed; fresh query returns new data for h1. h2 is not affected.
+	list.Merge(clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "new-addr", CQLPort: 9043},
+		{ConnectionID: "c2", HostID: "h1", Address: "new-addr2", CQLPort: 9043},
+	}, []string{"c1", "c2"}, []string{"h1"})
+
+	if len(list) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(list))
+	}
+	for _, r := range list {
+		if r.HostID == "h1" {
+			if r.Address != "new-addr" && r.Address != "new-addr2" {
+				t.Fatalf("expected h1 entries to have new addresses, got %s", r.Address)
+			}
+		}
+		if r.HostID == "h2" && r.Address != "keep" {
+			t.Fatalf("expected h2 entry to be preserved unchanged")
+		}
+	}
+}
+
+func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
+	list := clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042},
+	}
+
+	// Full refresh for connection c1: all entries for c1 are pruned, only h1 and h2 returned.
+	list.Merge(clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+	}, []string{"c1"}, nil)
+
+	if len(list) != 2 {
+		t.Fatalf("expected 2 entries after full refresh prune, got %d", len(list))
+	}
+	for _, r := range list {
+		if r.HostID == "h3" {
+			t.Fatalf("expected h3 to be pruned")
+		}
+	}
+}
+
 // TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries simulates the same
 // sequence of operations that updateHostPortMapping performs (lock → Merge → unlock)
 // to verify that a full refresh correctly prunes a host that disappeared.
+func TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries(t *testing.T) {
+	// Existing routes: h1, h2, h3.
+	routes := clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h3", Address: "a3", CQLPort: 9042},
+	}
+
+	// Cluster now returns only h1 and h2 (h3 was decommissioned).
+	incoming := clientRouteList{
+		{ConnectionID: "c1", HostID: "h1", Address: "a1", CQLPort: 9042},
+		{ConnectionID: "c1", HostID: "h2", Address: "a2", CQLPort: 9042},
+	}
+
+	routes.Merge(incoming, []string{"c1"}, nil)
+
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 entries after full-refresh prune, got %d", len(routes))
+	}
+	for _, r := range routes {
+		if r.HostID == "h3" {
+			t.Fatalf("h3 should have been pruned by full refresh")
+		}
+	}
+}

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -271,7 +271,57 @@ func TestMerge_FullRefresh_PrunesAllStale(t *testing.T) {
 	}
 	if _, ok := m["h3"]; ok {
 		t.Fatalf("expected h3 to be pruned")
+}
+}
+
+func TestTranslateHost_ConnectionAddrOverride(t *testing.T) {
+	addr := AddressPort{Address: net.ParseIP("1.1.1.1"), Port: 9042}
+
+	resolvedIPs := map[string]net.IP{
+		"route-addr":    net.ParseIP("10.0.0.1"),
+		"override-addr": net.ParseIP("10.0.0.99"),
 	}
+	resolver := dnsResolverFunc(func(host string) ([]net.IP, error) {
+		if ip, ok := resolvedIPs[host]; ok {
+			return []net.IP{ip}, nil
+		}
+		return nil, fmt.Errorf("unknown host %s", host)
+	})
+	routes := clientRouteMap{
+		"h1": {"c1": {connectionID: "c1", hostID: "h1", address: "route-addr", cqlPort: 9042}},
+	}
+
+	t.Run("no override uses route address", func(t *testing.T) {
+		handler := &ClientRoutesHandler{
+			addrOverrides: map[string]string{},
+			resolver:      resolver,
+			routes:        routes,
+		}
+
+		res, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.Address.Equal(resolvedIPs["route-addr"]) {
+			t.Fatalf("expected route-addr IP %v, got %v", resolvedIPs["route-addr"], res.Address)
+		}
+	})
+
+	t.Run("override replaces route address", func(t *testing.T) {
+		handler := &ClientRoutesHandler{
+			addrOverrides: map[string]string{"c1": "override-addr"},
+			resolver:      resolver,
+			routes:        routes,
+		}
+
+		res, err := handler.TranslateHost(testHostInfo{hostID: "h1"}, addr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !res.Address.Equal(resolvedIPs["override-addr"]) {
+			t.Fatalf("expected override-addr IP %v, got %v", resolvedIPs["override-addr"], res.Address)
+		}
+	})
 }
 
 // TestUpdateHostPortMapping_FullRefresh_PrunesStaleEntries simulates the same

--- a/client_routes_unit_test.go
+++ b/client_routes_unit_test.go
@@ -158,49 +158,96 @@ func TestClientRoutesHandlerTranslateHost(t *testing.T) {
 	}
 }
 
-func TestGetHostPortMappingFromClusterQuery(t *testing.T) {
+func TestGetHostPortMappingForConnectionIDsQuery(t *testing.T) {
 	tcases := []struct {
 		name          string
 		connectionIDs []string
-		hostIDs       []string
 		expectedStmt  string
 		expectedVals  []any
+		expectedErr   bool
 	}{
 		{
-			name:         "all",
-			expectedStmt: "select connection_id, host_id, address, port, tls_port from system.client_routes allow filtering",
-		},
-		{
-			name:          "connections-only",
+			name:          "multiple-connections",
 			connectionIDs: []string{"c1", "c2"},
-			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in (?,?) allow filtering",
-			expectedVals:  []any{"c1", "c2"},
+			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in ?",
+			expectedVals:  []any{[]string{"c1", "c2"}},
 		},
 		{
-			name:         "hosts-only",
-			hostIDs:      []string{"h1"},
-			expectedStmt: "select connection_id, host_id, address, port, tls_port from system.client_routes where host_id in (?) allow filtering",
-			expectedVals: []any{"h1"},
-		},
-		{
-			name:          "connections-and-hosts",
+			name:          "single-connection",
 			connectionIDs: []string{"c1"},
-			hostIDs:       []string{"h1", "h2"},
-			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in (?) and host_id in (?,?)",
-			expectedVals:  []any{"c1", "h1", "h2"},
+			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in ?",
+			expectedVals:  []any{[]string{"c1"}},
 		},
 		{
-			name:          "empty-slices",
-			connectionIDs: []string{},
-			hostIDs:       []string{},
-			expectedStmt:  "select connection_id, host_id, address, port, tls_port from system.client_routes allow filtering",
+			name:        "empty-slices",
+			expectedErr: true,
 		},
 	}
 
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := &fakeControlConn{}
-			_, err := getHostPortMappingFromCluster(ctrl, "system.client_routes", tc.connectionIDs, tc.hostIDs, false)
+			_, err := getHostPortMappingForConnectionIDs(ctrl, "system.client_routes", tc.connectionIDs, false)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ctrl.statement != tc.expectedStmt {
+				t.Fatalf("statement mismatch: got %q want %q", ctrl.statement, tc.expectedStmt)
+			}
+			if fmt.Sprint(ctrl.values) != fmt.Sprint(tc.expectedVals) {
+				t.Fatalf("values mismatch: got %v want %v", ctrl.values, tc.expectedVals)
+			}
+		})
+	}
+}
+
+func TestGetHostPortMappingForPairsQuery(t *testing.T) {
+	tcases := []struct {
+		name         string
+		pairs        []pair
+		expectedStmt string
+		expectedVals []any
+		expectedErr  bool
+	}{
+		{
+			name: "single-pair",
+			pairs: []pair{
+				{connectionID: "c1", hostID: "h1"},
+			},
+			expectedStmt: "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in ? and host_id in ?",
+			expectedVals: []any{[]string{"c1"}, []string{"h1"}},
+		},
+		{
+			name: "multiple-pairs",
+			pairs: []pair{
+				{connectionID: "c1", hostID: "h1"},
+				{connectionID: "c2", hostID: "h2"},
+			},
+			expectedStmt: "select connection_id, host_id, address, port, tls_port from system.client_routes where connection_id in ? and host_id in ?",
+			expectedVals: []any{[]string{"c1", "c2"}, []string{"h1", "h2"}},
+		},
+		{
+			name:        "empty-slices",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := &fakeControlConn{}
+			_, err := getHostPortMappingForPairs(ctrl, "system.client_routes", tc.pairs, false)
+			if tc.expectedErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/cluster.go
+++ b/cluster.go
@@ -458,16 +458,14 @@ func (cfg *ClusterConfig) WithOptions(opts ...ClusterOption) *ClusterConfig {
 
 type ClientRoutesOption func(*ClientRoutesConfig)
 
+// Deprecated: WithMaxResolverConcurrency no longer has any effect
 func WithMaxResolverConcurrency(val int) func(*ClientRoutesConfig) {
-	return func(cfg *ClientRoutesConfig) {
-		cfg.MaxResolverConcurrency = val
-	}
+	return func(cfg *ClientRoutesConfig) {}
 }
 
+// Deprecated: WithResolveHealthyEndpointPeriod no longer has any effect
 func WithResolveHealthyEndpointPeriod(val time.Duration) func(*ClientRoutesConfig) {
-	return func(cfg *ClientRoutesConfig) {
-		cfg.ResolveHealthyEndpointPeriod = val
-	}
+	return func(cfg *ClientRoutesConfig) {}
 }
 
 func WithEndpoints(endpoints ...ClientRoutesEndpoint) func(*ClientRoutesConfig) {
@@ -484,11 +482,7 @@ func WithTable(tableName string) func(*ClientRoutesConfig) {
 
 func WithClientRoutes(opts ...ClientRoutesOption) func(*ClusterConfig) {
 	pmCfg := ClientRoutesConfig{
-		// Don't resolve healthy nodes by default
-		ResolveHealthyEndpointPeriod: 0,
-		MaxResolverConcurrency:       1,
-		TableName:                    "system.client_routes",
-		ResolverCacheDuration:        time.Millisecond * 500,
+		TableName: "system.client_routes",
 	}
 	for _, opt := range opts {
 		opt(&pmCfg)


### PR DESCRIPTION
## Summary
Replaces the complex resolved-route caching and background DNS resolution system in `ClientRoutesHandler` with a simpler design: store unresolved routes and resolve DNS on demand during `TranslateHost`. Adds scoped pruning to automatically clean up stale entries, and sticky route tracking to avoid unnecessary connection churn.

## Motivation

The previous implementation maintained a `ResolvedClientRoute` type hierarchy with cached IP addresses, a `ClientRoutesResolver` interface, a DNS cache with configurable TTL, concurrent background resolution workers, and an `atomic.Pointer` with CAS-loop updates. This was complex, hard to reason about, and prone to stale-data bugs (e.g. decommissioned hosts lingering in the route list).

Fixes: https://github.com/scylladb/gocql/issues/835