### PR TITLE
fix: scanner Scan panics with tuple columns due to wrong index

### DIFF
--- a/session.go
+++ b/session.go
@@ -2210,9 +2210,9 @@ func (is *iterScanner) Scan(dest ...any) error {
 	// slices of dest
 	i := 0
 	var err error
-	for _, col := range iter.meta.columns {
+	for j, col := range iter.meta.columns {
 		var n int
-		n, err = scanColumn(is.cols[i], col, dest[i:])
+		n, err = scanColumn(is.cols[j], col, dest[i:])
 		if err != nil {
 			break
 		}

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -29,6 +29,7 @@ package gocql
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"reflect"
 	"slices"
@@ -1725,4 +1726,54 @@ func TestTableMetadataValidation(t *testing.T) {
 			t.Fatalf("TableMetadata: expected ErrNoTable, got %v", err)
 		}
 	})
+}
+
+func TestScannerScanTupleColumnUsesRawColumnIndex(t *testing.T) {
+	t.Parallel()
+
+	tupleInfo := TupleTypeInfo{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeTuple},
+		Elems: []TypeInfo{
+			NativeType{proto: protoVersion4, typ: TypeVarchar},
+			NativeType{proto: protoVersion4, typ: TypeVarchar},
+		},
+	}
+
+	encodeTuple := func(values ...string) []byte {
+		var out []byte
+		for _, v := range values {
+			data := []byte(v)
+			var lenBuf [4]byte
+			binary.BigEndian.PutUint32(lenBuf[:], uint32(len(data)))
+			out = append(out, lenBuf[:]...)
+			out = append(out, data...)
+		}
+		return out
+	}
+
+	iter := &Iter{
+		framer:  &testWarningFramer{},
+		numRows: 1,
+		meta: resultMetadata{
+			columns: []ColumnInfo{
+				{Name: "pair", TypeInfo: tupleInfo},
+				{Name: "tail", TypeInfo: NativeType{proto: protoVersion4, typ: TypeVarchar}},
+			},
+			actualColCount: 3,
+		},
+	}
+
+	scanner := iter.Scanner().(*iterScanner)
+	// Simulate that Next() already populated the raw column buffers.
+	scanner.valid = true
+	scanner.cols[0] = encodeTuple("left", "right")
+	scanner.cols[1] = []byte("tail")
+
+	var left, right, tail string
+	if err := scanner.Scan(&left, &right, &tail); err != nil {
+		t.Fatalf("Scan() returned unexpected error: %v", err)
+	}
+	if left != "left" || right != "right" || tail != "tail" {
+		t.Fatalf("scanned values = (%q, %q, %q), want (%q, %q, %q)", left, right, tail, "left", "right", "tail")
+	}
 }


### PR DESCRIPTION
## Summary
- Fix index-out-of-range panic in `iterScanner.Scan()` when scanning rows containing tuple columns
- `is.cols[]` was indexed by the expanded destination offset (`i`) instead of the raw column index (`j`), causing a panic when tuples expand into multiple destination slots
- Added unit test `TestScannerScanTupleColumnUsesRawColumnIndex` that reproduces the panic

## Details
When a row has columns `[tuple(2 elems), varchar]`:
- `is.cols` has length 2 (raw column count)
- After scanning the tuple, `i` becomes 2 (expanded to 2 dest slots)
- `is.cols[i]` → `is.cols[2]` → **panic: index out of range**

The fix uses the loop variable `j` (raw column index) to index `is.cols`.