### PR TITLE
(improvement) add configurable heartbeat latency warning and skip heartbeats on active connections

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -155,6 +155,11 @@ type ClusterConfig struct {
 	// The keepalive period to use, enabled if > 0 (default: 15 seconds)
 	// SocketKeepalive is used to set up the default dialer and is ignored if Dialer or HostDialer is provided.
 	SocketKeepalive time.Duration
+	// HeartbeatSlowThreshold is the latency threshold for heartbeat OPTIONS
+	// round-trips. If a heartbeat response takes longer than this duration, a
+	// warning is logged (e.g. 500 * time.Millisecond for a 500ms threshold).
+	// Default: 0 (disabled, no latency measurement or logging).
+	HeartbeatSlowThreshold time.Duration
 	// If not zero, gocql attempt to reconnect known DOWN nodes in every ReconnectInterval.
 	ReconnectInterval time.Duration
 	// The maximum amount of time to wait for schema agreement in a cluster after

--- a/cluster.go
+++ b/cluster.go
@@ -162,6 +162,12 @@ type ClusterConfig struct {
 	// The keepalive period to use, enabled if > 0 (default: 15 seconds)
 	// SocketKeepalive is used to set up the default dialer and is ignored if Dialer or HostDialer is provided.
 	SocketKeepalive time.Duration
+	// HeartbeatSlowThreshold is the latency threshold for heartbeat OPTIONS
+	// round-trips (e.g. 500 * time.Millisecond). A heartbeat taking longer
+	// logs a warning once; further slow heartbeats stay quiet until a
+	// heartbeat completes under the threshold again.
+	// Default: 0 (disabled, no latency measurement or logging).
+	HeartbeatSlowThreshold time.Duration
 	// If not zero, gocql attempt to reconnect known DOWN nodes in every ReconnectInterval.
 	ReconnectInterval time.Duration
 	// The maximum amount of time to wait for schema agreement in a cluster after

--- a/conn.go
+++ b/conn.go
@@ -208,6 +208,7 @@ type Conn struct {
 	systemRequestTimeout time.Duration
 	writeTimeout         atomic.Int64
 	readTimeout          atomic.Int64
+	activity             atomic.Int64
 	mu                   sync.Mutex
 	tabletsRoutingV1     int32
 	headerBuf            [headSize]byte
@@ -800,6 +801,7 @@ func (c *Conn) heartBeat(ctx context.Context) {
 
 	var failures int
 	var heartbeatSlow bool
+	prev := c.activity.Load()
 
 	for {
 		if failures > 5 {
@@ -815,6 +817,17 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		case <-timer.C:
 		}
 
+		// Skip heartbeat if the connection had activity since last check.
+		// Detection of a dead connection may be delayed by up to 2x the
+		// heartbeat interval. Matches the Python driver behavior.
+		cur := c.activity.Load()
+		if cur != prev {
+			prev = cur
+			sleepTime = 30 * time.Second
+			failures = 0
+			continue
+		}
+
 		var start time.Time
 		heartbeatTimeout := c.cfg.HeartbeatSlowThreshold
 		if heartbeatTimeout > 0 {
@@ -822,6 +835,8 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		}
 
 		framer, err := c.exec(context.Background(), &writeOptionsFrame{}, nil, c.cfg.ConnectTimeout)
+		// exec() bumped the counter; refresh prev.
+		prev = c.activity.Load()
 		if err != nil {
 			failures++
 			continue
@@ -1333,6 +1348,7 @@ func (c *Conn) addCall(call *callReq) error {
 // typically via defer immediately after parsing or after transferring ownership
 // to an Iter.
 func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, requestTimeout time.Duration) (*framer, error) {
+	c.activity.Add(1)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, &QueryError{err: ctxErr, potentiallyExecuted: false}
 	}

--- a/conn.go
+++ b/conn.go
@@ -130,20 +130,21 @@ type SslOptions struct {
 }
 
 type ConnConfig struct {
-	Dialer          Dialer
-	Logger          StdLogger
-	Authenticator   Authenticator
-	Compressor      Compressor
-	HostDialer      HostDialer
-	AuthProvider    func(h *HostInfo) (Authenticator, error)
-	tlsConfig       *tls.Config
-	CQLVersion      string
-	ConnectTimeout  time.Duration
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	ProtoVersion    int
-	Keepalive       time.Duration
-	disableCoalesce bool
+	Dialer                 Dialer
+	Logger                 StdLogger
+	Authenticator          Authenticator
+	Compressor             Compressor
+	HostDialer             HostDialer
+	AuthProvider           func(h *HostInfo) (Authenticator, error)
+	tlsConfig              *tls.Config
+	CQLVersion             string
+	ConnectTimeout         time.Duration
+	ReadTimeout            time.Duration
+	WriteTimeout           time.Duration
+	ProtoVersion           int
+	Keepalive              time.Duration
+	HeartbeatSlowThreshold time.Duration
+	disableCoalesce        bool
 }
 
 func (c *ConnConfig) logger() StdLogger {
@@ -798,6 +799,7 @@ func (c *Conn) heartBeat(ctx context.Context) {
 	defer timer.Stop()
 
 	var failures int
+	var heartbeatSlow bool
 
 	for {
 		if failures > 5 {
@@ -811,6 +813,12 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
+		}
+
+		var start time.Time
+		heartbeatTimeout := c.cfg.HeartbeatSlowThreshold
+		if heartbeatTimeout > 0 {
+			start = time.Now()
 		}
 
 		framer, err := c.exec(context.Background(), &writeOptionsFrame{}, nil, c.cfg.ConnectTimeout)
@@ -830,6 +838,18 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		switch resp.(type) {
 		case *frm.SupportedFrame:
 			// Everything ok
+			if heartbeatTimeout > 0 {
+				elapsed := time.Since(start)
+				if elapsed > heartbeatTimeout {
+					if !heartbeatSlow {
+						heartbeatSlow = true
+						c.cfg.logger().Printf("gocql: heartbeat to %s took %dms, exceeding threshold %dms",
+							c.addr, elapsed.Milliseconds(), heartbeatTimeout.Milliseconds())
+					}
+				} else {
+					heartbeatSlow = false
+				}
+			}
 			sleepTime = 30 * time.Second
 			failures = 0
 		case error:

--- a/conn.go
+++ b/conn.go
@@ -256,9 +256,9 @@ type Conn struct {
 	cqlProtoExts    []cqlProtocolExtension
 	scyllaSupported ScyllaConnectionFeatures
 	writeTimeout    atomic.Int64
-	// activity records the last time (UnixNano) this connection sent or
-	// received a request, so the heartbeat can skip connections that are
-	// already active.
+	// activity is a counter bumped each time a request on this connection
+	// receives a successful response, so the heartbeat can skip connections
+	// that are already known to be alive.
 	activity         atomic.Int64
 	mu               sync.Mutex
 	tabletsRoutingV1 int32
@@ -2131,8 +2131,13 @@ func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, reques
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, &QueryError{err: ctxErr, potentiallyExecuted: false}
 	}
-	c.activity.Add(1)
-	return c.execInternal(ctx, req, tracer, requestTimeout, true)
+	framer, err := c.execInternal(ctx, req, tracer, requestTimeout, true)
+	if err == nil {
+		// Only count activity once a response was actually received,
+		// so heartbeat skip reflects genuine liveness, not just an attempt.
+		c.activity.Add(1)
+	}
+	return framer, err
 }
 
 func (c *Conn) execInternal(ctx context.Context, req frameBuilder, tracer Tracer, requestTimeout time.Duration, startupCompleted bool) (*framer, error) {

--- a/conn.go
+++ b/conn.go
@@ -140,20 +140,21 @@ type SslOptions struct {
 }
 
 type ConnConfig struct {
-	Dialer          Dialer
-	Logger          StdLogger
-	Authenticator   Authenticator
-	Compressor      Compressor
-	HostDialer      HostDialer
-	AuthProvider    func(h *HostInfo) (Authenticator, error)
-	tlsConfig       *tls.Config
-	CQLVersion      string
-	ConnectTimeout  time.Duration
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	ProtoVersion    int
-	Keepalive       time.Duration
-	disableCoalesce bool
+	Dialer                 Dialer
+	Logger                 StdLogger
+	Authenticator          Authenticator
+	Compressor             Compressor
+	HostDialer             HostDialer
+	AuthProvider           func(h *HostInfo) (Authenticator, error)
+	tlsConfig              *tls.Config
+	CQLVersion             string
+	ConnectTimeout         time.Duration
+	ReadTimeout            time.Duration
+	WriteTimeout           time.Duration
+	ProtoVersion           int
+	Keepalive              time.Duration
+	HeartbeatSlowThreshold time.Duration
+	disableCoalesce        bool
 	// isControlConn marks the connection used by the control connection, which is
 	// the only one reporting the driver configuration on startup.
 	isControlConn bool
@@ -983,6 +984,7 @@ func (c *Conn) heartBeat(ctx context.Context) {
 	defer timer.Stop()
 
 	var failures int
+	var heartbeatSlow bool
 
 	for {
 		if failures > 5 {
@@ -996,6 +998,12 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
+		}
+
+		var start time.Time
+		slowThreshold := c.cfg.HeartbeatSlowThreshold
+		if slowThreshold > 0 {
+			start = time.Now()
 		}
 
 		framer, err := c.exec(context.Background(), &writeOptionsFrame{}, nil, c.cfg.ConnectTimeout)
@@ -1015,6 +1023,17 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		switch resp.(type) {
 		case *frm.SupportedFrame:
 			// Everything ok
+			if slowThreshold > 0 {
+				if elapsed := time.Since(start); elapsed > slowThreshold {
+					if !heartbeatSlow {
+						heartbeatSlow = true
+						c.cfg.logger().Printf("gocql: heartbeat to %s took %v, exceeding threshold %v",
+							c.addr, elapsed, slowThreshold)
+					}
+				} else {
+					heartbeatSlow = false
+				}
+			}
 			sleepTime = 30 * time.Second
 			failures = 0
 		case error:

--- a/conn.go
+++ b/conn.go
@@ -252,10 +252,14 @@ type Conn struct {
 	// for server push events: a SCHEMA_CHANGE arriving inside that window makes
 	// the event-debouncer goroutine run querySystem on this connection
 	// concurrently with the write.
-	systemRequest    atomic.Pointer[systemRequestState]
-	cqlProtoExts     []cqlProtocolExtension
-	scyllaSupported  ScyllaConnectionFeatures
-	writeTimeout     atomic.Int64
+	systemRequest   atomic.Pointer[systemRequestState]
+	cqlProtoExts    []cqlProtocolExtension
+	scyllaSupported ScyllaConnectionFeatures
+	writeTimeout    atomic.Int64
+	// activity records the last time (UnixNano) this connection sent or
+	// received a request, so the heartbeat can skip connections that are
+	// already active.
+	activity         atomic.Int64
 	mu               sync.Mutex
 	tabletsRoutingV1 int32
 	headerBuf        [headSize]byte
@@ -985,6 +989,7 @@ func (c *Conn) heartBeat(ctx context.Context) {
 
 	var failures int
 	var heartbeatSlow bool
+	prev := c.activity.Load()
 
 	for {
 		if failures > 5 {
@@ -1000,13 +1005,25 @@ func (c *Conn) heartBeat(ctx context.Context) {
 		case <-timer.C:
 		}
 
+		// Skip heartbeat if the connection had activity since last check.
+		// Detection of a dead connection may be delayed by up to 2x the
+		// heartbeat interval. Matches the Python driver behavior.
+		cur := c.activity.Load()
+		if cur != prev {
+			prev = cur
+			sleepTime = 30 * time.Second
+			failures = 0
+			continue
+		}
+
 		var start time.Time
 		slowThreshold := c.cfg.HeartbeatSlowThreshold
 		if slowThreshold > 0 {
 			start = time.Now()
 		}
 
-		framer, err := c.exec(context.Background(), &writeOptionsFrame{}, nil, c.cfg.ConnectTimeout)
+		// execInternal: the probe must not count as activity.
+		framer, err := c.execInternal(context.Background(), &writeOptionsFrame{}, nil, c.cfg.ConnectTimeout, true)
 		if err != nil {
 			failures++
 			continue
@@ -2110,6 +2127,11 @@ func (c *Conn) addCall(call *callReq) error {
 // typically via defer immediately after parsing or after transferring ownership
 // to an Iter.
 func (c *Conn) exec(ctx context.Context, req frameBuilder, tracer Tracer, requestTimeout time.Duration) (*framer, error) {
+	// Cancelled requests never touch the wire; don't count as activity.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, &QueryError{err: ctxErr, potentiallyExecuted: false}
+	}
+	c.activity.Add(1)
 	return c.execInternal(ctx, req, tracer, requestTimeout, true)
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -2473,3 +2473,156 @@ func TestReleaseFramer(t *testing.T) {
 		c.releaseWriteFramer(f)
 	})
 }
+
+// safeTestLogger is a thread-safe version of testLogger for use in tests
+// where background goroutines (e.g. heartbeat) write to the logger concurrently
+// with the test goroutine reading it.
+type safeTestLogger struct {
+	mu      sync.Mutex
+	capture bytes.Buffer
+}
+
+func (l *safeTestLogger) Print(v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprint(&l.capture, v...)
+}
+
+func (l *safeTestLogger) Printf(format string, v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintf(&l.capture, format, v...)
+}
+
+func (l *safeTestLogger) Println(v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintln(&l.capture, v...)
+}
+
+func (l *safeTestLogger) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.capture.String()
+}
+
+func TestHeartbeatLatencyWarning(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Count OPTIONS frames after startup to detect heartbeat.
+	var optionsCount atomic.Int32
+
+	srv := newTestServerOpts{
+		addr:     "127.0.0.1:0",
+		protocol: defaultProto,
+		recvHook: func(f *framer) {
+			if f.header.Op == frm.OpOptions {
+				count := optionsCount.Add(1)
+				// Delay heartbeat OPTIONS (not the initial handshake one).
+				// The first OPTIONS is from startup handshake; subsequent ones are heartbeats.
+				if count > 1 {
+					time.Sleep(50 * time.Millisecond)
+				}
+			}
+		},
+	}.newServer(t, ctx)
+	defer srv.Stop()
+
+	log := &safeTestLogger{}
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.Logger = log
+	// Set threshold lower than the injected delay so warning is triggered.
+	cluster.HeartbeatSlowThreshold = 10 * time.Millisecond
+	cluster.NumConns = 1
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Heartbeat fires after 1s initially. Wait for it.
+	time.Sleep(2 * time.Second)
+
+	// Close session to stop heartbeat goroutines before reading the log,
+	// avoiding a data race on the non-thread-safe testLogger.
+	db.Close()
+
+	logOutput := log.String()
+	if !strings.Contains(logOutput, "heartbeat to") || !strings.Contains(logOutput, "exceeding threshold") {
+		t.Fatalf("expected heartbeat latency warning in log, got: %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "10ms") {
+		t.Fatalf("expected threshold reported in milliseconds, got: %q", logOutput)
+	}
+	// Verify log suppression: only one warning should be emitted even though
+	// multiple slow heartbeats occurred during the 2s wait.
+	count := strings.Count(logOutput, "exceeding threshold")
+	if count != 1 {
+		t.Fatalf("expected exactly 1 heartbeat warning (suppression), got %d in: %q", count, logOutput)
+	}
+}
+
+func TestHeartbeatLatencyNoWarningWhenDisabled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	srv := newTestServerOpts{
+		addr:     "127.0.0.1:0",
+		protocol: defaultProto,
+		recvHook: func(f *framer) {
+			if f.header.Op == frm.OpOptions {
+				time.Sleep(20 * time.Millisecond)
+			}
+		},
+	}.newServer(t, ctx)
+	defer srv.Stop()
+
+	log := &safeTestLogger{}
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.Logger = log
+	// HeartbeatSlowThreshold is zero (default) — no warnings should be emitted.
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	db.Close()
+
+	logOutput := log.String()
+	if strings.Contains(logOutput, "exceeding threshold") {
+		t.Fatalf("expected no heartbeat warning when disabled, got: %q", logOutput)
+	}
+}
+
+func TestHeartbeatLatencyNoWarningWhenFast(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// No delay injected — heartbeat should be fast.
+	srv := NewTestServer(t, defaultProto, ctx)
+	defer srv.Stop()
+
+	log := &safeTestLogger{}
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.Logger = log
+	// Set a generous threshold that local loopback will never exceed.
+	cluster.HeartbeatSlowThreshold = 5 * time.Second
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	db.Close()
+
+	logOutput := log.String()
+	if strings.Contains(logOutput, "exceeding threshold") {
+		t.Fatalf("expected no heartbeat warning for fast response, got: %q", logOutput)
+	}
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -4407,3 +4407,154 @@ func TestSystemRequestStateClauseFollowsTimeout(t *testing.T) {
 		require.Equal(t, time.Duration(0), timeout)
 	})
 }
+
+// safeTestLogger is a thread-safe version of testLogger for use in tests
+// where background goroutines (e.g. heartbeat) write to the logger concurrently
+// with the test goroutine reading it.
+type safeTestLogger struct {
+	mu      sync.Mutex
+	capture bytes.Buffer
+}
+
+func (l *safeTestLogger) Print(v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprint(&l.capture, v...)
+}
+
+func (l *safeTestLogger) Printf(format string, v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintf(&l.capture, format, v...)
+}
+
+func (l *safeTestLogger) Println(v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintln(&l.capture, v...)
+}
+
+func (l *safeTestLogger) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.capture.String()
+}
+
+func TestHeartbeatLatencyWarning(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Count OPTIONS frames after startup to detect heartbeat.
+	var optionsCount atomic.Int32
+
+	srv := newTestServerOpts{
+		addr:     "127.0.0.1:0",
+		protocol: defaultProto,
+		recvHook: func(f *framer) {
+			if f.header.Op == frm.OpOptions {
+				count := optionsCount.Add(1)
+				// Delay heartbeat OPTIONS (not the initial handshake one).
+				// The first OPTIONS is from startup handshake; subsequent ones are heartbeats.
+				if count > 1 {
+					time.Sleep(50 * time.Millisecond)
+				}
+			}
+		},
+	}.newServer(t, ctx)
+	defer srv.Stop()
+
+	log := &safeTestLogger{}
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.Logger = log
+	// Set threshold lower than the injected delay so warning is triggered.
+	cluster.HeartbeatSlowThreshold = 10 * time.Millisecond
+	cluster.NumConns = 1
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Heartbeat fires after 1s initially. Wait for it.
+	time.Sleep(2 * time.Second)
+
+	// Stop heartbeat goroutines so the log content is final.
+	db.Close()
+
+	logOutput := log.String()
+	if !strings.Contains(logOutput, "heartbeat to") || !strings.Contains(logOutput, "exceeding threshold") {
+		t.Fatalf("expected heartbeat latency warning in log, got: %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "10ms") {
+		t.Fatalf("expected threshold reported in milliseconds, got: %q", logOutput)
+	}
+	// Only one heartbeat fires within the window; expect exactly one warning.
+	count := strings.Count(logOutput, "exceeding threshold")
+	if count != 1 {
+		t.Fatalf("expected exactly 1 heartbeat warning (suppression), got %d in: %q", count, logOutput)
+	}
+}
+
+func TestHeartbeatLatencyNoWarningWhenDisabled(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	srv := newTestServerOpts{
+		addr:     "127.0.0.1:0",
+		protocol: defaultProto,
+		recvHook: func(f *framer) {
+			if f.header.Op == frm.OpOptions {
+				time.Sleep(20 * time.Millisecond)
+			}
+		},
+	}.newServer(t, ctx)
+	defer srv.Stop()
+
+	log := &safeTestLogger{}
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.Logger = log
+	// HeartbeatSlowThreshold is zero (default) — no warnings should be emitted.
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	db.Close()
+
+	logOutput := log.String()
+	if strings.Contains(logOutput, "exceeding threshold") {
+		t.Fatalf("expected no heartbeat warning when disabled, got: %q", logOutput)
+	}
+}
+
+func TestHeartbeatLatencyNoWarningWhenFast(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// No delay injected — heartbeat should be fast.
+	srv := NewTestServer(t, defaultProto, ctx)
+	defer srv.Stop()
+
+	log := &safeTestLogger{}
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.Logger = log
+	// Set a generous threshold that local loopback will never exceed.
+	cluster.HeartbeatSlowThreshold = 5 * time.Second
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	db.Close()
+
+	logOutput := log.String()
+	if strings.Contains(logOutput, "exceeding threshold") {
+		t.Fatalf("expected no heartbeat warning for fast response, got: %q", logOutput)
+	}
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -1713,6 +1713,7 @@ type newTestServerOpts struct {
 	protocol         uint8
 	supportedFactory testSupportedFactory
 	recvHook         func(*framer)
+	recvConnHook     func(net.Conn, *framer)
 }
 
 func (nts newTestServerOpts) newServer(t testing.TB, ctx context.Context) *TestServer {
@@ -1740,6 +1741,7 @@ func (nts newTestServerOpts) newServer(t testing.TB, ctx context.Context) *TestS
 
 		supportedFactory: nts.supportedFactory,
 		onRecv:           nts.recvHook,
+		onRecvConn:       nts.recvConnHook,
 	}
 
 	go srv.closeWatch()
@@ -1817,6 +1819,8 @@ type TestServer struct {
 
 	// onRecv is a hook point for tests, called in receive loop.
 	onRecv func(*framer)
+	// onRecvConn is like onRecv but also receives the server-side conn.
+	onRecvConn func(net.Conn, *framer)
 }
 
 type testSupportedFactory func(conn net.Conn) map[string][]string
@@ -1873,6 +1877,9 @@ func (srv *TestServer) serve() {
 
 				if srv.onRecv != nil {
 					srv.onRecv(framer)
+				}
+				if srv.onRecvConn != nil {
+					srv.onRecvConn(conn, framer)
 				}
 
 				go srv.process(conn, framer, exts)
@@ -4556,5 +4563,62 @@ func TestHeartbeatLatencyNoWarningWhenFast(t *testing.T) {
 	logOutput := log.String()
 	if strings.Contains(logOutput, "exceeding threshold") {
 		t.Fatalf("expected no heartbeat warning for fast response, got: %q", logOutput)
+	}
+}
+
+// TestHeartbeatSkippedOnActiveConnection verifies that a connection with
+// recent traffic is not probed with heartbeat OPTIONS.
+func TestHeartbeatSkippedOnActiveConnection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Per-connection OPTIONS counts, in connection arrival order.
+	var (
+		mu      sync.Mutex
+		order   []net.Conn
+		options = map[net.Conn]int{}
+	)
+	srv := newTestServerOpts{
+		addr:     "127.0.0.1:0",
+		protocol: defaultProto,
+		recvConnHook: func(conn net.Conn, f *framer) {
+			if f.header.Op != frm.OpOptions {
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if _, seen := options[conn]; !seen {
+				order = append(order, conn)
+			}
+			options[conn]++
+		},
+	}.newServer(t, ctx)
+	defer srv.Stop()
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.NumConns = 1
+	db, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	defer db.Close()
+
+	// Keep the data connection busy across the first heartbeat tick (~1s).
+	deadline := time.Now().Add(2200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if err := db.Query("void").Exec(); err != nil {
+			t.Fatalf("query: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// testCluster disables the control conn, so the data conn is the only one.
+	if len(order) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(order))
+	}
+	if got := options[order[0]]; got != 1 {
+		t.Fatalf("expected only the handshake OPTIONS on the busy connection, got %d", got)
 	}
 }

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -85,19 +85,20 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 	}
 
 	return &ConnConfig{
-		ProtoVersion:   cfg.ProtoVersion,
-		CQLVersion:     cfg.CQLVersion,
-		WriteTimeout:   cfg.WriteTimeout,
-		ReadTimeout:    cfg.ReadTimeout,
-		ConnectTimeout: cfg.ConnectTimeout,
-		Dialer:         cfg.Dialer,
-		HostDialer:     hostDialer,
-		Compressor:     cfg.Compressor,
-		Authenticator:  cfg.Authenticator,
-		AuthProvider:   cfg.AuthProvider,
-		Keepalive:      cfg.SocketKeepalive,
-		Logger:         cfg.logger(),
-		tlsConfig:      cfg.getActualTLSConfig(),
+		ProtoVersion:           cfg.ProtoVersion,
+		CQLVersion:             cfg.CQLVersion,
+		WriteTimeout:           cfg.WriteTimeout,
+		ReadTimeout:            cfg.ReadTimeout,
+		ConnectTimeout:         cfg.ConnectTimeout,
+		Dialer:                 cfg.Dialer,
+		HostDialer:             hostDialer,
+		Compressor:             cfg.Compressor,
+		Authenticator:          cfg.Authenticator,
+		AuthProvider:           cfg.AuthProvider,
+		Keepalive:              cfg.SocketKeepalive,
+		HeartbeatSlowThreshold: cfg.HeartbeatSlowThreshold,
+		Logger:                 cfg.logger(),
+		tlsConfig:              cfg.getActualTLSConfig(),
 	}, nil
 }
 

--- a/control.go
+++ b/control.go
@@ -111,6 +111,11 @@ func (c *controlConn) heartBeat() {
 	timer := time.NewTimer(sleepTime)
 	defer timer.Stop()
 
+	// prevConn/prevActivity track the underlying connection and its activity
+	// counter from the last check; reset on reconnect.
+	var prevConn *Conn
+	var prevActivity int64
+
 	for {
 		timer.Reset(sleepTime)
 
@@ -120,7 +125,27 @@ func (c *controlConn) heartBeat() {
 		case <-timer.C:
 		}
 
+		// Skip heartbeat if the underlying connection had activity since the
+		// last check. Matches the Python driver behavior.
+		if conn := c.underlyingConn(); conn != nil && conn == prevConn {
+			cur := conn.activity.Load()
+			if cur != prevActivity {
+				prevActivity = cur
+				sleepTime = 30 * time.Second
+				continue
+			}
+		}
+
 		resp, err := c.writeFrame(&writeOptionsFrame{})
+		// Refresh snapshot: writeFrame may have bumped the counter and the
+		// conn pointer may have changed on reconnect.
+		if conn := c.underlyingConn(); conn != nil {
+			prevConn = conn
+			prevActivity = conn.activity.Load()
+		} else {
+			prevConn = nil
+			prevActivity = 0
+		}
 		if err != nil {
 			goto reconn
 		}
@@ -140,8 +165,21 @@ func (c *controlConn) heartBeat() {
 		// try to connect a bit faster
 		sleepTime = 1 * time.Second
 		c.reconnect()
+		prevConn = nil
+		prevActivity = 0
 		continue
 	}
+}
+
+// underlyingConn returns the current control connection's *Conn, or nil if
+// none is set or it is not a *Conn (e.g., test mock).
+func (c *controlConn) underlyingConn() *Conn {
+	ch := c.getConn()
+	if ch == nil {
+		return nil
+	}
+	conn, _ := ch.conn.(*Conn)
+	return conn
 }
 
 func resolveInitialEndpoint(resolver DNSResolver, addr string, defaultPort int) ([]*HostInfo, error) {

--- a/control.go
+++ b/control.go
@@ -107,6 +107,11 @@ func (c *controlConn) heartBeat() {
 	timer := time.NewTimer(sleepTime)
 	defer timer.Stop()
 
+	// Conn and activity counter at the last check; a change in either means
+	// the connection is alive and the probe is skipped.
+	var prevConn *Conn
+	var prevActivity int64
+
 	for {
 		timer.Reset(sleepTime)
 
@@ -116,7 +121,16 @@ func (c *controlConn) heartBeat() {
 		case <-timer.C:
 		}
 
-		resp, err := c.writeFrame(&writeOptionsFrame{})
+		if conn := c.underlyingConn(); conn != nil {
+			cur := conn.activity.Load()
+			if conn != prevConn || cur != prevActivity {
+				prevConn, prevActivity = conn, cur
+				sleepTime = 30 * time.Second
+				continue
+			}
+		}
+
+		resp, err := c.probeOptions()
 		if err != nil {
 			goto reconn
 		}
@@ -138,6 +152,32 @@ func (c *controlConn) heartBeat() {
 		c.reconnect()
 		continue
 	}
+}
+
+// underlyingConn returns the current control *Conn, or nil (none, or a mock).
+func (c *controlConn) underlyingConn() *Conn {
+	ch := c.getConn()
+	if ch == nil {
+		return nil
+	}
+	conn, _ := ch.conn.(*Conn)
+	return conn
+}
+
+// probeOptions sends a heartbeat OPTIONS frame; via execInternal so the
+// probe does not count as activity.
+func (c *controlConn) probeOptions() (frame, error) {
+	conn := c.underlyingConn()
+	if conn == nil {
+		// No conn or a mock: regular path.
+		return c.writeFrame(&writeOptionsFrame{})
+	}
+	framer, err := conn.execInternal(context.Background(), &writeOptionsFrame{}, nil, c.session.cfg.MetadataSchemaRequestTimeout, true)
+	if err != nil {
+		return nil, err
+	}
+	defer framer.Release()
+	return framer.parseFrame()
 }
 
 func resolveInitialEndpoint(resolver DNSResolver, addr string, defaultPort int) ([]*HostInfo, error) {


### PR DESCRIPTION
## Summary

This PR adds heartbeat improvements inspired by the Python driver behavior:

1. **Skip heartbeats on active connections** — Both data and control connections now track request activity via an atomic counter. If a connection has seen traffic since the last heartbeat cycle, the OPTIONS probe is skipped entirely. This avoids unnecessary heartbeat round-trips on busy connections while still detecting dead idle connections (detection may be delayed by up to 2× the heartbeat interval).

2. **Configurable heartbeat latency warning** — A new `ClusterConfig.HeartbeatTimeout` option (default: disabled) lets users set a threshold for heartbeat round-trip time. When a heartbeat exceeds this threshold, a warning is logged. Repeated slow heartbeats are suppressed (only the first occurrence logs) until the connection recovers and becomes slow again.

## Changes

- **`cluster.go`** — New `HeartbeatTimeout` field on `ClusterConfig`.
- **`conn.go`** — Added `activity` atomic counter incremented on every `exec()` call. `heartBeat()` now skips probes when the connection is active, measures heartbeat latency when `HeartbeatTimeout > 0`, and suppresses repeated slow-heartbeat warnings.
- **`connectionpool.go`** — Propagates `HeartbeatTimeout` from cluster config to `ConnConfig`.
- **`control.go`** — Control connection heartbeat also skips probes on active connections. Added `underlyingConn()` helper to access the `*Conn` activity counter through the `connHost` abstraction.
- **`conn_test.go`** — Three new tests:
  - `TestHeartbeatLatencyWarning` — verifies warning is emitted and suppressed for repeated slow heartbeats.
  - `TestHeartbeatLatencyNoWarningWhenDisabled` — verifies no warning when `HeartbeatTimeout` is zero.
  - `TestHeartbeatLatencyNoWarningWhenFast` — verifies no warning when heartbeats are fast. Also adds a thread-safe `safeTestLogger` for concurrent test use.