### PR TITLE
queryMetrics: use UUID map key instead of string to reduce allocations

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1775,7 +1775,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 			newQry := new(Query)
 			*newQry = *qry
 			newQry.pageState = x.meta.pagingState
-			newQry.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
+			newQry.metrics = &queryMetrics{m: make(map[UUID]*hostMetrics)}
 
 			iter.next = newNextIter(newQry, int((1-qry.prefetch)*float64(x.numRows)))
 

--- a/policies_test.go
+++ b/policies_test.go
@@ -455,7 +455,7 @@ func TestSimpleRetryPolicy(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		q.metrics = preFilledQueryMetrics(map[string]*hostMetrics{"127.0.0.1": {Attempts: c.attempts}})
+		q.metrics = preFilledQueryMetrics(map[UUID]*hostMetrics{TimeUUID(): {Attempts: c.attempts}})
 		if c.retryType != rt.GetRetryType(c.err) {
 			t.Fatalf("retry type for %v should be %v", c.err, c.retryType)
 		}
@@ -596,7 +596,7 @@ func TestDowngradingConsistencyRetryPolicy(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		q.metrics = preFilledQueryMetrics(map[string]*hostMetrics{"127.0.0.1": {Attempts: c.attempts}})
+		q.metrics = preFilledQueryMetrics(map[UUID]*hostMetrics{TimeUUID(): {Attempts: c.attempts}})
 		if c.retryType != rt.GetRetryType(c.err) {
 			t.Fatalf("retry type should be %v", c.retryType)
 		}

--- a/session.go
+++ b/session.go
@@ -102,7 +102,7 @@ var queryPool = &sync.Pool{
 	New: func() any {
 		return &Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 			refCount:    1,
 		}
 	},
@@ -1092,7 +1092,7 @@ type hostMetrics struct {
 }
 
 type queryMetrics struct {
-	m map[string]*hostMetrics
+	m map[UUID]*hostMetrics
 	// totalAttempts is total number of attempts.
 	// Equal to sum of all hostMetrics' Attempts
 	totalAttempts int
@@ -1100,7 +1100,7 @@ type queryMetrics struct {
 }
 
 // preFilledQueryMetrics initializes new queryMetrics based on per-host supplied data.
-func preFilledQueryMetrics(m map[string]*hostMetrics) *queryMetrics {
+func preFilledQueryMetrics(m map[UUID]*hostMetrics) *queryMetrics {
 	qm := &queryMetrics{m: m}
 	for _, hm := range qm.m {
 		qm.totalAttempts += hm.Attempts
@@ -1122,11 +1122,12 @@ func (qm *queryMetrics) hostMetrics(host *HostInfo) *hostMetrics {
 // hostMetricsLocked gets or creates host metrics for given host.
 // It must be called only while holding qm.l lock.
 func (qm *queryMetrics) hostMetricsLocked(host *HostInfo) *hostMetrics {
-	metrics, exists := qm.m[host.HostID()]
+	id := host.hostUUID()
+	metrics, exists := qm.m[id]
 	if !exists {
 		// if the host is not in the map, it means it's been accessed for the first time
 		metrics = &hostMetrics{}
-		qm.m[host.HostID()] = metrics
+		qm.m[id] = metrics
 	}
 
 	return metrics
@@ -1280,7 +1281,7 @@ func (q *Query) defaultsFromSession() {
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
 	if q.metrics == nil {
-		q.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
+		q.metrics = &queryMetrics{m: make(map[UUID]*hostMetrics)}
 	}
 
 	q.spec = defaultNonSpecExec
@@ -2538,7 +2539,7 @@ func (s *Session) Batch(typ BatchType) *Batch {
 		Cons:             s.cons,
 		defaultTimestamp: s.cfg.DefaultTimestamp,
 		keyspace:         s.cfg.Keyspace,
-		metrics:          &queryMetrics{m: make(map[string]*hostMetrics)},
+		metrics:          &queryMetrics{m: make(map[UUID]*hostMetrics)},
 		spec:             defaultNonSpecExec,
 		routingInfo:      &queryRoutingInfo{},
 		requestTimeout:   s.cfg.Timeout,

--- a/session_test.go
+++ b/session_test.go
@@ -135,13 +135,14 @@ func TestQueryBasicAPI(t *testing.T) {
 
 	// Initiate host
 	ip := "127.0.0.1"
+	hostID := TimeUUID()
 
-	qry.metrics = preFilledQueryMetrics(map[string]*hostMetrics{ip: {Attempts: 0, TotalLatency: 0}})
+	qry.metrics = preFilledQueryMetrics(map[UUID]*hostMetrics{hostID: {Attempts: 0, TotalLatency: 0}})
 	if qry.Latency() != 0 {
 		t.Fatalf("expected Query.Latency() to return 0, got %v", qry.Latency())
 	}
 
-	qry.metrics = preFilledQueryMetrics(map[string]*hostMetrics{ip: {Attempts: 2, TotalLatency: 4}})
+	qry.metrics = preFilledQueryMetrics(map[UUID]*hostMetrics{hostID: {Attempts: 2, TotalLatency: 4}})
 	if qry.Attempts() != 2 {
 		t.Fatalf("expected Query.Attempts() to return 2, got %v", qry.Attempts())
 	}
@@ -252,9 +253,10 @@ func TestBatchBasicAPI(t *testing.T) {
 	}
 
 	ip := "127.0.0.1"
+	hostID := TimeUUID()
 
 	// Test attempts
-	b.metrics = preFilledQueryMetrics(map[string]*hostMetrics{ip: {Attempts: 1}})
+	b.metrics = preFilledQueryMetrics(map[UUID]*hostMetrics{hostID: {Attempts: 1}})
 	if b.Attempts() != 1 {
 		t.Fatalf("expected batch.Attempts() to return %v, got %v", 1, b.Attempts())
 	}
@@ -269,7 +271,7 @@ func TestBatchBasicAPI(t *testing.T) {
 		t.Fatalf("expected batch.Latency() to be 0, got %v", b.Latency())
 	}
 
-	b.metrics = preFilledQueryMetrics(map[string]*hostMetrics{ip: {Attempts: 1, TotalLatency: 4}})
+	b.metrics = preFilledQueryMetrics(map[UUID]*hostMetrics{hostID: {Attempts: 1, TotalLatency: 4}})
 	if b.Latency() != 4 {
 		t.Fatalf("expected batch.Latency() to return %v, got %v", 4, b.Latency())
 	}

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -639,7 +639,7 @@ func newWarningTestQuery() *Query {
 	return &Query{
 		context:     context.Background(),
 		routingInfo: &queryRoutingInfo{},
-		metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+		metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 		rt:          &SimpleRetryPolicy{NumRetries: 0},
 		spec:        NonSpeculativeExecution{},
 	}
@@ -792,7 +792,7 @@ func TestIterWarningHandler(t *testing.T) {
 		host := &HostInfo{hostId: UUID{1}}
 		qry := &Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 		}
 		iter := (&Iter{
 			framer:      &testWarningFramer{warnings: []string{"page2"}},
@@ -825,7 +825,7 @@ func TestIterWarningHandler(t *testing.T) {
 			framer: &testWarningFramer{warnings: []string{"warn"}},
 		}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 		}, handler)
 
 		iter.Close()
@@ -859,7 +859,7 @@ func TestIterWarningHandler(t *testing.T) {
 	t.Run("BindIgnoresNilHandler", func(t *testing.T) {
 		iter := (&Iter{}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 		}, nil)
 		if iter.warningHandler != nil {
 			t.Fatal("expected warning handler to remain nil")
@@ -875,7 +875,7 @@ func TestIterWarningHandler(t *testing.T) {
 		}).bindWarningHandler(&Batch{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}, handler)
@@ -892,7 +892,7 @@ func TestIterWarningHandler(t *testing.T) {
 		batch := &Batch{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}
@@ -921,7 +921,7 @@ func TestIterWarningHandler(t *testing.T) {
 		}).bindWarningHandler(&Query{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}, handler)
@@ -940,7 +940,7 @@ func TestIterWarningHandler(t *testing.T) {
 			host:        &HostInfo{hostId: UUID{3}},
 		}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[string]*hostMetrics)},
+			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
 		}, handler)
 
 		iter.handleWarningsOnce()


### PR DESCRIPTION
## Summary

- Change `queryMetrics.m` from `map[string]*hostMetrics` to `map[UUID]*hostMetrics`
- Eliminates `UUID.String()` allocation on every map lookup/insert
- Removes per-entry string key heap allocations — UUID is `[16]byte`, stored inline in map buckets

Follow-up to https://github.com/scylladb/gocql/pull/832