### PR TITLE
perf: skip write coalesce delay for large frames / EXECUTE

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -126,6 +126,11 @@ type ClusterConfig struct {
 	// Default: nil
 	AuthProvider       func(h *HostInfo) (Authenticator, error)
 	ClientRoutesConfig *ClientRoutesConfig
+	// Per-host policy: returns true to enable coalescing, false to skip.
+	// Nil means coalesce all connections.
+	WriteCoalescePolicy func(host *HostInfo) bool
+	// CQL opcodes that bypass coalescing (flushed immediately).
+	WriteCoalesceBypassOps map[frm.Op]struct{}
 	// The version of the driver that is going to be reported to the server.
 	// Defaulted to current library version
 	DriverVersion string
@@ -149,13 +154,6 @@ type ClusterConfig struct {
 	//
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
-	// Flush immediately when buffered data exceeds this (default: 1400 bytes).
-	WriteCoalesceFlushThreshold int
-	// Per-host policy: returns true to enable coalescing, false to skip.
-	// Nil means coalesce all connections.
-	WriteCoalescePolicy func(host *HostInfo) bool
-	// CQL opcodes that bypass coalescing (flushed immediately).
-	WriteCoalesceBypassOps map[frm.Op]struct{}
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
@@ -230,6 +228,8 @@ type ClusterConfig struct {
 	// Maximum cache size for query info about statements for each session.
 	// Default: 1000
 	MaxRoutingKeyInfo int
+	// Flush immediately when buffered data exceeds this (default: 1400 bytes).
+	WriteCoalesceFlushThreshold int
 	// ReadTimeout limits the time the driver waits for data from the connection.
 	// It has only one purpose, identify faulty connection early and drop it.
 	// Default: 11 Seconds
@@ -400,6 +400,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		InitialReconnectionPolicy:     &NoReconnectionPolicy{},
 		SocketKeepalive:               15 * time.Second,
 		WriteCoalesceWaitTime:         200 * time.Microsecond,
+		WriteCoalesceBypassOps:        map[frm.Op]struct{}{frm.OpExecute: {}},
 		MetadataSchemaRequestTimeout:  60 * time.Second,
 		DisableSkipMetadata:           true,
 		WarningsHandlerBuilder:        DefaultWarningHandlerBuilder,

--- a/cluster.go
+++ b/cluster.go
@@ -155,6 +155,11 @@ type ClusterConfig struct {
 	//
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
+	// WriteCoalesceFlushThreshold is the buffered data size (in bytes) above which
+	// the write coalescer flushes immediately instead of waiting for the coalesce
+	// timer.  A frame that already fills a TCP segment gains nothing from waiting.
+	// Set to 0 to use the default (1400 bytes).
+	WriteCoalesceFlushThreshold int
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.

--- a/cluster.go
+++ b/cluster.go
@@ -153,6 +153,17 @@ type ClusterConfig struct {
 	// timer.  A frame that already fills a TCP segment gains nothing from waiting.
 	// Set to 0 to use the default (1400 bytes).
 	WriteCoalesceFlushThreshold int
+	// WriteCoalescePolicy, if set, is called when establishing a connection to
+	// decide whether write coalescing should be enabled for that host.  It
+	// receives the HostInfo of the remote node and returns true to enable
+	// coalescing or false to disable it.  This allows topology-aware decisions
+	// such as coalescing only for cross-DC or cross-rack connections where the
+	// network latency amortizes the coalesce wait.
+	//
+	// When nil, coalescing is applied to all connections (the default behavior).
+	// Use NewCoalescePolicyCrossDC or NewCoalescePolicyCrossRack as convenient
+	// constructors.
+	WriteCoalescePolicy func(host *HostInfo) bool
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
@@ -408,6 +419,27 @@ func NewCluster(hosts ...string) *ClusterConfig {
 	}
 
 	return cfg
+}
+
+// NewCoalescePolicyCrossDC returns a WriteCoalescePolicy that enables
+// coalescing only for hosts in a different data center than localDC.
+// Connections to hosts in localDC skip the coalesce wait since local-DC
+// round-trip times are low enough that the wait adds unnecessary latency.
+func NewCoalescePolicyCrossDC(localDC string) func(host *HostInfo) bool {
+	return func(host *HostInfo) bool {
+		return host.DataCenter() != localDC
+	}
+}
+
+// NewCoalescePolicyCrossRack returns a WriteCoalescePolicy that enables
+// coalescing only for hosts outside the local data center and rack.
+// Same-rack connections have the lowest latency and benefit least from
+// coalescing; cross-rack and cross-DC connections have higher latency
+// where the coalesce wait is amortized by network savings.
+func NewCoalescePolicyCrossRack(localDC, localRack string) func(host *HostInfo) bool {
+	return func(host *HostInfo) bool {
+		return host.DataCenter() != localDC || host.Rack() != localRack
+	}
 }
 
 func (cfg *ClusterConfig) logger() StdLogger {

--- a/cluster.go
+++ b/cluster.go
@@ -148,6 +148,11 @@ type ClusterConfig struct {
 	//
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
+	// WriteCoalesceFlushThreshold is the buffered data size (in bytes) above which
+	// the write coalescer flushes immediately instead of waiting for the coalesce
+	// timer.  A frame that already fills a TCP segment gains nothing from waiting.
+	// Set to 0 to use the default (1400 bytes).
+	WriteCoalesceFlushThreshold int
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.

--- a/cluster.go
+++ b/cluster.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql/internal/eventbus"
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 const defaultDriverName = "ScyllaDB GoCQL Driver"
@@ -148,22 +149,13 @@ type ClusterConfig struct {
 	//
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
-	// WriteCoalesceFlushThreshold is the buffered data size (in bytes) above which
-	// the write coalescer flushes immediately instead of waiting for the coalesce
-	// timer.  A frame that already fills a TCP segment gains nothing from waiting.
-	// Set to 0 to use the default (1400 bytes).
+	// Flush immediately when buffered data exceeds this (default: 1400 bytes).
 	WriteCoalesceFlushThreshold int
-	// WriteCoalescePolicy, if set, is called when establishing a connection to
-	// decide whether write coalescing should be enabled for that host.  It
-	// receives the HostInfo of the remote node and returns true to enable
-	// coalescing or false to disable it.  This allows topology-aware decisions
-	// such as coalescing only for cross-DC or cross-rack connections where the
-	// network latency amortizes the coalesce wait.
-	//
-	// When nil, coalescing is applied to all connections (the default behavior).
-	// Use NewCoalescePolicyCrossDC or NewCoalescePolicyCrossRack as convenient
-	// constructors.
+	// Per-host policy: returns true to enable coalescing, false to skip.
+	// Nil means coalesce all connections.
 	WriteCoalescePolicy func(host *HostInfo) bool
+	// CQL opcodes that bypass coalescing (flushed immediately).
+	WriteCoalesceBypassOps map[frm.Op]struct{}
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
@@ -421,21 +413,14 @@ func NewCluster(hosts ...string) *ClusterConfig {
 	return cfg
 }
 
-// NewCoalescePolicyCrossDC returns a WriteCoalescePolicy that enables
-// coalescing only for hosts in a different data center than localDC.
-// Connections to hosts in localDC skip the coalesce wait since local-DC
-// round-trip times are low enough that the wait adds unnecessary latency.
+// NewCoalescePolicyCrossDC enables coalescing only for hosts in a different DC.
 func NewCoalescePolicyCrossDC(localDC string) func(host *HostInfo) bool {
 	return func(host *HostInfo) bool {
 		return host.DataCenter() != localDC
 	}
 }
 
-// NewCoalescePolicyCrossRack returns a WriteCoalescePolicy that enables
-// coalescing only for hosts outside the local data center and rack.
-// Same-rack connections have the lowest latency and benefit least from
-// coalescing; cross-rack and cross-DC connections have higher latency
-// where the coalesce wait is amortized by network savings.
+// NewCoalescePolicyCrossRack enables coalescing only for hosts outside the local DC+rack.
 func NewCoalescePolicyCrossRack(localDC, localRack string) func(host *HostInfo) bool {
 	return func(host *HostInfo) bool {
 		return host.DataCenter() != localDC || host.Rack() != localRack

--- a/cluster.go
+++ b/cluster.go
@@ -160,6 +160,17 @@ type ClusterConfig struct {
 	// timer.  A frame that already fills a TCP segment gains nothing from waiting.
 	// Set to 0 to use the default (1400 bytes).
 	WriteCoalesceFlushThreshold int
+	// WriteCoalescePolicy, if set, is called when establishing a connection to
+	// decide whether write coalescing should be enabled for that host.  It
+	// receives the HostInfo of the remote node and returns true to enable
+	// coalescing or false to disable it.  This allows topology-aware decisions
+	// such as coalescing only for cross-DC or cross-rack connections where the
+	// network latency amortizes the coalesce wait.
+	//
+	// When nil, coalescing is applied to all connections (the default behavior).
+	// Use NewCoalescePolicyCrossDC or NewCoalescePolicyCrossRack as convenient
+	// constructors.
+	WriteCoalescePolicy func(host *HostInfo) bool
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
@@ -426,6 +437,27 @@ func NewCluster(hosts ...string) *ClusterConfig {
 	}
 
 	return cfg
+}
+
+// NewCoalescePolicyCrossDC returns a WriteCoalescePolicy that enables
+// coalescing only for hosts in a different data center than localDC.
+// Connections to hosts in localDC skip the coalesce wait since local-DC
+// round-trip times are low enough that the wait adds unnecessary latency.
+func NewCoalescePolicyCrossDC(localDC string) func(host *HostInfo) bool {
+	return func(host *HostInfo) bool {
+		return host.DataCenter() != localDC
+	}
+}
+
+// NewCoalescePolicyCrossRack returns a WriteCoalescePolicy that enables
+// coalescing only for hosts outside the local data center and rack.
+// Same-rack connections have the lowest latency and benefit least from
+// coalescing; cross-rack and cross-DC connections have higher latency
+// where the coalesce wait is amortized by network savings.
+func NewCoalescePolicyCrossRack(localDC, localRack string) func(host *HostInfo) bool {
+	return func(host *HostInfo) bool {
+		return host.DataCenter() != localDC || host.Rack() != localRack
+	}
 }
 
 func (cfg *ClusterConfig) logger() StdLogger {

--- a/cluster.go
+++ b/cluster.go
@@ -127,6 +127,11 @@ type ClusterConfig struct {
 	// Default: nil
 	AuthProvider       func(h *HostInfo) (Authenticator, error)
 	ClientRoutesConfig *ClientRoutesConfig
+	// Per-host policy: returns true to enable coalescing, false to skip.
+	// Nil means coalesce all connections.
+	WriteCoalescePolicy func(host *HostInfo) bool
+	// CQL opcodes that bypass coalescing (flushed immediately).
+	WriteCoalesceBypassOps map[frm.Op]struct{}
 	// The version of the driver that is going to be reported to the server.
 	// Defaulted to current library version
 	DriverVersion string
@@ -156,13 +161,6 @@ type ClusterConfig struct {
 	//
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
-	// Flush immediately when buffered data exceeds this (default: 1400 bytes).
-	WriteCoalesceFlushThreshold int
-	// Per-host policy: returns true to enable coalescing, false to skip.
-	// Nil means coalesce all connections.
-	WriteCoalescePolicy func(host *HostInfo) bool
-	// CQL opcodes that bypass coalescing (flushed immediately).
-	WriteCoalesceBypassOps map[frm.Op]struct{}
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
@@ -249,6 +247,9 @@ type ClusterConfig struct {
 	// Maximum cache size for query info about statements for each session.
 	// Default: 1000
 	MaxRoutingKeyInfo int
+	// Flush immediately when buffered data exceeds this.
+	// Zero or negative uses the default threshold (1400 bytes).
+	WriteCoalesceFlushThreshold int
 	// ReadTimeout limits the time the driver waits for data from the connection.
 	// It has only one purpose, identify faulty connection early and drop it.
 	// Default: 11 Seconds
@@ -418,6 +419,7 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		InitialReconnectionPolicy:     &NoReconnectionPolicy{},
 		SocketKeepalive:               15 * time.Second,
 		WriteCoalesceWaitTime:         200 * time.Microsecond,
+		WriteCoalesceBypassOps:        map[frm.Op]struct{}{frm.OpExecute: {}},
 		MetadataSchemaRequestTimeout:  60 * time.Second,
 		DisableSkipMetadata:           true,
 		WarningsHandlerBuilder:        DefaultWarningHandlerBuilder,

--- a/cluster.go
+++ b/cluster.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql/internal/eventbus"
+	frm "github.com/gocql/gocql/internal/frame"
 )
 
 const defaultDriverName = "ScyllaDB GoCQL Driver"
@@ -155,22 +156,13 @@ type ClusterConfig struct {
 	//
 	// (default: 200 microseconds)
 	WriteCoalesceWaitTime time.Duration
-	// WriteCoalesceFlushThreshold is the buffered data size (in bytes) above which
-	// the write coalescer flushes immediately instead of waiting for the coalesce
-	// timer.  A frame that already fills a TCP segment gains nothing from waiting.
-	// Set to 0 to use the default (1400 bytes).
+	// Flush immediately when buffered data exceeds this (default: 1400 bytes).
 	WriteCoalesceFlushThreshold int
-	// WriteCoalescePolicy, if set, is called when establishing a connection to
-	// decide whether write coalescing should be enabled for that host.  It
-	// receives the HostInfo of the remote node and returns true to enable
-	// coalescing or false to disable it.  This allows topology-aware decisions
-	// such as coalescing only for cross-DC or cross-rack connections where the
-	// network latency amortizes the coalesce wait.
-	//
-	// When nil, coalescing is applied to all connections (the default behavior).
-	// Use NewCoalescePolicyCrossDC or NewCoalescePolicyCrossRack as convenient
-	// constructors.
+	// Per-host policy: returns true to enable coalescing, false to skip.
+	// Nil means coalesce all connections.
 	WriteCoalescePolicy func(host *HostInfo) bool
+	// CQL opcodes that bypass coalescing (flushed immediately).
+	WriteCoalesceBypassOps map[frm.Op]struct{}
 	// WriteTimeout limits the time the driver waits to write a request to a network connection.
 	// WriteTimeout should be lower than or equal to Timeout.
 	// WriteTimeout defaults to the value of Timeout.
@@ -439,21 +431,15 @@ func NewCluster(hosts ...string) *ClusterConfig {
 	return cfg
 }
 
-// NewCoalescePolicyCrossDC returns a WriteCoalescePolicy that enables
-// coalescing only for hosts in a different data center than localDC.
-// Connections to hosts in localDC skip the coalesce wait since local-DC
-// round-trip times are low enough that the wait adds unnecessary latency.
+// NewCoalescePolicyCrossDC enables coalescing only for hosts in a different DC.
+// If a host's datacenter is unknown or empty, coalescing is enabled (safe default).
 func NewCoalescePolicyCrossDC(localDC string) func(host *HostInfo) bool {
 	return func(host *HostInfo) bool {
 		return host.DataCenter() != localDC
 	}
 }
 
-// NewCoalescePolicyCrossRack returns a WriteCoalescePolicy that enables
-// coalescing only for hosts outside the local data center and rack.
-// Same-rack connections have the lowest latency and benefit least from
-// coalescing; cross-rack and cross-DC connections have higher latency
-// where the coalesce wait is amortized by network savings.
+// NewCoalescePolicyCrossRack enables coalescing only for hosts outside the local DC+rack.
 func NewCoalescePolicyCrossRack(localDC, localRack string) func(host *HostInfo) bool {
 	return func(host *HostInfo) bool {
 		return host.DataCenter() != localDC || host.Rack() != localRack

--- a/conn.go
+++ b/conn.go
@@ -437,7 +437,7 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 
 	// dont coalesce startup frames
 	if c.session.cfg.WriteCoalesceWaitTime > 0 && !c.cfg.disableCoalesce && !dialedHost.DisableCoalesce {
-		c.w = newWriteCoalescer(c.conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, ctx.Done())
+		c.w = newWriteCoalescer(c.conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
 	}
 
 	if c.isScyllaConn() { // ScyllaDB does not support system.peers_v2
@@ -1119,12 +1119,23 @@ func (c *deadlineContextWriter) writeContext(ctx context.Context, p []byte) (int
 	return c.w.Write(p)
 }
 
+// defaultFlushThreshold is the size threshold above which coalesced frames are
+// flushed immediately, without waiting for the coalesce timer.  A frame that
+// already fills a typical TCP segment (~1460 bytes for a 1500-byte MTU) gains
+// nothing from waiting for more data — the kernel will send it as a full
+// packet anyway.
+const defaultFlushThreshold = 1400
+
 func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.Duration,
-	quit <-chan struct{}) *writeCoalescer {
+	flushThreshold int, quit <-chan struct{}) *writeCoalescer {
+	if flushThreshold == 0 {
+		flushThreshold = defaultFlushThreshold
+	}
 	wc := &writeCoalescer{
-		writeCh: make(chan writeRequest),
-		c:       conn,
-		quit:    quit,
+		writeCh:        make(chan writeRequest),
+		c:              conn,
+		quit:           quit,
+		flushThreshold: flushThreshold,
 	}
 	wc.setWriteTimeout(writeTimeout)
 	go wc.writeFlusher(coalesceDuration)
@@ -1138,6 +1149,7 @@ type writeCoalescer struct {
 	testEnqueuedHook func()
 	testFlushedHook  func()
 	timeout          atomic.Int64
+	flushThreshold   int
 	mu               sync.Mutex
 }
 
@@ -1211,14 +1223,25 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 
 	var buffers net.Buffers
 	var resultChans []chan<- writeResult
+	var bufferedBytes int
 
 	for {
 		select {
 		case req := <-w.writeCh:
 			buffers = append(buffers, req.data)
 			resultChans = append(resultChans, req.resultChan)
-			if !running {
-				// Start timer on first write.
+			bufferedBytes += len(req.data)
+			if w.flushThreshold > 0 && bufferedBytes >= w.flushThreshold {
+				// Buffer already fills a TCP segment; flush now.
+				running = false
+				w.flush(resultChans, buffers)
+				buffers = nil
+				resultChans = nil
+				bufferedBytes = 0
+				if w.testFlushedHook != nil {
+					w.testFlushedHook()
+				}
+			} else if !running {
 				resetTimer()
 				running = true
 			}
@@ -1238,6 +1261,7 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 			w.flush(resultChans, buffers)
 			buffers = nil
 			resultChans = nil
+			bufferedBytes = 0
 			if w.testFlushedHook != nil {
 				w.testFlushedHook()
 			}

--- a/conn.go
+++ b/conn.go
@@ -437,7 +437,9 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 
 	// dont coalesce startup frames
 	if c.session.cfg.WriteCoalesceWaitTime > 0 && !c.cfg.disableCoalesce && !dialedHost.DisableCoalesce {
-		c.w = newWriteCoalescer(c.conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
+		if policy := c.session.cfg.WriteCoalescePolicy; policy == nil || policy(c.host) {
+			c.w = newWriteCoalescer(c.conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
+		}
 	}
 
 	if c.isScyllaConn() { // ScyllaDB does not support system.peers_v2

--- a/conn.go
+++ b/conn.go
@@ -438,7 +438,7 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 	// dont coalesce startup frames
 	if c.session.cfg.WriteCoalesceWaitTime > 0 && !c.cfg.disableCoalesce && !dialedHost.DisableCoalesce {
 		if policy := c.session.cfg.WriteCoalescePolicy; policy == nil || policy(c.host) {
-			c.w = newWriteCoalescer(c.conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
+			c.w = newWriteCoalescer(c.conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, c.session.cfg.WriteCoalesceBypassOps, ctx.Done())
 		}
 	}
 
@@ -1121,15 +1121,11 @@ func (c *deadlineContextWriter) writeContext(ctx context.Context, p []byte) (int
 	return c.w.Write(p)
 }
 
-// defaultFlushThreshold is the size threshold above which coalesced frames are
-// flushed immediately, without waiting for the coalesce timer.  A frame that
-// already fills a typical TCP segment (~1460 bytes for a 1500-byte MTU) gains
-// nothing from waiting for more data — the kernel will send it as a full
-// packet anyway.
+// defaultFlushThreshold: frames above this skip the coalesce wait (~1 TCP segment).
 const defaultFlushThreshold = 1400
 
 func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.Duration,
-	flushThreshold int, quit <-chan struct{}) *writeCoalescer {
+	flushThreshold int, bypassOps map[frm.Op]struct{}, quit <-chan struct{}) *writeCoalescer {
 	if flushThreshold == 0 {
 		flushThreshold = defaultFlushThreshold
 	}
@@ -1138,6 +1134,13 @@ func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.
 		c:              conn,
 		quit:           quit,
 		flushThreshold: flushThreshold,
+		bypassOps:      bypassOps,
+	}
+	if len(bypassOps) == 1 {
+		for op := range bypassOps {
+			wc.singleBypassOp = op
+			wc.hasSingleBypass = true
+		}
 	}
 	wc.setWriteTimeout(writeTimeout)
 	go wc.writeFlusher(coalesceDuration)
@@ -1150,9 +1153,12 @@ type writeCoalescer struct {
 	writeCh          chan writeRequest
 	testEnqueuedHook func()
 	testFlushedHook  func()
+	bypassOps        map[frm.Op]struct{}
+	scratchBufs      net.Buffers
 	timeout          atomic.Int64
 	flushThreshold   int
-	mu               sync.Mutex
+	singleBypassOp   frm.Op
+	hasSingleBypass  bool
 }
 
 func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {
@@ -1160,10 +1166,9 @@ func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {
 }
 
 type writeRequest struct {
-	// resultChan is a channel (with buffer size 1) where to send results of the write.
-	resultChan chan<- writeResult
-	// data to write.
-	data []byte
+	resultChan       chan<- writeResult
+	data             []byte
+	flushImmediately bool
 }
 
 type writeResult struct {
@@ -1171,22 +1176,34 @@ type writeResult struct {
 	n   int
 }
 
-// writeResultChanPool pools buffered channels used for write coalescer results.
-// Each channel is used in a strict produce-once/consume-once pattern:
-// the flusher goroutine sends exactly one writeResult, and writeContext
-// reads exactly one. After reading, the channel is empty and safe to reuse.
+// writeResultChanPool: produce-once/consume-once buffered channels.
 var writeResultChanPool = sync.Pool{
 	New: func() interface{} {
 		return make(chan writeResult, 1)
 	},
 }
 
+// Opcode byte offset in serialized CQL frame header.
+const cqlFrameOpcodeOffset = 4
+
 // writeContext implements contextWriter.
 func (w *writeCoalescer) writeContext(ctx context.Context, p []byte) (int, error) {
 	resultChan := writeResultChanPool.Get().(chan writeResult)
+
+	flush := false
+	if len(p) > cqlFrameOpcodeOffset {
+		op := frm.Op(p[cqlFrameOpcodeOffset])
+		if w.hasSingleBypass {
+			flush = op == w.singleBypassOp
+		} else if len(w.bypassOps) > 0 {
+			_, flush = w.bypassOps[op]
+		}
+	}
+
 	wr := writeRequest{
-		resultChan: resultChan,
-		data:       p,
+		resultChan:       resultChan,
+		data:             p,
+		flushImmediately: flush,
 	}
 
 	select {
@@ -1227,22 +1244,40 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 	var resultChans []chan<- writeResult
 	var bufferedBytes int
 
+	flushAndReset := func() {
+		running = false
+		w.flush(resultChans, buffers)
+		buffers = buffers[:0]
+		resultChans = resultChans[:0]
+		bufferedBytes = 0
+		if w.testFlushedHook != nil {
+			w.testFlushedHook()
+		}
+	}
+
 	for {
 		select {
 		case req := <-w.writeCh:
 			buffers = append(buffers, req.data)
 			resultChans = append(resultChans, req.resultChan)
 			bufferedBytes += len(req.data)
-			if w.flushThreshold > 0 && bufferedBytes >= w.flushThreshold {
-				// Buffer already fills a TCP segment; flush now.
-				running = false
-				w.flush(resultChans, buffers)
-				buffers = nil
-				resultChans = nil
-				bufferedBytes = 0
-				if w.testFlushedHook != nil {
-					w.testFlushedHook()
+
+			needsFlush := req.flushImmediately ||
+				(w.flushThreshold > 0 && bufferedBytes >= w.flushThreshold)
+
+			if needsFlush {
+				// Drain queued requests to batch into the same writev.
+			drain:
+				for {
+					select {
+					case r := <-w.writeCh:
+						buffers = append(buffers, r.data)
+						resultChans = append(resultChans, r.resultChan)
+					default:
+						break drain
+					}
 				}
+				flushAndReset()
 			} else if !running {
 				resetTimer()
 				running = true
@@ -1252,27 +1287,30 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 				n:   0,
 				err: io.EOF, // TODO: better error here?
 			}
-			// Unblock whoever was waiting.
 			for _, resultChan := range resultChans {
-				// resultChan has capacity 1, so it does not block.
 				resultChan <- result
 			}
 			return
 		case <-timerC:
-			running = false
-			w.flush(resultChans, buffers)
-			buffers = nil
-			resultChans = nil
-			bufferedBytes = 0
-			if w.testFlushedHook != nil {
-				w.testFlushedHook()
+		timerDrain:
+			for {
+				select {
+				case r := <-w.writeCh:
+					buffers = append(buffers, r.data)
+					resultChans = append(resultChans, r.resultChan)
+				default:
+					break timerDrain
+				}
 			}
+			flushAndReset()
 		}
 	}
 }
 
 func (w *writeCoalescer) flush(resultChans []chan<- writeResult, buffers net.Buffers) {
-	// Flush everything we have so far.
+	if len(resultChans) == 0 {
+		return
+	}
 	timeout := w.timeout.Load()
 	if timeout > 0 {
 		err := w.c.SetWriteDeadline(time.Now().Add(time.Duration(timeout)))
@@ -1286,22 +1324,17 @@ func (w *writeCoalescer) flush(resultChans []chan<- writeResult, buffers net.Buf
 			return
 		}
 	}
-	// Copy buffers because WriteTo modifies buffers in-place.
-	buffers2 := make(net.Buffers, len(buffers))
-	copy(buffers2, buffers)
-	n, err := buffers2.WriteTo(w.c)
-	// Writes of bytes before n succeeded, writes of bytes starting from n failed with err.
-	// Use n as remaining byte counter.
+	// Reuse scratch slice; WriteTo modifies in-place.
+	w.scratchBufs = append(w.scratchBufs[:0], buffers...)
+	n, err := w.scratchBufs.WriteTo(w.c)
 	for i := range buffers {
 		if int64(len(buffers[i])) <= n {
-			// this buffer was fully written.
 			resultChans[i] <- writeResult{
 				n:   len(buffers[i]),
 				err: nil,
 			}
 			n -= int64(len(buffers[i]))
 		} else {
-			// this buffer was not (fully) written.
 			resultChans[i] <- writeResult{
 				n:   int(n),
 				err: err,

--- a/conn.go
+++ b/conn.go
@@ -1815,10 +1815,10 @@ type writeCoalescer struct {
 	writeCh          chan writeRequest
 	testEnqueuedHook func()
 	testFlushedHook  func()
+	bypassOps        map[frm.Op]struct{}
+	scratchBufs      net.Buffers
 	timeout          atomic.Int64
 	flushThreshold   int
-	bypassOps        map[frm.Op]struct{}
-	scratchBufs      net.Buffers // reusable scratch for flush WriteTo
 }
 
 func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {

--- a/conn.go
+++ b/conn.go
@@ -468,7 +468,7 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 	// dont coalesce startup frames
 	if c.session.cfg.WriteCoalesceWaitTime > 0 && !c.cfg.disableCoalesce && !dialedHost.DisableCoalesce {
 		if policy := c.session.cfg.WriteCoalescePolicy; policy == nil || policy(c.host) {
-			c.w = newWriteCoalescer(dialedHost.Conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
+			c.w = newWriteCoalescer(dialedHost.Conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, c.session.cfg.WriteCoalesceBypassOps, ctx.Done())
 		}
 	}
 
@@ -1789,15 +1789,11 @@ func (c *deadlineContextWriter) writeContext(ctx context.Context, p []byte) (int
 	return c.w.Write(p)
 }
 
-// defaultFlushThreshold is the size threshold above which coalesced frames are
-// flushed immediately, without waiting for the coalesce timer.  A frame that
-// already fills a typical TCP segment (~1460 bytes for a 1500-byte MTU) gains
-// nothing from waiting for more data — the kernel will send it as a full
-// packet anyway.
+// defaultFlushThreshold: frames above this skip the coalesce wait (~1 TCP segment).
 const defaultFlushThreshold = 1400
 
 func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.Duration,
-	flushThreshold int, quit <-chan struct{}) *writeCoalescer {
+	flushThreshold int, bypassOps map[frm.Op]struct{}, quit <-chan struct{}) *writeCoalescer {
 	if flushThreshold <= 0 {
 		flushThreshold = defaultFlushThreshold
 	}
@@ -1806,6 +1802,7 @@ func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.
 		c:              conn,
 		quit:           quit,
 		flushThreshold: flushThreshold,
+		bypassOps:      bypassOps,
 	}
 	wc.setWriteTimeout(writeTimeout)
 	go wc.writeFlusher(coalesceDuration)
@@ -1820,7 +1817,8 @@ type writeCoalescer struct {
 	testFlushedHook  func()
 	timeout          atomic.Int64
 	flushThreshold   int
-	mu               sync.Mutex
+	bypassOps        map[frm.Op]struct{}
+	scratchBufs      net.Buffers // reusable scratch for flush WriteTo
 }
 
 func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {
@@ -1828,10 +1826,9 @@ func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {
 }
 
 type writeRequest struct {
-	// resultChan is a channel (with buffer size 1) where to send results of the write.
-	resultChan chan<- writeResult
-	// data to write.
-	data []byte
+	resultChan       chan<- writeResult
+	data             []byte
+	flushImmediately bool
 }
 
 type writeResult struct {
@@ -1839,22 +1836,31 @@ type writeResult struct {
 	n   int
 }
 
-// writeResultChanPool pools buffered channels used for write coalescer results.
-// Each channel is used in a strict produce-once/consume-once pattern:
-// the flusher goroutine sends exactly one writeResult, and writeContext
-// reads exactly one. After reading, the channel is empty and safe to reuse.
+// writeResultChanPool: produce-once/consume-once buffered channels.
 var writeResultChanPool = sync.Pool{
 	New: func() interface{} {
 		return make(chan writeResult, 1)
 	},
 }
 
+// Opcode byte offset in serialized CQL frame header.
+const cqlFrameOpcodeOffset = 4
+
 // writeContext implements contextWriter.
 func (w *writeCoalescer) writeContext(ctx context.Context, p []byte) (int, error) {
 	resultChan := writeResultChanPool.Get().(chan writeResult)
+
+	flush := false
+	if len(w.bypassOps) > 0 && len(p) > cqlFrameOpcodeOffset {
+		if _, ok := w.bypassOps[frm.Op(p[cqlFrameOpcodeOffset])]; ok {
+			flush = true
+		}
+	}
+
 	wr := writeRequest{
-		resultChan: resultChan,
-		data:       p,
+		resultChan:       resultChan,
+		data:             p,
+		flushImmediately: flush,
 	}
 
 	select {
@@ -1895,22 +1901,40 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 	var resultChans []chan<- writeResult
 	var bufferedBytes int
 
+	flushAndReset := func() {
+		running = false
+		w.flush(resultChans, buffers)
+		buffers = buffers[:0]
+		resultChans = resultChans[:0]
+		bufferedBytes = 0
+		if w.testFlushedHook != nil {
+			w.testFlushedHook()
+		}
+	}
+
 	for {
 		select {
 		case req := <-w.writeCh:
 			buffers = append(buffers, req.data)
 			resultChans = append(resultChans, req.resultChan)
 			bufferedBytes += len(req.data)
-			if w.flushThreshold > 0 && bufferedBytes >= w.flushThreshold {
-				// Buffer already fills a TCP segment; flush now.
-				running = false
-				w.flush(resultChans, buffers)
-				buffers = nil
-				resultChans = nil
-				bufferedBytes = 0
-				if w.testFlushedHook != nil {
-					w.testFlushedHook()
+
+			needsFlush := req.flushImmediately ||
+				(w.flushThreshold > 0 && bufferedBytes >= w.flushThreshold)
+
+			if needsFlush {
+				// Drain queued requests to batch into the same writev.
+			drain:
+				for {
+					select {
+					case r := <-w.writeCh:
+						buffers = append(buffers, r.data)
+						resultChans = append(resultChans, r.resultChan)
+					default:
+						break drain
+					}
 				}
+				flushAndReset()
 			} else if !running {
 				resetTimer()
 				running = true
@@ -1920,27 +1944,30 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 				n:   0,
 				err: io.EOF, // TODO: better error here?
 			}
-			// Unblock whoever was waiting.
 			for _, resultChan := range resultChans {
-				// resultChan has capacity 1, so it does not block.
 				resultChan <- result
 			}
 			return
 		case <-timerC:
-			running = false
-			w.flush(resultChans, buffers)
-			buffers = nil
-			resultChans = nil
-			bufferedBytes = 0
-			if w.testFlushedHook != nil {
-				w.testFlushedHook()
+		timerDrain:
+			for {
+				select {
+				case r := <-w.writeCh:
+					buffers = append(buffers, r.data)
+					resultChans = append(resultChans, r.resultChan)
+				default:
+					break timerDrain
+				}
 			}
+			flushAndReset()
 		}
 	}
 }
 
 func (w *writeCoalescer) flush(resultChans []chan<- writeResult, buffers net.Buffers) {
-	// Flush everything we have so far.
+	if len(resultChans) == 0 {
+		return
+	}
 	timeout := w.timeout.Load()
 	if timeout > 0 {
 		err := w.c.SetWriteDeadline(time.Now().Add(time.Duration(timeout)))
@@ -1954,22 +1981,17 @@ func (w *writeCoalescer) flush(resultChans []chan<- writeResult, buffers net.Buf
 			return
 		}
 	}
-	// Copy buffers because WriteTo modifies buffers in-place.
-	buffers2 := make(net.Buffers, len(buffers))
-	copy(buffers2, buffers)
-	n, err := buffers2.WriteTo(w.c)
-	// Writes of bytes before n succeeded, writes of bytes starting from n failed with err.
-	// Use n as remaining byte counter.
+	// Reuse scratch slice; WriteTo modifies in-place.
+	w.scratchBufs = append(w.scratchBufs[:0], buffers...)
+	n, err := w.scratchBufs.WriteTo(w.c)
 	for i := range buffers {
 		if int64(len(buffers[i])) <= n {
-			// this buffer was fully written.
 			resultChans[i] <- writeResult{
 				n:   len(buffers[i]),
 				err: nil,
 			}
 			n -= int64(len(buffers[i]))
 		} else {
-			// this buffer was not (fully) written.
 			resultChans[i] <- writeResult{
 				n:   int(n),
 				err: err,

--- a/conn.go
+++ b/conn.go
@@ -467,7 +467,7 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 
 	// dont coalesce startup frames
 	if c.session.cfg.WriteCoalesceWaitTime > 0 && !c.cfg.disableCoalesce && !dialedHost.DisableCoalesce {
-		c.w = newWriteCoalescer(dialedHost.Conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, ctx.Done())
+		c.w = newWriteCoalescer(dialedHost.Conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
 	}
 
 	if c.isScyllaConn() { // ScyllaDB does not support system.peers_v2
@@ -1787,12 +1787,23 @@ func (c *deadlineContextWriter) writeContext(ctx context.Context, p []byte) (int
 	return c.w.Write(p)
 }
 
+// defaultFlushThreshold is the size threshold above which coalesced frames are
+// flushed immediately, without waiting for the coalesce timer.  A frame that
+// already fills a typical TCP segment (~1460 bytes for a 1500-byte MTU) gains
+// nothing from waiting for more data — the kernel will send it as a full
+// packet anyway.
+const defaultFlushThreshold = 1400
+
 func newWriteCoalescer(conn deadlineWriter, writeTimeout, coalesceDuration time.Duration,
-	quit <-chan struct{}) *writeCoalescer {
+	flushThreshold int, quit <-chan struct{}) *writeCoalescer {
+	if flushThreshold <= 0 {
+		flushThreshold = defaultFlushThreshold
+	}
 	wc := &writeCoalescer{
-		writeCh: make(chan writeRequest),
-		c:       conn,
-		quit:    quit,
+		writeCh:        make(chan writeRequest),
+		c:              conn,
+		quit:           quit,
+		flushThreshold: flushThreshold,
 	}
 	wc.setWriteTimeout(writeTimeout)
 	go wc.writeFlusher(coalesceDuration)
@@ -1806,6 +1817,8 @@ type writeCoalescer struct {
 	testEnqueuedHook func()
 	testFlushedHook  func()
 	timeout          atomic.Int64
+	flushThreshold   int
+	mu               sync.Mutex
 }
 
 func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {
@@ -1878,14 +1891,25 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 
 	var buffers net.Buffers
 	var resultChans []chan<- writeResult
+	var bufferedBytes int
 
 	for {
 		select {
 		case req := <-w.writeCh:
 			buffers = append(buffers, req.data)
 			resultChans = append(resultChans, req.resultChan)
-			if !running {
-				// Start timer on first write.
+			bufferedBytes += len(req.data)
+			if w.flushThreshold > 0 && bufferedBytes >= w.flushThreshold {
+				// Buffer already fills a TCP segment; flush now.
+				running = false
+				w.flush(resultChans, buffers)
+				buffers = nil
+				resultChans = nil
+				bufferedBytes = 0
+				if w.testFlushedHook != nil {
+					w.testFlushedHook()
+				}
+			} else if !running {
 				resetTimer()
 				running = true
 			}
@@ -1905,6 +1929,7 @@ func (w *writeCoalescer) writeFlusherImpl(timerC <-chan time.Time, resetTimer fu
 			w.flush(resultChans, buffers)
 			buffers = nil
 			resultChans = nil
+			bufferedBytes = 0
 			if w.testFlushedHook != nil {
 				w.testFlushedHook()
 			}

--- a/conn.go
+++ b/conn.go
@@ -467,7 +467,9 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 
 	// dont coalesce startup frames
 	if c.session.cfg.WriteCoalesceWaitTime > 0 && !c.cfg.disableCoalesce && !dialedHost.DisableCoalesce {
-		c.w = newWriteCoalescer(dialedHost.Conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
+		if policy := c.session.cfg.WriteCoalescePolicy; policy == nil || policy(c.host) {
+			c.w = newWriteCoalescer(dialedHost.Conn, c.cfg.ConnectTimeout, c.session.cfg.WriteCoalesceWaitTime, c.session.cfg.WriteCoalesceFlushThreshold, ctx.Done())
+		}
 	}
 
 	if c.isScyllaConn() { // ScyllaDB does not support system.peers_v2

--- a/conn_test.go
+++ b/conn_test.go
@@ -1513,7 +1513,7 @@ func TestWriteCoalescing_WriteAfterClose(t *testing.T) {
 		server.Close()
 		close(done)
 	}()
-	w := newWriteCoalescer(client, 0, 5*time.Millisecond, ctx.Done())
+	w := newWriteCoalescer(client, 0, 5*time.Millisecond, 0, ctx.Done())
 
 	// ensure 1 write works
 	if _, err := w.writeContext(context.Background(), []byte("one")); err != nil {
@@ -1534,6 +1534,260 @@ func TestWriteCoalescing_WriteAfterClose(t *testing.T) {
 		t.Fatal("expected to get error for write after closing")
 	} else if err != io.EOF {
 		t.Fatalf("expected to get EOF got %v", err)
+	}
+}
+
+func TestWriteCoalescing_LargeFrameFlushesImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	resetTimer := make(chan struct{}, 1)
+	threshold := 100
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: threshold,
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	// Write a single frame larger than the threshold.
+	largeData := bytes.Repeat([]byte("x"), threshold+50)
+	go func() {
+		if _, err := w.writeContext(context.Background(), largeData); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// The flush should happen without us firing the timer.
+	select {
+	case <-flushed:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected immediate flush for large frame, but timed out waiting")
+	}
+
+	// Timer should NOT have been started since we flushed immediately.
+	select {
+	case <-resetTimer:
+		t.Fatal("timer should not have been started for a large frame")
+	default:
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.String()
+	bufMutex.Unlock()
+
+	if got != string(largeData) {
+		t.Fatalf("expected %d bytes, got %d", len(largeData), len(got))
+	}
+}
+
+func TestWriteCoalescing_SmallFramesBelowThresholdWaitForTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	enqueued := make(chan struct{}, 2)
+	resetTimer := make(chan struct{}, 1)
+	threshold := 1400
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: threshold,
+		testEnqueuedHook: func() {
+			enqueued <- struct{}{}
+		},
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	// Write a small frame (well under threshold).
+	go func() {
+		if _, err := w.writeContext(context.Background(), []byte("small")); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	<-enqueued
+	<-resetTimer
+
+	// No flush should happen yet — data is below threshold.
+	select {
+	case <-flushed:
+		t.Fatal("should not have flushed before timer fires for small frame")
+	case <-time.After(50 * time.Millisecond):
+		// expected: no flush yet
+	}
+
+	// Now fire the timer.
+	timerC <- time.Now()
+
+	select {
+	case <-flushed:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected flush after timer, timed out")
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.String()
+	bufMutex.Unlock()
+
+	if got != "small" {
+		t.Fatalf("expected %q got %q", "small", got)
+	}
+}
+
+func TestWriteCoalescing_MultipleSmallFramesExceedThreshold(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	enqueued := make(chan struct{}, 4)
+	resetTimer := make(chan struct{}, 1)
+	threshold := 100
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: threshold,
+		testEnqueuedHook: func() {
+			enqueued <- struct{}{}
+		},
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	// Write two frames that together exceed threshold.
+	frame1 := bytes.Repeat([]byte("a"), 60)
+	frame2 := bytes.Repeat([]byte("b"), 60)
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame1); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	<-enqueued
+	<-resetTimer // timer started for first (small) frame
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame2); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Second frame pushes total over threshold — should flush immediately.
+	select {
+	case <-flushed:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected immediate flush when accumulated frames exceed threshold")
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.Bytes()
+	bufMutex.Unlock()
+
+	if len(got) != 120 {
+		t.Fatalf("expected 120 bytes, got %d", len(got))
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -1513,7 +1513,7 @@ func TestWriteCoalescing_WriteAfterClose(t *testing.T) {
 		server.Close()
 		close(done)
 	}()
-	w := newWriteCoalescer(client, 0, 5*time.Millisecond, 0, ctx.Done())
+	w := newWriteCoalescer(client, 0, 5*time.Millisecond, 0, nil, ctx.Done())
 
 	// ensure 1 write works
 	if _, err := w.writeContext(context.Background(), []byte("one")); err != nil {
@@ -1788,6 +1788,228 @@ func TestWriteCoalescing_MultipleSmallFramesExceedThreshold(t *testing.T) {
 
 	if len(got) != 120 {
 		t.Fatalf("expected 120 bytes, got %d", len(got))
+	}
+}
+
+func TestWriteCoalescing_BypassOpFlushesImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	resetTimer := make(chan struct{}, 1)
+
+	// Build a fake CQL frame with OpExecute at byte 4.
+	frame := make([]byte, 20)
+	frame[cqlFrameOpcodeOffset] = byte(frm.OpExecute)
+
+	bypassOps := map[frm.Op]struct{}{frm.OpExecute: {}}
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: 9999, // large threshold — won't trigger by size
+		bypassOps:      bypassOps,
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	select {
+	case <-flushed:
+		// expected: bypass op triggered immediate flush
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected immediate flush for bypass opcode")
+	}
+
+	client.Close()
+	<-done
+}
+
+func TestWriteCoalescing_NonBypassOpWaitsForTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		io.Copy(&buf, server)
+	}()
+
+	flushed := make(chan struct{}, 1)
+	enqueued := make(chan struct{}, 1)
+	resetTimer := make(chan struct{}, 1)
+
+	// Frame with OpQuery — not in bypass set.
+	frame := make([]byte, 20)
+	frame[cqlFrameOpcodeOffset] = byte(frm.OpQuery)
+
+	bypassOps := map[frm.Op]struct{}{frm.OpExecute: {}}
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: 9999,
+		bypassOps:      bypassOps,
+		testEnqueuedHook: func() {
+			enqueued <- struct{}{}
+		},
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	<-enqueued
+	<-resetTimer
+
+	// Should NOT flush yet.
+	select {
+	case <-flushed:
+		t.Fatal("non-bypass op should wait for timer")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	timerC <- time.Now()
+
+	select {
+	case <-flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected flush after timer")
+	}
+
+	client.Close()
+	<-done
+}
+
+func TestWriteCoalescing_DrainBeforeFlush(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+
+	// Use a buffered writeCh so we can pre-load requests.
+	writeCh := make(chan writeRequest, 10)
+	w := &writeCoalescer{
+		writeCh:        writeCh,
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: 50,
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() {})
+
+	// Pre-load 3 requests into the buffered channel.
+	// First is large enough to trigger flush; the other two should be drained.
+	r1Chan := make(chan writeResult, 1)
+	r2Chan := make(chan writeResult, 1)
+	r3Chan := make(chan writeResult, 1)
+	writeCh <- writeRequest{resultChan: r1Chan, data: bytes.Repeat([]byte("a"), 60)}
+	writeCh <- writeRequest{resultChan: r2Chan, data: []byte("bb")}
+	writeCh <- writeRequest{resultChan: r3Chan, data: []byte("cc")}
+
+	select {
+	case <-flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected flush")
+	}
+
+	// All three should have been written in one flush.
+	r1 := <-r1Chan
+	r2 := <-r2Chan
+	r3 := <-r3Chan
+
+	if r1.err != nil || r2.err != nil || r3.err != nil {
+		t.Fatalf("unexpected errors: %v, %v, %v", r1.err, r2.err, r3.err)
+	}
+	if r1.n != 60 || r2.n != 2 || r3.n != 2 {
+		t.Fatalf("unexpected byte counts: %d, %d, %d", r1.n, r2.n, r3.n)
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.Len()
+	bufMutex.Unlock()
+
+	if got != 64 {
+		t.Fatalf("expected 64 bytes total, got %d", got)
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -1791,6 +1791,50 @@ func TestWriteCoalescing_MultipleSmallFramesExceedThreshold(t *testing.T) {
 	}
 }
 
+func TestCoalescePolicyCrossDC(t *testing.T) {
+	policy := NewCoalescePolicyCrossDC("dc1")
+
+	tests := []struct {
+		dc   string
+		want bool
+	}{
+		{"dc1", false}, // same DC → no coalesce
+		{"dc2", true},  // different DC → coalesce
+		{"", true},     // unknown DC → coalesce (safe default)
+	}
+
+	for _, tt := range tests {
+		host := &HostInfo{dataCenter: tt.dc}
+		got := policy(host)
+		if got != tt.want {
+			t.Errorf("CrossDC policy for dc=%q: got %v, want %v", tt.dc, got, tt.want)
+		}
+	}
+}
+
+func TestCoalescePolicyCrossRack(t *testing.T) {
+	policy := NewCoalescePolicyCrossRack("dc1", "rack1")
+
+	tests := []struct {
+		dc   string
+		rack string
+		want bool
+	}{
+		{"dc1", "rack1", false}, // same DC+rack → no coalesce
+		{"dc1", "rack2", true},  // same DC, different rack → coalesce
+		{"dc2", "rack1", true},  // different DC → coalesce
+		{"dc2", "rack2", true},  // different DC+rack → coalesce
+	}
+
+	for _, tt := range tests {
+		host := &HostInfo{dataCenter: tt.dc, rack: tt.rack}
+		got := policy(host)
+		if got != tt.want {
+			t.Errorf("CrossRack policy for dc=%q rack=%q: got %v, want %v", tt.dc, tt.rack, got, tt.want)
+		}
+	}
+}
+
 func TestSkipMetadata(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/conn_test.go
+++ b/conn_test.go
@@ -1525,7 +1525,7 @@ func TestWriteCoalescing_WriteAfterClose(t *testing.T) {
 		server.Close()
 		close(done)
 	}()
-	w := newWriteCoalescer(client, 0, 5*time.Millisecond, ctx.Done())
+	w := newWriteCoalescer(client, 0, 5*time.Millisecond, 0, ctx.Done())
 
 	// ensure 1 write works
 	if _, err := w.writeContext(context.Background(), []byte("one")); err != nil {
@@ -1546,6 +1546,260 @@ func TestWriteCoalescing_WriteAfterClose(t *testing.T) {
 		t.Fatal("expected to get error for write after closing")
 	} else if err != io.EOF {
 		t.Fatalf("expected to get EOF got %v", err)
+	}
+}
+
+func TestWriteCoalescing_LargeFrameFlushesImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	resetTimer := make(chan struct{}, 1)
+	threshold := 100
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: threshold,
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	// Write a single frame larger than the threshold.
+	largeData := bytes.Repeat([]byte("x"), threshold+50)
+	go func() {
+		if _, err := w.writeContext(context.Background(), largeData); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// The flush should happen without us firing the timer.
+	select {
+	case <-flushed:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected immediate flush for large frame, but timed out waiting")
+	}
+
+	// Timer should NOT have been started since we flushed immediately.
+	select {
+	case <-resetTimer:
+		t.Fatal("timer should not have been started for a large frame")
+	default:
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.String()
+	bufMutex.Unlock()
+
+	if got != string(largeData) {
+		t.Fatalf("expected %d bytes, got %d", len(largeData), len(got))
+	}
+}
+
+func TestWriteCoalescing_SmallFramesBelowThresholdWaitForTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	enqueued := make(chan struct{}, 2)
+	resetTimer := make(chan struct{}, 1)
+	threshold := 1400
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: threshold,
+		testEnqueuedHook: func() {
+			enqueued <- struct{}{}
+		},
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	// Write a small frame (well under threshold).
+	go func() {
+		if _, err := w.writeContext(context.Background(), []byte("small")); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	<-enqueued
+	<-resetTimer
+
+	// No flush should happen yet — data is below threshold.
+	select {
+	case <-flushed:
+		t.Fatal("should not have flushed before timer fires for small frame")
+	case <-time.After(50 * time.Millisecond):
+		// expected: no flush yet
+	}
+
+	// Now fire the timer.
+	timerC <- time.Now()
+
+	select {
+	case <-flushed:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected flush after timer, timed out")
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.String()
+	bufMutex.Unlock()
+
+	if got != "small" {
+		t.Fatalf("expected %q got %q", "small", got)
+	}
+}
+
+func TestWriteCoalescing_MultipleSmallFramesExceedThreshold(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	enqueued := make(chan struct{}, 4)
+	resetTimer := make(chan struct{}, 1)
+	threshold := 100
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: threshold,
+		testEnqueuedHook: func() {
+			enqueued <- struct{}{}
+		},
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	// Write two frames that together exceed threshold.
+	frame1 := bytes.Repeat([]byte("a"), 60)
+	frame2 := bytes.Repeat([]byte("b"), 60)
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame1); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	<-enqueued
+	<-resetTimer // timer started for first (small) frame
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame2); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Second frame pushes total over threshold — should flush immediately.
+	select {
+	case <-flushed:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected immediate flush when accumulated frames exceed threshold")
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.Bytes()
+	bufMutex.Unlock()
+
+	if len(got) != 120 {
+		t.Fatalf("expected 120 bytes, got %d", len(got))
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -1525,7 +1525,7 @@ func TestWriteCoalescing_WriteAfterClose(t *testing.T) {
 		server.Close()
 		close(done)
 	}()
-	w := newWriteCoalescer(client, 0, 5*time.Millisecond, 0, ctx.Done())
+	w := newWriteCoalescer(client, 0, 5*time.Millisecond, 0, nil, ctx.Done())
 
 	// ensure 1 write works
 	if _, err := w.writeContext(context.Background(), []byte("one")); err != nil {
@@ -1800,6 +1800,230 @@ func TestWriteCoalescing_MultipleSmallFramesExceedThreshold(t *testing.T) {
 
 	if len(got) != 120 {
 		t.Fatalf("expected 120 bytes, got %d", len(got))
+	}
+}
+
+func TestWriteCoalescing_BypassOpFlushesImmediately(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+	resetTimer := make(chan struct{}, 1)
+
+	// Build a fake CQL frame with OpExecute at byte 4.
+	frame := make([]byte, 20)
+	frame[cqlFrameOpcodeOffset] = byte(frm.OpExecute)
+
+	bypassOps := map[frm.Op]struct{}{frm.OpExecute: {}}
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: 9999, // large threshold — won't trigger by size
+		bypassOps:      bypassOps,
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	select {
+	case <-flushed:
+		// expected: bypass op triggered immediate flush
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected immediate flush for bypass opcode")
+	}
+
+	client.Close()
+	<-done
+}
+
+func TestWriteCoalescing_NonBypassOpWaitsForTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		io.Copy(&buf, server)
+	}()
+
+	flushed := make(chan struct{}, 1)
+	enqueued := make(chan struct{}, 1)
+	resetTimer := make(chan struct{}, 1)
+
+	// Frame with OpQuery — not in bypass set.
+	frame := make([]byte, 20)
+	frame[cqlFrameOpcodeOffset] = byte(frm.OpQuery)
+
+	bypassOps := map[frm.Op]struct{}{frm.OpExecute: {}}
+
+	w := &writeCoalescer{
+		writeCh:        make(chan writeRequest),
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: 9999,
+		bypassOps:      bypassOps,
+		testEnqueuedHook: func() {
+			enqueued <- struct{}{}
+		},
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() { resetTimer <- struct{}{} })
+
+	go func() {
+		if _, err := w.writeContext(context.Background(), frame); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	<-enqueued
+	<-resetTimer
+
+	// Should NOT flush yet.
+	select {
+	case <-flushed:
+		t.Fatal("non-bypass op should wait for timer")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	timerC <- time.Now()
+
+	select {
+	case <-flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected flush after timer")
+	}
+
+	client.Close()
+	<-done
+}
+
+func TestWriteCoalescing_DrainBeforeFlush(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client, err := tcpConnPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	var bufMutex sync.Mutex
+	done := make(chan struct{}, 1)
+	go func() {
+		defer close(done)
+		b := make([]byte, 4096)
+		for {
+			n, err := server.Read(b)
+			if err != nil {
+				break
+			}
+			bufMutex.Lock()
+			buf.Write(b[:n])
+			bufMutex.Unlock()
+		}
+	}()
+
+	flushed := make(chan struct{}, 1)
+
+	// Use a buffered writeCh so we can pre-load requests.
+	writeCh := make(chan writeRequest, 10)
+	w := &writeCoalescer{
+		writeCh:        writeCh,
+		c:              client,
+		quit:           ctx.Done(),
+		flushThreshold: 50,
+		testFlushedHook: func() {
+			flushed <- struct{}{}
+		},
+	}
+	w.setWriteTimeout(500 * time.Millisecond)
+
+	// Pre-load 3 requests into the buffered channel before starting the
+	// flusher goroutine, so the drain logic is guaranteed to observe all
+	// three requests regardless of scheduling order.
+	// First is large enough to trigger flush; the other two should be drained.
+	r1Chan := make(chan writeResult, 1)
+	r2Chan := make(chan writeResult, 1)
+	r3Chan := make(chan writeResult, 1)
+	writeCh <- writeRequest{resultChan: r1Chan, data: bytes.Repeat([]byte("a"), 60)}
+	writeCh <- writeRequest{resultChan: r2Chan, data: []byte("bb")}
+	writeCh <- writeRequest{resultChan: r3Chan, data: []byte("cc")}
+
+	timerC := make(chan time.Time, 1)
+	go w.writeFlusherImpl(timerC, func() {})
+
+	select {
+	case <-flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected flush")
+	}
+
+	// All three should have been written in one flush.
+	r1 := <-r1Chan
+	r2 := <-r2Chan
+	r3 := <-r3Chan
+
+	if r1.err != nil || r2.err != nil || r3.err != nil {
+		t.Fatalf("unexpected errors: %v, %v, %v", r1.err, r2.err, r3.err)
+	}
+	if r1.n != 60 || r2.n != 2 || r3.n != 2 {
+		t.Fatalf("unexpected byte counts: %d, %d, %d", r1.n, r2.n, r3.n)
+	}
+
+	client.Close()
+	<-done
+
+	bufMutex.Lock()
+	got := buf.Len()
+	bufMutex.Unlock()
+
+	if got != 64 {
+		t.Fatalf("expected 64 bytes total, got %d", got)
 	}
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -1803,6 +1803,50 @@ func TestWriteCoalescing_MultipleSmallFramesExceedThreshold(t *testing.T) {
 	}
 }
 
+func TestCoalescePolicyCrossDC(t *testing.T) {
+	policy := NewCoalescePolicyCrossDC("dc1")
+
+	tests := []struct {
+		dc   string
+		want bool
+	}{
+		{"dc1", false}, // same DC → no coalesce
+		{"dc2", true},  // different DC → coalesce
+		{"", true},     // unknown DC → coalesce (safe default)
+	}
+
+	for _, tt := range tests {
+		host := &HostInfo{dataCenter: tt.dc}
+		got := policy(host)
+		if got != tt.want {
+			t.Errorf("CrossDC policy for dc=%q: got %v, want %v", tt.dc, got, tt.want)
+		}
+	}
+}
+
+func TestCoalescePolicyCrossRack(t *testing.T) {
+	policy := NewCoalescePolicyCrossRack("dc1", "rack1")
+
+	tests := []struct {
+		dc   string
+		rack string
+		want bool
+	}{
+		{"dc1", "rack1", false}, // same DC+rack → no coalesce
+		{"dc1", "rack2", true},  // same DC, different rack → coalesce
+		{"dc2", "rack1", true},  // different DC → coalesce
+		{"dc2", "rack2", true},  // different DC+rack → coalesce
+	}
+
+	for _, tt := range tests {
+		host := &HostInfo{dataCenter: tt.dc, rack: tt.rack}
+		got := policy(host)
+		if got != tt.want {
+			t.Errorf("CrossRack policy for dc=%q rack=%q: got %v, want %v", tt.dc, tt.rack, got, tt.want)
+		}
+	}
+}
+
 func TestSkipMetadata(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Motivation

Balance between performance (throughput), latency and to some extent cost reduction when coalecing.
1. Some frames are already big enough that coalescing them with others will not work anyway, as they'll be broken to multiple packets anyway, so why pay the 200us cost
2. Some frames are 'more important' than others, that the cost of 200us is not worth it. EXECUTE as an example.
3. Some frames are sent to local rack (AZ), where the latency is already quite low, so that 200us tax is quiet hefty.
4. OTOH, it may be true that some (mainly) ingest workload can benefit greatly from coalescing. 

This series comes to improve the current situation with multiple stratgies.
While at it, it tries to reduce memory consumption and improve performance of the coalescing mechanism as a whole.

## Summary

Overhaul the write coalescer to reduce latency for latency-sensitive operations while preserving coalescing benefits for small frames and cross-DC traffic.

In benchmarks against ScyllaDB with a Temporal workflow stress test, disabling coalescing entirely gave **+22% throughput**. These changes recover most of that benefit while keeping coalescing where it helps.

## Changes

### Commit 1: Size-based flush threshold
- Flush immediately when buffered data exceeds `WriteCoalesceFlushThreshold` (default 1400 bytes, ~1 TCP segment)
- Frames that already fill a packet gain nothing from the coalesce wait

### Commit 2: Topology-aware coalescing policy
- `WriteCoalescePolicy func(host *HostInfo) bool` — per-host callback to enable/disable coalescing
- `NewCoalescePolicyCrossDC(localDC)` — coalesce only for remote DCs
- `NewCoalescePolicyCrossRack(localDC, localRack)` — coalesce only for remote racks/DCs
- Nil (default) coalesces all connections as before

### Commit 3: Internal optimizations and per-opcode bypass
- Retain slice capacity across flushes (`[:0]` instead of `nil`)
- Reuse scratch slice in `flush()` instead of allocating per `writev`
- Remove unused `mu sync.Mutex`
- Drain `writeCh` before flushing to batch more into each `writev` syscall
- Guard `flush()` against empty calls
- `WriteCoalesceBypassOps map[frm.Op]struct{}` — per-opcode coalesce bypass by reading the opcode from CQL frame header byte 4
- `flushImmediately` flag on `writeRequest` for bypass-triggered immediate flush

### Commit 4: Default EXECUTE bypass
- Default `WriteCoalesceBypassOps` includes `OpExecute`
- EXECUTE is the hot path for prepared statements — independent requests with no batching benefit

## Default behavior

| Frame type | Coalesce behavior |
|---|---|
| **EXECUTE** | Always flush immediately (bypass) |
| **All others** (BATCH, QUERY, PREPARE, etc.) | Flush immediately if buffered >= 1400 bytes, otherwise wait 200µs |

## Testing

579 unit tests pass. 8 new tests cover:
- Large frame immediate flush
- Small frame timer wait
- Multiple small frames accumulating past threshold
- Bypass op immediate flush
- Non-bypass op timer wait
- Drain before flush (buffered channel pre-load)
- CrossDC policy
- CrossRack policy