### PR TITLE
query metrics: add replacement observer metrics API

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -168,6 +168,7 @@ type ConnInterface interface {
 	exec(ctx context.Context, req frameBuilder, tracer Tracer, requestTimeout time.Duration) (*framer, error)
 	awaitSchemaAgreement(ctx context.Context) error
 	executeQuery(ctx context.Context, qry *Query) *Iter
+	executeQueryWithMetrics(ctx context.Context, qry *Query, metrics *queryMetrics) *Iter
 	querySystem(ctx context.Context, query string, values ...any) *Iter
 	getIsSchemaV2() bool
 	setSchemaV2(s bool)
@@ -1639,6 +1640,10 @@ func marshalQueryValue(typ TypeInfo, value any, dst *queryValues) error {
 }
 
 func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
+	return c.executeQueryWithMetrics(ctx, qry, qry.metrics)
+}
+
+func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics *queryMetrics) (iter *Iter) {
 	params := queryParams{
 		consistency: qry.cons,
 	}
@@ -1733,14 +1738,16 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 
 	resp, err := framer.parseFrame()
 	if err != nil {
-		return newErrorIterWithReleasedFramer(err, framer).bindWarningHandler(qry, warningHandler)
+		return newErrorIterWithReleasedFramer(err, framer).
+			bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 	}
 
 	if len(framer.customPayload) > 0 {
 		if hint, ok := framer.customPayload["tablets-routing-v1"]; ok {
 			tablet, err := unmarshalTabletHint(hint, c.version, qry.routingInfo.keyspace, qry.routingInfo.table)
 			if err != nil {
-				return newErrorIterWithReleasedFramer(err, framer).bindWarningHandler(qry, warningHandler)
+				return newErrorIterWithReleasedFramer(err, framer).
+					bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 			}
 			c.session.metadataDescriber.AddTablet(tablet)
 		}
@@ -1752,30 +1759,31 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 
 	switch x := resp.(type) {
 	case *resultVoidFrame:
-		return (&Iter{framer: framer}).bindWarningHandler(qry, warningHandler)
+		return (&Iter{framer: framer}).
+			bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 	case *resultRowsFrame:
+		if params.skipMeta && info == nil {
+			return newErrorIterWithReleasedFramer(
+				errors.New("gocql: did not receive metadata but prepared info is nil"),
+				framer,
+			).bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
+		}
+
 		iter := (&Iter{
 			meta:    x.meta,
 			framer:  framer,
 			numRows: x.numRows,
-		}).bindWarningHandler(qry, warningHandler)
+		}).bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 
 		if params.skipMeta {
-			if info != nil {
-				iter.meta = info.response
-				// pagingState is already independently allocated by readBytesCopy()
-				// during frame parsing, no additional copy needed.
-				iter.meta.pagingState = x.meta.pagingState
-			} else {
-				return newErrorIterWithReleasedFramer(errors.New("gocql: did not receive metadata but prepared info is nil"), framer).bindWarningHandler(qry, warningHandler)
-			}
+			iter.meta = info.response
+			// pagingState is already independently allocated by readBytesCopy()
+			// during frame parsing, no additional copy needed.
+			iter.meta.pagingState = x.meta.pagingState
 		}
 
 		if x.meta.morePages() && !qry.disableAutoPage {
-			newQry := new(Query)
-			*newQry = *qry
-			newQry.pageState = x.meta.pagingState
-			newQry.metrics = &queryMetrics{m: make(map[UUID]*hostMetrics)}
+			newQry := cloneQueryForNextPage(qry, metrics, x.meta.pagingState)
 
 			iter.next = newNextIter(newQry, int((1-qry.prefetch)*float64(x.numRows)))
 
@@ -1786,9 +1794,11 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 
 		return iter
 	case *resultKeyspaceFrame:
-		return (&Iter{framer: framer}).bindWarningHandler(qry, warningHandler)
+		return (&Iter{framer: framer}).
+			bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 	case *frm.SchemaChangeKeyspace, *frm.SchemaChangeTable, *frm.SchemaChangeFunction, *frm.SchemaChangeAggregate, *frm.SchemaChangeType:
-		iter := (&Iter{framer: framer}).bindWarningHandler(qry, warningHandler)
+		iter := (&Iter{framer: framer}).
+			bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 		if err := c.awaitSchemaAgreement(ctx); err != nil {
 			// TODO: should have this behind a flag
 			c.logger.Println(err)
@@ -1801,12 +1811,24 @@ func (c *Conn) executeQuery(ctx context.Context, qry *Query) (iter *Iter) {
 		stmtCacheKey := c.session.stmtsLRU.keyFor(c.host.HostID(), c.currentKeyspace, qry.stmt)
 		c.session.stmtsLRU.evictPreparedID(stmtCacheKey, x.StatementId)
 		framer.Release()
-		return c.executeQuery(ctx, qry)
+		return c.executeQueryWithMetrics(ctx, qry, metrics)
 	case error:
-		return newErrorIterWithReleasedFramer(x, framer).bindWarningHandler(qry, warningHandler)
+		return newErrorIterWithReleasedFramer(x, framer).
+			bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 	default:
-		return newErrorIterWithReleasedFramer(NewErrProtocol("Unknown type in response to execute query (%T): %s", x, x), framer).bindWarningHandler(qry, warningHandler)
+		return newErrorIterWithReleasedFramer(
+			NewErrProtocol("Unknown type in response to execute query (%T): %s", x, x),
+			framer,
+		).bindWarningHandlerWithMetrics(qry, metrics, warningHandler)
 	}
+}
+
+func cloneQueryForNextPage(qry *Query, metrics *queryMetrics, pageState []byte) *Query {
+	next := cloneQuery(qry, metrics)
+	next.pageState = pageState
+	// Automatic pages belong to one logical execution, and newNextIter pins
+	// this exact run until the page is retired.
+	return next
 }
 
 func (c *Conn) Pick(qry *Query) *Conn {

--- a/query_executor.go
+++ b/query_executor.go
@@ -29,14 +29,15 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 type ExecutableQuery interface {
 	borrowForExecution()    // Used to ensure that the query stays alive for lifetime of a particular execution goroutine.
 	releaseAfterExecution() // Used when a goroutine finishes its execution attempts, either with ok result or an error.
-	execute(ctx context.Context, conn *Conn) *Iter
-	attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo)
+	execute(ctx context.Context, conn *Conn, metrics *queryMetrics) *Iter
+	finishAttempt(token attemptToken, keyspace string, end time.Time, iter *Iter, host *HostInfo)
 	retryPolicy() RetryPolicy
 	speculativeExecutionPolicy() SpeculativeExecutionPolicy
 	GetRoutingKey() ([]byte, error)
@@ -59,37 +60,63 @@ type queryExecutor struct {
 	policy HostSelectionPolicy
 }
 
-func (q *queryExecutor) attemptQuery(ctx context.Context, qry ExecutableQuery, conn *Conn) *Iter {
-	start := time.Now()
-	iter := qry.execute(ctx, conn)
+type queryExecutionResult struct {
+	iter        *Iter
+	consistency Consistency
+}
+
+// queryExecutionResults returns an unbuffered result handoff. Once the caller
+// accepts a winner it stops receiving and cancels the execution context. A
+// buffer could accept a late loser after that point and orphan its Iter.
+func queryExecutionResults() chan queryExecutionResult {
+	return make(chan queryExecutionResult)
+}
+
+func (q *queryExecutor) attemptQuery(ctx context.Context, qry ExecutableQuery, metrics *queryMetrics,
+	executionAttempts *atomic.Int64, localAttempts *int64, conn *Conn) *Iter {
+	token := metrics.beginAttempt()
+	iter := qry.execute(ctx, conn, metrics)
 	end := time.Now()
 
-	qry.attempt(q.pool.keyspace, end, start, iter, conn.host)
+	// Retry accounting is page-scoped and must become visible before an
+	// observer callback can block this runner while another speculative branch
+	// asks the retry policy for the completed-attempt count.
+	if executionAttempts != nil {
+		executionAttempts.Add(1)
+	} else {
+		*localAttempts++
+	}
+	qry.finishAttempt(token, q.pool.keyspace, end, iter, conn.host)
 
 	return iter
 }
 
-func (q *queryExecutor) speculate(ctx context.Context, qry ExecutableQuery, sp SpeculativeExecutionPolicy,
-	hostIter NextHost, results chan *Iter) *Iter {
+func (q *queryExecutor) speculate(ctx context.Context, qry, releaseQry ExecutableQuery, sp SpeculativeExecutionPolicy,
+	metrics *queryMetrics, executionAttempts *atomic.Int64, hostIter NextHost,
+	results chan queryExecutionResult) queryExecutionResult {
 	ticker := time.NewTicker(sp.Delay())
 	defer ticker.Stop()
 
 	for i := 0; i < sp.Attempts(); i++ {
 		select {
 		case <-ticker.C:
-			qry.borrowForExecution() // ensure liveness in case of executing Query to prevent races with Query.Release().
-			go q.run(ctx, qry, hostIter, results)
+			releaseQry.borrowForExecution() // prevent Query.Release while this runner uses the captured execution view.
+			metrics.retain()
+			go q.run(ctx, qry, releaseQry, metrics, executionAttempts, hostIter, results)
 		case <-ctx.Done():
-			return &Iter{err: ctx.Err()}
-		case iter := <-results:
-			return iter
+			return queryExecutionResult{
+				iter:        &Iter{err: ctx.Err()},
+				consistency: qry.GetConsistency(),
+			}
+		case result := <-results:
+			return result
 		}
 	}
 
-	return nil
+	return queryExecutionResult{}
 }
 
-func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
+func (q *queryExecutor) executeQuery(qry ExecutableQuery, metrics *queryMetrics) (*Iter, error) {
 	var hostIter NextHost
 
 	// check if the hostID is specified for the query,
@@ -113,8 +140,18 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 	// it is, we force the policy to NonSpeculative
 	sp := qry.speculativeExecutionPolicy()
 	if qry.GetHostID() != "" || !qry.IsIdempotent() || sp.Attempts() == 0 {
-		return q.do(qry.Context(), qry, hostIter), nil
+		iter, consistency := q.do(qry.Context(), qry, metrics, nil, hostIter)
+		if consistency != qry.GetConsistency() {
+			qry.SetConsistency(consistency)
+		}
+		return iter, nil
 	}
+	executionQry := queryForSpeculativeExecution(qry, metrics)
+	executionAttempts := new(atomic.Int64)
+	// Runner borrows can be released immediately after publishing a result.
+	// Keep the original alive through winner-state propagation below.
+	qry.borrowForExecution()
+	defer qry.releaseAfterExecution()
 
 	// When speculative execution is enabled, we could be accessing the host iterator from multiple goroutines below.
 	// To ensure we don't call it concurrently, we wrap the returned NextHost function here to synchronize access to it.
@@ -129,28 +166,95 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 	ctx, cancel := context.WithCancel(qry.Context())
 	defer cancel()
 
-	results := make(chan *Iter, 1)
+	results := queryExecutionResults()
 
 	// Launch the main execution
-	qry.borrowForExecution() // ensure liveness in case of executing Query to prevent races with Query.Release().
-	go q.run(ctx, qry, hostIter, results)
+	qry.borrowForExecution() // prevent Query.Release while this runner uses the captured execution view.
+	metrics.retain()
+	go q.run(ctx, executionQry, qry, metrics, executionAttempts, hostIter, results)
 
 	// The speculative executions are launched _in addition_ to the main
 	// execution, on a timer. So Speculation{2} would make 3 executions running
 	// in total.
-	if iter := q.speculate(ctx, qry, sp, hostIter, results); iter != nil {
-		return iter, nil
+	if result := q.speculate(ctx, executionQry, qry, sp, metrics, executionAttempts, hostIter, results); result.iter != nil {
+		if result.consistency != qry.GetConsistency() {
+			qry.SetConsistency(result.consistency)
+		}
+		return result.iter, nil
 	}
 
 	select {
-	case iter := <-results:
-		return iter, nil
+	case result := <-results:
+		if result.consistency != qry.GetConsistency() {
+			qry.SetConsistency(result.consistency)
+		}
+		return result.iter, nil
 	case <-ctx.Done():
 		return &Iter{err: ctx.Err()}, nil
 	}
 }
 
-func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter NextHost) *Iter {
+func queryForSpeculativeExecution(qry ExecutableQuery, metrics *queryMetrics) ExecutableQuery {
+	switch qry := qry.(type) {
+	case *Query:
+		return cloneQuery(qry, metrics)
+	case *Batch:
+		executionBatch := *qry
+		executionBatch.metrics = metrics
+		executionBatch.metricsOwner = queryMetricsOwner{}
+		executionBatch.executionAttempts = nil
+		executionBatch.Entries = append([]BatchEntry(nil), qry.Entries...)
+		return &executionBatch
+	default:
+		return qry.withContext(qry.Context())
+	}
+}
+
+type fallbackExecutionRetryableQuery struct {
+	ExecutableQuery
+	attempts *atomic.Int64
+}
+
+func (q fallbackExecutionRetryableQuery) Attempts() int {
+	return int(q.attempts.Load())
+}
+
+func queryForExecution(qry ExecutableQuery, metrics *queryMetrics, attempts *atomic.Int64) ExecutableQuery {
+	switch qry := qry.(type) {
+	case *Query:
+		executionQry := cloneQuery(qry, metrics)
+		executionQry.executionAttempts = attempts
+		return executionQry
+	case *Batch:
+		executionBatch := *qry
+		executionBatch.metrics = metrics
+		executionBatch.executionAttempts = attempts
+		return &executionBatch
+	default:
+		return &fallbackExecutionRetryableQuery{
+			ExecutableQuery: qry,
+			attempts:        attempts,
+		}
+	}
+}
+
+func queryForRetryExecution(qry ExecutableQuery, metrics *queryMetrics) ExecutableQuery {
+	switch qry := qry.(type) {
+	case *Query:
+		return cloneQuery(qry, metrics)
+	case *Batch:
+		executionBatch := *qry
+		executionBatch.metrics = metrics
+		executionBatch.metricsOwner = queryMetricsOwner{}
+		executionBatch.executionAttempts = nil
+		return &executionBatch
+	default:
+		return qry.withContext(qry.Context())
+	}
+}
+
+func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, metrics *queryMetrics,
+	executionAttempts *atomic.Int64, hostIter NextHost) (*Iter, Consistency) {
 	rt := qry.retryPolicy()
 	if rt == nil {
 		rt = &SimpleRetryPolicy{NumRetries: 3}
@@ -168,8 +272,9 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 		getShouldRetry = rt.Attempt
 		getRetryType = rt.GetRetryType
 	}
-
 	var potentiallyExecuted bool
+	var retryableQry RetryableQuery
+	var localAttempts int64
 
 	execute := func(qry ExecutableQuery, selectedHost SelectedHost) (iter *Iter, retry RetryType) {
 		host := selectedHost.Info()
@@ -199,7 +304,7 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 				},
 			}, RetryNextHost
 		}
-		iter = q.attemptQuery(ctx, qry, conn)
+		iter = q.attemptQuery(ctx, qry, metrics, executionAttempts, &localAttempts, conn)
 		iter.host = selectedHost.Info()
 		// Update host
 		if iter.err == nil {
@@ -238,14 +343,29 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 	for selectedHost != nil {
 		iter, retryType := execute(qry, selectedHost)
 		if iter.err == nil {
-			return iter
+			return iter, qry.GetConsistency()
 		}
 		lastErr = iter.err
 
 		// Exit if retry policy decides to not retry anymore
 		if retryType == RetryType(255) {
-			if !getShouldRetry(qry) {
-				return iter
+			if retryableQry == nil {
+				// Retry policies may mutate consistency. Lazily copy the query
+				// after the first failed attempt so successful executions keep
+				// their allocation profile, concurrent speculative executions
+				// do not race, and custom policies still see *Query or *Batch.
+				if executionAttempts == nil {
+					executionAttempts = new(atomic.Int64)
+					executionAttempts.Store(localAttempts)
+				}
+				qry = queryForRetryExecution(qry, metrics)
+				retryableQry = queryForExecution(qry, metrics, executionAttempts)
+			}
+			retryableQry.SetConsistency(qry.GetConsistency())
+			shouldRetry := getShouldRetry(retryableQry)
+			qry.SetConsistency(retryableQry.GetConsistency())
+			if !shouldRetry {
+				return iter, qry.GetConsistency()
 			}
 			retryType = getRetryType(iter.err)
 		}
@@ -257,7 +377,7 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 			// retry on the same host
 			continue
 		case Rethrow, Ignore:
-			return iter
+			return iter, qry.GetConsistency()
 		case RetryNextHost:
 			iter.finalize(true)
 			// retry on the next host
@@ -265,21 +385,23 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, hostIter Ne
 			continue
 		default:
 			// Undefined? Return nil and error, this will panic in the requester
-			return &Iter{err: ErrUnknownRetryType}
+			return &Iter{err: ErrUnknownRetryType}, qry.GetConsistency()
 		}
 	}
 	if lastErr != nil {
-		return &Iter{err: lastErr}
+		return &Iter{err: lastErr}, qry.GetConsistency()
 	}
-	return &Iter{err: ErrNoConnections}
+	return &Iter{err: ErrNoConnections}, qry.GetConsistency()
 }
 
-func (q *queryExecutor) run(ctx context.Context, qry ExecutableQuery, hostIter NextHost, results chan<- *Iter) {
-	iter := q.do(ctx, qry, hostIter)
+func (q *queryExecutor) run(ctx context.Context, qry, releaseQry ExecutableQuery, metrics *queryMetrics,
+	executionAttempts *atomic.Int64, hostIter NextHost, results chan<- queryExecutionResult) {
+	defer metrics.release()
+	iter, consistency := q.do(ctx, qry, metrics, executionAttempts, hostIter)
 	select {
-	case results <- iter:
+	case results <- queryExecutionResult{iter: iter, consistency: consistency}:
 	case <-ctx.Done():
 		iter.discard()
 	}
-	qry.releaseAfterExecution()
+	releaseQry.releaseAfterExecution()
 }

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -93,6 +93,9 @@ func (*mockConnection) exec(ctx context.Context, req frameBuilder, tracer Tracer
 }
 func (*mockConnection) awaitSchemaAgreement(ctx context.Context) error     { return nil }
 func (*mockConnection) executeQuery(ctx context.Context, qry *Query) *Iter { return nil }
+func (*mockConnection) executeQueryWithMetrics(context.Context, *Query, *queryMetrics) *Iter {
+	return nil
+}
 
 var systemLocalResultMetadata = resultMetadata{
 	flags:          0,
@@ -301,6 +304,9 @@ func (*trackingRingConnection) exec(context.Context, frameBuilder, Tracer, time.
 }
 func (*trackingRingConnection) awaitSchemaAgreement(context.Context) error { return nil }
 func (*trackingRingConnection) executeQuery(context.Context, *Query) *Iter { return nil }
+func (*trackingRingConnection) executeQueryWithMetrics(context.Context, *Query, *queryMetrics) *Iter {
+	return nil
+}
 func (c *trackingRingConnection) querySystem(_ context.Context, q string, _ ...any) *Iter {
 	c.lastQuery = q
 	return c.iter

--- a/session.go
+++ b/session.go
@@ -1085,10 +1085,68 @@ func translateAddressPort(addressTranslator AddressTranslator, host *HostInfo, a
 type hostMetrics struct {
 	// Attempts is count of how many times this query has been attempted for this host.
 	// An attempt is either a retry or fetching next page of results.
+	//
+	// Deprecated: use ObservedQuery.AttemptMetrics.Attempts or ObservedBatch.AttemptMetrics.Attempts.
 	Attempts int
 
 	// TotalLatency is the sum of attempt latencies for this host in nanoseconds.
+	//
+	// Deprecated: use ObservedQuery.AttemptMetrics.TotalLatency or ObservedBatch.AttemptMetrics.TotalLatency.
 	TotalLatency int64
+}
+
+// AttemptMetric is the metrics for one observed physical query or batch attempt.
+type AttemptMetric struct {
+	// Host is the host where the attempt was executed.
+	Host *HostInfo
+
+	// Attempt is the index of this physical attempt.
+	Attempt int
+
+	// Latency is the attempt latency in nanoseconds.
+	Latency int64
+}
+
+// AttemptMetrics is a snapshot of observed query or batch attempts.
+//
+// Its zero value is empty. The concrete storage is intentionally hidden so the
+// metrics representation can change without affecting observer implementations.
+type AttemptMetrics struct {
+	attempt      AttemptMetric
+	attempts     int
+	totalLatency int64
+	hasAttempt   bool
+}
+
+func newAttemptMetrics(metrics *hostMetrics, attempt AttemptMetric) AttemptMetrics {
+	if metrics == nil {
+		return AttemptMetrics{}
+	}
+
+	return AttemptMetrics{
+		attempts:     metrics.Attempts,
+		totalLatency: metrics.TotalLatency,
+		attempt:      attempt,
+		hasAttempt:   true,
+	}
+}
+
+// Attempts returns the number of attempts in the snapshot.
+func (m AttemptMetrics) Attempts() int {
+	return m.attempts
+}
+
+// TotalLatency returns the sum of attempt latencies in nanoseconds.
+func (m AttemptMetrics) TotalLatency() int64 {
+	return m.totalLatency
+}
+
+// ForEachAttempt calls iter for each recorded attempt in attempt order.
+// Iteration stops when iter returns false.
+func (m AttemptMetrics) ForEachAttempt(iter func(AttemptMetric) bool) {
+	if m.hasAttempt {
+		iter(m.attempt)
+	}
 }
 
 type queryMetrics struct {
@@ -1486,17 +1544,23 @@ func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 	attempt, metricsForHost := q.metrics.attempt(1, latency, host, q.observer != nil)
 
 	if q.observer != nil {
+		attemptMetric := AttemptMetric{
+			Attempt: attempt,
+			Host:    host,
+			Latency: latency.Nanoseconds(),
+		}
 		q.observer.ObserveQuery(q.Context(), ObservedQuery{
-			Keyspace:  keyspace,
-			Statement: q.stmt,
-			Values:    q.values,
-			Start:     start,
-			End:       end,
-			Rows:      iter.numRows,
-			Host:      host,
-			Metrics:   metricsForHost,
-			Err:       iter.err,
-			Attempt:   attempt,
+			Keyspace:       keyspace,
+			Statement:      q.stmt,
+			Values:         q.values,
+			Start:          start,
+			End:            end,
+			Rows:           iter.numRows,
+			Host:           host,
+			Metrics:        metricsForHost,
+			AttemptMetrics: newAttemptMetrics(metricsForHost, attemptMetric),
+			Err:            iter.err,
+			Attempt:        attempt,
 		})
 	}
 }
@@ -2789,6 +2853,11 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		values[i] = entry.Args
 	}
 
+	attemptMetric := AttemptMetric{
+		Attempt: attempt,
+		Host:    host,
+		Latency: latency.Nanoseconds(),
+	}
 	b.observer.ObserveBatch(b.Context(), ObservedBatch{
 		Keyspace:   keyspace,
 		Statements: statements,
@@ -2796,10 +2865,11 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		Start:      start,
 		End:        end,
 		// Rows not used in batch observations // TODO - might be able to support it when using BatchCAS
-		Host:    host,
-		Metrics: metricsForHost,
-		Err:     iter.err,
-		Attempt: attempt,
+		Host:           host,
+		Metrics:        metricsForHost,
+		AttemptMetrics: newAttemptMetrics(metricsForHost, attemptMetric),
+		Err:            iter.err,
+		Attempt:        attempt,
 	})
 }
 
@@ -3037,13 +3107,17 @@ type ObservedQuery struct {
 	Err error
 	// Host is a reference to the host where the query was executed.
 	Host *HostInfo
-	// Metrics is the metrics for this attempt
+	// Metrics is the metrics for this attempt.
+	//
+	// Deprecated: use AttemptMetrics.
 	Metrics   *hostMetrics
 	Keyspace  string
 	Statement string
 	// Values holds a slice of bound values for the query.
 	// Do not modify the values here, they are shared with multiple goroutines.
 	Values []any
+	// AttemptMetrics is the replacement metrics API for observed attempts.
+	AttemptMetrics AttemptMetrics
 	// Rows is the number of rows in the current iter.
 	// In paginated queries, rows from previous scans are not counted.
 	// Rows is not used in batch queries and remains at the default value
@@ -3071,7 +3145,9 @@ type ObservedBatch struct {
 	Err error
 	// Host is a reference to the host where the batch was executed.
 	Host *HostInfo
-	// Metrics is the metrics for this attempt
+	// Metrics is the metrics for this attempt.
+	//
+	// Deprecated: use AttemptMetrics.
 	Metrics    *hostMetrics
 	Keyspace   string
 	Statements []string
@@ -3079,6 +3155,8 @@ type ObservedBatch struct {
 	// Values[i] are bound values passed to Statements[i].
 	// Do not modify the values here, they are shared with multiple goroutines.
 	Values [][]any
+	// AttemptMetrics is the replacement metrics API for observed attempts.
+	AttemptMetrics AttemptMetrics
 	// Attempt is the index of attempt at executing this query.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int

--- a/session.go
+++ b/session.go
@@ -1275,8 +1275,9 @@ func forEachAttemptMetricNode(node *attemptMetricNode, yield func(AttemptMetric)
 // Iteration stops when yield returns false.
 //
 // A snapshot can contain gaps when a later speculative attempt completes before
-// an earlier attempt. Each snapshot is immutable and includes the attempt whose
-// observer callback carries it.
+// an earlier attempt, or when a positive AddAttempts advances the launch index without
+// adding entries to the history. Each snapshot is immutable and includes the
+// attempt whose observer callback carries it.
 func (m AttemptMetrics) ForEachAttempt(yield func(AttemptMetric) bool) {
 	if m.count == 1 {
 		yield(m.attempt)
@@ -1850,6 +1851,9 @@ func (q *Query) Attempts() int {
 	return q.metrics.attempts()
 }
 
+// AddAttempts adds i to the query's attempt count for host. An adjustment that
+// makes the total negative permanently switches the metrics to mutex-backed
+// full-width storage until reset.
 func (q *Query) AddAttempts(i int, host *HostInfo) {
 	q.metrics.recordHostAttempt(i, 0, host, false)
 }
@@ -1859,6 +1863,9 @@ func (q *Query) Latency() int64 {
 	return q.metrics.latency()
 }
 
+// AddLatency adds l nanoseconds to the query's latency for host. An adjustment
+// that makes the total negative also makes Latency return a negative value and
+// permanently switches the metrics to mutex-backed full-width storage until reset.
 func (q *Query) AddLatency(l int64, host *HostInfo) {
 	q.metrics.recordHostAttempt(0, time.Duration(l)*time.Nanosecond, host, false)
 }
@@ -3266,6 +3273,9 @@ func (b *Batch) Attempts() int {
 	return b.metrics.attempts()
 }
 
+// AddAttempts adds i to the batch's attempt count for host. An adjustment that
+// makes the total negative permanently switches the metrics to mutex-backed
+// full-width storage until reset.
 func (b *Batch) AddAttempts(i int, host *HostInfo) {
 	b.metrics.recordHostAttempt(i, 0, host, false)
 }
@@ -3275,6 +3285,9 @@ func (b *Batch) Latency() int64 {
 	return b.metrics.latency()
 }
 
+// AddLatency adds l nanoseconds to the batch's latency for host. An adjustment
+// that makes the total negative also makes Latency return a negative value and
+// permanently switches the metrics to mutex-backed full-width storage until reset.
 func (b *Batch) AddLatency(l int64, host *HostInfo) {
 	b.metrics.recordHostAttempt(0, time.Duration(l)*time.Nanosecond, host, false)
 }
@@ -3713,8 +3726,10 @@ type ObservedQuery struct {
 	// In paginated queries, rows from previous scans are not counted.
 	// Rows is not used in batch queries and remains at the default value
 	Rows int
-	// Attempt is the index of attempt at executing this query.
-	// The first attempt is number zero and any retries have non-zero attempt number.
+	// Attempt is the launch-order index of the attempt executing this query.
+	// The first attempt is number zero and any retries have a non-zero attempt
+	// number. With speculative execution, observer callbacks can arrive out of
+	// launch order.
 	Attempt int
 }
 
@@ -3776,8 +3791,10 @@ type ObservedBatch struct {
 	// Values[i] are bound values passed to Statements[i].
 	// Do not modify the values here, they are shared with multiple goroutines.
 	Values [][]any
-	// Attempt is the index of attempt at executing this batch.
-	// The first attempt is number zero and any retries have non-zero attempt number.
+	// Attempt is the launch-order index of the attempt executing this batch.
+	// The first attempt is number zero and any retries have a non-zero attempt
+	// number. With speculative execution, observer callbacks can arrive out of
+	// launch order.
 	Attempt int
 }
 

--- a/session.go
+++ b/session.go
@@ -100,11 +100,13 @@ type Session struct {
 
 var queryPool = &sync.Pool{
 	New: func() any {
-		return &Query{
+		q := &Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			refCount:    1,
 		}
+		q.metricsOwner.self = &q.metricsOwner
+		return q
 	},
 }
 
@@ -670,6 +672,15 @@ func (s *Session) WaitUntilReady() error {
 }
 
 func (s *Session) executeQuery(qry *Query) (it *Iter) {
+	metrics := qry.metrics
+	if metrics == nil {
+		metrics = newQueryMetrics()
+		qry.metrics = metrics
+	}
+	return s.executeQueryWithMetrics(qry, metrics)
+}
+
+func (s *Session) executeQueryWithMetrics(qry *Query, metrics *queryMetrics) (it *Iter) {
 	if s.Closed() {
 		return &Iter{err: ErrSessionClosed}
 	}
@@ -677,7 +688,7 @@ func (s *Session) executeQuery(qry *Query) (it *Iter) {
 		return &Iter{err: err}
 	}
 
-	iter, err := s.executor.executeQuery(qry)
+	iter, err := s.executor.executeQuery(qry, metrics)
 	if err != nil {
 		return &Iter{err: err}
 	}
@@ -955,7 +966,7 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string, requestTimeou
 	return routingKeyInfo, nil
 }
 
-func (b *Batch) execute(ctx context.Context, conn *Conn) *Iter {
+func (b *Batch) execute(ctx context.Context, conn *Conn, _ *queryMetrics) *Iter {
 	return conn.executeBatch(ctx, b)
 }
 
@@ -975,8 +986,10 @@ func (s *Session) executeBatch(batch *Batch) *Iter {
 		return &Iter{err: err}
 	}
 
-	// Drop metrics from prior query executions
-	batch.metrics.reset()
+	// Start one metrics run for this batch execution. If a speculative loser
+	// still owns the old run, prepareQueryMetrics detaches instead of resetting
+	// storage that the loser can still update.
+	metrics := prepareQueryMetrics(&batch.metrics, &batch.metricsOwner)
 
 	// Prevent the execution of the batch if greater than the limit
 	// Currently batches have a limit of 65536 queries.
@@ -985,7 +998,7 @@ func (s *Session) executeBatch(batch *Batch) *Iter {
 		return &Iter{err: ErrTooManyStmts}
 	}
 
-	iter, err := s.executor.executeQuery(batch)
+	iter, err := s.executor.executeQuery(batch, metrics)
 	if err != nil {
 		return &Iter{err: err}
 	}
@@ -1083,88 +1096,561 @@ func translateAddressPort(addressTranslator AddressTranslator, host *HostInfo, a
 }
 
 type hostMetrics struct {
-	// Attempts is count of how many times this query has been attempted for this host.
-	// An attempt is either a retry or fetching next page of results.
+	// Attempts is the number of attempts recorded for this host. Driver-recorded
+	// attempts include initial attempts, retries, speculative executions, and
+	// fetching subsequent pages of results.
+	//
+	// Deprecated: implement QueryObserverWithAttemptMetrics or
+	// BatchObserverWithAttemptMetrics. Aggregate AttemptMetrics entries by Host
+	// for observed-attempt per-host totals. Explicit AddAttempts and AddLatency
+	// adjustments are not included in AttemptMetrics.
 	Attempts int
 
 	// TotalLatency is the sum of attempt latencies for this host in nanoseconds.
+	//
+	// Deprecated: implement QueryObserverWithAttemptMetrics or
+	// BatchObserverWithAttemptMetrics. Aggregate AttemptMetrics entries by Host
+	// for observed-attempt per-host totals. Explicit AddAttempts and AddLatency
+	// adjustments are not included in AttemptMetrics.
 	TotalLatency int64
 }
 
-type queryMetrics struct {
-	m map[UUID]*hostMetrics
-	// totalAttempts is total number of attempts.
-	// Equal to sum of all hostMetrics' Attempts
-	totalAttempts int
-	l             sync.RWMutex
+// AttemptMetric is the metrics for one observed driver query or batch attempt.
+type AttemptMetric struct {
+	// Prevent external positional literals so this new API can grow without
+	// repeating the compatibility constraint of ObservedQuery and ObservedBatch.
+	noUnkeyedLiterals struct{}
+
+	// Host is the host where the attempt was executed.
+	Host *HostInfo
+
+	// Attempt is the launch-order index of this attempt.
+	Attempt int
+
+	// Latency is the attempt latency in nanoseconds.
+	Latency int64
 }
+
+// AttemptMetrics is a snapshot of observed query or batch attempts.
+//
+// Its zero value is empty. Snapshot history is not capped: retained storage
+// grows with the number of completed attempts it contains, and retaining a
+// snapshot also retains the persistent storage for that history. The concrete
+// storage is intentionally hidden so the metrics representation can change
+// without affecting observer implementations.
+type AttemptMetrics struct {
+	noCompare    [0]func()
+	root         *attemptMetricNode
+	attempt      AttemptMetric
+	count        int
+	totalLatency int64
+}
+
+func newAttemptMetrics(attempt AttemptMetric) AttemptMetrics {
+	return AttemptMetrics{
+		attempt:      attempt,
+		count:        1,
+		totalLatency: attempt.Latency,
+	}
+}
+
+type attemptMetricNode struct {
+	left    *attemptMetricNode
+	right   *attemptMetricNode
+	attempt AttemptMetric
+	height  int
+}
+
+func newAttemptMetricNode(attempt AttemptMetric, left, right *attemptMetricNode) *attemptMetricNode {
+	height := attemptMetricNodeHeight(left)
+	if rightHeight := attemptMetricNodeHeight(right); rightHeight > height {
+		height = rightHeight
+	}
+	return &attemptMetricNode{
+		attempt: attempt,
+		left:    left,
+		right:   right,
+		height:  height + 1,
+	}
+}
+
+func attemptMetricNodeHeight(node *attemptMetricNode) int {
+	if node == nil {
+		return 0
+	}
+	return node.height
+}
+
+func rotateAttemptMetricNodeLeft(node *attemptMetricNode) *attemptMetricNode {
+	right := node.right
+	newLeft := newAttemptMetricNode(node.attempt, node.left, right.left)
+	return newAttemptMetricNode(right.attempt, newLeft, right.right)
+}
+
+func rotateAttemptMetricNodeRight(node *attemptMetricNode) *attemptMetricNode {
+	left := node.left
+	newRight := newAttemptMetricNode(node.attempt, left.right, node.right)
+	return newAttemptMetricNode(left.attempt, left.left, newRight)
+}
+
+func balanceAttemptMetricNode(node *attemptMetricNode) *attemptMetricNode {
+	balance := attemptMetricNodeHeight(node.left) - attemptMetricNodeHeight(node.right)
+	if balance > 1 {
+		if attemptMetricNodeHeight(node.left.left) < attemptMetricNodeHeight(node.left.right) {
+			node = newAttemptMetricNode(node.attempt, rotateAttemptMetricNodeLeft(node.left), node.right)
+		}
+		return rotateAttemptMetricNodeRight(node)
+	}
+	if balance < -1 {
+		if attemptMetricNodeHeight(node.right.right) < attemptMetricNodeHeight(node.right.left) {
+			node = newAttemptMetricNode(node.attempt, node.left, rotateAttemptMetricNodeRight(node.right))
+		}
+		return rotateAttemptMetricNodeLeft(node)
+	}
+	return node
+}
+
+func insertAttemptMetricNode(node *attemptMetricNode, attempt AttemptMetric) *attemptMetricNode {
+	if node == nil {
+		return newAttemptMetricNode(attempt, nil, nil)
+	}
+	if attempt.Attempt < node.attempt.Attempt {
+		return balanceAttemptMetricNode(newAttemptMetricNode(
+			node.attempt,
+			insertAttemptMetricNode(node.left, attempt),
+			node.right,
+		))
+	}
+	return balanceAttemptMetricNode(newAttemptMetricNode(
+		node.attempt,
+		node.left,
+		insertAttemptMetricNode(node.right, attempt),
+	))
+}
+
+func (m AttemptMetrics) withAttempt(attempt AttemptMetric) AttemptMetrics {
+	if m.count == 0 {
+		return newAttemptMetrics(attempt)
+	}
+
+	var root *attemptMetricNode
+	if m.count == 1 {
+		root = insertAttemptMetricNode(nil, m.attempt)
+	} else {
+		root = m.root
+	}
+	root = insertAttemptMetricNode(root, attempt)
+
+	return AttemptMetrics{
+		root:         root,
+		count:        m.count + 1,
+		totalLatency: m.totalLatency + attempt.Latency,
+	}
+}
+
+// Attempts returns the number of completed attempts in the snapshot.
+func (m AttemptMetrics) Attempts() int {
+	return m.count
+}
+
+// TotalLatency returns the sum of attempt latencies in nanoseconds.
+func (m AttemptMetrics) TotalLatency() int64 {
+	return m.totalLatency
+}
+
+func forEachAttemptMetricNode(node *attemptMetricNode, yield func(AttemptMetric) bool) bool {
+	if node == nil {
+		return true
+	}
+	if !forEachAttemptMetricNode(node.left, yield) {
+		return false
+	}
+	if !yield(node.attempt) {
+		return false
+	}
+	return forEachAttemptMetricNode(node.right, yield)
+}
+
+// ForEachAttempt calls yield for each completed attempt in launch order.
+// Iteration stops when yield returns false.
+//
+// A snapshot can contain gaps when a later speculative attempt completes before
+// an earlier attempt. Each snapshot is immutable and includes the attempt whose
+// observer callback carries it.
+func (m AttemptMetrics) ForEachAttempt(yield func(AttemptMetric) bool) {
+	if m.count == 1 {
+		yield(m.attempt)
+		return
+	}
+	forEachAttemptMetricNode(m.root, yield)
+}
+
+type queryMetrics struct {
+	// extra is allocated only when a query observes more than one host.
+	extra map[UUID]hostMetrics
+	// history is populated only for extended observers. It is deliberately
+	// unbounded and spans automatic result pages to preserve the complete
+	// logical-execution history required by AttemptMetrics, then is cleared when
+	// a new logical execution starts.
+	history AttemptMetrics
+	host    hostMetrics
+
+	fullLatency    int64
+	nextAttempt    atomic.Int64
+	ownerEpoch     uint64
+	nextOwnerEpoch uint64
+	// totals packs attempts and latency into one atomic word on the fast path,
+	// giving readers a coherent snapshot without waiting for an idle writer.
+	totals atomic.Uint64
+
+	// refs includes one explicitly claimed Query or Batch owner plus in-flight
+	// attempts, speculative runners, and automatic paging owners.
+	refs            atomic.Int64
+	fullAttempts    int64
+	fullTotalsMu    sync.Mutex
+	l               sync.Mutex
+	lifecycle       sync.Mutex
+	hostID          UUID
+	ownerClaimed    bool
+	hostInitialized bool
+}
+
+func newQueryMetrics() *queryMetrics {
+	return &queryMetrics{}
+}
+
+const (
+	// queryMetricsLatencyBits reserves 44 low bits for cumulative latency
+	// nanoseconds and the remaining 20 bits for attempts. Packed totals support
+	// at most 1,048,575 attempts and about 4h53m of cumulative latency.
+	queryMetricsLatencyBits uint = 44
+	queryMetricsAttemptsMax      = int64(1<<(64-queryMetricsLatencyBits) - 1)
+	queryMetricsLatencyMax       = int64(1<<queryMetricsLatencyBits - 1)
+	queryMetricsLatencyMask      = uint64(1<<queryMetricsLatencyBits - 1)
+
+	// queryMetricsFullTotals reserves the all-ones packed value as the sentinel
+	// for full-width totals. Crossing either packed limit, producing a negative
+	// total, or reaching the reserved combination moves totals to fullTotalsMu
+	// until reset.
+	queryMetricsFullTotals = ^uint64(0)
+)
 
 // preFilledQueryMetrics initializes new queryMetrics based on per-host supplied data.
 func preFilledQueryMetrics(m map[UUID]*hostMetrics) *queryMetrics {
-	qm := &queryMetrics{m: m}
-	for _, hm := range qm.m {
-		qm.totalAttempts += hm.Attempts
+	qm := newQueryMetrics()
+	hostIDs := make([]UUID, 0, len(m))
+	for hostID, hm := range m {
+		if hm != nil {
+			hostIDs = append(hostIDs, hostID)
+		}
 	}
+	slices.SortFunc(hostIDs, func(a, b UUID) int {
+		return bytes.Compare(a[:], b[:])
+	})
+
+	qm.l.Lock()
+	var attempts int64
+	for _, hostID := range hostIDs {
+		hm := m[hostID]
+		qm.addHostMetricsLocked(hostID, *hm)
+		qm.addTotals(hm.Attempts, hm.TotalLatency)
+		attempts += int64(hm.Attempts)
+	}
+	qm.nextAttempt.Store(attempts)
+	qm.l.Unlock()
 	return qm
 }
 
-// hostMetrics returns a snapshot of metrics for given host.
-// If the metrics for host don't exist, they are created.
+func (qm *queryMetrics) retain() {
+	qm.refs.Add(1)
+}
+
+func (qm *queryMetrics) release() {
+	if refs := qm.refs.Add(-1); refs < 0 {
+		// Continuing after an ownership imbalance could let this storage be
+		// reset while an old attempt or page can still update it.
+		panic("gocql: negative query metrics reference count")
+	}
+}
+
+type queryMetricsOwner struct {
+	// self detects raw Query and Batch value copies without making queryMetrics
+	// retain an interior pointer into the owning object. A self-cycle is
+	// collectible when the Query or Batch becomes unreachable.
+	self  *queryMetricsOwner
+	epoch uint64
+}
+
+// claimQueryMetricsOwner runs with qm.lifecycle held. Epochs only need to be
+// unique among copies sharing qm, so keeping the generation local avoids a
+// process-wide atomic on every query execution.
+func (qm *queryMetrics) claimQueryMetricsOwner(owner *queryMetricsOwner) {
+	qm.nextOwnerEpoch++
+	if qm.nextOwnerEpoch == 0 {
+		panic("gocql: query metrics owner epoch overflow")
+	}
+	qm.ownerEpoch = qm.nextOwnerEpoch
+	qm.ownerClaimed = true
+	owner.self = owner
+	owner.epoch = qm.ownerEpoch
+}
+
+func newOwnedQueryMetrics(owner *queryMetricsOwner) *queryMetrics {
+	qm := newQueryMetrics()
+	qm.claimQueryMetricsOwner(owner)
+	qm.refs.Store(1)
+	return qm
+}
+
+// transferQueryMetricsOwner gives an official shallow copy ownership of the
+// shared idle metrics storage. The source remains valid and lazily detaches if
+// it is executed later. No allocation is needed for the common
+// Query(...).WithContext(...).Exec() path.
+func transferQueryMetricsOwner(qm *queryMetrics, from, to *queryMetricsOwner) {
+	to.self = to
+	to.epoch = 0
+	if qm == nil {
+		return
+	}
+	qm.lifecycle.Lock()
+	switch {
+	case qm.ownerClaimed && from.self == from && qm.ownerEpoch == from.epoch:
+		qm.claimQueryMetricsOwner(to)
+	case !qm.ownerClaimed && qm.refs.Load() == 0 &&
+		(from.self == from || from.self == nil && from.epoch == 0):
+		qm.claimQueryMetricsOwner(to)
+		qm.refs.Store(1)
+	}
+	qm.lifecycle.Unlock()
+}
+
+// prepareQueryMetrics starts a new logical execution. It reuses storage when
+// this value owns the idle state and detaches for copied values or when an old
+// speculative attempt or page still pins the prior execution.
+func prepareQueryMetrics(metrics **queryMetrics, owner *queryMetricsOwner) *queryMetrics {
+	qm := *metrics
+	if qm == nil {
+		qm = newOwnedQueryMetrics(owner)
+		*metrics = qm
+		return qm
+	}
+
+	qm.lifecycle.Lock()
+	if !qm.ownerClaimed && qm.refs.Load() == 0 &&
+		(owner.self == owner || owner.self == nil && owner.epoch == 0) {
+		qm.claimQueryMetricsOwner(owner)
+		qm.refs.Store(1)
+		qm.reset()
+		qm.lifecycle.Unlock()
+		return qm
+	}
+
+	if qm.ownerClaimed && owner.self == owner &&
+		qm.ownerEpoch == owner.epoch && qm.refs.Load() == 1 {
+		// Rotate the epoch before reuse so raw value copies carrying the prior
+		// epoch become stale and detach on their first execution.
+		qm.claimQueryMetricsOwner(owner)
+		qm.reset()
+		qm.lifecycle.Unlock()
+		return qm
+	}
+
+	if qm.ownerClaimed && owner.self == owner && qm.ownerEpoch == owner.epoch {
+		qm.ownerClaimed = false
+		qm.release()
+	}
+	qm.lifecycle.Unlock()
+
+	qm = newOwnedQueryMetrics(owner)
+	*metrics = qm
+	return qm
+}
+
+type attemptToken struct {
+	start   time.Time
+	metrics *queryMetrics
+	attempt int
+}
+
+func (qm *queryMetrics) beginAttempt() attemptToken {
+	qm.retain()
+	return attemptToken{
+		metrics: qm,
+		attempt: int(qm.nextAttempt.Add(1) - 1),
+		start:   time.Now(),
+	}
+}
+
+// hostMetrics returns a snapshot of metrics for the given host, or a zero value
+// if no per-host metrics were recorded for it. Per-host metrics include observed
+// attempts and explicit AddAttempts or AddLatency updates. Other unobserved
+// attempts update only execution totals, so zero does not imply the host was
+// never attempted.
 func (qm *queryMetrics) hostMetrics(host *HostInfo) *hostMetrics {
 	qm.l.Lock()
 	metrics := qm.hostMetricsLocked(host)
-	copied := new(hostMetrics)
-	*copied = *metrics
 	qm.l.Unlock()
+
+	copied := new(hostMetrics)
+	*copied = metrics
 	return copied
 }
 
-// hostMetricsLocked gets or creates host metrics for given host.
+// hostMetricsLocked returns a copy of metrics for the given host, or a zero
+// value if no per-host metrics were recorded for it. Per-host metrics include
+// observed attempts and explicit AddAttempts or AddLatency updates. Other
+// unobserved attempts update only execution totals, so zero does not imply the
+// host was never attempted.
 // It must be called only while holding qm.l lock.
-func (qm *queryMetrics) hostMetricsLocked(host *HostInfo) *hostMetrics {
-	id := host.hostUUID()
-	metrics, exists := qm.m[id]
-	if !exists {
-		// if the host is not in the map, it means it's been accessed for the first time
-		metrics = &hostMetrics{}
-		qm.m[id] = metrics
+func (qm *queryMetrics) hostMetricsLocked(host *HostInfo) hostMetrics {
+	return qm.hostMetricsByIDLocked(host.hostUUID())
+}
+
+func (qm *queryMetrics) hostMetricsByIDLocked(hostID UUID) hostMetrics {
+	if !qm.hostInitialized {
+		return hostMetrics{}
 	}
 
+	if qm.hostID == hostID {
+		return qm.host
+	}
+
+	if qm.extra == nil {
+		return hostMetrics{}
+	}
+	return qm.extra[hostID]
+}
+
+func (qm *queryMetrics) addHostMetricsLocked(hostID UUID, add hostMetrics) hostMetrics {
+	if !qm.hostInitialized {
+		qm.hostID = hostID
+		qm.hostInitialized = true
+	}
+
+	if qm.hostID == hostID {
+		qm.host.Attempts += add.Attempts
+		qm.host.TotalLatency += add.TotalLatency
+		return qm.host
+	}
+
+	if qm.extra == nil {
+		qm.extra = make(map[UUID]hostMetrics)
+	}
+
+	metrics := qm.extra[hostID]
+	metrics.Attempts += add.Attempts
+	metrics.TotalLatency += add.TotalLatency
+	qm.extra[hostID] = metrics
 	return metrics
 }
 
 // attempts returns the number of times the query was executed.
 func (qm *queryMetrics) attempts() int {
-	qm.l.Lock()
-	attempts := qm.totalAttempts
-	qm.l.Unlock()
-	return attempts
+	attempts, _ := qm.totalsSnapshot()
+	return int(attempts)
 }
 
 func (qm *queryMetrics) latency() int64 {
-	qm.l.Lock()
-	var (
-		attempts int
-		latency  int64
-	)
-	for _, metric := range qm.m {
-		attempts += metric.Attempts
-		latency += metric.TotalLatency
-	}
-	qm.l.Unlock()
+	attempts, latency := qm.totalsSnapshot()
 	if attempts > 0 {
-		return latency / int64(attempts)
+		return latency / attempts
 	}
 	return 0
 }
 
+func (qm *queryMetrics) totalsSnapshot() (attempts, latency int64) {
+	packed := qm.totals.Load()
+	if packed != queryMetricsFullTotals {
+		return unpackQueryMetricsTotals(packed)
+	}
+
+	qm.fullTotalsMu.Lock()
+	attempts, latency = qm.fullAttempts, qm.fullLatency
+	qm.fullTotalsMu.Unlock()
+	return attempts, latency
+}
+
+func unpackQueryMetricsTotals(packed uint64) (attempts, latency int64) {
+	return int64(packed >> queryMetricsLatencyBits), int64(packed & queryMetricsLatencyMask)
+}
+
+func packQueryMetricsTotals(attempts, latency int64) uint64 {
+	return uint64(attempts)<<queryMetricsLatencyBits | uint64(latency)
+}
+
+func canPackQueryMetricsTotals(attempts, latency int64) bool {
+	if attempts < 0 || attempts > queryMetricsAttemptsMax || latency < 0 || latency > queryMetricsLatencyMax {
+		return false
+	}
+	// Keep the all-ones combination unambiguous as the full-width sentinel.
+	return packQueryMetricsTotals(attempts, latency) != queryMetricsFullTotals
+}
+
+func (qm *queryMetrics) addFullTotals(addAttempts, addLatencyNanos int64) (int64, bool) {
+	qm.fullTotalsMu.Lock()
+	if qm.totals.Load() != queryMetricsFullTotals {
+		qm.fullTotalsMu.Unlock()
+		return 0, false
+	}
+	totalAttempts := qm.fullAttempts
+	qm.fullAttempts += addAttempts
+	qm.fullLatency += addLatencyNanos
+	qm.fullTotalsMu.Unlock()
+	return totalAttempts, true
+}
+
+func (qm *queryMetrics) addTotals(addAttempts int, addLatencyNanos int64) int64 {
+	addAttempts64 := int64(addAttempts)
+	for {
+		packed := qm.totals.Load()
+		if packed == queryMetricsFullTotals {
+			if totalAttempts, ok := qm.addFullTotals(addAttempts64, addLatencyNanos); ok {
+				return totalAttempts
+			}
+			continue
+		}
+
+		attempts, latency := unpackQueryMetricsTotals(packed)
+		nextAttempts := attempts + addAttempts64
+		nextLatency := latency + addLatencyNanos
+		if canPackQueryMetricsTotals(nextAttempts, nextLatency) {
+			if qm.totals.CompareAndSwap(packed, packQueryMetricsTotals(nextAttempts, nextLatency)) {
+				return attempts
+			}
+			continue
+		}
+
+		qm.fullTotalsMu.Lock()
+		if qm.totals.Load() != packed {
+			qm.fullTotalsMu.Unlock()
+			continue
+		}
+		qm.fullAttempts = nextAttempts
+		qm.fullLatency = nextLatency
+		if qm.totals.CompareAndSwap(packed, queryMetricsFullTotals) {
+			qm.fullTotalsMu.Unlock()
+			return attempts
+		}
+		qm.fullTotalsMu.Unlock()
+	}
+}
+
 // reset resets metrics, to forget about prior query executions.
-// Uses clear() instead of make() to preserve the map's backing array,
-// avoiding a heap allocation on each re-execution.
+// Uses clear() instead of make() to preserve the extra map's backing array
+// when a query has observed more than one host.
 func (qm *queryMetrics) reset() {
 	qm.l.Lock()
-	clear(qm.m)
-	qm.totalAttempts = 0
+	qm.hostID = UUID{}
+	qm.hostInitialized = false
+	qm.host = hostMetrics{}
+	qm.history = AttemptMetrics{}
+	clear(qm.extra)
+	qm.nextAttempt.Store(0)
+	qm.fullTotalsMu.Lock()
+	qm.fullAttempts = 0
+	qm.fullLatency = 0
+	qm.totals.Store(0)
+	qm.fullTotalsMu.Unlock()
 	qm.l.Unlock()
 }
 
@@ -1173,23 +1659,72 @@ func (qm *queryMetrics) reset() {
 // If needsHostMetrics is true, a copy of updated hostMetrics is returned.
 func (qm *queryMetrics) attempt(addAttempts int, addLatency time.Duration,
 	host *HostInfo, needsHostMetrics bool) (int, *hostMetrics) {
-	qm.l.Lock()
+	addLatencyNanos := addLatency.Nanoseconds()
 
-	totalAttempts := qm.totalAttempts
-	qm.totalAttempts += addAttempts
-
-	updateHostMetrics := qm.hostMetricsLocked(host)
-	updateHostMetrics.Attempts += addAttempts
-	updateHostMetrics.TotalLatency += addLatency.Nanoseconds()
-
-	var hostMetricsCopy *hostMetrics
-	if needsHostMetrics {
-		hostMetricsCopy = new(hostMetrics)
-		*hostMetricsCopy = *updateHostMetrics
+	if !needsHostMetrics {
+		qm.nextAttempt.Add(int64(addAttempts))
+		totalAttempts := qm.addTotals(addAttempts, addLatencyNanos)
+		return int(totalAttempts), nil
 	}
 
+	return qm.recordHostAttempt(addAttempts, addLatency, host, true)
+}
+
+// recordHostAttempt records totals and deprecated per-host metrics.
+// If needsHostMetrics is true, a copy of updated hostMetrics is returned.
+func (qm *queryMetrics) recordHostAttempt(addAttempts int, addLatency time.Duration,
+	host *HostInfo, needsHostMetrics bool) (int, *hostMetrics) {
+	addLatencyNanos := addLatency.Nanoseconds()
+	qm.nextAttempt.Add(int64(addAttempts))
+
+	qm.l.Lock()
+	totalAttempts := qm.addTotals(addAttempts, addLatencyNanos)
+
+	updateHostMetrics := qm.addHostMetricsLocked(host.hostUUID(), hostMetrics{
+		Attempts:     addAttempts,
+		TotalLatency: addLatencyNanos,
+	})
 	qm.l.Unlock()
-	return totalAttempts, hostMetricsCopy
+
+	if !needsHostMetrics {
+		return int(totalAttempts), nil
+	}
+
+	hostMetricsCopy := new(hostMetrics)
+	*hostMetricsCopy = updateHostMetrics
+	return int(totalAttempts), hostMetricsCopy
+}
+
+// finishAttempt records the completion of one launch-assigned attempt. The
+// token pins its exact logical execution even if the Query has since detached
+// to a new metrics object.
+func (qm *queryMetrics) finishAttempt(token attemptToken, latency time.Duration,
+	host *HostInfo, observed, needsAttemptMetrics bool) (int, *hostMetrics, AttemptMetrics) {
+	addLatencyNanos := latency.Nanoseconds()
+	if !observed {
+		qm.addTotals(1, addLatencyNanos)
+		return token.attempt, nil, AttemptMetrics{}
+	}
+
+	qm.l.Lock()
+	qm.addTotals(1, addLatencyNanos)
+	updateHostMetrics := qm.addHostMetricsLocked(host.hostUUID(), hostMetrics{
+		Attempts:     1,
+		TotalLatency: addLatencyNanos,
+	})
+	if needsAttemptMetrics {
+		qm.history = qm.history.withAttempt(AttemptMetric{
+			Attempt: token.attempt,
+			Host:    host,
+			Latency: addLatencyNanos,
+		})
+	}
+	attemptMetrics := qm.history
+	qm.l.Unlock()
+
+	hostMetricsCopy := new(hostMetrics)
+	*hostMetricsCopy = updateHostMetrics
+	return token.attempt, hostMetricsCopy, attemptMetrics
 }
 
 // Query represents a CQL statement that can be executed.
@@ -1210,8 +1745,10 @@ type Query struct {
 	// getKeyspace is field so that it can be overriden in tests
 	getKeyspace func() string
 	// routingInfo is a pointer because Query can be copied and copyable struct can't hold a mutex.
-	routingInfo *queryRoutingInfo
-	binding     func(q *QueryInfo) ([]any, error)
+	routingInfo       *queryRoutingInfo
+	binding           func(q *QueryInfo) ([]any, error)
+	executionAttempts *atomic.Int64
+	metricsOwner      queryMetricsOwner
 	// hostID specifies the host on which the query should be executed.
 	// If it is empty, then the host is picked by HostSelectionPolicy
 	hostID     string
@@ -1281,7 +1818,8 @@ func (q *Query) defaultsFromSession() {
 	q.defaultTimestamp = s.cfg.DefaultTimestamp
 	q.idempotent = s.cfg.DefaultIdempotence
 	if q.metrics == nil {
-		q.metrics = &queryMetrics{m: make(map[UUID]*hostMetrics)}
+		q.metrics = newQueryMetrics()
+		q.metricsOwner.self = &q.metricsOwner
 	}
 
 	q.spec = defaultNonSpecExec
@@ -1306,11 +1844,14 @@ func (q Query) String() string {
 
 // Attempts returns the number of times the query was executed.
 func (q *Query) Attempts() int {
+	if q.executionAttempts != nil {
+		return int(q.executionAttempts.Load())
+	}
 	return q.metrics.attempts()
 }
 
 func (q *Query) AddAttempts(i int, host *HostInfo) {
-	q.metrics.attempt(i, 0, host, false)
+	q.metrics.recordHostAttempt(i, 0, host, false)
 }
 
 // Latency returns the average amount of nanoseconds per attempt of the query.
@@ -1319,7 +1860,7 @@ func (q *Query) Latency() int64 {
 }
 
 func (q *Query) AddLatency(l int64, host *HostInfo) {
-	q.metrics.attempt(0, time.Duration(l)*time.Nanosecond, host, false)
+	q.metrics.recordHostAttempt(0, time.Duration(l)*time.Nanosecond, host, false)
 }
 
 // Consistency sets the consistency level for this query. If no consistency
@@ -1419,9 +1960,50 @@ func (q *Query) withContext(ctx context.Context) ExecutableQuery {
 // query, queries will be canceled and return once the context is
 // canceled.
 func (q *Query) WithContext(ctx context.Context) *Query {
-	q2 := *q
+	q2 := cloneQuery(q, q.metrics)
 	q2.context = ctx
-	return &q2
+	transferQueryMetricsOwner(q.metrics, &q.metricsOwner, &q2.metricsOwner)
+	return q2
+}
+
+// cloneQuery makes a shallow copy without reading the atomically updated
+// refCount as an ordinary field. The copy receives an independent lifecycle;
+// prepareCache is transferred with an atomic read.
+func cloneQuery(q *Query, metrics *queryMetrics) *Query {
+	return &Query{
+		trace:                      q.trace,
+		context:                    q.context,
+		pageContextParent:          q.pageContextParent,
+		spec:                       q.spec,
+		rt:                         q.rt,
+		conn:                       q.conn,
+		observer:                   q.observer,
+		metrics:                    metrics,
+		session:                    q.session,
+		customPayload:              q.customPayload,
+		getKeyspace:                q.getKeyspace,
+		routingInfo:                q.routingInfo,
+		binding:                    q.binding,
+		hostID:                     q.hostID,
+		stmt:                       q.stmt,
+		routingKey:                 q.routingKey,
+		values:                     q.values,
+		pageState:                  q.pageState,
+		requestTimeout:             q.requestTimeout,
+		defaultTimestampValue:      q.defaultTimestampValue,
+		prefetch:                   q.prefetch,
+		pageSize:                   q.pageSize,
+		refCount:                   1,
+		cons:                       q.cons,
+		serialCons:                 q.serialCons,
+		disableAutoPage:            q.disableAutoPage,
+		deferReleasedErrorFinalize: q.deferReleasedErrorFinalize,
+		idempotent:                 q.idempotent,
+		skipPrepare:                q.skipPrepare,
+		disableSkipMetadata:        q.disableSkipMetadata,
+		defaultTimestamp:           q.defaultTimestamp,
+		prepareCache:               atomic.LoadUint32(&q.prepareCache),
+	}
 }
 
 // Deprecate: does nothing, cancel the context passed to WithContext
@@ -1429,27 +2011,45 @@ func (q *Query) Cancel() {
 	// TODO: delete
 }
 
-func (q *Query) execute(ctx context.Context, conn *Conn) *Iter {
-	return conn.executeQuery(ctx, q)
+func (q *Query) execute(ctx context.Context, conn *Conn, metrics *queryMetrics) *Iter {
+	return conn.executeQueryWithMetrics(ctx, q, metrics)
 }
 
 func (q *Query) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
-	latency := end.Sub(start)
-	attempt, metricsForHost := q.metrics.attempt(1, latency, host, q.observer != nil)
+	token := q.metrics.beginAttempt()
+	token.start = start
+	q.finishAttempt(token, keyspace, end, iter, host)
+}
+
+func (q *Query) finishAttempt(token attemptToken, keyspace string, end time.Time, iter *Iter, host *HostInfo) {
+	defer token.metrics.release()
+	latency := end.Sub(token.start)
+	extendedObserver, needsAttemptMetrics := q.observer.(QueryObserverWithAttemptMetrics)
+	attempt, metricsForHost, attemptMetrics := token.metrics.finishAttempt(
+		token, latency, host, q.observer != nil, needsAttemptMetrics,
+	)
 
 	if q.observer != nil {
-		q.observer.ObserveQuery(q.Context(), ObservedQuery{
+		observed := ObservedQuery{
 			Keyspace:  keyspace,
 			Statement: q.stmt,
 			Values:    q.values,
-			Start:     start,
+			Start:     token.start,
 			End:       end,
 			Rows:      iter.numRows,
 			Host:      host,
 			Metrics:   metricsForHost,
 			Err:       iter.err,
 			Attempt:   attempt,
-		})
+		}
+		if needsAttemptMetrics {
+			extendedObserver.ObserveQueryWithAttemptMetrics(q.Context(), ObservedQueryWithAttemptMetrics{
+				ObservedQuery:  observed,
+				AttemptMetrics: attemptMetrics,
+			})
+		} else {
+			q.observer.ObserveQuery(q.Context(), observed)
+		}
 	}
 }
 
@@ -1731,7 +2331,8 @@ func (q *Query) Iter() *Iter {
 	}
 
 	// Retry on empty page if pagination is manual
-	iter := q.executeQueryForIterPostProcessing()
+	metrics := prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	iter := q.executeQueryForIterPostProcessing(metrics)
 	var hiddenWarnings []string
 	for iter.err == nil && iter.numRows == 0 && !iter.LastPage() {
 		if warnings := iter.Warnings(); len(warnings) > 0 {
@@ -1740,7 +2341,7 @@ func (q *Query) Iter() *Iter {
 		ps := iter.PageState()
 		iter.discard()
 		q.PageState(ps)
-		iter = q.executeQueryForIterPostProcessing()
+		iter = q.executeQueryForIterPostProcessing(metrics)
 	}
 	if len(hiddenWarnings) > 0 {
 		iter.allWarnings = append(hiddenWarnings, iter.allWarnings...)
@@ -1751,24 +2352,26 @@ func (q *Query) Iter() *Iter {
 	return iter
 }
 
-func (q *Query) executeQueryForIterPostProcessing() (iter *Iter) {
+func (q *Query) executeQueryForIterPostProcessing(metrics *queryMetrics) (iter *Iter) {
 	q.deferReleasedErrorFinalize = true
 	defer func() {
 		q.deferReleasedErrorFinalize = false
 	}()
-	return q.executeQuery()
+	return q.executeQueryWithMetrics(metrics)
 }
 
 func (q *Query) executeQuery() *Iter {
-	// Drop metrics from prior query executions
-	q.metrics.reset()
+	metrics := prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	return q.executeQueryWithMetrics(metrics)
+}
 
+func (q *Query) executeQueryWithMetrics(metrics *queryMetrics) *Iter {
 	if q.conn != nil {
 		// if the query was specifically run on a connection then re-use that
 		// connection when fetching the next results
-		return q.conn.executeQuery(q.Context(), q)
+		return q.conn.executeQueryWithMetrics(q.Context(), q, metrics)
 	}
-	return q.session.executeQuery(q)
+	return q.session.executeQueryWithMetrics(q, metrics)
 }
 
 // MapScan executes the query, copies the columns of the first selected
@@ -1865,16 +2468,15 @@ func (q *Query) Release() {
 }
 
 // reset zeroes out all fields of a query so that it can be safely pooled.
-// It preserves the metrics allocation for reuse. routingInfo is always freshly
-// allocated because paging copies share the pointer (see conn.go executeQuery).
+// It reuses idle metrics storage, but detaches if an in-flight attempt still
+// pins the prior execution. routingInfo is always freshly allocated because
+// paging copies share the pointer (see conn.go executeQuery).
 func (q *Query) reset() {
-	m := q.metrics
-	if m != nil {
-		clear(m.m)
-		m.totalAttempts = 0
-	}
+	m := prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	owner := q.metricsOwner
 
-	*q = Query{routingInfo: &queryRoutingInfo{}, metrics: m, refCount: 1}
+	*q = Query{routingInfo: &queryRoutingInfo{}, metrics: m, metricsOwner: owner, refCount: 1}
+	q.metricsOwner.self = &q.metricsOwner
 }
 
 func (q *Query) incRefCount() {
@@ -1933,6 +2535,7 @@ func (q *Query) GetHostID() string {
 // Close() or each other will result in undefined behavior.
 type Iter struct {
 	warningQuery          ExecutableQuery
+	warningMetrics        *queryMetrics
 	framer                framerInterface
 	err                   error
 	warningHandler        WarningHandler
@@ -1984,6 +2587,7 @@ func (iter *Iter) copyPageData(src *Iter) {
 	if iter.warningQuery == nil {
 		iter.warningHandler = src.warningHandler
 		iter.warningQuery = src.warningQuery
+		iter.warningMetrics = src.warningMetrics
 		iter.warningQueryOwned = src.warningQueryOwned
 	} else {
 		src.releaseWarningQuery()
@@ -1996,16 +2600,45 @@ func (iter *Iter) copyPageData(src *Iter) {
 	src.next = nil
 	src.warningHandler = nil
 	src.warningQuery = nil
+	src.warningMetrics = nil
 	src.warningQueryOwned = false
 	// Intentionally don't copy iter.closed - it's managed with atomic operations
 }
 
 func (iter *Iter) bindWarningHandler(qry ExecutableQuery, handler WarningHandler) *Iter {
+	var metrics *queryMetrics
+	switch qry := qry.(type) {
+	case *Query:
+		metrics = qry.metrics
+	case *Batch:
+		metrics = qry.metrics
+	}
+	return iter.bindWarningHandlerWithMetrics(qry, metrics, handler)
+}
+
+func (iter *Iter) bindWarningHandlerWithMetrics(
+	qry ExecutableQuery,
+	metrics *queryMetrics,
+	handler WarningHandler,
+) *Iter {
 	if iter == nil || handler == nil {
 		return iter
 	}
+	// A private paging or retry view can detach its field from the metrics
+	// pinned by the execution. Give warning handlers a Query whose public
+	// metrics methods describe that exact execution.
+	if query, ok := qry.(*Query); ok && query.metrics != metrics {
+		warningQuery := cloneQuery(query, metrics)
+		// The warning binding below takes the clone's sole lifecycle reference.
+		warningQuery.refCount = 0
+		qry = warningQuery
+	}
 	iter.warningQuery = qry
 	iter.warningHandler = handler
+	iter.warningMetrics = metrics
+	if iter.warningMetrics != nil {
+		iter.warningMetrics.retain()
+	}
 	if pooledQuery, ok := qry.(*Query); ok {
 		pooledQuery.incRefCount()
 		iter.warningQueryOwned = true
@@ -2023,8 +2656,14 @@ func (iter *Iter) bindWarningHandler(qry ExecutableQuery, handler WarningHandler
 func (iter *Iter) releaseWarningQuery() {
 	qry := iter.warningQuery
 	owned := iter.warningQueryOwned
+	metrics := iter.warningMetrics
 	iter.warningQueryOwned = false
 	iter.warningQuery = nil
+	iter.warningMetrics = nil
+
+	if metrics != nil {
+		metrics.release()
+	}
 
 	if !owned {
 		return
@@ -2395,14 +3034,18 @@ func (iter *Iter) NumRows() int {
 // nextIter holds state for fetching a single page in an iterator.
 // single page might be attempted multiple times due to retries.
 type nextIter struct {
-	qry    *Query
-	next   *Iter
-	cancel context.CancelFunc
-	oncea  sync.Once
-	once   sync.Once
-	mu     sync.Mutex
-	pos    int
-	closed bool
+	qry     *Query
+	next    *Iter
+	metrics *queryMetrics
+	cancel  context.CancelFunc
+	pos     int
+	oncea   sync.Once
+	once    sync.Once
+	// metricsRelease releases the automatic-page ownership acquired by
+	// newNextIter. A fetch takes a temporary reference while it is in flight.
+	metricsRelease sync.Once
+	mu             sync.Mutex
+	closed         bool
 }
 
 func newNextIter(qry *Query, pos int) *nextIter {
@@ -2411,13 +3054,26 @@ func newNextIter(qry *Query, pos int) *nextIter {
 		parentCtx = qry.Context()
 	}
 	ctx, cancel := context.WithCancel(parentCtx)
-	nextQry := qry.WithContext(ctx)
+	nextQry := cloneQuery(qry, qry.metrics)
+	nextQry.context = ctx
 	nextQry.pageContextParent = parentCtx
-	return &nextIter{
-		qry:    nextQry,
-		pos:    pos,
-		cancel: cancel,
+	if nextQry.metrics != nil {
+		nextQry.metrics.retain()
 	}
+	return &nextIter{
+		qry:     nextQry,
+		metrics: nextQry.metrics,
+		pos:     pos,
+		cancel:  cancel,
+	}
+}
+
+func (n *nextIter) releaseMetrics() {
+	n.metricsRelease.Do(func() {
+		if n.metrics != nil {
+			n.metrics.release()
+		}
+	})
 }
 
 func (n *nextIter) fetchAsync() {
@@ -2451,6 +3107,7 @@ func (n *nextIter) close() {
 	next := n.next
 	n.next = nil
 	n.mu.Unlock()
+	n.releaseMetrics()
 
 	if next != nil {
 		next.discard()
@@ -2469,17 +3126,34 @@ func (n *nextIter) consume() {
 	n.closed = true
 	n.next = nil
 	n.mu.Unlock()
+	n.releaseMetrics()
 }
 
 func (n *nextIter) fetch() *Iter {
 	n.once.Do(func() {
+		// Synchronize with close before taking an execution reference. If close
+		// wins, the page owner can be released without a reset racing this fetch.
+		n.mu.Lock()
+		if n.closed {
+			n.mu.Unlock()
+			return
+		}
+		metrics := n.qry.metrics
+		if metrics != nil {
+			metrics.retain()
+		}
+		n.mu.Unlock()
+		if metrics != nil {
+			defer metrics.release()
+		}
+
 		// if the query was specifically run on a connection then re-use that
 		// connection when fetching the next results
 		var next *Iter
 		if n.qry.conn != nil {
-			next = n.qry.conn.executeQuery(n.qry.Context(), n.qry)
+			next = n.qry.conn.executeQueryWithMetrics(n.qry.Context(), n.qry, metrics)
 		} else {
-			next = n.qry.session.executeQuery(n.qry)
+			next = n.qry.session.executeQueryWithMetrics(n.qry, metrics)
 		}
 		n.storeFetched(next)
 	})
@@ -2497,12 +3171,14 @@ type Batch struct {
 	trace    Tracer
 	observer BatchObserver
 	// routingInfo is a pointer because Query can be copied and copyable struct can't hold a mutex.
-	routingInfo   *queryRoutingInfo
-	metrics       *queryMetrics
-	cancelBatch   func()
-	CustomPayload map[string][]byte
-	session       *Session
-	keyspace      string
+	routingInfo       *queryRoutingInfo
+	metrics           *queryMetrics
+	cancelBatch       func()
+	CustomPayload     map[string][]byte
+	session           *Session
+	executionAttempts *atomic.Int64
+	metricsOwner      queryMetricsOwner
+	keyspace          string
 	// hostID specifies the host on which the query should be executed.
 	// If it is empty, then the host is picked by HostSelectionPolicy
 	hostID                string
@@ -2544,11 +3220,12 @@ func (s *Session) Batch(typ BatchType) *Batch {
 		Cons:             s.cons,
 		defaultTimestamp: s.cfg.DefaultTimestamp,
 		keyspace:         s.cfg.Keyspace,
-		metrics:          &queryMetrics{m: make(map[UUID]*hostMetrics)},
+		metrics:          newQueryMetrics(),
 		spec:             defaultNonSpecExec,
 		routingInfo:      &queryRoutingInfo{},
 		requestTimeout:   s.cfg.Timeout,
 	}
+	batch.metricsOwner.self = &batch.metricsOwner
 
 	s.mu.RUnlock()
 	return batch
@@ -2583,11 +3260,14 @@ func (b *Batch) GetSession() *Session {
 
 // Attempts returns the number of attempts made to execute the batch.
 func (b *Batch) Attempts() int {
+	if b.executionAttempts != nil {
+		return int(b.executionAttempts.Load())
+	}
 	return b.metrics.attempts()
 }
 
 func (b *Batch) AddAttempts(i int, host *HostInfo) {
-	b.metrics.attempt(i, 0, host, false)
+	b.metrics.recordHostAttempt(i, 0, host, false)
 }
 
 // Latency returns the average number of nanoseconds to execute a single attempt of the batch.
@@ -2596,7 +3276,7 @@ func (b *Batch) Latency() int64 {
 }
 
 func (b *Batch) AddLatency(l int64, host *HostInfo) {
-	b.metrics.attempt(0, time.Duration(l)*time.Nanosecond, host, false)
+	b.metrics.recordHostAttempt(0, time.Duration(l)*time.Nanosecond, host, false)
 }
 
 // GetConsistency returns the currently configured consistency level for the batch
@@ -2678,8 +3358,12 @@ func (b *Batch) withContext(ctx context.Context) ExecutableQuery {
 // query, queries will be canceled and return once the context is
 // canceled.
 func (b *Batch) WithContext(ctx context.Context) *Batch {
+	// Unlike Query, Batch has no atomically updated value fields
+	// (executionAttempts is a pointer), so a direct shallow copy is safe.
 	b2 := *b
 	b2.context = ctx
+	b2.executionAttempts = nil
+	transferQueryMetricsOwner(b.metrics, &b.metricsOwner, &b2.metricsOwner)
 	return &b2
 }
 
@@ -2732,8 +3416,18 @@ func (b *Batch) WithTimestamp(timestamp int64) *Batch {
 }
 
 func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host *HostInfo) {
-	latency := end.Sub(start)
-	attempt, metricsForHost := b.metrics.attempt(1, latency, host, b.observer != nil)
+	token := b.metrics.beginAttempt()
+	token.start = start
+	b.finishAttempt(token, keyspace, end, iter, host)
+}
+
+func (b *Batch) finishAttempt(token attemptToken, keyspace string, end time.Time, iter *Iter, host *HostInfo) {
+	defer token.metrics.release()
+	latency := end.Sub(token.start)
+	extendedObserver, needsAttemptMetrics := b.observer.(BatchObserverWithAttemptMetrics)
+	attempt, metricsForHost, attemptMetrics := token.metrics.finishAttempt(
+		token, latency, host, b.observer != nil, needsAttemptMetrics,
+	)
 
 	if b.observer == nil {
 		return
@@ -2747,18 +3441,26 @@ func (b *Batch) attempt(keyspace string, end, start time.Time, iter *Iter, host 
 		values[i] = entry.Args
 	}
 
-	b.observer.ObserveBatch(b.Context(), ObservedBatch{
+	observed := ObservedBatch{
 		Keyspace:   keyspace,
 		Statements: statements,
 		Values:     values,
-		Start:      start,
+		Start:      token.start,
 		End:        end,
 		// Rows not used in batch observations // TODO - might be able to support it when using BatchCAS
 		Host:    host,
 		Metrics: metricsForHost,
 		Err:     iter.err,
 		Attempt: attempt,
-	})
+	}
+	if needsAttemptMetrics {
+		extendedObserver.ObserveBatchWithAttemptMetrics(b.Context(), ObservedBatchWithAttemptMetrics{
+			ObservedBatch:  observed,
+			AttemptMetrics: attemptMetrics,
+		})
+	} else {
+		b.observer.ObserveBatch(b.Context(), observed)
+	}
 }
 
 func (b *Batch) GetRoutingKey() ([]byte, error) {
@@ -2995,7 +3697,12 @@ type ObservedQuery struct {
 	Err error
 	// Host is a reference to the host where the query was executed.
 	Host *HostInfo
-	// Metrics is the metrics for this attempt
+	// Metrics is the cumulative metrics for this host through this attempt.
+	//
+	// Deprecated: implement QueryObserverWithAttemptMetrics for execution-wide
+	// attempt metrics. Aggregate AttemptMetrics entries by Host for
+	// observed-attempt per-host totals. Explicit AddAttempts and AddLatency
+	// adjustments remain available only through Metrics.
 	Metrics   *hostMetrics
 	Keyspace  string
 	Statement string
@@ -3019,6 +3726,33 @@ type QueryObserver interface {
 	ObserveQuery(context.Context, ObservedQuery)
 }
 
+// ObservedQueryWithAttemptMetrics is the source-compatible extension payload
+// delivered to QueryObserverWithAttemptMetrics.
+type ObservedQueryWithAttemptMetrics struct {
+	noUnkeyedLiterals struct{}
+	ObservedQuery
+	// AttemptMetrics is an immutable snapshot of all attempts in this logical
+	// execution that had completed when this observer callback was prepared.
+	//
+	// Attempts are iterated in launch order and can contain gaps when a later
+	// speculative attempt completes first. Automatic result pages share the
+	// same logical execution, so the history is not capped and a long
+	// automatically paged query retains storage proportional to its completed
+	// attempts. Manual paging starts a separate logical execution for each call
+	// to Iter.
+	AttemptMetrics AttemptMetrics
+}
+
+// QueryObserverWithAttemptMetrics optionally extends QueryObserver. When an
+// observer implements this interface, ObserveQueryWithAttemptMetrics is called
+// instead of ObserveQuery. ObserveQuery is required only to satisfy the
+// embedded interface and can be a no-op; gocql does not call it for that
+// observer.
+type QueryObserverWithAttemptMetrics interface {
+	QueryObserver
+	ObserveQueryWithAttemptMetrics(context.Context, ObservedQueryWithAttemptMetrics)
+}
+
 type ObservedBatch struct {
 	// Start is a time when the batch was attempted
 	Start time.Time
@@ -3029,7 +3763,12 @@ type ObservedBatch struct {
 	Err error
 	// Host is a reference to the host where the batch was executed.
 	Host *HostInfo
-	// Metrics is the metrics for this attempt
+	// Metrics is the cumulative metrics for this host through this attempt.
+	//
+	// Deprecated: implement BatchObserverWithAttemptMetrics for execution-wide
+	// attempt metrics. Aggregate AttemptMetrics entries by Host for
+	// observed-attempt per-host totals. Explicit AddAttempts and AddLatency
+	// adjustments remain available only through Metrics.
 	Metrics    *hostMetrics
 	Keyspace   string
 	Statements []string
@@ -3037,7 +3776,7 @@ type ObservedBatch struct {
 	// Values[i] are bound values passed to Statements[i].
 	// Do not modify the values here, they are shared with multiple goroutines.
 	Values [][]any
-	// Attempt is the index of attempt at executing this query.
+	// Attempt is the index of attempt at executing this batch.
 	// The first attempt is number zero and any retries have non-zero attempt number.
 	Attempt int
 }
@@ -3050,6 +3789,29 @@ type BatchObserver interface {
 	// The error reported only shows query errors, i.e. if a SELECT is valid but finds no matches it will be nil.
 	// Unlike QueryObserver.ObserveQuery it does no reporting on rows read.
 	ObserveBatch(context.Context, ObservedBatch)
+}
+
+// ObservedBatchWithAttemptMetrics is the source-compatible extension payload
+// delivered to BatchObserverWithAttemptMetrics.
+type ObservedBatchWithAttemptMetrics struct {
+	noUnkeyedLiterals struct{}
+	ObservedBatch
+	// AttemptMetrics is an immutable snapshot of all attempts in this logical
+	// execution that had completed when this observer callback was prepared.
+	//
+	// Attempts are iterated in launch order and can contain gaps when a later
+	// speculative attempt completes first.
+	AttemptMetrics AttemptMetrics
+}
+
+// BatchObserverWithAttemptMetrics optionally extends BatchObserver. When an
+// observer implements this interface, ObserveBatchWithAttemptMetrics is called
+// instead of ObserveBatch. ObserveBatch is required only to satisfy the
+// embedded interface and can be a no-op; gocql does not call it for that
+// observer.
+type BatchObserverWithAttemptMetrics interface {
+	BatchObserver
+	ObserveBatchWithAttemptMetrics(context.Context, ObservedBatchWithAttemptMetrics)
 }
 
 type ObservedConnect struct {

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -752,6 +752,33 @@ func TestQueryMetricsAttemptWithoutSnapshotSkipsHostStorage(t *testing.T) {
 	}
 }
 
+func TestAttemptMetricsReplacesHostMetricsAPI(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	attemptMetric := AttemptMetric{
+		Attempt: 1,
+		Host:    host,
+		Latency: 20,
+	}
+	metrics := newAttemptMetrics(&hostMetrics{
+		Attempts:     2,
+		TotalLatency: 30,
+	}, attemptMetric)
+
+	if metrics.Attempts() != 2 || metrics.TotalLatency() != 30 {
+		t.Fatalf("attempt metrics = %+v, want attempts=2 latency=30", metrics)
+	}
+	var attempts []AttemptMetric
+	metrics.ForEachAttempt(func(attempt AttemptMetric) bool {
+		attempts = append(attempts, attempt)
+		return true
+	})
+	if len(attempts) != 1 || attempts[0] != attemptMetric {
+		t.Fatalf("attempt metrics entries = %+v, want [%+v]", attempts, attemptMetric)
+	}
+}
+
 func TestQueryMetricsObservedAttemptSerializesTotalAttemptWithHostMetrics(t *testing.T) {
 	t.Parallel()
 

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -31,9 +31,12 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -473,11 +476,13 @@ func (f *testWarningFramer) GetHeaderWarnings() []string { return f.warnings }
 func (f *testWarningFramer) Release()                    { f.released = true }
 
 type recordingWarningHandler struct {
-	calls     int
-	lastHost  *HostInfo
-	lastQry   ExecutableQuery
-	queryStmt string
-	warnings  []string
+	calls         int
+	lastHost      *HostInfo
+	lastQry       ExecutableQuery
+	queryStmt     string
+	queryAttempts int
+	queryMetrics  *queryMetrics
+	warnings      []string
 }
 
 func (h *recordingWarningHandler) HandleWarnings(qry ExecutableQuery, host *HostInfo, warnings []string) {
@@ -486,8 +491,45 @@ func (h *recordingWarningHandler) HandleWarnings(qry ExecutableQuery, host *Host
 	h.lastHost = host
 	if query, ok := qry.(*Query); ok {
 		h.queryStmt = query.stmt
+		h.queryAttempts = query.Attempts()
+		h.queryMetrics = query.metrics
 	}
 	h.warnings = slices.Clone(warnings)
+}
+
+func TestIterWarningHandlerPinsExactExecutionMetrics(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	executionMetrics := q.metrics
+	executionMetrics.attempt(1, time.Nanosecond, &HostInfo{hostId: UUID{17}}, false)
+	executionQuery := cloneQuery(q, executionMetrics)
+	handler := &recordingWarningHandler{}
+	iter := (&Iter{
+		framer: &testWarningFramer{warnings: []string{"pinned"}},
+	}).bindWarningHandler(executionQuery, handler)
+
+	if refs := executionMetrics.refs.Load(); refs != 2 {
+		t.Fatalf("execution metrics references = %d, want owner plus warning iterator (2)", refs)
+	}
+	q.reset()
+	if q.metrics == executionMetrics {
+		t.Fatal("source query did not detach from warning-pinned execution metrics")
+	}
+	if refs := executionMetrics.refs.Load(); refs != 1 {
+		t.Fatalf("execution metrics references after source reset = %d, want warning iterator only", refs)
+	}
+
+	if err := iter.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if handler.calls != 1 || handler.lastQry.Attempts() != 1 {
+		t.Fatalf("warning handler calls/attempts = (%d,%d), want (1,1)", handler.calls, handler.lastQry.Attempts())
+	}
+	if refs := executionMetrics.refs.Load(); refs != 0 {
+		t.Fatalf("execution metrics references after warning dispatch = %d, want 0", refs)
+	}
 }
 
 type staticConnPicker struct {
@@ -516,7 +558,8 @@ func (h staticSelectedHost) Token() Token    { return nil }
 func (h staticSelectedHost) Mark(error)      {}
 
 type pagingTestConn struct {
-	executeQueryFunc func(ctx context.Context, qry *Query) *Iter
+	executeQueryFunc            func(ctx context.Context, qry *Query) *Iter
+	executeQueryWithMetricsFunc func(ctx context.Context, qry *Query, metrics *queryMetrics) *Iter
 }
 
 func (*pagingTestConn) Close() {}
@@ -526,6 +569,14 @@ func (*pagingTestConn) exec(context.Context, frameBuilder, Tracer, time.Duration
 func (*pagingTestConn) awaitSchemaAgreement(context.Context) error { return nil }
 func (c *pagingTestConn) executeQuery(ctx context.Context, qry *Query) *Iter {
 	return c.executeQueryFunc(ctx, qry)
+}
+func (c *pagingTestConn) executeQueryWithMetrics(
+	ctx context.Context, qry *Query, metrics *queryMetrics,
+) *Iter {
+	if c.executeQueryWithMetricsFunc != nil {
+		return c.executeQueryWithMetricsFunc(ctx, qry, metrics)
+	}
+	return c.executeQuery(ctx, qry)
 }
 func (*pagingTestConn) querySystem(context.Context, string, ...any) *Iter { return nil }
 func (*pagingTestConn) getIsSchemaV2() bool                               { return false }
@@ -548,32 +599,75 @@ func (p *fixedRetryPolicy) GetRetryType(error) RetryType {
 	return p.retryType
 }
 
-type executorTestQuery struct {
-	ctx         context.Context
-	rt          RetryPolicy
-	spec        SpeculativeExecutionPolicy
-	idempotent  bool
+type consistencyRetryPolicy struct {
 	consistency Consistency
-	attempts    int
-	borrowed    int
-	released    int
-	executeFunc func(context.Context, *Conn) *Iter
+}
+
+func (p *consistencyRetryPolicy) Attempt(q RetryableQuery) bool {
+	if q.Attempts() != 1 {
+		return false
+	}
+	q.SetConsistency(p.consistency)
+	return true
+}
+
+func (*consistencyRetryPolicy) GetRetryType(error) RetryType {
+	return Retry
+}
+
+type synchronizedRetryPolicy struct {
+	maxRetries int
+	entered    atomic.Int32
+	allEntered chan struct{}
+}
+
+func (p *synchronizedRetryPolicy) Attempt(q RetryableQuery) bool {
+	if p.entered.Add(1) == 2 {
+		close(p.allEntered)
+	}
+	<-p.allEntered
+	return q.Attempts() <= p.maxRetries
+}
+
+func (*synchronizedRetryPolicy) GetRetryType(error) RetryType {
+	return Retry
+}
+
+type executorTestQuery struct {
+	ctx               context.Context
+	rt                RetryPolicy
+	spec              SpeculativeExecutionPolicy
+	idempotent        bool
+	consistency       Consistency
+	hostID            string
+	attempts          atomic.Int32
+	borrowed          atomic.Int32
+	released          atomic.Int32
+	consistencyWrites atomic.Int32
+	executeFunc       func(context.Context, *Conn) *Iter
+	finishFunc        func(attemptToken, time.Time, *Iter, *HostInfo)
 }
 
 func (q *executorTestQuery) borrowForExecution() {
-	q.borrowed++
+	q.borrowed.Add(1)
 }
 
 func (q *executorTestQuery) releaseAfterExecution() {
-	q.released++
+	q.released.Add(1)
 }
 
-func (q *executorTestQuery) execute(ctx context.Context, conn *Conn) *Iter {
+func (q *executorTestQuery) execute(ctx context.Context, conn *Conn, _ *queryMetrics) *Iter {
 	return q.executeFunc(ctx, conn)
 }
 
-func (q *executorTestQuery) attempt(string, time.Time, time.Time, *Iter, *HostInfo) {
-	q.attempts++
+func (q *executorTestQuery) finishAttempt(token attemptToken, _ string, end time.Time, iter *Iter, host *HostInfo) {
+	if q.finishFunc != nil {
+		q.finishFunc(token, end, iter, host)
+		return
+	}
+	defer token.metrics.release()
+	token.metrics.finishAttempt(token, end.Sub(token.start), host, false, false)
+	q.attempts.Add(1)
 }
 
 func (q *executorTestQuery) retryPolicy() RetryPolicy {
@@ -595,19 +689,31 @@ func (q *executorTestQuery) IsLWT() bool                    { return false }
 func (q *executorTestQuery) GetCustomPartitioner() Partitioner {
 	return nil
 }
-func (q *executorTestQuery) GetHostID() string { return "" }
+func (q *executorTestQuery) GetHostID() string { return q.hostID }
 
 func (q *executorTestQuery) withContext(ctx context.Context) ExecutableQuery {
-	q2 := *q
-	q2.ctx = ctx
-	return &q2
+	q2 := &executorTestQuery{
+		ctx:         ctx,
+		rt:          q.rt,
+		spec:        q.spec,
+		idempotent:  q.idempotent,
+		consistency: q.consistency,
+		hostID:      q.hostID,
+		executeFunc: q.executeFunc,
+		finishFunc:  q.finishFunc,
+	}
+	q2.attempts.Store(q.attempts.Load())
+	q2.borrowed.Store(q.borrowed.Load())
+	q2.released.Store(q.released.Load())
+	return q2
 }
 
 func (q *executorTestQuery) Attempts() int {
-	return q.attempts
+	return int(q.attempts.Load())
 }
 
 func (q *executorTestQuery) SetConsistency(c Consistency) {
+	q.consistencyWrites.Add(1)
 	q.consistency = c
 }
 
@@ -625,15 +731,1528 @@ func (q *executorTestQuery) Context() context.Context {
 func (q *executorTestQuery) GetSession() *Session { return nil }
 
 func newTestQueryExecutor(host *HostInfo) *queryExecutor {
+	policy := RoundRobinHostPolicy()
+	policy.AddHost(host)
 	return &queryExecutor{
 		pool: &policyConnPool{
 			hostConnPools: map[string]*hostConnPool{
 				host.HostID(): &hostConnPool{
 					host:       host,
-					connPicker: staticConnPicker{conn: &Conn{}},
+					connPicker: staticConnPicker{conn: &Conn{host: host}},
 				},
 			},
 		},
+		policy: policy,
+	}
+}
+
+func TestQueryMetricsAttemptTracksTotalsAndHostSnapshots(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	host1 := &HostInfo{hostId: UUID{1}}
+	host2 := &HostInfo{hostId: UUID{2}}
+
+	attempt, metrics := qm.attempt(1, 10*time.Nanosecond, host1, true)
+	if attempt != 0 {
+		t.Fatalf("first attempt index = %d, want 0", attempt)
+	}
+	if metrics.Attempts != 1 || metrics.TotalLatency != 10 {
+		t.Fatalf("first host metrics = %+v, want attempts=1 latency=10", metrics)
+	}
+	if got := qm.attempts(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+	if got := qm.latency(); got != 10 {
+		t.Fatalf("latency = %d, want 10", got)
+	}
+
+	attempt, metrics = qm.attempt(2, 20*time.Nanosecond, host1, true)
+	if attempt != 1 {
+		t.Fatalf("second attempt index = %d, want 1", attempt)
+	}
+	if metrics.Attempts != 3 || metrics.TotalLatency != 30 {
+		t.Fatalf("updated host metrics = %+v, want attempts=3 latency=30", metrics)
+	}
+	if qm.extra != nil {
+		t.Fatal("extra host metrics map allocated for one host")
+	}
+	snapshot := *metrics
+
+	attempt, metrics = qm.attempt(1, 6*time.Nanosecond, host2, true)
+	if attempt != 3 {
+		t.Fatalf("third attempt index = %d, want 3", attempt)
+	}
+	if metrics.Attempts != 1 || metrics.TotalLatency != 6 {
+		t.Fatalf("second host metrics = %+v, want attempts=1 latency=6", metrics)
+	}
+	if qm.extra == nil {
+		t.Fatal("extra host metrics map not allocated for second host")
+	}
+	if got := qm.attempts(); got != 4 {
+		t.Fatalf("attempts = %d, want 4", got)
+	}
+	if got := qm.latency(); got != 9 {
+		t.Fatalf("latency = %d, want 9", got)
+	}
+	if snapshot.Attempts != 3 || snapshot.TotalLatency != 30 {
+		t.Fatalf("host metrics snapshot mutated = %+v", snapshot)
+	}
+
+	qm.reset()
+	if got := qm.attempts(); got != 0 {
+		t.Fatalf("attempts after reset = %d, want 0", got)
+	}
+	if got := qm.latency(); got != 0 {
+		t.Fatalf("latency after reset = %d, want 0", got)
+	}
+}
+
+func TestQueryMetricsTotalsDoNotClampAtPackedLimits(t *testing.T) {
+	t.Parallel()
+
+	const (
+		largeAttempts = 1<<20 + 1
+		largeLatency  = int64(1<<44) + 7
+	)
+	qm := preFilledQueryMetrics(map[UUID]*hostMetrics{
+		{1}: {Attempts: largeAttempts, TotalLatency: largeLatency},
+	})
+
+	if attempts, latency := qm.totalsSnapshot(); attempts != largeAttempts || latency != largeLatency {
+		t.Fatalf("large totals = (%d,%d), want (%d,%d)", attempts, latency, largeAttempts, largeLatency)
+	}
+
+	const addLatency = int64(1<<44) + 11
+	if previous := qm.addTotals(1, addLatency); previous != largeAttempts {
+		t.Fatalf("previous attempts = %d, want %d", previous, largeAttempts)
+	}
+	if attempts, latency := qm.totalsSnapshot(); attempts != largeAttempts+1 || latency != largeLatency+addLatency {
+		t.Fatalf("updated large totals = (%d,%d), want (%d,%d)",
+			attempts, latency, largeAttempts+1, largeLatency+addLatency)
+	}
+}
+
+func TestQueryMetricsTotalsConcurrentOverflowTransition(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workers        = 8
+		addsPerWorker  = 20_000
+		seedLatency    = int64(17)
+		latencyPerAdd  = int64(3)
+		totalAdditions = workers * addsPerWorker
+	)
+
+	seedAttempts := queryMetricsAttemptsMax - 1000
+	qm := newQueryMetrics()
+	if previous := qm.addTotals(int(seedAttempts), seedLatency); previous != 0 {
+		t.Fatalf("seed previous attempts = %d, want 0", previous)
+	}
+	if packed := qm.totals.Load(); packed == queryMetricsFullTotals {
+		t.Fatal("seed totals unexpectedly use full-width storage")
+	}
+
+	previousAttempts := make([]int64, totalAdditions)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	var writers sync.WaitGroup
+	ready.Add(workers)
+	for worker := range workers {
+		offset := worker * addsPerWorker
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			ready.Done()
+			<-start
+			for i := range addsPerWorker {
+				previousAttempts[offset+i] = qm.addTotals(1, latencyPerAdd)
+			}
+		}()
+	}
+	ready.Wait()
+	close(start)
+	writers.Wait()
+
+	wantAttempts := seedAttempts + totalAdditions
+	wantLatency := seedLatency + int64(totalAdditions)*latencyPerAdd
+	if attempts, latency := qm.totalsSnapshot(); attempts != wantAttempts || latency != wantLatency {
+		t.Fatalf("concurrent totals = (%d,%d), want (%d,%d)",
+			attempts, latency, wantAttempts, wantLatency)
+	}
+	if packed := qm.totals.Load(); packed != queryMetricsFullTotals {
+		t.Fatalf("packed totals = %#x, want full-width sentinel %#x", packed, uint64(queryMetricsFullTotals))
+	}
+
+	seen := make([]bool, totalAdditions)
+	for _, previous := range previousAttempts {
+		offset := previous - seedAttempts
+		if offset < 0 || offset >= int64(totalAdditions) {
+			t.Fatalf("previous attempts = %d, want range [%d,%d)", previous, seedAttempts, wantAttempts)
+		}
+		if seen[int(offset)] {
+			t.Fatalf("duplicate previous attempt index %d", previous)
+		}
+		seen[int(offset)] = true
+	}
+}
+
+func TestQueryMetricsAttemptKeepsEmptyHostIDSeparate(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	emptyHostID := &HostInfo{}
+	realHostID := &HostInfo{hostId: UUID{1}}
+
+	_, metrics := qm.attempt(1, 10*time.Nanosecond, emptyHostID, true)
+	if metrics.Attempts != 1 || metrics.TotalLatency != 10 {
+		t.Fatalf("empty host metrics = %+v, want attempts=1 latency=10", metrics)
+	}
+
+	_, metrics = qm.attempt(1, 6*time.Nanosecond, realHostID, true)
+	if metrics.Attempts != 1 || metrics.TotalLatency != 6 {
+		t.Fatalf("real host metrics = %+v, want attempts=1 latency=6", metrics)
+	}
+
+	if !qm.hostInitialized || !qm.hostID.IsEmpty() {
+		t.Fatalf("primary host ID = %v initialized=%t, want empty initialized", qm.hostID, qm.hostInitialized)
+	}
+	if qm.host.Attempts != 1 || qm.host.TotalLatency != 10 {
+		t.Fatalf("primary host metrics = %+v, want empty host metrics", qm.host)
+	}
+	if metrics := qm.extra[realHostID.hostUUID()]; metrics.Attempts != 1 || metrics.TotalLatency != 6 {
+		t.Fatalf("extra real host metrics = %+v, want attempts=1 latency=6", metrics)
+	}
+}
+
+func TestQueryMetricsAttemptWithoutSnapshotSkipsHostStorage(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	host := &HostInfo{hostId: UUID{1}}
+
+	attempt, metrics := qm.attempt(1, 10*time.Nanosecond, host, false)
+	if attempt != 0 {
+		t.Fatalf("attempt index = %d, want 0", attempt)
+	}
+	if metrics != nil {
+		t.Fatalf("metrics = %+v, want nil", metrics)
+	}
+	if got := qm.attempts(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+	if got := qm.latency(); got != 10 {
+		t.Fatalf("latency = %d, want 10", got)
+	}
+	if qm.hostInitialized || !qm.hostID.IsEmpty() || qm.host != (hostMetrics{}) {
+		t.Fatal("host metrics were stored without snapshot request")
+	}
+	if qm.extra != nil {
+		t.Fatal("extra host metrics map allocated without snapshot request")
+	}
+}
+
+func TestQueryMetricsObservedAttemptAllocatesOneImmutableHostSnapshot(t *testing.T) {
+	const runs = 1000
+	host := &HostInfo{hostId: UUID{1}}
+	qm := newQueryMetrics()
+	var snapshot *hostMetrics
+	var attemptMetrics AttemptMetrics
+
+	allocs := testing.AllocsPerRun(runs, func() {
+		qm.reset()
+		token := qm.beginAttempt()
+		_, snapshot, attemptMetrics = qm.finishAttempt(token, time.Nanosecond, host, true, true)
+		token.metrics.release()
+		if snapshot == nil || snapshot.Attempts != 1 || snapshot.TotalLatency != 1 ||
+			attemptMetrics.Attempts() != 1 {
+			panic("unexpected host metrics snapshot")
+		}
+	})
+	// Metrics is a retainable pointer with no release callback. A distinct heap
+	// object is therefore required for every immutable observer snapshot.
+	if allocs != 1 {
+		t.Fatalf("first observed attempt allocations = %f, want 1", allocs)
+	}
+}
+
+func TestQueryMetricsObservedSnapshotsRemainImmutableAcrossResets(t *testing.T) {
+	const runs = 32
+	host1 := &HostInfo{hostId: UUID{1}}
+	host2 := &HostInfo{hostId: UUID{2}}
+	qm := newQueryMetrics()
+	retained := make([]*hostMetrics, 0, runs)
+	retainedAttempts := make([]AttemptMetrics, 0, runs)
+	for i := 0; i < runs; i++ {
+		qm.reset()
+		host := host1
+		if i%2 != 0 {
+			host = host2
+		}
+		token := qm.beginAttempt()
+		_, snapshot, attemptMetrics := qm.finishAttempt(token, time.Duration(i+1)*time.Nanosecond, host, true, true)
+		token.metrics.release()
+		retained = append(retained, snapshot)
+		retainedAttempts = append(retainedAttempts, attemptMetrics)
+	}
+
+	for i, snapshot := range retained {
+		if snapshot == nil || snapshot.Attempts != 1 || snapshot.TotalLatency != int64(i+1) {
+			t.Fatalf("retained snapshot %d = %+v, want attempts=1 latency=%d", i, snapshot, i+1)
+		}
+		expectedHost := host1
+		if i%2 != 0 {
+			expectedHost = host2
+		}
+		assertSingleAttemptMetric(t, retainedAttempts[i], AttemptMetric{
+			Attempt: 0,
+			Host:    expectedHost,
+			Latency: int64(i + 1),
+		})
+		for j := i + 1; j < len(retained); j++ {
+			if snapshot == retained[j] {
+				t.Fatalf("snapshots %d and %d reused the same address", i, j)
+			}
+		}
+	}
+}
+
+func TestQueryObserverDeprecatedMetricsIncludeManualHostUpdates(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	start := time.Unix(0, 100)
+	var observedQuery ObservedQueryWithAttemptMetrics
+	var observed bool
+	q := &Query{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitQueryObserverWithAttemptMetricsFunc(func(
+			_ context.Context, query ObservedQueryWithAttemptMetrics,
+		) {
+			observedQuery, observed = query, true
+		}),
+		routingInfo: &queryRoutingInfo{},
+		stmt:        "SELECT v FROM tbl WHERE k = ?",
+		values:      []any{1},
+	}
+
+	q.AddAttempts(2, host)
+	q.AddLatency(30, host)
+	q.attempt("ks", start.Add(10*time.Nanosecond), start, &Iter{}, host)
+
+	if !observed {
+		t.Fatal("query observation was not called")
+	}
+	if observedQuery.Metrics == nil || observedQuery.Metrics.Attempts != 3 || observedQuery.Metrics.TotalLatency != 40 {
+		t.Fatalf("deprecated metrics = %+v, want attempts=3 latency=40", observedQuery.Metrics)
+	}
+	if observedQuery.Attempt != 2 || observedQuery.Host != host {
+		t.Fatalf("query observation = %+v, want attempt=2 host=%p", observedQuery, host)
+	}
+	assertSingleAttemptMetric(t, observedQuery.AttemptMetrics, AttemptMetric{
+		Attempt: 2,
+		Host:    host,
+		Latency: 10,
+	})
+}
+
+func TestBatchObserverDeprecatedMetricsIncludeManualHostUpdates(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	start := time.Unix(0, 200)
+	var observedBatch ObservedBatchWithAttemptMetrics
+	var observed bool
+	b := &Batch{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitBatchObserverWithAttemptMetricsFunc(func(
+			_ context.Context, batch ObservedBatchWithAttemptMetrics,
+		) {
+			observedBatch, observed = batch, true
+		}),
+		routingInfo: &queryRoutingInfo{},
+		Entries: []BatchEntry{
+			{Stmt: "INSERT INTO tbl (k, v) VALUES (?, ?)", Args: []any{1, "v"}},
+		},
+	}
+
+	b.AddAttempts(2, host)
+	b.AddLatency(30, host)
+	b.attempt("ks", start.Add(10*time.Nanosecond), start, &Iter{}, host)
+
+	if !observed {
+		t.Fatal("batch observation was not called")
+	}
+	if observedBatch.Metrics == nil || observedBatch.Metrics.Attempts != 3 || observedBatch.Metrics.TotalLatency != 40 {
+		t.Fatalf("deprecated metrics = %+v, want attempts=3 latency=40", observedBatch.Metrics)
+	}
+	if observedBatch.Attempt != 2 || observedBatch.Host != host {
+		t.Fatalf("batch observation = %+v, want attempt=2 host=%p", observedBatch, host)
+	}
+	assertSingleAttemptMetric(t, observedBatch.AttemptMetrics, AttemptMetric{
+		Attempt: 2,
+		Host:    host,
+		Latency: 10,
+	})
+}
+
+func TestQueryMetricsLatencyMakesProgressWithConcurrentAttempts(t *testing.T) {
+	qm := newQueryMetrics()
+	host := &HostInfo{hostId: UUID{1}}
+	stop := make(chan struct{})
+	var writers sync.WaitGroup
+	t.Cleanup(func() {
+		close(stop)
+		writers.Wait()
+	})
+	for i := 0; i < min(4, runtime.GOMAXPROCS(0)); i++ {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					qm.attempt(1, time.Nanosecond, host, false)
+				}
+			}
+		}()
+	}
+
+	readsDone := make(chan error, 1)
+	go func() {
+		for i := 0; i < 1000; i++ {
+			attempts, latency := qm.totalsSnapshot()
+			if attempts < 0 || latency < 0 || latency != attempts {
+				readsDone <- fmt.Errorf("incoherent totals attempts=%d latency=%d", attempts, latency)
+				return
+			}
+			if got := qm.latency(); got != 0 && got != 1 {
+				readsDone <- fmt.Errorf("average latency=%d, want 0 or 1", got)
+				return
+			}
+		}
+		readsDone <- nil
+	}()
+
+	select {
+	case err := <-readsDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("metrics readers made no progress during sustained concurrent updates")
+	}
+}
+
+type unitQueryObserverFunc func(context.Context, ObservedQuery)
+
+func (f unitQueryObserverFunc) ObserveQuery(ctx context.Context, q ObservedQuery) {
+	f(ctx, q)
+}
+
+type unitQueryObserverWithAttemptMetricsFunc func(context.Context, ObservedQueryWithAttemptMetrics)
+
+func (unitQueryObserverWithAttemptMetricsFunc) ObserveQuery(context.Context, ObservedQuery) {
+	panic("legacy query observer callback used for extended observer")
+}
+
+func (f unitQueryObserverWithAttemptMetricsFunc) ObserveQueryWithAttemptMetrics(
+	ctx context.Context, q ObservedQueryWithAttemptMetrics,
+) {
+	f(ctx, q)
+}
+
+type unitBatchObserverFunc func(context.Context, ObservedBatch)
+
+func (f unitBatchObserverFunc) ObserveBatch(ctx context.Context, b ObservedBatch) {
+	f(ctx, b)
+}
+
+type unitBatchObserverWithAttemptMetricsFunc func(context.Context, ObservedBatchWithAttemptMetrics)
+
+func (unitBatchObserverWithAttemptMetricsFunc) ObserveBatch(context.Context, ObservedBatch) {
+	panic("legacy batch observer callback used for extended observer")
+}
+
+func (f unitBatchObserverWithAttemptMetricsFunc) ObserveBatchWithAttemptMetrics(
+	ctx context.Context, b ObservedBatchWithAttemptMetrics,
+) {
+	f(ctx, b)
+}
+
+func assertSingleAttemptMetric(t *testing.T, metrics AttemptMetrics, want AttemptMetric) {
+	t.Helper()
+	assertAttemptMetrics(t, metrics, []AttemptMetric{want})
+}
+
+func assertAttemptMetrics(t *testing.T, metrics AttemptMetrics, want []AttemptMetric) {
+	t.Helper()
+
+	if got := metrics.Attempts(); got != len(want) {
+		t.Fatalf("attempt metrics attempts = %d, want %d", got, len(want))
+	}
+	var wantLatency int64
+	for _, attempt := range want {
+		wantLatency += attempt.Latency
+	}
+	if got := metrics.TotalLatency(); got != wantLatency {
+		t.Fatalf("attempt metrics latency = %d, want %d", got, wantLatency)
+	}
+
+	var attempts []AttemptMetric
+	metrics.ForEachAttempt(func(attempt AttemptMetric) bool {
+		attempts = append(attempts, attempt)
+		return true
+	})
+	if !slices.Equal(attempts, want) {
+		t.Fatalf("attempt metrics entries = %+v, want %+v", attempts, want)
+	}
+}
+
+func TestQueryObserverAttemptMetricsAndDeprecatedMetrics(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	start := time.Unix(0, 100)
+	var observations []ObservedQueryWithAttemptMetrics
+	q := &Query{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitQueryObserverWithAttemptMetricsFunc(func(
+			_ context.Context, observed ObservedQueryWithAttemptMetrics,
+		) {
+			observations = append(observations, observed)
+		}),
+		routingInfo: &queryRoutingInfo{},
+		stmt:        "SELECT v FROM tbl WHERE k = ?",
+		values:      []any{1},
+	}
+
+	q.attempt("ks", start.Add(10*time.Nanosecond), start, &Iter{numRows: 2}, host)
+	q.attempt("ks", start.Add(30*time.Nanosecond), start.Add(10*time.Nanosecond), &Iter{numRows: 3}, host)
+
+	if len(observations) != 2 {
+		t.Fatalf("observations = %d, want 2", len(observations))
+	}
+
+	first := observations[0]
+	if first.Metrics == nil || first.Metrics.Attempts != 1 || first.Metrics.TotalLatency != 10 {
+		t.Fatalf("first deprecated metrics = %+v, want attempts=1 latency=10", first.Metrics)
+	}
+	if first.Attempt != 0 || first.Rows != 2 || first.Host != host {
+		t.Fatalf("first observation = %+v, want attempt=0 rows=2 host=%p", first, host)
+	}
+	assertSingleAttemptMetric(t, first.AttemptMetrics, AttemptMetric{
+		Attempt: 0,
+		Host:    host,
+		Latency: 10,
+	})
+
+	second := observations[1]
+	if second.Metrics == nil || second.Metrics.Attempts != 2 || second.Metrics.TotalLatency != 30 {
+		t.Fatalf("second deprecated metrics = %+v, want attempts=2 latency=30", second.Metrics)
+	}
+	if second.Attempt != 1 || second.Rows != 3 || second.Host != host {
+		t.Fatalf("second observation = %+v, want attempt=1 rows=3 host=%p", second, host)
+	}
+	assertAttemptMetrics(t, second.AttemptMetrics, []AttemptMetric{
+		{Attempt: 0, Host: host, Latency: 10},
+		{Attempt: 1, Host: host, Latency: 20},
+	})
+}
+
+func TestBatchObserverAttemptMetricsAndDeprecatedMetrics(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	start := time.Unix(0, 200)
+	var observedBatch ObservedBatchWithAttemptMetrics
+	var observed bool
+	b := &Batch{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitBatchObserverWithAttemptMetricsFunc(func(
+			_ context.Context, batch ObservedBatchWithAttemptMetrics,
+		) {
+			observedBatch, observed = batch, true
+		}),
+		routingInfo: &queryRoutingInfo{},
+		Entries: []BatchEntry{
+			{Stmt: "INSERT INTO tbl (k, v) VALUES (?, ?)", Args: []any{1, "v"}},
+		},
+	}
+
+	b.attempt("ks", start.Add(12*time.Nanosecond), start, &Iter{}, host)
+
+	if !observed {
+		t.Fatal("batch observation was not called")
+	}
+	if observedBatch.Metrics == nil || observedBatch.Metrics.Attempts != 1 || observedBatch.Metrics.TotalLatency != 12 {
+		t.Fatalf("deprecated metrics = %+v, want attempts=1 latency=12", observedBatch.Metrics)
+	}
+	if observedBatch.Attempt != 0 || observedBatch.Host != host || observedBatch.Keyspace != "ks" {
+		t.Fatalf("batch observation = %+v, want attempt=0 host=%p keyspace=ks", observedBatch, host)
+	}
+	if len(observedBatch.Statements) != 1 || observedBatch.Statements[0] != "INSERT INTO tbl (k, v) VALUES (?, ?)" {
+		t.Fatalf("batch statements = %+v, want inserted statement", observedBatch.Statements)
+	}
+	if len(observedBatch.Values) != 1 || !reflect.DeepEqual(observedBatch.Values[0], []any{1, "v"}) {
+		t.Fatalf("batch values = %+v, want [[1 v]]", observedBatch.Values)
+	}
+	assertSingleAttemptMetric(t, observedBatch.AttemptMetrics, AttemptMetric{
+		Attempt: 0,
+		Host:    host,
+		Latency: 12,
+	})
+}
+
+func TestBatchObserverAttemptMetricsAreCumulative(t *testing.T) {
+	t.Parallel()
+
+	host1 := &HostInfo{hostId: UUID{1}}
+	host2 := &HostInfo{hostId: UUID{2}}
+	var observations []ObservedBatchWithAttemptMetrics
+	b := &Batch{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitBatchObserverWithAttemptMetricsFunc(func(
+			_ context.Context, batch ObservedBatchWithAttemptMetrics,
+		) {
+			observations = append(observations, batch)
+		}),
+		routingInfo: &queryRoutingInfo{},
+	}
+	start := time.Unix(0, 200)
+
+	b.attempt("ks", start.Add(5*time.Nanosecond), start, &Iter{}, host1)
+	b.attempt("ks", start.Add(12*time.Nanosecond), start.Add(5*time.Nanosecond), &Iter{}, host2)
+
+	if len(observations) != 2 {
+		t.Fatalf("observations = %d, want 2", len(observations))
+	}
+	assertSingleAttemptMetric(t, observations[0].AttemptMetrics, AttemptMetric{
+		Attempt: 0,
+		Host:    host1,
+		Latency: 5,
+	})
+	assertAttemptMetrics(t, observations[1].AttemptMetrics, []AttemptMetric{
+		{Attempt: 0, Host: host1, Latency: 5},
+		{Attempt: 1, Host: host2, Latency: 7},
+	})
+	if observations[0].Metrics.Attempts != 1 || observations[1].Metrics.Attempts != 1 {
+		t.Fatalf("deprecated per-host attempts = (%d,%d), want (1,1)",
+			observations[0].Metrics.Attempts, observations[1].Metrics.Attempts)
+	}
+}
+
+func TestQueryObserverAttemptMetricsConcurrentAttempts(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	observed := make(chan ObservedQueryWithAttemptMetrics, 2)
+	q := &Query{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitQueryObserverWithAttemptMetricsFunc(func(
+			_ context.Context, query ObservedQueryWithAttemptMetrics,
+		) {
+			observed <- query
+		}),
+		routingInfo: &queryRoutingInfo{},
+		stmt:        "SELECT v FROM tbl WHERE k = ?",
+		values:      []any{1},
+	}
+
+	start := make(chan struct{})
+	done := make(chan struct{}, 2)
+	for _, latency := range []time.Duration{10 * time.Nanosecond, 20 * time.Nanosecond} {
+		latency := latency
+		go func() {
+			<-start
+			now := time.Unix(0, int64(latency))
+			q.attempt("ks", now.Add(latency), now, &Iter{}, host)
+			done <- struct{}{}
+		}()
+	}
+	close(start)
+	for i := 0; i < 2; i++ {
+		<-done
+	}
+
+	observations := []ObservedQueryWithAttemptMetrics{<-observed, <-observed}
+	slices.SortFunc(observations, func(a, b ObservedQueryWithAttemptMetrics) int {
+		return a.AttemptMetrics.Attempts() - b.AttemptMetrics.Attempts()
+	})
+	seenAttempts := map[int]bool{}
+	seenDeprecatedAttempts := map[int]bool{}
+	var observedLatency int64
+	for observationIndex, observation := range observations {
+		seenAttempts[observation.Attempt] = true
+		if observation.Metrics == nil {
+			t.Fatal("deprecated metrics are nil")
+		}
+		seenDeprecatedAttempts[observation.Metrics.Attempts] = true
+
+		var attempts []AttemptMetric
+		observation.AttemptMetrics.ForEachAttempt(func(attempt AttemptMetric) bool {
+			attempts = append(attempts, attempt)
+			return true
+		})
+		if len(attempts) != observationIndex+1 {
+			t.Fatalf("attempt metrics entries = %+v, want %d entries", attempts, observationIndex+1)
+		}
+		var totalLatency int64
+		foundCurrent := false
+		for i, attempt := range attempts {
+			if i > 0 && attempts[i-1].Attempt >= attempt.Attempt {
+				t.Fatalf("attempt metrics not in launch order: %+v", attempts)
+			}
+			if attempt.Host != host || attempt.Latency <= 0 {
+				t.Fatalf("attempt metric = %+v, want host=%p and positive latency", attempt, host)
+			}
+			if attempt.Attempt == observation.Attempt {
+				foundCurrent = true
+				observedLatency += attempt.Latency
+			}
+			totalLatency += attempt.Latency
+		}
+		if !foundCurrent {
+			t.Fatalf("snapshot %+v does not include current attempt %d", attempts, observation.Attempt)
+		}
+		if observation.AttemptMetrics.TotalLatency() != totalLatency {
+			t.Fatalf("attempt metrics latency = %d, want %d", observation.AttemptMetrics.TotalLatency(), totalLatency)
+		}
+	}
+
+	if !seenAttempts[0] || !seenAttempts[1] {
+		t.Fatalf("observed attempts = %+v, want attempts 0 and 1", seenAttempts)
+	}
+	if !seenDeprecatedAttempts[1] || !seenDeprecatedAttempts[2] {
+		t.Fatalf("deprecated metric attempts = %+v, want snapshots 1 and 2", seenDeprecatedAttempts)
+	}
+	if observedLatency != 30 {
+		t.Fatalf("observed attempt latency = %d, want 30", observedLatency)
+	}
+	if got := q.metrics.attempts(); got != 2 {
+		t.Fatalf("query attempts = %d, want 2", got)
+	}
+	if got := q.metrics.latency(); got != 15 {
+		t.Fatalf("query latency = %d, want 15", got)
+	}
+}
+
+func TestQueryObserverAttemptMetricsOutOfOrderCompletion(t *testing.T) {
+	t.Parallel()
+
+	host1 := &HostInfo{hostId: UUID{1}}
+	host2 := &HostInfo{hostId: UUID{2}}
+	observed := make(chan ObservedQueryWithAttemptMetrics, 2)
+	q := &Query{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitQueryObserverWithAttemptMetricsFunc(func(
+			_ context.Context, query ObservedQueryWithAttemptMetrics,
+		) {
+			observed <- query
+		}),
+		routingInfo: &queryRoutingInfo{},
+	}
+
+	start := time.Unix(0, 100)
+	firstLaunched := q.metrics.beginAttempt()
+	firstLaunched.start = start
+	secondLaunched := q.metrics.beginAttempt()
+	secondLaunched.start = start
+
+	q.finishAttempt(secondLaunched, "ks", start.Add(20*time.Nanosecond), &Iter{}, host2)
+	firstSnapshot := (<-observed).AttemptMetrics
+	assertAttemptMetrics(t, firstSnapshot, []AttemptMetric{
+		{Attempt: 1, Host: host2, Latency: 20},
+	})
+
+	q.finishAttempt(firstLaunched, "ks", start.Add(10*time.Nanosecond), &Iter{}, host1)
+	secondSnapshot := (<-observed).AttemptMetrics
+	assertAttemptMetrics(t, secondSnapshot, []AttemptMetric{
+		{Attempt: 0, Host: host1, Latency: 10},
+		{Attempt: 1, Host: host2, Latency: 20},
+	})
+
+	// Completing another attempt must not mutate a retained earlier snapshot.
+	assertAttemptMetrics(t, firstSnapshot, []AttemptMetric{
+		{Attempt: 1, Host: host2, Latency: 20},
+	})
+}
+
+func TestQueryMetricsExecutionGenerationIsolation(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	observed := make(chan ObservedQueryWithAttemptMetrics, 2)
+	q := &Query{
+		context: context.Background(),
+		metrics: newQueryMetrics(),
+		observer: unitQueryObserverWithAttemptMetricsFunc(func(
+			_ context.Context, query ObservedQueryWithAttemptMetrics,
+		) {
+			observed <- query
+		}),
+		routingInfo: &queryRoutingInfo{},
+	}
+
+	start := time.Unix(0, 100)
+	oldMetrics := q.metrics
+	oldToken := oldMetrics.beginAttempt()
+	oldToken.start = start
+
+	newMetrics := prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	if newMetrics == oldMetrics {
+		t.Fatal("new execution reused metrics still pinned by an old attempt")
+	}
+	newToken := newMetrics.beginAttempt()
+	newToken.start = start
+	q.finishAttempt(newToken, "ks", start.Add(7*time.Nanosecond), &Iter{}, host)
+	newObservation := <-observed
+
+	q.finishAttempt(oldToken, "ks", start.Add(11*time.Nanosecond), &Iter{}, host)
+	oldObservation := <-observed
+
+	if attempts, latency := q.metrics.totalsSnapshot(); attempts != 1 || latency != 7 {
+		t.Fatalf("current execution totals = (%d,%d), want (1,7)", attempts, latency)
+	}
+	if attempts, latency := oldMetrics.totalsSnapshot(); attempts != 1 || latency != 11 {
+		t.Fatalf("old execution totals = (%d,%d), want (1,11)", attempts, latency)
+	}
+	assertSingleAttemptMetric(t, newObservation.AttemptMetrics, AttemptMetric{
+		Attempt: 0,
+		Host:    host,
+		Latency: 7,
+	})
+	assertSingleAttemptMetric(t, oldObservation.AttemptMetrics, AttemptMetric{
+		Attempt: 0,
+		Host:    host,
+		Latency: 11,
+	})
+	if refs := oldMetrics.refs.Load(); refs != 0 {
+		t.Fatalf("old execution references = %d, want 0", refs)
+	}
+}
+
+func TestConnectionBoundQueryForwardsExplicitMetrics(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	pinnedMetrics := newQueryMetrics()
+	if q.metrics == pinnedMetrics {
+		t.Fatal("test requires distinct field and execution metrics")
+	}
+	q.conn = &pagingTestConn{
+		executeQueryFunc: func(context.Context, *Query) *Iter {
+			t.Fatal("connection-bound query used the legacy metrics path")
+			return nil
+		},
+		executeQueryWithMetricsFunc: func(
+			_ context.Context,
+			gotQuery *Query,
+			gotMetrics *queryMetrics,
+		) *Iter {
+			if gotQuery != q {
+				t.Fatal("connection-bound query forwarded a different Query")
+			}
+			if gotMetrics != pinnedMetrics {
+				t.Fatal("connection-bound query did not forward its pinned metrics")
+			}
+			return &Iter{}
+		},
+	}
+
+	if iter := q.executeQueryWithMetrics(pinnedMetrics); iter == nil {
+		t.Fatal("connection-bound query returned a nil iterator")
+	}
+}
+
+func TestNextIterFetchForwardsPinnedMetrics(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	var pinnedMetrics *queryMetrics
+	q.conn = &pagingTestConn{
+		executeQueryFunc: func(context.Context, *Query) *Iter {
+			t.Fatal("automatic page used the legacy metrics path")
+			return nil
+		},
+		executeQueryWithMetricsFunc: func(
+			_ context.Context,
+			_ *Query,
+			gotMetrics *queryMetrics,
+		) *Iter {
+			if gotMetrics != pinnedMetrics {
+				t.Fatal("automatic page did not forward its pinned metrics")
+			}
+			return &Iter{}
+		},
+	}
+
+	page := newNextIter(q, 1)
+	pinnedMetrics = page.qry.metrics
+
+	iter := page.fetch()
+	if iter == nil {
+		t.Fatal("automatic page returned a nil iterator")
+	}
+	page.consume()
+	iter.Close()
+	if refs := pinnedMetrics.refs.Load(); refs != 1 {
+		t.Fatalf("pinned metrics references = %d, want only the root owner", refs)
+	}
+}
+
+func TestBindWarningHandlerWithMetricsUsesExplicitMetrics(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	metricsOwner := newWarningTestQuery()
+	prepareQueryMetrics(&metricsOwner.metrics, &metricsOwner.metricsOwner)
+	pinnedMetrics := metricsOwner.metrics
+	pinnedMetrics.attempt(1, time.Nanosecond, nil, false)
+	handler := &recordingWarningHandler{}
+	iter := (&Iter{
+		framer: &testWarningFramer{warnings: []string{"pinned"}},
+	}).bindWarningHandlerWithMetrics(q, pinnedMetrics, handler)
+
+	if iter.warningMetrics != pinnedMetrics {
+		t.Fatal("warning handler did not retain the explicit execution metrics")
+	}
+	if refs := pinnedMetrics.refs.Load(); refs != 2 {
+		t.Fatalf("pinned metrics references while iterator is open = %d, want owner plus iterator (2)", refs)
+	}
+	iter.Close()
+	if handler.calls != 1 {
+		t.Fatalf("warning handler calls = %d, want 1", handler.calls)
+	}
+	if handler.queryMetrics != pinnedMetrics || handler.queryAttempts != 1 {
+		t.Fatalf(
+			"warning handler metrics = (%p,%d), want pinned execution (%p,1)",
+			handler.queryMetrics,
+			handler.queryAttempts,
+			pinnedMetrics,
+		)
+	}
+	if refs := pinnedMetrics.refs.Load(); refs != 1 {
+		t.Fatalf("pinned metrics references after iterator close = %d, want owner only", refs)
+	}
+}
+
+func TestQueryResetDetachesMetricsPinnedByAutomaticPage(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	oldMetrics := q.metrics
+	page := newNextIter(q, 1)
+	if refs := oldMetrics.refs.Load(); refs != 2 {
+		t.Fatalf("metrics references with page owner = %d, want 2", refs)
+	}
+
+	q.reset()
+	if q.metrics == oldMetrics {
+		t.Fatal("pooled query retained metrics still owned by an automatic page")
+	}
+	if page.qry.metrics != oldMetrics {
+		t.Fatal("automatic page did not retain its original metrics run")
+	}
+	if refs := oldMetrics.refs.Load(); refs != 1 {
+		t.Fatalf("old metrics references after query reset = %d, want page owner only", refs)
+	}
+
+	page.close()
+	if refs := oldMetrics.refs.Load(); refs != 0 {
+		t.Fatalf("old metrics references after page close = %d, want 0", refs)
+	}
+}
+
+func TestNextIterReleasesExactMetricsRetainedBeforeQueryDetach(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	retainedMetrics := q.metrics
+	page := newNextIter(q, 1)
+	if refs := retainedMetrics.refs.Load(); refs != 2 {
+		t.Fatalf("metrics references with page owner = %d, want 2", refs)
+	}
+
+	// A reentrant use of the page Query can detach it to a new metrics run.
+	// Closing the page must still release the exact run retained above.
+	detachedMetrics := prepareQueryMetrics(&page.qry.metrics, &page.qry.metricsOwner)
+	if detachedMetrics == retainedMetrics {
+		t.Fatal("page query did not detach from the retained metrics run")
+	}
+	page.close()
+
+	if refs := retainedMetrics.refs.Load(); refs != 1 {
+		t.Fatalf("retained metrics references after page close = %d, want root owner only", refs)
+	}
+	if refs := detachedMetrics.refs.Load(); refs != 1 {
+		t.Fatalf("detached metrics references after page close = %d, want page query owner", refs)
+	}
+}
+
+func TestWithContextMetricsAreCopyOnWrite(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	qCopy := q.WithContext(context.Background())
+	if qCopy.metrics != q.metrics {
+		t.Fatal("Query.WithContext eagerly allocated metrics instead of making a shallow copy")
+	}
+	if !q.metrics.ownerClaimed || q.metrics.ownerEpoch != qCopy.metricsOwner.epoch {
+		t.Fatal("Query.WithContext did not transfer the copy-on-write owner")
+	}
+	originalMetrics := q.metrics
+	prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	if q.metrics == originalMetrics {
+		t.Fatal("executing the source query did not detach from its WithContext copy")
+	}
+	qCopy.metrics.attempt(1, 7*time.Nanosecond, nil, false)
+	rawCopy := *qCopy
+	prepareQueryMetrics(&rawCopy.metrics, &rawCopy.metricsOwner)
+	if rawCopy.metrics == qCopy.metrics {
+		t.Fatal("direct Query value copy did not detach on first execution")
+	}
+	if attempts, latency := qCopy.metrics.totalsSnapshot(); attempts != 1 || latency != 7 {
+		t.Fatalf("direct Query value copy changed source totals = (%d,%d), want (1,7)",
+			attempts, latency)
+	}
+
+	page := newNextIter(qCopy, 1)
+	if page.qry.metrics != qCopy.metrics {
+		t.Fatal("private automatic-page copy did not share the query metrics run")
+	}
+	page.close()
+
+	b := &Batch{metrics: newQueryMetrics()}
+	bCopy := b.WithContext(context.Background())
+	if bCopy.metrics != b.metrics {
+		t.Fatal("Batch.WithContext eagerly allocated metrics instead of making a shallow copy")
+	}
+	originalBatchMetrics := b.metrics
+	prepareQueryMetrics(&b.metrics, &b.metricsOwner)
+	if b.metrics == originalBatchMetrics {
+		t.Fatal("executing the source batch did not detach from its WithContext copy")
+	}
+	bCopy.metrics.attempt(1, 11*time.Nanosecond, nil, false)
+	rawBatchCopy := *bCopy
+	prepareQueryMetrics(&rawBatchCopy.metrics, &rawBatchCopy.metricsOwner)
+	if rawBatchCopy.metrics == bCopy.metrics {
+		t.Fatal("direct Batch value copy did not detach on first execution")
+	}
+	if attempts, latency := bCopy.metrics.totalsSnapshot(); attempts != 1 || latency != 11 {
+		t.Fatalf("direct Batch value copy changed source totals = (%d,%d), want (1,11)",
+			attempts, latency)
+	}
+}
+
+func TestCloneQueryAccountsForEveryField(t *testing.T) {
+	t.Parallel()
+
+	// Keep this list in sync with the ordinary shallow-copy assignments in
+	// cloneQuery. A newly added Query field must choose copy semantics here
+	// instead of silently inheriting its zero value in speculative, paging,
+	// retry, and WithContext clones.
+	copied := map[string]struct{}{
+		"trace":                      {},
+		"context":                    {},
+		"pageContextParent":          {},
+		"spec":                       {},
+		"rt":                         {},
+		"conn":                       {},
+		"observer":                   {},
+		"metrics":                    {},
+		"session":                    {},
+		"customPayload":              {},
+		"getKeyspace":                {},
+		"routingInfo":                {},
+		"binding":                    {},
+		"hostID":                     {},
+		"stmt":                       {},
+		"routingKey":                 {},
+		"values":                     {},
+		"pageState":                  {},
+		"requestTimeout":             {},
+		"defaultTimestampValue":      {},
+		"prefetch":                   {},
+		"pageSize":                   {},
+		"cons":                       {},
+		"serialCons":                 {},
+		"disableAutoPage":            {},
+		"deferReleasedErrorFinalize": {},
+		"idempotent":                 {},
+		"skipPrepare":                {},
+		"disableSkipMetadata":        {},
+		"defaultTimestamp":           {},
+	}
+	speciallyHandled := map[string]struct{}{
+		"executionAttempts": {},
+		"metricsOwner":      {},
+		"refCount":          {},
+		"prepareCache":      {},
+	}
+
+	queryType := reflect.TypeOf(Query{})
+	for i := 0; i < queryType.NumField(); i++ {
+		name := queryType.Field(i).Name
+		_, isCopied := copied[name]
+		_, isSpecial := speciallyHandled[name]
+		if isCopied == isSpecial {
+			t.Errorf("Query field %q must be in exactly one cloneQuery field list", name)
+		}
+		delete(copied, name)
+		delete(speciallyHandled, name)
+	}
+	for name := range copied {
+		t.Errorf("cloneQuery copied-field list contains unknown Query field %q", name)
+	}
+	for name := range speciallyHandled {
+		t.Errorf("cloneQuery special-field list contains unknown Query field %q", name)
+	}
+}
+
+func TestWithContextFromStaleValueDoesNotStealMetricsOwner(t *testing.T) {
+	t.Parallel()
+
+	q := newWarningTestQuery()
+	prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	staleQuery := *q
+	currentQueryMetrics := prepareQueryMetrics(&q.metrics, &q.metricsOwner)
+	currentQueryMetrics.attempt(1, 13*time.Nanosecond, nil, false)
+
+	queryCopy := staleQuery.WithContext(context.Background())
+	prepareQueryMetrics(&queryCopy.metrics, &queryCopy.metricsOwner)
+	if queryCopy.metrics == currentQueryMetrics {
+		t.Fatal("WithContext from a stale Query value stole the current metrics owner")
+	}
+	if attempts, latency := currentQueryMetrics.totalsSnapshot(); attempts != 1 || latency != 13 {
+		t.Fatalf("stale Query.WithContext changed current totals = (%d,%d), want (1,13)",
+			attempts, latency)
+	}
+
+	b := &Batch{metrics: newQueryMetrics()}
+	prepareQueryMetrics(&b.metrics, &b.metricsOwner)
+	staleBatch := *b
+	currentBatchMetrics := prepareQueryMetrics(&b.metrics, &b.metricsOwner)
+	currentBatchMetrics.attempt(1, 17*time.Nanosecond, nil, false)
+
+	batchCopy := staleBatch.WithContext(context.Background())
+	prepareQueryMetrics(&batchCopy.metrics, &batchCopy.metricsOwner)
+	if batchCopy.metrics == currentBatchMetrics {
+		t.Fatal("WithContext from a stale Batch value stole the current metrics owner")
+	}
+	if attempts, latency := currentBatchMetrics.totalsSnapshot(); attempts != 1 || latency != 17 {
+		t.Fatalf("stale Batch.WithContext changed current totals = (%d,%d), want (1,17)",
+			attempts, latency)
+	}
+}
+
+func TestQueryResetReusesMetricsAllocationAndOwner(t *testing.T) {
+	q := newWarningTestQuery()
+	q.reset()
+
+	metricsChanged := false
+	ownerLost := false
+	allocs := testing.AllocsPerRun(1000, func() {
+		metrics := q.metrics
+		q.reset()
+		if q.metrics != metrics {
+			metricsChanged = true
+		}
+		if q.metricsOwner.self != &q.metricsOwner ||
+			!q.metrics.ownerClaimed ||
+			q.metrics.ownerEpoch != q.metricsOwner.epoch {
+			ownerLost = true
+		}
+	})
+	if metricsChanged {
+		t.Fatal("pooled Query reset replaced idle metrics storage")
+	}
+	if ownerLost {
+		t.Fatal("pooled Query reset lost its metrics ownership marker")
+	}
+	if allocs != 1 {
+		t.Fatalf("Query reset allocations = %f, want only the fresh routing info", allocs)
+	}
+}
+
+func TestWithContextDoesNotAllocateMetrics(t *testing.T) {
+	query := newWarningTestQuery()
+	var queryCopy *Query
+	queryAllocs := testing.AllocsPerRun(1000, func() {
+		queryCopy = query.WithContext(context.Background())
+	})
+	if queryAllocs != 1 {
+		t.Fatalf("Query.WithContext allocations = %f, want only the returned Query copy", queryAllocs)
+	}
+	if queryCopy == nil {
+		t.Fatal("Query.WithContext returned nil")
+	}
+
+	batch := &Batch{metrics: newQueryMetrics()}
+	var batchCopy *Batch
+	batchAllocs := testing.AllocsPerRun(1000, func() {
+		batchCopy = batch.WithContext(context.Background())
+	})
+	if batchAllocs != 1 {
+		t.Fatalf("Batch.WithContext allocations = %f, want only the returned Batch copy", batchAllocs)
+	}
+	if batchCopy == nil {
+		t.Fatal("Batch.WithContext returned nil")
+	}
+}
+
+func TestQueryMetricsConcurrentValueCopiesClaimDifferentRuns(t *testing.T) {
+	t.Parallel()
+
+	base := Query{metrics: newQueryMetrics()}
+	first := base
+	second := base
+	start := make(chan struct{})
+	results := make(chan *queryMetrics, 2)
+
+	go func() {
+		<-start
+		results <- prepareQueryMetrics(&first.metrics, &first.metricsOwner)
+	}()
+	go func() {
+		<-start
+		results <- prepareQueryMetrics(&second.metrics, &second.metricsOwner)
+	}()
+	close(start)
+
+	firstMetrics := <-results
+	secondMetrics := <-results
+	if firstMetrics == secondMetrics {
+		t.Fatal("concurrent Query value copies claimed the same metrics run")
+	}
+	if firstMetrics.refs.Load() != 1 || secondMetrics.refs.Load() != 1 {
+		t.Fatalf("claimed references = (%d,%d), want one owner each",
+			firstMetrics.refs.Load(), secondMetrics.refs.Load())
+	}
+}
+
+func TestObservedMetricsSourceCompatibleLayout(t *testing.T) {
+	t.Parallel()
+
+	// Keep old positional literals compiling. These are valid in downstream
+	// packages even though Metrics points at an unexported concrete type.
+	_ = ObservedQuery{time.Time{}, time.Time{}, nil, nil, nil, "", "", nil, 0, 0}
+	_ = ObservedBatch{time.Time{}, time.Time{}, nil, nil, nil, "", nil, nil, 0}
+
+	assertFields := func(value any, want []string) {
+		t.Helper()
+		typ := reflect.TypeOf(value)
+		if typ.NumField() != len(want) {
+			t.Fatalf("%s field count = %d, want %d", typ, typ.NumField(), len(want))
+		}
+		for i, name := range want {
+			if got := typ.Field(i).Name; got != name {
+				t.Fatalf("%s field %d = %s, want %s", typ, i, got, name)
+			}
+		}
+	}
+	assertFields(ObservedQuery{}, []string{
+		"Start", "End", "Err", "Host", "Metrics", "Keyspace", "Statement", "Values", "Rows", "Attempt",
+	})
+	assertFields(ObservedBatch{}, []string{
+		"Start", "End", "Err", "Host", "Metrics", "Keyspace", "Statements", "Values", "Attempt",
+	})
+
+	if got := (ObservedQueryWithAttemptMetrics{}).AttemptMetrics.Attempts(); got != 0 {
+		t.Fatalf("zero query attempt metrics count = %d, want 0", got)
+	}
+	if got := (ObservedBatchWithAttemptMetrics{}).AttemptMetrics.Attempts(); got != 0 {
+		t.Fatalf("zero batch attempt metrics count = %d, want 0", got)
+	}
+
+	// Keep equality and formatting of the legacy metrics value unchanged.
+	left := hostMetrics{Attempts: 1, TotalLatency: 2}
+	right := hostMetrics{Attempts: 1, TotalLatency: 2}
+	if left != right {
+		t.Fatal("equal legacy host metrics compare unequal")
+	}
+	if got, want := fmt.Sprintf("%+v", left), "{Attempts:1 TotalLatency:2}"; got != want {
+		t.Fatalf("legacy host metrics formatting = %q, want %q", got, want)
+	}
+}
+
+func TestAttemptMetricsReportsRecordedAttempts(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{1}}
+	qm := newQueryMetrics()
+
+	_, hostMetrics := qm.attempt(1, 10*time.Nanosecond, host, true)
+	if hostMetrics.Attempts != 1 || hostMetrics.TotalLatency != 10 {
+		t.Fatalf("first host metrics = %+v, want attempts=1 latency=10", hostMetrics)
+	}
+
+	attempt, hostMetrics := qm.attempt(1, 20*time.Nanosecond, host, true)
+	if hostMetrics.Attempts != 2 || hostMetrics.TotalLatency != 30 {
+		t.Fatalf("second host metrics = %+v, want attempts=2 latency=30", hostMetrics)
+	}
+
+	attemptMetric := AttemptMetric{
+		Attempt: attempt,
+		Host:    host,
+		Latency: 20,
+	}
+	metrics := newAttemptMetrics(attemptMetric)
+	if metrics.Attempts() != 1 || metrics.TotalLatency() != 20 {
+		t.Fatalf("attempt metrics = %+v, want attempts=1 latency=20", metrics)
+	}
+
+	var attempts []AttemptMetric
+	metrics.ForEachAttempt(func(attempt AttemptMetric) bool {
+		attempts = append(attempts, attempt)
+		return true
+	})
+	if len(attempts) != 1 || attempts[0] != attemptMetric {
+		t.Fatalf("attempt metrics entries = %+v, want [%+v]", attempts, attemptMetric)
+	}
+
+	twoAttempts := metrics.withAttempt(AttemptMetric{Attempt: attempt + 1, Host: host, Latency: 30})
+	var stopped []AttemptMetric
+	twoAttempts.ForEachAttempt(func(attempt AttemptMetric) bool {
+		stopped = append(stopped, attempt)
+		return false
+	})
+	if !slices.Equal(stopped, []AttemptMetric{attemptMetric}) {
+		t.Fatalf("early-stop entries = %+v, want [%+v]", stopped, attemptMetric)
+	}
+
+	var zero AttemptMetrics
+	if zero.Attempts() != 0 || zero.TotalLatency() != 0 {
+		t.Fatalf("zero attempt metrics = %+v, want zero totals", zero)
+	}
+	var zeroAttempts []AttemptMetric
+	zero.ForEachAttempt(func(attempt AttemptMetric) bool {
+		zeroAttempts = append(zeroAttempts, attempt)
+		return true
+	})
+	if len(zeroAttempts) != 0 {
+		t.Fatalf("zero attempt metrics entries = %+v, want none", zeroAttempts)
+	}
+}
+
+func TestAttemptMetricsIsIntentionallyNotComparable(t *testing.T) {
+	t.Parallel()
+
+	if reflect.TypeOf(AttemptMetrics{}).Comparable() {
+		t.Fatal("AttemptMetrics is comparable; add an unexported non-comparable field to preserve representation freedom")
+	}
+}
+
+func TestAttemptMetricsPersistentHistoryScalesAndStaysOrdered(t *testing.T) {
+	t.Parallel()
+
+	const attemptsCount = 1024
+	var metrics AttemptMetrics
+	var retained AttemptMetrics
+	retainedOrdinals := make(map[int]bool)
+	for i := 0; i < attemptsCount; i++ {
+		ordinal := (i * 641) % attemptsCount
+		metrics = metrics.withAttempt(AttemptMetric{
+			Attempt: ordinal,
+			Latency: int64(ordinal + 1),
+		})
+		if i == attemptsCount/2-1 {
+			retained = metrics
+			retained.ForEachAttempt(func(attempt AttemptMetric) bool {
+				retainedOrdinals[attempt.Attempt] = true
+				return true
+			})
+		}
+	}
+
+	if metrics.Attempts() != attemptsCount {
+		t.Fatalf("attempt count = %d, want %d", metrics.Attempts(), attemptsCount)
+	}
+	if metrics.TotalLatency() != attemptsCount*(attemptsCount+1)/2 {
+		t.Fatalf("total latency = %d, want %d", metrics.TotalLatency(), attemptsCount*(attemptsCount+1)/2)
+	}
+	if metrics.root == nil || metrics.root.height > 20 {
+		t.Fatalf("persistent history height = %d, want balanced tree", attemptMetricNodeHeight(metrics.root))
+	}
+	ordinal := 0
+	metrics.ForEachAttempt(func(attempt AttemptMetric) bool {
+		if attempt.Attempt != ordinal {
+			t.Fatalf("attempt ordinal = %d, want %d", attempt.Attempt, ordinal)
+		}
+		ordinal++
+		return true
+	})
+	if ordinal != attemptsCount {
+		t.Fatalf("iterated attempts = %d, want %d", ordinal, attemptsCount)
+	}
+
+	var retainedCount int
+	retained.ForEachAttempt(func(attempt AttemptMetric) bool {
+		if !retainedOrdinals[attempt.Attempt] {
+			t.Fatalf("retained snapshot gained attempt %d", attempt.Attempt)
+		}
+		retainedCount++
+		return true
+	})
+	if retainedCount != attemptsCount/2 {
+		t.Fatalf("retained attempts = %d, want %d", retainedCount, attemptsCount/2)
+	}
+}
+
+func TestQueryMetricsObservedAttemptSerializesTotalAttemptWithHostMetrics(t *testing.T) {
+	t.Parallel()
+
+	qm := newQueryMetrics()
+	host := &HostInfo{hostId: UUID{1}}
+
+	qm.l.Lock()
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		close(started)
+		attempt, metrics := qm.attempt(1, 10*time.Nanosecond, host, true)
+		if attempt != 0 {
+			t.Errorf("attempt index = %d, want 0", attempt)
+		}
+		if metrics.Attempts != 1 || metrics.TotalLatency != 10 {
+			t.Errorf("host metrics = %+v, want attempts=1 latency=10", metrics)
+		}
+	}()
+
+	<-started
+	deadline := time.After(100 * time.Millisecond)
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-done:
+			qm.l.Unlock()
+			t.Fatal("observed attempt completed while host metrics lock was held")
+		case <-tick.C:
+			if got, _ := qm.totalsSnapshot(); got != 0 {
+				qm.l.Unlock()
+				<-done
+				t.Fatalf("total attempts advanced before host metrics lock: got %d, want 0", got)
+			}
+		case <-deadline:
+			if got, _ := qm.totalsSnapshot(); got != 0 {
+				qm.l.Unlock()
+				<-done
+				t.Fatalf("total attempts advanced before host metrics lock: got %d, want 0", got)
+			}
+			qm.l.Unlock()
+			<-done
+			return
+		}
+	}
+}
+
+func BenchmarkQueryMetricsAttempt(b *testing.B) {
+	host := &HostInfo{hostId: UUID{1}}
+	qm := newQueryMetrics()
+	qm.attempt(1, time.Nanosecond, host, false)
+	qm.reset()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%1024 == 0 {
+			qm.reset()
+		}
+		qm.attempt(1, time.Nanosecond, host, false)
+	}
+}
+
+func BenchmarkQueryMetricsResetAttempt(b *testing.B) {
+	host := &HostInfo{hostId: UUID{1}}
+	qm := newQueryMetrics()
+	qm.attempt(1, time.Nanosecond, host, false)
+	qm.reset()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		qm.reset()
+		qm.attempt(1, time.Nanosecond, host, false)
+	}
+}
+
+func BenchmarkQueryResetWithStraggler(b *testing.B) {
+	q := newWarningTestQuery()
+	q.reset()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stragglerMetrics := q.metrics
+		stragglerMetrics.retain()
+		q.reset()
+		stragglerMetrics.release()
+	}
+}
+
+func BenchmarkQueryMetricsAttemptWithSnapshot(b *testing.B) {
+	hosts := []*HostInfo{
+		{hostId: UUID{1}},
+		{hostId: UUID{2}},
+		{hostId: UUID{3}},
+		{hostId: UUID{4}},
+	}
+	qm := newQueryMetrics()
+	for _, host := range hosts {
+		qm.attempt(1, time.Nanosecond, host, true)
+	}
+	qm.reset()
+
+	var metrics *hostMetrics
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; {
+		qm.reset()
+		for _, host := range hosts {
+			if i >= b.N {
+				break
+			}
+			_, metrics = qm.attempt(1, time.Nanosecond, host, true)
+			i++
+		}
+	}
+	if metrics == nil {
+		b.Fatal("expected metrics snapshot")
+	}
+}
+
+func BenchmarkAttemptMetricsPersistentHistory(b *testing.B) {
+	for _, attemptsPerExecution := range []int{1, 2, 4, 8} {
+		b.Run(fmt.Sprintf("Attempts%d", attemptsPerExecution), func(b *testing.B) {
+			var metrics AttemptMetrics
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				metrics = AttemptMetrics{}
+				for attempt := 0; attempt < attemptsPerExecution; attempt++ {
+					metrics = metrics.withAttempt(AttemptMetric{Attempt: attempt, Latency: 1})
+				}
+			}
+			if metrics.Attempts() != attemptsPerExecution {
+				b.Fatalf("attempt history count = %d, want %d", metrics.Attempts(), attemptsPerExecution)
+			}
+		})
 	}
 }
 
@@ -641,7 +2260,7 @@ func newWarningTestQuery() *Query {
 	return &Query{
 		context:     context.Background(),
 		routingInfo: &queryRoutingInfo{},
-		metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+		metrics:     newQueryMetrics(),
 		rt:          &SimpleRetryPolicy{NumRetries: 0},
 		spec:        NonSpeculativeExecution{},
 	}
@@ -794,7 +2413,7 @@ func TestIterWarningHandler(t *testing.T) {
 		host := &HostInfo{hostId: UUID{1}}
 		qry := &Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}
 		iter := (&Iter{
 			framer:      &testWarningFramer{warnings: []string{"page2"}},
@@ -827,7 +2446,7 @@ func TestIterWarningHandler(t *testing.T) {
 			framer: &testWarningFramer{warnings: []string{"warn"}},
 		}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}, handler)
 
 		iter.Close()
@@ -861,7 +2480,7 @@ func TestIterWarningHandler(t *testing.T) {
 	t.Run("BindIgnoresNilHandler", func(t *testing.T) {
 		iter := (&Iter{}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}, nil)
 		if iter.warningHandler != nil {
 			t.Fatal("expected warning handler to remain nil")
@@ -877,7 +2496,7 @@ func TestIterWarningHandler(t *testing.T) {
 		}).bindWarningHandler(&Batch{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}, handler)
@@ -894,7 +2513,7 @@ func TestIterWarningHandler(t *testing.T) {
 		batch := &Batch{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}
@@ -923,7 +2542,7 @@ func TestIterWarningHandler(t *testing.T) {
 		}).bindWarningHandler(&Query{
 			context:     context.Background(),
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 			rt:          &SimpleRetryPolicy{NumRetries: 0},
 			spec:        NonSpeculativeExecution{},
 		}, handler)
@@ -942,7 +2561,7 @@ func TestIterWarningHandler(t *testing.T) {
 			host:        &HostInfo{hostId: UUID{3}},
 		}).bindWarningHandler(&Query{
 			routingInfo: &queryRoutingInfo{},
-			metrics:     &queryMetrics{m: make(map[UUID]*hostMetrics)},
+			metrics:     newQueryMetrics(),
 		}, handler)
 
 		iter.handleWarningsOnce()
@@ -1113,7 +2732,14 @@ func TestQueryExecutorRetryAndDiscardWarningHandling(t *testing.T) {
 		cancel()
 
 		executor := newTestQueryExecutor(host)
-		executor.run(ctx, qry, func() SelectedHost { return staticSelectedHost{host: host} }, make(chan *Iter))
+		metrics := newQueryMetrics()
+		var executionAttempts atomic.Int64
+		metrics.retain()
+		executor.run(
+			ctx, qry, qry, metrics, &executionAttempts,
+			func() SelectedHost { return staticSelectedHost{host: host} },
+			make(chan queryExecutionResult),
+		)
 
 		if handler.calls != 0 {
 			t.Fatalf("handler call count = %d, want 0", handler.calls)
@@ -1121,8 +2747,54 @@ func TestQueryExecutorRetryAndDiscardWarningHandling(t *testing.T) {
 		if !framer.released {
 			t.Fatal("speculative loser framer was not released")
 		}
-		if qry.released != 1 {
-			t.Fatalf("releaseAfterExecution calls = %d, want 1", qry.released)
+		if qry.released.Load() != 1 {
+			t.Fatalf("releaseAfterExecution calls = %d, want 1", qry.released.Load())
+		}
+	})
+
+	t.Run("LateSpeculativeResultCannotBeBuffered", func(t *testing.T) {
+		host := (&HostInfo{hostId: UUID{18}}).setState(NodeUp)
+		handler := &recordingWarningHandler{}
+		framer := &testWarningFramer{warnings: []string{"late-loser"}}
+		metrics := newQueryMetrics()
+		warningBatch := &Batch{metrics: metrics}
+		qry := &executorTestQuery{
+			rt:         &fixedRetryPolicy{maxRetries: 0, retryType: Rethrow},
+			spec:       NonSpeculativeExecution{},
+			idempotent: true,
+		}
+		qry.executeFunc = func(context.Context, *Conn) *Iter {
+			return (&Iter{framer: framer}).bindWarningHandler(warningBatch, handler)
+		}
+
+		results := queryExecutionResults()
+		if capacity := cap(results); capacity != 0 {
+			t.Fatalf("execution result channel capacity = %d, want unbuffered", capacity)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Models a loser completing after the winner has been returned.
+
+		executor := newTestQueryExecutor(host)
+		var executionAttempts atomic.Int64
+		metrics.retain() // runner ownership consumed by run.
+		executor.run(
+			ctx, qry, qry, metrics, &executionAttempts,
+			func() SelectedHost { return staticSelectedHost{host: host} },
+			results,
+		)
+
+		if !framer.released {
+			t.Fatal("late speculative result framer was not released")
+		}
+		if handler.calls != 0 {
+			t.Fatalf("warning handler call count = %d, want 0", handler.calls)
+		}
+		if refs := metrics.refs.Load(); refs != 0 {
+			t.Fatalf("execution metrics references = %d, want 0", refs)
+		}
+		if released := qry.released.Load(); released != 1 {
+			t.Fatalf("releaseAfterExecution calls = %d, want 1", released)
 		}
 	})
 
@@ -1148,7 +2820,12 @@ func TestQueryExecutorRetryAndDiscardWarningHandling(t *testing.T) {
 		}
 
 		executor := newTestQueryExecutor(host)
-		iter := executor.do(context.Background(), qry, func() SelectedHost { return staticSelectedHost{host: host} })
+		metrics := newQueryMetrics()
+		var executionAttempts atomic.Int64
+		iter, _ := executor.do(
+			context.Background(), qry, metrics, &executionAttempts,
+			func() SelectedHost { return staticSelectedHost{host: host} },
+		)
 		defer iter.Close()
 
 		if iter.err != nil {
@@ -1164,6 +2841,515 @@ func TestQueryExecutorRetryAndDiscardWarningHandling(t *testing.T) {
 			t.Fatalf("handler warnings = %v, want %v", handler.warnings, []string{"retry-warn"})
 		}
 	})
+}
+
+func TestQueryExecutorAutomaticPageHasIndependentRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	host := (&HostInfo{hostId: UUID{9}}).setState(NodeUp)
+	executor := newTestQueryExecutor(host)
+	metrics := newQueryMetrics()
+	calls := 0
+	qry := &executorTestQuery{
+		ctx:        context.Background(),
+		rt:         &fixedRetryPolicy{maxRetries: 1, retryType: Retry},
+		spec:       NonSpeculativeExecution{},
+		idempotent: true,
+	}
+	qry.executeFunc = func(context.Context, *Conn) *Iter {
+		calls++
+		switch calls {
+		case 1:
+			return &Iter{} // first page
+		case 2:
+			return &Iter{err: errors.New("transient second-page failure")}
+		case 3:
+			return &Iter{} // second-page retry
+		default:
+			t.Fatalf("unexpected query attempt %d", calls)
+			return &Iter{}
+		}
+	}
+
+	firstPage, err := executor.executeQuery(qry, metrics)
+	if err != nil || firstPage.err != nil {
+		t.Fatalf("first page failed: executor=%v iter=%v", err, firstPage.err)
+	}
+	firstPage.Close()
+
+	// Automatic paging starts a new executor run but deliberately preserves
+	// the logical metrics run and cumulative observer history.
+	secondPageQuery := qry.withContext(context.Background())
+	secondPage, err := executor.executeQuery(secondPageQuery, metrics)
+	if err != nil || secondPage.err != nil {
+		t.Fatalf("second page failed: executor=%v iter=%v", err, secondPage.err)
+	}
+	secondPage.Close()
+
+	if calls != 3 {
+		t.Fatalf("physical attempts = %d, want first page plus second-page retry (3)", calls)
+	}
+	if attempts, _ := metrics.totalsSnapshot(); attempts != 3 {
+		t.Fatalf("cumulative metrics attempts = %d, want 3", attempts)
+	}
+}
+
+func TestQueryExecutorPropagatesWinningRetryConsistency(t *testing.T) {
+	t.Run("NonSpeculative", func(t *testing.T) {
+		host := (&HostInfo{hostId: UUID{14}}).setState(NodeUp)
+		executor := newTestQueryExecutor(host)
+		metrics := newQueryMetrics()
+		calls := 0
+		qry := &executorTestQuery{
+			ctx:         context.Background(),
+			rt:          &consistencyRetryPolicy{consistency: All},
+			spec:        NonSpeculativeExecution{},
+			idempotent:  true,
+			consistency: One,
+		}
+		qry.executeFunc = func(context.Context, *Conn) *Iter {
+			calls++
+			if calls == 1 {
+				return &Iter{err: errors.New("retry")}
+			}
+			return &Iter{}
+		}
+
+		iter, err := executor.executeQuery(qry, metrics)
+		if err != nil || iter.err != nil {
+			t.Fatalf("execution failed: executor=%v iter=%v", err, iter.err)
+		}
+		iter.Close()
+		if got := qry.GetConsistency(); got != All {
+			t.Fatalf("caller consistency = %v, want winning retry consistency %v", got, All)
+		}
+	})
+
+	t.Run("SpeculativeWinner", func(t *testing.T) {
+		host := (&HostInfo{hostId: UUID{15}}).setState(NodeUp)
+		secondHost := (&HostInfo{hostId: UUID{16}}).setState(NodeUp)
+		executor := newTestQueryExecutor(host)
+		executor.policy.AddHost(secondHost)
+		executor.pool.hostConnPools[secondHost.HostID()] = &hostConnPool{
+			host:       secondHost,
+			connPicker: staticConnPicker{conn: &Conn{host: secondHost}},
+		}
+		metrics := newQueryMetrics()
+		var calls atomic.Int32
+		mainStarted := make(chan struct{})
+		qry := &executorTestQuery{
+			ctx:         context.Background(),
+			rt:          &consistencyRetryPolicy{consistency: All},
+			spec:        &SimpleSpeculativeExecution{NumAttempts: 1, TimeoutDelay: time.Millisecond},
+			idempotent:  true,
+			consistency: One,
+		}
+		qry.executeFunc = func(ctx context.Context, _ *Conn) *Iter {
+			switch calls.Add(1) {
+			case 1:
+				close(mainStarted)
+				<-ctx.Done()
+				return &Iter{err: ctx.Err()}
+			case 2:
+				<-mainStarted
+				return &Iter{err: errors.New("speculative retry")}
+			case 3:
+				return &Iter{}
+			default:
+				t.Fatal("unexpected extra attempt")
+				return &Iter{}
+			}
+		}
+
+		iter, err := executor.executeQuery(qry, metrics)
+		if err != nil || iter.err != nil {
+			t.Fatalf("execution failed: executor=%v iter=%v", err, iter.err)
+		}
+		iter.Close()
+		if got := qry.GetConsistency(); got != All {
+			t.Fatalf("caller consistency = %v, want winning retry consistency %v", got, All)
+		}
+
+		deadline := time.After(2 * time.Second)
+		poll := time.NewTicker(time.Millisecond)
+		defer poll.Stop()
+		for qry.released.Load() != 3 {
+			select {
+			case <-deadline:
+				t.Fatalf("execution borrows released = %d, want 3", qry.released.Load())
+			case <-poll.C:
+			}
+		}
+		if got := qry.GetConsistency(); got != All {
+			t.Fatalf("loser changed caller consistency to %v, want winner value %v", got, All)
+		}
+	})
+}
+
+func TestQueryExecutorSuccessfulAttemptDoesNotWriteConsistency(t *testing.T) {
+	t.Parallel()
+
+	host := (&HostInfo{hostId: UUID{17}}).setState(NodeUp)
+	qry := &executorTestQuery{
+		ctx:         context.Background(),
+		rt:          &fixedRetryPolicy{maxRetries: 0, retryType: Rethrow},
+		spec:        NonSpeculativeExecution{},
+		idempotent:  true,
+		consistency: One,
+		executeFunc: func(context.Context, *Conn) *Iter {
+			return &Iter{}
+		},
+	}
+
+	iter, err := newTestQueryExecutor(host).executeQuery(qry, newQueryMetrics())
+	if err != nil || iter.err != nil {
+		t.Fatalf("execution failed: executor=%v iter=%v", err, iter.err)
+	}
+	iter.Close()
+	if writes := qry.consistencyWrites.Load(); writes != 0 {
+		t.Fatalf("consistency writes = %d, want 0 on unchanged successful execution", writes)
+	}
+}
+
+func TestQueryExecutorSuccessfulAttemptDoesNotAddRetryCounterAllocation(t *testing.T) {
+	host := (&HostInfo{hostId: UUID{13}}).setState(NodeUp)
+	executor := newTestQueryExecutor(host)
+	metrics := newQueryMetrics()
+	iter := &Iter{}
+	qry := &executorTestQuery{
+		ctx:        context.Background(),
+		rt:         &fixedRetryPolicy{maxRetries: 0, retryType: Rethrow},
+		spec:       NonSpeculativeExecution{},
+		idempotent: true,
+		executeFunc: func(context.Context, *Conn) *Iter {
+			return iter
+		},
+	}
+	selected := staticSelectedHost{host: host}
+	hostIter := func() SelectedHost { return selected }
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		if got, _ := executor.do(qry.Context(), qry, metrics, nil, hostIter); got != iter {
+			panic("unexpected iterator")
+		}
+	})
+	// The host-pool lookup allocates one HostID string. The retry counter must
+	// remain stack-local and add no second allocation on this fast path.
+	if allocs != 1 {
+		t.Fatalf("successful execution allocations = %f, want host lookup baseline of 1", allocs)
+	}
+}
+
+func TestQueryExecutorSpeculativeBranchesShareRetryBudget(t *testing.T) {
+	host := (&HostInfo{hostId: UUID{10}}).setState(NodeUp)
+	secondHost := (&HostInfo{hostId: UUID{11}}).setState(NodeUp)
+	executor := newTestQueryExecutor(host)
+	executor.policy.AddHost(secondHost)
+	executor.pool.hostConnPools[secondHost.HostID()] = &hostConnPool{
+		host:       secondHost,
+		connPicker: staticConnPicker{conn: &Conn{host: secondHost}},
+	}
+	metrics := newQueryMetrics()
+	policy := &synchronizedRetryPolicy{
+		maxRetries: 1,
+		allEntered: make(chan struct{}),
+	}
+	initialAttemptsStarted := make(chan struct{})
+	var calls atomic.Int32
+	qry := &executorTestQuery{
+		ctx:        context.Background(),
+		rt:         policy,
+		spec:       &SimpleSpeculativeExecution{NumAttempts: 1, TimeoutDelay: time.Millisecond},
+		idempotent: true,
+	}
+	qry.executeFunc = func(context.Context, *Conn) *Iter {
+		attempt := calls.Add(1)
+		if attempt <= 2 {
+			if attempt == 2 {
+				close(initialAttemptsStarted)
+			}
+			<-initialAttemptsStarted
+			return &Iter{err: errors.New("initial attempt failed")}
+		}
+		return &Iter{}
+	}
+
+	iter, err := executor.executeQuery(qry, metrics)
+	if err != nil {
+		t.Fatalf("executor failed: %v", err)
+	}
+	iter.Close()
+
+	deadline := time.After(2 * time.Second)
+	poll := time.NewTicker(time.Millisecond)
+	defer poll.Stop()
+	for qry.released.Load() != 3 {
+		select {
+		case <-deadline:
+			t.Fatalf(
+				"execution borrows released = %d, want 3 (borrowed=%d calls=%d policy=%d)",
+				qry.released.Load(), qry.borrowed.Load(), calls.Load(), policy.entered.Load(),
+			)
+		case <-poll.C:
+		}
+	}
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("physical attempts = %d, want two failed speculative branches sharing one exhausted retry budget", got)
+	}
+	if got := policy.entered.Load(); got != 2 {
+		t.Fatalf("retry policy calls = %d, want 2", got)
+	}
+	if attempts, _ := metrics.totalsSnapshot(); attempts != 2 {
+		t.Fatalf("cumulative metrics attempts = %d, want 2", attempts)
+	}
+}
+
+func TestQueryExecutorSpeculativeAttemptOrdinalsFollowLaunchOrder(t *testing.T) {
+	host := (&HostInfo{hostId: UUID{6}}).setState(NodeUp)
+	secondHost := (&HostInfo{hostId: UUID{7}}).setState(NodeUp)
+	executor := newTestQueryExecutor(host)
+	executor.policy.AddHost(secondHost)
+	executor.pool.hostConnPools[secondHost.HostID()] = &hostConnPool{
+		host:       secondHost,
+		connPicker: staticConnPicker{conn: &Conn{host: secondHost}},
+	}
+	metrics := newQueryMetrics()
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseFirst) })
+	}
+	defer release()
+
+	type observation struct {
+		attempt int
+		metrics AttemptMetrics
+	}
+	observed := make(chan observation, 2)
+	var launches atomic.Int32
+	qry := &executorTestQuery{
+		ctx:        context.Background(),
+		rt:         &fixedRetryPolicy{maxRetries: 0, retryType: Rethrow},
+		spec:       &SimpleSpeculativeExecution{NumAttempts: 1, TimeoutDelay: time.Millisecond},
+		idempotent: true,
+	}
+	qry.executeFunc = func(context.Context, *Conn) *Iter {
+		if launches.Add(1) == 1 {
+			close(firstStarted)
+			<-releaseFirst
+		}
+		return &Iter{}
+	}
+	qry.finishFunc = func(token attemptToken, end time.Time, _ *Iter, completedHost *HostInfo) {
+		defer token.metrics.release()
+		attempt, _, attemptMetrics := token.metrics.finishAttempt(token, end.Sub(token.start), completedHost, true, true)
+		observed <- observation{attempt: attempt, metrics: attemptMetrics}
+	}
+
+	result := make(chan *Iter, 1)
+	go func() {
+		iter, err := executor.executeQuery(qry, metrics)
+		if err != nil {
+			result <- &Iter{err: err}
+			return
+		}
+		result <- iter
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first attempt did not start")
+	}
+
+	select {
+	case iter := <-result:
+		if iter.err != nil {
+			t.Fatalf("speculative execution returned error: %v", iter.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("later speculative attempt did not complete promptly")
+	}
+
+	fast := <-observed
+	if fast.attempt != 1 {
+		t.Fatalf("fast attempt ordinal = %d, want 1", fast.attempt)
+	}
+	var fastEntries []AttemptMetric
+	fast.metrics.ForEachAttempt(func(attempt AttemptMetric) bool {
+		fastEntries = append(fastEntries, attempt)
+		return true
+	})
+	if len(fastEntries) != 1 || fastEntries[0].Attempt != 1 {
+		t.Fatalf("fast snapshot = %+v, want only launch ordinal 1", fastEntries)
+	}
+
+	release()
+	slow := <-observed
+	if slow.attempt != 0 {
+		t.Fatalf("slow attempt ordinal = %d, want 0", slow.attempt)
+	}
+	var slowEntries []AttemptMetric
+	slow.metrics.ForEachAttempt(func(attempt AttemptMetric) bool {
+		slowEntries = append(slowEntries, attempt)
+		return true
+	})
+	if len(slowEntries) != 2 || slowEntries[0].Attempt != 0 || slowEntries[1].Attempt != 1 {
+		t.Fatalf("final snapshot = %+v, want launch ordinals [0 1]", slowEntries)
+	}
+}
+
+func TestQueryForExecutionPreservesConcreteTypes(t *testing.T) {
+	host := &HostInfo{hostId: UUID{9}}
+
+	queryMetrics := newQueryMetrics()
+	queryMetrics.attempt(7, 4*time.Nanosecond, host, false)
+	var queryAttempts atomic.Int64
+	queryAttempts.Store(2)
+	query := &Query{
+		metrics:     newQueryMetrics(),
+		routingInfo: &queryRoutingInfo{},
+		cons:        One,
+	}
+	executionQuery := queryForRetryExecution(query, queryMetrics)
+	concreteExecutionQuery, ok := executionQuery.(*Query)
+	if !ok {
+		t.Fatalf("execution query has type %T, want *Query", executionQuery)
+	}
+	if concreteExecutionQuery.Attempts() != 7 {
+		t.Fatalf("execution query attempts = %d, want cumulative count 7", concreteExecutionQuery.Attempts())
+	}
+	retryableQuery := queryForExecution(executionQuery, queryMetrics, &queryAttempts)
+	concreteQuery, ok := retryableQuery.(*Query)
+	if !ok {
+		t.Fatalf("retry-policy query has type %T, want *Query", retryableQuery)
+	}
+	if concreteQuery.Attempts() != 2 {
+		t.Fatalf("query retry attempts = %d, want 2", concreteQuery.Attempts())
+	}
+	concreteQuery.SetConsistency(All)
+	if query.GetConsistency() != One {
+		t.Fatalf("original query consistency = %v, want %v", query.GetConsistency(), One)
+	}
+	if concreteQuery.GetConsistency() != All {
+		t.Fatalf("execution query consistency = %v, want %v", concreteQuery.GetConsistency(), All)
+	}
+	concreteExecutionQuery.SetConsistency(concreteQuery.GetConsistency())
+	if concreteExecutionQuery.GetConsistency() != All {
+		t.Fatalf("retry execution consistency = %v, want %v", concreteExecutionQuery.GetConsistency(), All)
+	}
+
+	batchMetrics := newQueryMetrics()
+	batchMetrics.attempt(8, 9*time.Nanosecond, host, false)
+	var batchAttempts atomic.Int64
+	batchAttempts.Store(3)
+	batch := &Batch{
+		metrics:     newQueryMetrics(),
+		routingInfo: &queryRoutingInfo{},
+		Cons:        One,
+	}
+	executionBatch := queryForRetryExecution(batch, batchMetrics)
+	concreteExecutionBatch, ok := executionBatch.(*Batch)
+	if !ok {
+		t.Fatalf("execution batch has type %T, want *Batch", executionBatch)
+	}
+	if concreteExecutionBatch.Attempts() != 8 {
+		t.Fatalf("execution batch attempts = %d, want cumulative count 8", concreteExecutionBatch.Attempts())
+	}
+	retryableBatch := queryForExecution(executionBatch, batchMetrics, &batchAttempts)
+	concreteBatch, ok := retryableBatch.(*Batch)
+	if !ok {
+		t.Fatalf("retry-policy batch has type %T, want *Batch", retryableBatch)
+	}
+	if concreteBatch.Attempts() != 3 {
+		t.Fatalf("batch retry attempts = %d, want 3", concreteBatch.Attempts())
+	}
+	concreteBatch.SetConsistency(All)
+	if batch.GetConsistency() != One {
+		t.Fatalf("original batch consistency = %v, want %v", batch.GetConsistency(), One)
+	}
+	if concreteBatch.GetConsistency() != All {
+		t.Fatalf("execution batch consistency = %v, want %v", concreteBatch.GetConsistency(), All)
+	}
+	concreteExecutionBatch.SetConsistency(concreteBatch.GetConsistency())
+	if concreteExecutionBatch.GetConsistency() != All {
+		t.Fatalf("retry execution batch consistency = %v, want %v", concreteExecutionBatch.GetConsistency(), All)
+	}
+}
+
+func TestSpeculativeExecutionViewCapturesObserverPayload(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{12}}
+	start := time.Unix(0, 100)
+
+	queryObserved := make(chan ObservedQueryWithAttemptMetrics, 1)
+	query := &Query{
+		context: context.Background(),
+		observer: unitQueryObserverWithAttemptMetricsFunc(func(
+			_ context.Context, observed ObservedQueryWithAttemptMetrics,
+		) {
+			queryObserved <- observed
+		}),
+		metrics:     newQueryMetrics(),
+		routingInfo: &queryRoutingInfo{},
+		stmt:        "old query",
+		values:      []any{"old value"},
+	}
+	capturedQuery := queryForSpeculativeExecution(query, query.metrics).(*Query)
+	query.observer = unitQueryObserverFunc(func(context.Context, ObservedQuery) {
+		t.Error("new-generation query observer received old attempt")
+	})
+	query.stmt = "new query"
+	query.values = []any{"new value"}
+
+	queryToken := query.metrics.beginAttempt()
+	queryToken.start = start
+	capturedQuery.finishAttempt(
+		queryToken, "ks", start.Add(time.Nanosecond), &Iter{}, host,
+	)
+	queryObservation := <-queryObserved
+	if queryObservation.Statement != "old query" ||
+		!reflect.DeepEqual(queryObservation.Values, []any{"old value"}) {
+		t.Fatalf("captured query payload = (%q,%v), want old generation", queryObservation.Statement, queryObservation.Values)
+	}
+
+	batchObserved := make(chan ObservedBatchWithAttemptMetrics, 1)
+	batch := &Batch{
+		context: context.Background(),
+		observer: unitBatchObserverWithAttemptMetricsFunc(func(
+			_ context.Context, observed ObservedBatchWithAttemptMetrics,
+		) {
+			batchObserved <- observed
+		}),
+		metrics:     newQueryMetrics(),
+		routingInfo: &queryRoutingInfo{},
+		Entries: []BatchEntry{
+			{Stmt: "old batch", Args: []any{"old value"}},
+		},
+	}
+	capturedBatch := queryForSpeculativeExecution(batch, batch.metrics).(*Batch)
+	batch.observer = unitBatchObserverFunc(func(context.Context, ObservedBatch) {
+		t.Error("new-generation batch observer received old attempt")
+	})
+	batch.Entries[0] = BatchEntry{Stmt: "new batch", Args: []any{"new value"}}
+
+	batchToken := batch.metrics.beginAttempt()
+	batchToken.start = start
+	capturedBatch.finishAttempt(
+		batchToken, "ks", start.Add(time.Nanosecond), &Iter{}, host,
+	)
+	batchObservation := <-batchObserved
+	if !slices.Equal(batchObservation.Statements, []string{"old batch"}) ||
+		!reflect.DeepEqual(batchObservation.Values, [][]any{{"old value"}}) {
+		t.Fatalf(
+			"captured batch payload = (%v,%v), want old generation",
+			batchObservation.Statements, batchObservation.Values,
+		)
+	}
 }
 
 func TestScannerScanTupleColumnUsesRawColumnIndex(t *testing.T) {
@@ -1357,6 +3543,70 @@ func TestIterFetchNextPageRetiresConsumedFetchContextOnly(t *testing.T) {
 	}
 }
 
+func TestQueryObserverMetricsContinueAcrossAutomaticPages(t *testing.T) {
+	t.Parallel()
+
+	host := &HostInfo{hostId: UUID{8}}
+	baseQry := newWarningTestQuery()
+	baseQry.refCount = 1
+	var observations []ObservedQueryWithAttemptMetrics
+	baseQry.observer = unitQueryObserverWithAttemptMetricsFunc(func(
+		_ context.Context, query ObservedQueryWithAttemptMetrics,
+	) {
+		observations = append(observations, query)
+	})
+
+	var firstPageMetrics *queryMetrics
+	call := 0
+	baseQry.conn = &pagingTestConn{
+		executeQueryFunc: func(_ context.Context, qry *Query) *Iter {
+			call++
+			if call == 1 {
+				firstPageMetrics = qry.metrics
+			} else if qry.metrics != firstPageMetrics {
+				t.Fatal("automatic page detached from the first page metrics run")
+			}
+
+			start := time.Unix(0, int64(call)*100)
+			qry.attempt("ks", start.Add(time.Duration(call)*time.Nanosecond), start, &Iter{numRows: 1}, host)
+			if call == 1 {
+				nextQry := cloneQueryForNextPage(qry, qry.metrics, []byte("next"))
+				return &Iter{
+					framer:  &testWarningFramer{},
+					numRows: 1,
+					pos:     1,
+					next:    newNextIter(nextQry, 1),
+				}
+			}
+			if call == 2 {
+				return &Iter{framer: &testWarningFramer{}, numRows: 1}
+			}
+			t.Fatalf("unexpected executeQuery call %d", call)
+			return nil
+		},
+	}
+
+	iter := baseQry.Iter()
+	if !iter.fetchNextPage() {
+		t.Fatal("automatic next-page fetch failed")
+	}
+	defer iter.Close()
+
+	if len(observations) != 2 || observations[0].Attempt != 0 || observations[1].Attempt != 1 {
+		t.Fatalf("page observations = %+v, want attempts [0 1]", observations)
+	}
+	assertAttemptMetrics(t, observations[1].AttemptMetrics, []AttemptMetric{
+		{Attempt: 0, Host: host, Latency: 1},
+		{Attempt: 1, Host: host, Latency: 2},
+	})
+	if attempts, latency := firstPageMetrics.totalsSnapshot(); attempts != 2 || latency != 3 {
+		t.Fatalf("automatic-page totals = (%d,%d), want (2,3)", attempts, latency)
+	}
+	if refs := firstPageMetrics.refs.Load(); refs != 1 {
+		t.Fatalf("automatic-page references after consume = %d, want root owner only", refs)
+	}
+}
+
 func TestQueryIterManualPagingDefersHiddenEmptyPageWarnings(t *testing.T) {
 	t.Parallel()
 
@@ -1366,11 +3616,20 @@ func TestQueryIterManualPagingDefersHiddenEmptyPageWarnings(t *testing.T) {
 	baseQry := newWarningTestQuery()
 	baseQry.refCount = 1
 	baseQry.PageState([]byte("initial"))
+	host := &HostInfo{hostId: UUID{7}}
+	var observations []ObservedQueryWithAttemptMetrics
+	baseQry.observer = unitQueryObserverWithAttemptMetricsFunc(func(
+		_ context.Context, query ObservedQueryWithAttemptMetrics,
+	) {
+		observations = append(observations, query)
+	})
 
 	call := 0
 	baseQry.conn = &pagingTestConn{
 		executeQueryFunc: func(_ context.Context, qry *Query) *Iter {
 			call++
+			start := time.Unix(0, int64(call)*100)
+			qry.attempt("ks", start.Add(time.Duration(call)*time.Nanosecond), start, &Iter{}, host)
 			switch call {
 			case 1:
 				if !slices.Equal(qry.pageState, []byte("initial")) {
@@ -1403,6 +3662,13 @@ func TestQueryIterManualPagingDefersHiddenEmptyPageWarnings(t *testing.T) {
 	if call != 2 {
 		t.Fatalf("executeQuery call count = %d, want 2", call)
 	}
+	if len(observations) != 2 || observations[0].Attempt != 0 || observations[1].Attempt != 1 {
+		t.Fatalf("page observations = %+v, want attempts [0 1]", observations)
+	}
+	assertAttemptMetrics(t, observations[1].AttemptMetrics, []AttemptMetric{
+		{Attempt: 0, Host: host, Latency: 1},
+		{Attempt: 1, Host: host, Latency: 2},
+	})
 	if handler.calls != 0 {
 		t.Fatalf("handler call count before Close = %d, want 0", handler.calls)
 	}

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -1102,15 +1102,15 @@ func TestQueryMetricsLatencyMakesProgressWithConcurrentAttempts(t *testing.T) {
 	qm := newQueryMetrics()
 	host := &HostInfo{hostId: UUID{1}}
 	stop := make(chan struct{})
-	var writers sync.WaitGroup
+	var goroutines sync.WaitGroup
 	t.Cleanup(func() {
 		close(stop)
-		writers.Wait()
+		goroutines.Wait()
 	})
 	for i := 0; i < min(4, runtime.GOMAXPROCS(0)); i++ {
-		writers.Add(1)
+		goroutines.Add(1)
 		go func() {
-			defer writers.Done()
+			defer goroutines.Done()
 			for {
 				select {
 				case <-stop:
@@ -1123,7 +1123,9 @@ func TestQueryMetricsLatencyMakesProgressWithConcurrentAttempts(t *testing.T) {
 	}
 
 	readsDone := make(chan error, 1)
+	goroutines.Add(1)
 	go func() {
+		defer goroutines.Done()
 		for i := 0; i < 1000; i++ {
 			attempts, latency := qm.totalsSnapshot()
 			if attempts < 0 || latency < 0 || latency != attempts {


### PR DESCRIPTION
Refs #862.

## Summary

This PR implements the replacement attempt-oriented observer metrics API together with cumulative execution history.

- Adds `AttemptMetric` and immutable `AttemptMetrics` snapshots with hidden storage, aggregate accessors, and ordered iteration.
- Adds source-compatible `QueryObserverWithAttemptMetrics` / `BatchObserverWithAttemptMetrics` extension interfaces and payloads without changing the layout of `ObservedQuery` or `ObservedBatch`.
- Reports all completed attempts in one logical execution across hosts, retries, speculative branches, and automatic result pages.
- Iterates attempts in launch order. A snapshot can temporarily contain gaps when speculative attempts complete out of order.
- Keeps automatic pages in the same metrics history while giving each page an independent retry budget; speculative branches share that page’s completed-attempt count.
- Propagates retry-policy consistency changes from the winning execution and avoids allocating retry state or writing unchanged consistency on successful executions.
- Adds execution ownership and reference tracking so query reuse, pooling, `WithContext`, raw value copies, paging, warning handling, and late speculative attempts cannot reset or update another execution’s metrics.
- Uses coherent packed atomic totals on the common path, with an exact full-width fallback when packed limits are exceeded.

## Compatibility and allocation notes

Existing `QueryObserver` and `BatchObserver` implementations remain source-compatible and continue receiving the legacy payload. Observers implementing the corresponding extension interface receive the new payload instead.

Deprecated `ObservedQuery.Metrics` and `ObservedBatch.Metrics` remain immutable cumulative snapshots for the current host through the observed attempt, including explicit `AddAttempts` and `AddLatency` updates. Those explicit adjustments are not included in `AttemptMetrics`.

Per-host buckets are recorded only for observed attempts and explicit `AddAttempts` / `AddLatency` calls. Unobserved driver attempts still update execution-wide attempts and latency, but do not populate internal per-host storage.

The no-observer recording path remains allocation-free. Observed callbacks still allocate one immutable deprecated host snapshot; eliminating that allocation requires a separate compatibility design for the pointer-backed deprecated field.

`AttemptMetrics` deliberately preserves the complete logical-execution history required by #862. For an extended query observer, automatic result pages share that history and it is not capped, so retained storage grows with the number of completed attempts in a long paged execution. Manual paging starts a separate logical execution for each `Iter` call. Legacy observers and queries without an extended observer do not build this history.

## Validation

- `make check`
- `go vet -tags=unit ./...`
- `go test -tags=unit -race -count=1 ./...`
- `go test -tags=unit -run '^$' -bench '^(BenchmarkQueryResetWithStraggler|BenchmarkAttemptMetricsPersistentHistory)$' -benchmem -benchtime=10000x -count=1 .`