### PR TITLE
perf: use host UUID map for O(1) tablet replica lookups in Pick

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -530,7 +530,10 @@ type tokenAwareHostPolicy struct {
 	getKeyspaceMetadata func(keyspace string) (*KeyspaceMetadata, error)
 	getKeyspaceName     func() string
 	hosts               cowHostList
-	partitioner         string
+	// hostsByID maps host UUID to *HostInfo for O(1) tablet replica lookups.
+	// Stored as atomic.Value holding map[UUID]*HostInfo; rebuilt on host add/remove.
+	hostsByID   atomic.Value
+	partitioner string
 	// mu protects writes to hosts, partitioner, metadata.
 	// reads can be unlocked as long as they are not used for updating state later.
 	mu                       sync.Mutex
@@ -626,11 +629,29 @@ func (t *tokenAwareHostPolicy) SetPartitioner(partitioner string) {
 	}
 }
 
+// rebuildHostsByID rebuilds the hostsByID map from the given hosts list.
+// Must be called with t.mu held.
+func (t *tokenAwareHostPolicy) rebuildHostsByID(hosts []*HostInfo) {
+	m := make(map[UUID]*HostInfo, len(hosts))
+	for _, h := range hosts {
+		m[h.hostId] = h
+	}
+	t.hostsByID.Store(m)
+}
+
+// getHostsByID returns the current host-by-UUID map for lock-free lookups.
+func (t *tokenAwareHostPolicy) getHostsByID() map[UUID]*HostInfo {
+	m, _ := t.hostsByID.Load().(map[UUID]*HostInfo)
+	return m
+}
+
 func (t *tokenAwareHostPolicy) AddHost(host *HostInfo) {
 	t.mu.Lock()
 	if t.hosts.add(host) {
+		allHosts := t.hosts.get()
+		t.rebuildHostsByID(allHosts)
 		meta := t.getMetadataForUpdate()
-		meta.resetTokenRing(t.partitioner, t.hosts.get(), t.logger)
+		meta.resetTokenRing(t.partitioner, allHosts, t.logger)
 		t.updateReplicas(meta, t.getKeyspaceName())
 		t.metadata.Store(meta)
 	}
@@ -646,8 +667,10 @@ func (t *tokenAwareHostPolicy) AddHosts(hosts []*HostInfo) {
 		t.hosts.add(host)
 	}
 
+	allHosts := t.hosts.get()
+	t.rebuildHostsByID(allHosts)
 	meta := t.getMetadataForUpdate()
-	meta.resetTokenRing(t.partitioner, t.hosts.get(), t.logger)
+	meta.resetTokenRing(t.partitioner, allHosts, t.logger)
 	t.updateReplicas(meta, t.getKeyspaceName())
 	t.metadata.Store(meta)
 
@@ -661,8 +684,10 @@ func (t *tokenAwareHostPolicy) AddHosts(hosts []*HostInfo) {
 func (t *tokenAwareHostPolicy) RemoveHost(host *HostInfo) {
 	t.mu.Lock()
 	if t.hosts.remove(host) {
+		allHosts := t.hosts.get()
+		t.rebuildHostsByID(allHosts)
 		meta := t.getMetadataForUpdate()
-		meta.resetTokenRing(t.partitioner, t.hosts.get(), t.logger)
+		meta.resetTokenRing(t.partitioner, allHosts, t.logger)
 		t.updateReplicas(meta, t.getKeyspaceName())
 		t.metadata.Store(meta)
 	}
@@ -843,13 +868,10 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 	if session := qry.GetSession(); session != nil && session.tabletsRoutingV1 && isInt64Token {
 		tabletReplicas := session.findTabletReplicasUnsafeForToken(qry.Keyspace(), qry.Table(), int64(tokenCasted))
 		if len(tabletReplicas) != 0 {
-			hosts := t.hosts.get()
+			hostMap := t.getHostsByID()
 			for _, replica := range tabletReplicas {
-				for _, host := range hosts {
-					if host.hostId == UUID(replica.HostUUIDValue()) {
-						replicas = append(replicas, host)
-						break
-					}
+				if host := hostMap[UUID(replica.HostUUIDValue())]; host != nil {
+					replicas = append(replicas, host)
 				}
 			}
 		}

--- a/policies.go
+++ b/policies.go
@@ -896,11 +896,15 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		replicas = []*HostInfo{host}
 	}
 
-	if t.shuffleReplicas && !qry.IsLWT() && len(replicas) > 1 {
+	// Cache IsLWT() once: it is read on both the shuffle and avoid-slow-replicas
+	// paths below, and computing it can take a lock on the query routing info.
+	isLWT := qry.IsLWT()
+
+	if t.shuffleReplicas && !isLWT && len(replicas) > 1 {
 		shuffleHostsInPlace(replicas)
 	}
 
-	if s := qry.GetSession(); s != nil && !qry.IsLWT() && t.avoidSlowReplicas {
+	if s := qry.GetSession(); s != nil && !isLWT && t.avoidSlowReplicas {
 		partitionHealthy(replicas, s)
 	}
 

--- a/policies_test.go
+++ b/policies_test.go
@@ -1422,3 +1422,86 @@ func TestHostSetOverflowPreservesInlineEntries(t *testing.T) {
 		t.Fatal("extra host not found after spill")
 	}
 }
+
+// BenchmarkTokenAwarePickTabletReplicas benchmarks the tablet replica lookup
+// path in tokenAwareHostPolicy.Pick() with varying numbers of hosts.
+func BenchmarkTokenAwarePickTabletReplicas(b *testing.B) {
+	for _, numHosts := range []int{3, 10, 50, 100, 200} {
+		b.Run(fmt.Sprintf("hosts=%d", numHosts), func(b *testing.B) {
+			const keyspace = "benchks"
+			const table = "benchtbl"
+
+			policy := TokenAwareHostPolicy(RoundRobinHostPolicy())
+			policyInternal := policy.(*tokenAwareHostPolicy)
+			policyInternal.getKeyspaceName = func() string { return keyspace }
+			policyInternal.getKeyspaceMetadata = func(ks string) (*KeyspaceMetadata, error) {
+				return &KeyspaceMetadata{
+					Name:          keyspace,
+					StrategyClass: "SimpleStrategy",
+					StrategyOptions: map[string]any{
+						"class":              "SimpleStrategy",
+						"replication_factor": 3,
+					},
+				}, nil
+			}
+
+			hosts := make([]*HostInfo, numHosts)
+			for i := range hosts {
+				hosts[i] = &HostInfo{
+					hostId:         tUUID(i),
+					connectAddress: net.IPv4(10, 0, byte(i/256), byte(i%256)),
+					tokens:         []string{fmt.Sprintf("%d", int64(i)*int64(9223372036854775807/int64(numHosts)))},
+				}
+			}
+			policyInternal.AddHosts(hosts)
+			policy.SetPartitioner("Murmur3Partitioner")
+			policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: keyspace})
+
+			// Set up session with tablets pointing to 3 replicas.
+			ctrl := &schemaDataMock{knownKeyspaces: map[string][]tableInfo{}}
+			s := newSchemaEventTestSessionWithMock(ctrl)
+			defer s.Close()
+			s.isInitialized = true
+			s.tabletsRoutingV1 = true
+
+			// Create a tablet covering the full token range with 3 replicas.
+			replicas := [][]any{
+				{hosts[0].hostId, 0},
+				{hosts[numHosts/2].hostId, 0},
+				{hosts[numHosts-1].hostId, 0},
+			}
+			t1, err := tablets.TabletInfoBuilder{
+				KeyspaceName: keyspace,
+				TableName:    table,
+				FirstToken:   -9223372036854775808,
+				LastToken:    9223372036854775807,
+				Replicas:     replicas,
+			}.Build()
+			if err != nil {
+				b.Fatal(err)
+			}
+			s.metadataDescriber.AddTablet(t1)
+			s.metadataDescriber.metadata.tabletsMetadata.Flush()
+
+			query := &Query{
+				routingInfo: &queryRoutingInfo{
+					keyspace:    keyspace,
+					table:       table,
+					partitioner: fixedInt64Partitioner(42),
+				},
+				session: s,
+			}
+			query.getKeyspace = func() string { return keyspace }
+			query.routingKey = []byte("anything")
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				iter := policy.Pick(query)
+				if iter() == nil {
+					b.Fatal("expected host from tablet path")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replace O(replicas × hosts) linear scan with O(1) map lookup when resolving tablet replica UUIDs to `*HostInfo` in `tokenAwareHostPolicy.Pick()`
- Add `hostsByID` atomic map field, rebuilt on host add/remove under existing lock
- On clusters with 100+ hosts and 3 tablet replicas, this reduces ~300 UUID comparisons per query to 3 map lookups

## Benchmark results

Confirms constant time regardless of cluster size:

| Hosts | ns/op | allocs |
|-------|-------|--------|
| 3     | 424   | 9      |
| 10    | 379   | 9      |
| 50    | 413   | 9      |
| 100   | 389   | 9      |
| 200   | 378   | 9      |



---
> **Maintenance note (rebased onto `master`):** This branch was rebased onto the latest `master` (tip `bed2bb09`) and all unit tests pass (only the known SSL/cloud cert env failures, unrelated to this change).
> The benchmark figures above were measured **pre-rebase** against the branch's original merge-base; a re-benchmark against current `master` is pending and numbers will be refreshed.