### PR TITLE
perf: optimize query metrics tracking

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1775,7 +1775,7 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 			newQry := new(Query)
 			*newQry = *qry
 			newQry.pageState = x.meta.pagingState
-			newQry.metrics = &queryMetrics{m: make(map[UUID]*hostMetrics)}
+			newQry.metrics = newQueryMetrics()
 
 			iter.next = newNextIter(newQry, int((1-qry.prefetch)*float64(x.numRows)))
 

--- a/session.go
+++ b/session.go
@@ -102,7 +102,7 @@ var queryPool = &sync.Pool{
 	New: func() any {
 		return &Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			refCount:    1,
 		}
 	},
@@ -1092,19 +1092,36 @@ type hostMetrics struct {
 }
 
 type queryMetrics struct {
-	m map[UUID]*hostMetrics
-	// totalAttempts is total number of attempts.
-	// Equal to sum of all hostMetrics' Attempts
-	totalAttempts int
-	l             sync.RWMutex
+	// extra is allocated only when a query observes more than one host.
+	extra map[UUID]hostMetrics
+
+	// totalAttempts and totalLatency are tracked independently from per-host
+	// observer metrics so the non-observer path does not need host bucket work.
+	totalAttempts   atomic.Int64
+	totalLatency    atomic.Int64
+	l               sync.Mutex
+	hostID          UUID
+	host            hostMetrics
+	hostInitialized bool
+}
+
+func newQueryMetrics() *queryMetrics {
+	return &queryMetrics{}
 }
 
 // preFilledQueryMetrics initializes new queryMetrics based on per-host supplied data.
 func preFilledQueryMetrics(m map[UUID]*hostMetrics) *queryMetrics {
-	qm := &queryMetrics{m: m}
-	for _, hm := range qm.m {
-		qm.totalAttempts += hm.Attempts
+	qm := newQueryMetrics()
+	qm.l.Lock()
+	for hostID, hm := range m {
+		if hm == nil {
+			continue
+		}
+		qm.addHostMetricsLocked(hostID, *hm)
+		qm.totalAttempts.Add(int64(hm.Attempts))
+		qm.totalLatency.Add(hm.TotalLatency)
 	}
+	qm.l.Unlock()
 	return qm
 }
 
@@ -1114,57 +1131,83 @@ func (qm *queryMetrics) hostMetrics(host *HostInfo) *hostMetrics {
 	qm.l.Lock()
 	metrics := qm.hostMetricsLocked(host)
 	copied := new(hostMetrics)
-	*copied = *metrics
+	*copied = metrics
 	qm.l.Unlock()
 	return copied
 }
 
 // hostMetricsLocked gets or creates host metrics for given host.
 // It must be called only while holding qm.l lock.
-func (qm *queryMetrics) hostMetricsLocked(host *HostInfo) *hostMetrics {
-	id := host.hostUUID()
-	metrics, exists := qm.m[id]
-	if !exists {
-		// if the host is not in the map, it means it's been accessed for the first time
-		metrics = &hostMetrics{}
-		qm.m[id] = metrics
+func (qm *queryMetrics) hostMetricsLocked(host *HostInfo) hostMetrics {
+	return qm.hostMetricsByIDLocked(host.hostUUID())
+}
+
+func (qm *queryMetrics) hostMetricsByIDLocked(hostID UUID) hostMetrics {
+	if !qm.hostInitialized {
+		qm.hostID = hostID
+		qm.hostInitialized = true
+		return qm.host
 	}
 
+	if qm.hostID == hostID {
+		return qm.host
+	}
+
+	if qm.extra == nil {
+		qm.extra = make(map[UUID]hostMetrics)
+	}
+	metrics := qm.extra[hostID]
+	qm.extra[hostID] = metrics
+	return metrics
+}
+
+func (qm *queryMetrics) addHostMetricsLocked(hostID UUID, add hostMetrics) hostMetrics {
+	if !qm.hostInitialized {
+		qm.hostID = hostID
+		qm.hostInitialized = true
+	}
+
+	if qm.hostID == hostID {
+		qm.host.Attempts += add.Attempts
+		qm.host.TotalLatency += add.TotalLatency
+		return qm.host
+	}
+
+	if qm.extra == nil {
+		qm.extra = make(map[UUID]hostMetrics)
+	}
+
+	metrics := qm.extra[hostID]
+	metrics.Attempts += add.Attempts
+	metrics.TotalLatency += add.TotalLatency
+	qm.extra[hostID] = metrics
 	return metrics
 }
 
 // attempts returns the number of times the query was executed.
 func (qm *queryMetrics) attempts() int {
-	qm.l.Lock()
-	attempts := qm.totalAttempts
-	qm.l.Unlock()
-	return attempts
+	return int(qm.totalAttempts.Load())
 }
 
 func (qm *queryMetrics) latency() int64 {
-	qm.l.Lock()
-	var (
-		attempts int
-		latency  int64
-	)
-	for _, metric := range qm.m {
-		attempts += metric.Attempts
-		latency += metric.TotalLatency
-	}
-	qm.l.Unlock()
+	attempts := qm.totalAttempts.Load()
 	if attempts > 0 {
-		return latency / int64(attempts)
+		return qm.totalLatency.Load() / attempts
 	}
 	return 0
 }
 
 // reset resets metrics, to forget about prior query executions.
-// Uses clear() instead of make() to preserve the map's backing array,
-// avoiding a heap allocation on each re-execution.
+// Uses clear() instead of make() to preserve the extra map's backing array
+// when a query has observed more than one host.
 func (qm *queryMetrics) reset() {
 	qm.l.Lock()
-	clear(qm.m)
-	qm.totalAttempts = 0
+	qm.hostID = UUID{}
+	qm.hostInitialized = false
+	qm.host = hostMetrics{}
+	clear(qm.extra)
+	qm.totalAttempts.Store(0)
+	qm.totalLatency.Store(0)
 	qm.l.Unlock()
 }
 
@@ -1173,23 +1216,28 @@ func (qm *queryMetrics) reset() {
 // If needsHostMetrics is true, a copy of updated hostMetrics is returned.
 func (qm *queryMetrics) attempt(addAttempts int, addLatency time.Duration,
 	host *HostInfo, needsHostMetrics bool) (int, *hostMetrics) {
-	qm.l.Lock()
+	addLatencyNanos := addLatency.Nanoseconds()
 
-	totalAttempts := qm.totalAttempts
-	qm.totalAttempts += addAttempts
-
-	updateHostMetrics := qm.hostMetricsLocked(host)
-	updateHostMetrics.Attempts += addAttempts
-	updateHostMetrics.TotalLatency += addLatency.Nanoseconds()
-
-	var hostMetricsCopy *hostMetrics
-	if needsHostMetrics {
-		hostMetricsCopy = new(hostMetrics)
-		*hostMetricsCopy = *updateHostMetrics
+	if !needsHostMetrics {
+		totalAttempts := qm.totalAttempts.Add(int64(addAttempts)) - int64(addAttempts)
+		qm.totalLatency.Add(addLatencyNanos)
+		return int(totalAttempts), nil
 	}
 
+	qm.l.Lock()
+	totalAttempts := qm.totalAttempts.Add(int64(addAttempts)) - int64(addAttempts)
+	qm.totalLatency.Add(addLatencyNanos)
+
+	updateHostMetrics := qm.addHostMetricsLocked(host.hostUUID(), hostMetrics{
+		Attempts:     addAttempts,
+		TotalLatency: addLatencyNanos,
+	})
+
+	hostMetricsCopy := new(hostMetrics)
+	*hostMetricsCopy = updateHostMetrics
+
 	qm.l.Unlock()
-	return totalAttempts, hostMetricsCopy
+	return int(totalAttempts), hostMetricsCopy
 }
 
 // Query represents a CQL statement that can be executed.
@@ -1281,7 +1329,7 @@ func (q *Query) defaultsFromSession() {
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
 	if q.metrics == nil {
-		q.metrics = &queryMetrics{m: make(map[UUID]*hostMetrics)}
+		q.metrics = newQueryMetrics()
 	}
 
 	q.spec = defaultNonSpecExec
@@ -1870,8 +1918,7 @@ func (q *Query) Release() {
 func (q *Query) reset() {
 	m := q.metrics
 	if m != nil {
-		clear(m.m)
-		m.totalAttempts = 0
+		m.reset()
 	}
 
 	*q = Query{routingInfo: &queryRoutingInfo{}, metrics: m, refCount: 1}
@@ -2539,7 +2586,7 @@ func (s *Session) Batch(typ BatchType) *Batch {
 		Cons:             s.cons,
 		defaultTimestamp: s.cfg.DefaultTimestamp,
 		keyspace:         s.cfg.Keyspace,
-		metrics:          &queryMetrics{m: make(map[UUID]*hostMetrics)},
+		metrics:          newQueryMetrics(),
 		spec:             defaultNonSpecExec,
 		routingInfo:      &queryRoutingInfo{},
 		requestTimeout:   s.cfg.Timeout,

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -635,11 +635,223 @@ func newTestQueryExecutor(host *HostInfo) *queryExecutor {
 	}
 }
 
+func TestQueryMetricsAttemptTracksTotalsAndHostSnapshots(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	host1 := &HostInfo{hostId: UUID{1}}
+	host2 := &HostInfo{hostId: UUID{2}}
+
+	attempt, metrics := qm.attempt(1, 10*time.Nanosecond, host1, true)
+	if attempt != 0 {
+		t.Fatalf("first attempt index = %d, want 0", attempt)
+	}
+	if metrics.Attempts != 1 || metrics.TotalLatency != 10 {
+		t.Fatalf("first host metrics = %+v, want attempts=1 latency=10", metrics)
+	}
+	if got := qm.attempts(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+	if got := qm.latency(); got != 10 {
+		t.Fatalf("latency = %d, want 10", got)
+	}
+
+	attempt, metrics = qm.attempt(2, 20*time.Nanosecond, host1, true)
+	if attempt != 1 {
+		t.Fatalf("second attempt index = %d, want 1", attempt)
+	}
+	if metrics.Attempts != 3 || metrics.TotalLatency != 30 {
+		t.Fatalf("updated host metrics = %+v, want attempts=3 latency=30", metrics)
+	}
+	if qm.extra != nil {
+		t.Fatal("extra host metrics map allocated for one host")
+	}
+	snapshot := *metrics
+
+	attempt, metrics = qm.attempt(1, 6*time.Nanosecond, host2, true)
+	if attempt != 3 {
+		t.Fatalf("third attempt index = %d, want 3", attempt)
+	}
+	if metrics.Attempts != 1 || metrics.TotalLatency != 6 {
+		t.Fatalf("second host metrics = %+v, want attempts=1 latency=6", metrics)
+	}
+	if qm.extra == nil {
+		t.Fatal("extra host metrics map not allocated for second host")
+	}
+	if got := qm.attempts(); got != 4 {
+		t.Fatalf("attempts = %d, want 4", got)
+	}
+	if got := qm.latency(); got != 9 {
+		t.Fatalf("latency = %d, want 9", got)
+	}
+	if snapshot.Attempts != 3 || snapshot.TotalLatency != 30 {
+		t.Fatalf("host metrics snapshot mutated = %+v", snapshot)
+	}
+
+	qm.reset()
+	if got := qm.attempts(); got != 0 {
+		t.Fatalf("attempts after reset = %d, want 0", got)
+	}
+	if got := qm.latency(); got != 0 {
+		t.Fatalf("latency after reset = %d, want 0", got)
+	}
+}
+
+func TestQueryMetricsAttemptKeepsEmptyHostIDSeparate(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	emptyHostID := &HostInfo{}
+	realHostID := &HostInfo{hostId: UUID{1}}
+
+	_, metrics := qm.attempt(1, 10*time.Nanosecond, emptyHostID, true)
+	if metrics.Attempts != 1 || metrics.TotalLatency != 10 {
+		t.Fatalf("empty host metrics = %+v, want attempts=1 latency=10", metrics)
+	}
+
+	_, metrics = qm.attempt(1, 6*time.Nanosecond, realHostID, true)
+	if metrics.Attempts != 1 || metrics.TotalLatency != 6 {
+		t.Fatalf("real host metrics = %+v, want attempts=1 latency=6", metrics)
+	}
+
+	if !qm.hostInitialized || !qm.hostID.IsEmpty() {
+		t.Fatalf("primary host ID = %v initialized=%t, want empty initialized", qm.hostID, qm.hostInitialized)
+	}
+	if qm.host.Attempts != 1 || qm.host.TotalLatency != 10 {
+		t.Fatalf("primary host metrics = %+v, want empty host metrics", qm.host)
+	}
+	if metrics := qm.extra[realHostID.hostUUID()]; metrics.Attempts != 1 || metrics.TotalLatency != 6 {
+		t.Fatalf("extra real host metrics = %+v, want attempts=1 latency=6", metrics)
+	}
+}
+
+func TestQueryMetricsAttemptWithoutSnapshotSkipsHostStorage(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	host := &HostInfo{hostId: UUID{1}}
+
+	attempt, metrics := qm.attempt(1, 10*time.Nanosecond, host, false)
+	if attempt != 0 {
+		t.Fatalf("attempt index = %d, want 0", attempt)
+	}
+	if metrics != nil {
+		t.Fatalf("metrics = %+v, want nil", metrics)
+	}
+	if got := qm.attempts(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+	if got := qm.latency(); got != 10 {
+		t.Fatalf("latency = %d, want 10", got)
+	}
+	if qm.hostInitialized || !qm.hostID.IsEmpty() || qm.host != (hostMetrics{}) {
+		t.Fatal("host metrics were stored without snapshot request")
+	}
+	if qm.extra != nil {
+		t.Fatal("extra host metrics map allocated without snapshot request")
+	}
+}
+
+func TestQueryMetricsObservedAttemptSerializesTotalAttemptWithHostMetrics(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	host := &HostInfo{hostId: UUID{1}}
+
+	qm.l.Lock()
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		close(started)
+		attempt, metrics := qm.attempt(1, 10*time.Nanosecond, host, true)
+		if attempt != 0 {
+			t.Errorf("attempt index = %d, want 0", attempt)
+		}
+		if metrics.Attempts != 1 || metrics.TotalLatency != 10 {
+			t.Errorf("host metrics = %+v, want attempts=1 latency=10", metrics)
+		}
+	}()
+
+	<-started
+	deadline := time.After(100 * time.Millisecond)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-done:
+			qm.l.Unlock()
+			t.Fatal("observed attempt completed while host metrics lock was held")
+		case <-tick.C:
+			if got := qm.totalAttempts.Load(); got != 0 {
+				qm.l.Unlock()
+				<-done
+				t.Fatalf("total attempts advanced before host metrics lock: got %d, want 0", got)
+			}
+		case <-deadline:
+			if got := qm.totalAttempts.Load(); got != 0 {
+				qm.l.Unlock()
+				<-done
+				t.Fatalf("total attempts advanced before host metrics lock: got %d, want 0", got)
+			}
+			qm.l.Unlock()
+			<-done
+			return
+		}
+	}
+}
+
+func BenchmarkQueryMetricsAttempt(b *testing.B) {
+	host := &HostInfo{hostId: UUID{1}}
+	qm := newQueryMetrics()
+	qm.attempt(1, time.Nanosecond, host, false)
+	qm.reset()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		qm.attempt(1, time.Nanosecond, host, false)
+	}
+}
+
+func BenchmarkQueryMetricsResetAttempt(b *testing.B) {
+	host := &HostInfo{hostId: UUID{1}}
+	qm := newQueryMetrics()
+	qm.attempt(1, time.Nanosecond, host, false)
+	qm.reset()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		qm.reset()
+		qm.attempt(1, time.Nanosecond, host, false)
+	}
+}
+
+func BenchmarkQueryMetricsAttemptWithSnapshot(b *testing.B) {
+	host := &HostInfo{hostId: UUID{1}}
+	qm := newQueryMetrics()
+	qm.attempt(1, time.Nanosecond, host, true)
+	qm.reset()
+
+	var metrics *hostMetrics
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, metrics = qm.attempt(1, time.Nanosecond, host, true)
+	}
+	if metrics == nil {
+		b.Fatal("expected metrics snapshot")
+	}
+}
+
 func newWarningTestQuery() *Query {
 	return &Query{
 		context:     context.Background(),
 		routingInfo: &queryRoutingInfo{},
-		metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+		metrics:     newQueryMetrics(),
 		rt:          &SimpleRetryPolicy{NumRetries: 0},
 		spec:        NonSpeculativeExecution{},
 	}
@@ -792,7 +1004,7 @@ func TestIterWarningHandler(t *testing.T) {
 		host := &HostInfo{hostId: UUID{1}}
 		qry := &Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}
 		iter := (&Iter{
 			framer:      &testWarningFramer{warnings: []string{"page2"}},
@@ -825,7 +1037,7 @@ func TestIterWarningHandler(t *testing.T) {
 			framer: &testWarningFramer{warnings: []string{"warn"}},
 		}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}, handler)
 
 		iter.Close()
@@ -859,7 +1071,7 @@ func TestIterWarningHandler(t *testing.T) {
 	t.Run("BindIgnoresNilHandler", func(t *testing.T) {
 		iter := (&Iter{}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}, nil)
 		if iter.warningHandler != nil {
 			t.Fatal("expected warning handler to remain nil")
@@ -875,7 +1087,7 @@ func TestIterWarningHandler(t *testing.T) {
 		}).bindWarningHandler(&Batch{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}, handler)
@@ -892,7 +1104,7 @@ func TestIterWarningHandler(t *testing.T) {
 		batch := &Batch{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}
@@ -921,7 +1133,7 @@ func TestIterWarningHandler(t *testing.T) {
 		}).bindWarningHandler(&Query{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}, handler)
@@ -940,7 +1152,7 @@ func TestIterWarningHandler(t *testing.T) {
 			host:        &HostInfo{hostId: UUID{3}},
 		}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}, handler)
 
 		iter.handleWarningsOnce()


### PR DESCRIPTION
## Summary
- track aggregate query metrics with atomic counters so attempts/latency reads avoid the metrics lock
- avoid host metrics bookkeeping on the non-observer attempt path
- keep per-host observer snapshots behind a small lazy inline/extra bucket structure

## Tests
- `go test -tags unit ./...`
- `go test -race -tags unit -run 'TestQueryMetrics|TestSpeculativeExecution' .`
- `go test -tags unit -run 'TestQueryMetrics' -bench 'BenchmarkQueryMetrics' -benchmem ./...`

## Benchmark Results
Compared `origin/master` (`ebb0249`) with this rebased branch (`8562c22`) using:

```sh
go test -tags unit -run '^$' -bench '^BenchmarkQueryMetrics' -benchmem -count=10 .
```

Environment: `linux/amd64`, Go `go1.26.2`, CPU `12th Gen Intel(R) Core(TM) i9-12900HK`.

Note: `origin/master` was measured with equivalent temporary benchmark definitions because these benchmarks are introduced by this branch. The new base already includes `queryMetrics: use UUID map key instead of string to reduce allocations`, so this comparison isolates the remaining optimization on top of that change.

| Benchmark | origin/master | branch | change |
| --- | ---: | ---: | ---: |
| `QueryMetricsAttempt` | `39.230 ns/op`, `0 B/op`, `0 allocs/op` | `9.155 ns/op`, `0 B/op`, `0 allocs/op` | `-76.66% ns/op` |
| `QueryMetricsResetAttempt` | `82.07 ns/op`, `16 B/op`, `1 alloc/op` | `27.56 ns/op`, `0 B/op`, `0 allocs/op` | `-66.42% ns/op`, `-100% B/op`, `-100% allocs/op` |
| `QueryMetricsAttemptWithSnapshot` | `49.54 ns/op`, `16 B/op`, `1 alloc/op` | `44.24 ns/op`, `16 B/op`, `1 alloc/op` | `-10.69% ns/op` |

`benchstat` geomean: `54.23 ns/op` -> `22.35 ns/op` (`-58.79%`).
