### PR TITLE
ci: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/bench-tests.yml
+++ b/.github/workflows/bench-tests.yml
@@ -13,8 +13,8 @@ jobs:
     name: Run benchmark tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache-dependency-path: |

--- a/.github/workflows/clean_dockerhub_images.yml
+++ b/.github/workflows/clean_dockerhub_images.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -16,13 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        # actions/setup-python@v6 poetry cache feature requires poetry to be installed beforehand
+        # which makes use of it extremely awkward.
         with:
           path: |
             /home/runner/.cache/pip
@@ -30,7 +32,7 @@ jobs:
           key: docs-cache-${{ runner.os }}-${{ hashFiles('docs/pyproject.toml', 'docs/Makefile') }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 
@@ -55,7 +57,7 @@ jobs:
             .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar
@@ -81,4 +83,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -22,12 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        # actions/setup-python@v6 poetry cache feature requires poetry to be installed beforehand
+        # which makes use of it extremely awkward.
         with:
           path: |
             /home/runner/.cache/pip
@@ -35,7 +37,7 @@ jobs:
           key: docs-cache-${{ runner.os }}-${{ hashFiles('docs/pyproject.toml', 'docs/Makefile') }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
+++ b/.github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
@@ -13,19 +13,19 @@ jobs:
         scylla-version: [ENTERPRISE-RELEASE, OSS-RELEASE]
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Check out the scylla-bench repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: scylladb/scylla-bench
           path: scylla-bench
 
       - name: Checkout GoCQL PR Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Start Jenkins job
-        uses: scylladb-actions/jenkins-client@v0.2.0
+        uses: scylladb-actions/jenkins-client@b947e07e8b588db2a8028313274992d3eda73360 # v0.2.0
         with:
           job_name: scylla-drivers/job/gocql/job/extended-ci/job/longevity-large-partitions-with-network-nemesis-1h-test
           job_parameters: '{"email_recipients": "scylla-drivers@scylladb.com", "scylla_version": "${{ steps.scylla-version.outputs.value }}", "extra_environment_variables": "SCT_STRESS_IMAGE.scylla-bench=scylladb/gocql-extended-ci:scylla-bench-${{ github.event.pull_request.head.sha }}"}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             /home/runner/.cache/pip
@@ -39,7 +39,7 @@ jobs:
           # CCM, scylla, cassandra and java versions are in Makefile
           key: pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache-dependency-path: |
@@ -66,13 +66,13 @@ jobs:
     env:
       SCYLLA_VERSION: ${{ matrix.scylla-version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             /home/runner/.cache/pip
@@ -83,7 +83,7 @@ jobs:
           # CCM, pip and java versions are in Makefile
           key: pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache-dependency-path: |
@@ -96,7 +96,7 @@ jobs:
         run: make resolve-scylla-version
 
       - name: Pull CCM image from the cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: steps.scylla-version.outputs.value != 'NOT-FOUND'
         id: ccm-cache
         with:
@@ -109,7 +109,7 @@ jobs:
 
       - name: Save CCM ScyllaDB image into the cache
         if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.ccm/repository
           key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
@@ -134,13 +134,13 @@ jobs:
       CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             /home/runner/.cache/pip
@@ -151,7 +151,7 @@ jobs:
           # CCM, python and java versions are in Makefile
           key: pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache-dependency-path: |
@@ -164,7 +164,7 @@ jobs:
         run: make resolve-cassandra-version
 
       - name: Pull CCM image from the cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: steps.cassandra-version.outputs.value != 'NOT-FOUND'
         id: ccm-cache
         with:
@@ -177,7 +177,7 @@ jobs:
 
       - name: Save CCM Cassandra image into the cache
         if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.cassandra-version.outputs.value != 'NOT-FOUND'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.ccm/repository
           key: ccm-cassandra-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}


### PR DESCRIPTION
Replace all third-party GitHub Action version tags with full commit SHAs to reduce supply chain attack surface. Mutable tags can be silently redirected to malicious code, while pinned SHAs are permanent.

Original version tags are preserved as inline comments for maintainability.

Closes DRIVER-581