### PR TITLE
marshal: fix UDT unmarshal into *any for MapScan (fix similar to CASSGO-115 )

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1642,52 +1642,21 @@ func unmarshalUDT(info TypeInfo, data []byte, value any) error {
 		}
 
 		return nil
-	case *map[string]any:
-		udt := info.(UDTTypeInfo)
-
-		rv := reflect.ValueOf(value)
-		if rv.Kind() != reflect.Ptr {
-			return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
-		}
-
-		rv = rv.Elem()
-		t := rv.Type()
-		if t.Kind() != reflect.Map {
-			return unmarshalErrorf("can not unmarshal %s into %T", info, value)
-		} else if data == nil {
-			rv.Set(reflect.Zero(t))
-			return nil
-		}
-
-		rv.Set(reflect.MakeMap(t))
-		m := *v
-
-		for id, e := range udt.Elements {
-			if len(data) == 0 {
+	case *any:
+		if v != nil {
+			if data == nil {
+				*v = nil
 				return nil
 			}
-			if len(data) < 4 {
-				return unmarshalErrorf("can not unmarshal %s: field [%d]%s: unexpected eof", info, id, e.Name)
-			}
-
-			valType, err := goType(e.Type)
-			if err != nil {
-				return unmarshalErrorf("can not unmarshal %s: %v", info, err)
-			}
-
-			val := reflect.New(valType)
-
-			var p []byte
-			p, data = readBytes(data)
-
-			if err := Unmarshal(e.Type, p, val.Interface()); err != nil {
+			var m map[string]any
+			if err := unmarshalUDTIntoMap(info.(UDTTypeInfo), data, &m); err != nil {
 				return err
 			}
-
-			m[e.Name] = val.Elem().Interface()
+			*v = m
+			return nil
 		}
-
-		return nil
+	case *map[string]any:
+		return unmarshalUDTIntoMap(info.(UDTTypeInfo), data, v)
 	}
 
 	rv := reflect.ValueOf(value)
@@ -1748,6 +1717,43 @@ func unmarshalUDT(info TypeInfo, data []byte, value any) error {
 		if err := Unmarshal(e.Type, p, fk); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// unmarshalUDTIntoMap unmarshals UDT data into a *map[string]any.
+func unmarshalUDTIntoMap(udt UDTTypeInfo, data []byte, dstMap *map[string]any) error {
+	if data == nil {
+		*dstMap = nil
+		return nil
+	}
+
+	m := make(map[string]any, len(udt.Elements))
+	*dstMap = m
+
+	for id, e := range udt.Elements {
+		if len(data) == 0 {
+			return nil
+		}
+		if len(data) < 4 {
+			return unmarshalErrorf("can not unmarshal %s: field [%d]%s: unexpected eof", udt, id, e.Name)
+		}
+
+		valType, err := goType(e.Type)
+		if err != nil {
+			return unmarshalErrorf("can not unmarshal %s: %v", udt, err)
+		}
+
+		val := reflect.New(valType)
+
+		var p []byte
+		p, data = readBytes(data)
+
+		if err := Unmarshal(e.Type, p, val.Interface()); err != nil {
+			return err
+		}
+		m[e.Name] = val.Elem().Interface()
 	}
 
 	return nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -866,6 +866,58 @@ func TestUnmarshalUDT(t *testing.T) {
 	}
 }
 
+// TestUnmarshalUDTIntoInterface tests that UDTs can be unmarshaled into *any.
+// This is used by MapScan when the destination map has a pre-existing entry
+// for a UDT column (the value is an any, so Scan receives *any).
+func TestUnmarshalUDTIntoInterface(t *testing.T) {
+	t.Parallel()
+
+	info := UDTTypeInfo{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeUDT},
+		Name:       "myudt",
+		KeySpace:   "myks",
+		Elements: []UDTField{
+			{
+				Name: "first",
+				Type: NativeType{proto: protoVersion4, typ: TypeAscii},
+			},
+			{
+				Name: "second",
+				Type: NativeType{proto: protoVersion4, typ: TypeSmallInt},
+			},
+		},
+	}
+	data := append(
+		bytesWithLength([]byte("Hello")),       // first
+		bytesWithLength([]byte("\x00\x2a"))..., // second
+	)
+
+	var dest any
+	if err := Unmarshal(info, data, &dest); err != nil {
+		t.Fatalf("Unmarshal into *any failed: %v", err)
+	}
+
+	result, ok := dest.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", dest)
+	}
+	if result["first"] != "Hello" {
+		t.Errorf("expected first=Hello, got %v", result["first"])
+	}
+	if result["second"] != int16(42) {
+		t.Errorf("expected second=42, got %v (%T)", result["second"], result["second"])
+	}
+
+	// nil data should produce nil
+	var dest2 any
+	if err := Unmarshal(info, nil, &dest2); err != nil {
+		t.Fatalf("Unmarshal nil into *any failed: %v", err)
+	}
+	if dest2 != nil {
+		t.Errorf("expected nil for nil data, got %v", dest2)
+	}
+}
+
 // TestUnmarshalListIntoInterface tests that lists can be unmarshaled into *any
 // This is used by MapScan and SliceMap functions.
 func TestUnmarshalListIntoInterface(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `Iter.MapScan` failing to scan UDT columns when the destination map has a pre-existing entry (causing the scan destination to be `*any` instead of `*map[string]any`)
- Extract map-unmarshaling logic into `unmarshalUDTIntoMap` helper to avoid code duplication between the `*any` and `*map[string]any` cases
- Add unit test `TestUnmarshalUDTIntoInterface` covering both non-nil and nil data paths

Refs: https://issues.apache.org/jira/browse/CASSGO-115
Upstream fix: https://github.com/apache/cassandra-gocql-driver/commit/c65c762b83eccdb6a6a083c123a5935c4302745c