### PR TITLE
Replace SimpleStrategy with NetworkTopologyStrategy in example tests

### DIFF
--- a/example_batch_test.go
+++ b/example_batch_test.go
@@ -35,7 +35,7 @@ import (
 // Example_batch demonstrates how to execute a batch of statements.
 func Example_batch() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.batches(pk int, ck int, description text, PRIMARY KEY(pk, ck));
 	*/
 	cluster := gocql.NewCluster("localhost:9042")

--- a/example_dynamic_columns_test.go
+++ b/example_dynamic_columns_test.go
@@ -38,7 +38,7 @@ import (
 // Example_dynamicColumns demonstrates how to handle dynamic column list.
 func Example_dynamicColumns() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.table1(pk text, ck int, value1 text, value2 int, PRIMARY KEY(pk, ck));
 	insert into example.table1 (pk, ck, value1, value2) values ('a', 1, 'b', 2);
 	insert into example.table1 (pk, ck, value1, value2) values ('c', 3, 'd', 4);

--- a/example_lwt_batch_test.go
+++ b/example_lwt_batch_test.go
@@ -35,7 +35,7 @@ import (
 // ExampleSession_MapExecuteBatchCAS demonstrates how to execute a batch lightweight transaction.
 func ExampleSession_MapExecuteBatchCAS() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.my_lwt_batch_table(pk text, ck text, version int, value text, PRIMARY KEY(pk, ck));
 	*/
 	cluster := gocql.NewCluster("localhost:9042")

--- a/example_lwt_test.go
+++ b/example_lwt_test.go
@@ -35,7 +35,7 @@ import (
 // ExampleQuery_MapScanCAS demonstrates how to execute a single-statement lightweight transaction.
 func ExampleQuery_MapScanCAS() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.my_lwt_table(pk int, version int, value text, PRIMARY KEY(pk));
 	*/
 	cluster := gocql.NewCluster("localhost:9042")

--- a/example_marshaler_test.go
+++ b/example_marshaler_test.go
@@ -75,7 +75,7 @@ func (m *MyMarshaler) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
 // Example_marshalerUnmarshaler demonstrates how to implement a Marshaler and Unmarshaler.
 func Example_marshalerUnmarshaler() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.my_marshaler_table(pk int, value text, PRIMARY KEY(pk));
 	*/
 	cluster := gocql.NewCluster("localhost:9042")

--- a/example_nulls_test.go
+++ b/example_nulls_test.go
@@ -37,7 +37,7 @@ import (
 // column being null and empty string, you can unmarshal into *string field.
 func Example_nulls() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.stringvals(id int, value text, PRIMARY KEY(id));
 	insert into example.stringvals (id, value) values (1, null);
 	insert into example.stringvals (id, value) values (2, '');

--- a/example_paging_test.go
+++ b/example_paging_test.go
@@ -36,7 +36,7 @@ import (
 // See also package documentation about paging.
 func Example_paging() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.itoa(id int, description text, PRIMARY KEY(id));
 	insert into example.itoa (id, description) values (1, 'one');
 	insert into example.itoa (id, description) values (2, 'two');

--- a/example_set_test.go
+++ b/example_set_test.go
@@ -35,7 +35,7 @@ import (
 // Example_set demonstrates how to use sets.
 func Example_set() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.sets(id int, value set<text>, PRIMARY KEY(id));
 	*/
 	cluster := gocql.NewCluster("localhost:9042")

--- a/example_test.go
+++ b/example_test.go
@@ -34,7 +34,7 @@ import (
 
 func Example() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create table example.tweet(timeline text, id UUID, text text, PRIMARY KEY(id));
 	create index on example.tweet(timeline);
 	*/

--- a/example_udt_map_test.go
+++ b/example_udt_map_test.go
@@ -36,7 +36,7 @@ import (
 // See also Example_userDefinedTypesStruct and examples for UDTMarshaler and UDTUnmarshaler if you want to map to structs.
 func Example_userDefinedTypesMap() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create type example.my_udt (field_a text, field_b int);
 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
 	*/

--- a/example_udt_marshaler_test.go
+++ b/example_udt_marshaler_test.go
@@ -55,7 +55,7 @@ func (m MyUDTMarshaler) MarshalUDT(name string, info gocql.TypeInfo) ([]byte, er
 // ExampleUDTMarshaler demonstrates how to implement a UDTMarshaler.
 func ExampleUDTMarshaler() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create type example.my_udt (field_a text, field_b int);
 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
 	*/

--- a/example_udt_struct_test.go
+++ b/example_udt_struct_test.go
@@ -41,7 +41,7 @@ type MyUDT struct {
 // See also examples for UDTMarshaler and UDTUnmarshaler if you need more control/better performance.
 func Example_userDefinedTypesStruct() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create type example.my_udt (field_a text, field_b int);
 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
 	*/

--- a/example_udt_unmarshaler_test.go
+++ b/example_udt_unmarshaler_test.go
@@ -56,7 +56,7 @@ func (m *MyUDTUnmarshaler) UnmarshalUDT(name string, info gocql.TypeInfo, data [
 // ExampleUDTUnmarshaler demonstrates how to implement a UDTUnmarshaler.
 func ExampleUDTUnmarshaler() {
 	/* The example assumes the following CQL was used to setup the keyspace:
-	create keyspace example with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+	create keyspace example with replication = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 1 };
 	create type example.my_udt (field_a text, field_b int);
 	create table example.my_udt_table(pk int, value frozen<my_udt>, PRIMARY KEY(pk));
 	insert into example.my_udt_table (pk, value) values (1, {field_a: 'a value', field_b: 42});


### PR DESCRIPTION
## Summary

Updates CQL documentation comments in all `example_*_test.go` files to use `NetworkTopologyStrategy` instead of `SimpleStrategy`.

## Changes
- Updated 13 `example_*_test.go` files: replaced `SimpleStrategy` with `NetworkTopologyStrategy` using `'datacenter1': 1`
- No functional code changes — these are CQL snippets in code comments that instruct users on keyspace setup

## Motivation

Scylla 2026.2+ enables tablets by default, which makes `SimpleStrategy` incompatible. While these are only documentation comments (not executed by tests), updating them ensures the examples reflect current best practices and won't confuse users who copy-paste them against a modern Scylla cluster.

**Note:** This is a documentation-only improvement. The actual test failures in upstream driver tests (e.g., Jenkins [#865](https://jenkins.scylladb.com/job/scylla-master/job/driver-tests/job/gocql-driver-matrix-test/865/)) are addressed separately by [gocql-driver-matrix#61](https://github.com/scylladb/gocql-driver-matrix/pull/61), which patches upstream `common_test.go` at runtime.