### PR TITLE
perf: skip reflect.ValueOf in Marshal() for common types

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -173,18 +173,31 @@ func Marshal(info TypeInfo, value any) ([]byte, error) {
 		panic("protocol version not set")
 	}
 
-	if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
-		if valueRef.IsNil() {
-			return nil, nil
-		} else if v, ok := value.(Marshaler); ok {
+	// Fast path: skip reflect.ValueOf for common non-pointer types.
+	// The sub-marshalers (e.g., bigint.Marshal) handle both pointer and
+	// non-pointer variants via their own type-switch, including nil pointers.
+	// We only need the reflect path for custom types (Marshaler on pointer
+	// receiver, or unnamed pointer types not in any sub-marshaler's switch).
+	switch value.(type) {
+	case nil:
+		return nil, nil
+	case string, int64, int, int32, int16, int8, float64, float32, bool,
+		uint64, uint32, uint16, uint8, uint,
+		[]byte, time.Time, time.Duration,
+		*string, *int64, *int, *int32, *int16, *int8, *float64, *float32, *bool,
+		*uint64, *uint32, *uint16, *uint8, *uint,
+		*[]byte, *time.Time, *time.Duration:
+		// Known non-Marshaler types — skip reflect and Marshaler check.
+	default:
+		if v, ok := value.(Marshaler); ok {
 			return v.MarshalCQL(info)
-		} else {
+		}
+		if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
+			if valueRef.IsNil() {
+				return nil, nil
+			}
 			return Marshal(info, valueRef.Elem().Interface())
 		}
-	}
-
-	if v, ok := value.(Marshaler); ok {
-		return v.MarshalCQL(info)
 	}
 
 	switch info.Type() {

--- a/marshal.go
+++ b/marshal.go
@@ -174,18 +174,36 @@ func Marshal(info TypeInfo, value any) ([]byte, error) {
 		panic("protocol version not set")
 	}
 
-	if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
-		if valueRef.IsNil() {
-			return nil, nil
-		} else if v, ok := value.(Marshaler); ok {
-			return v.MarshalCQL(info)
-		} else {
+	// Fast path: skip reflect.ValueOf for common non-pointer types.
+	// The sub-marshalers (e.g., bigint.Marshal) handle both pointer and
+	// non-pointer variants via their own type-switch, including nil pointers.
+	// We only need the reflect path for custom types (Marshaler on pointer
+	// receiver, or unnamed pointer types not in any sub-marshaler's switch).
+	switch value.(type) {
+	case nil:
+		return nil, nil
+	case string, int64, int, int32, int16, int8, float64, float32, bool,
+		uint64, uint32, uint16, uint8, uint,
+		[]byte, time.Time, time.Duration,
+		*string, *int64, *int, *int32, *int16, *int8, *float64, *float32, *bool,
+		*uint64, *uint32, *uint16, *uint8, *uint,
+		*[]byte, *time.Time, *time.Duration:
+		// Known non-Marshaler types — skip reflect and Marshaler check.
+	default:
+		// Mirror the original precedence: for pointers, nil must be checked
+		// before the Marshaler assertion, since a nil pointer can still
+		// satisfy Marshaler via a value-receiver method and would panic.
+		if valueRef := reflect.ValueOf(value); valueRef.Kind() == reflect.Ptr {
+			if valueRef.IsNil() {
+				return nil, nil
+			} else if v, ok := value.(Marshaler); ok {
+				return v.MarshalCQL(info)
+			}
 			return Marshal(info, valueRef.Elem().Interface())
 		}
-	}
-
-	if v, ok := value.(Marshaler); ok {
-		return v.MarshalCQL(info)
+		if v, ok := value.(Marshaler); ok {
+			return v.MarshalCQL(info)
+		}
 	}
 
 	switch info.Type() {

--- a/marshal_reflect_bench_test.go
+++ b/marshal_reflect_bench_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package gocql
+
+import (
+	"testing"
+	"time"
+)
+
+// BenchmarkMarshalReflectFastPath benchmarks Marshal with common types
+// to measure the benefit of skipping reflect.ValueOf for known non-pointer types.
+func BenchmarkMarshalReflectFastPath(b *testing.B) {
+	info := NativeType{proto: 4, typ: TypeBigInt}
+
+	benchmarks := []struct {
+		name  string
+		info  TypeInfo
+		value any
+	}{
+		{"int64", NativeType{proto: 4, typ: TypeBigInt}, int64(42)},
+		{"*int64", NativeType{proto: 4, typ: TypeBigInt}, ptrInt64(42)},
+		{"string", NativeType{proto: 4, typ: TypeVarchar}, "hello world"},
+		{"*string", NativeType{proto: 4, typ: TypeVarchar}, ptrString("hello world")},
+		{"[]byte", NativeType{proto: 4, typ: TypeBlob}, []byte("binary data")},
+		{"bool", NativeType{proto: 4, typ: TypeBoolean}, true},
+		{"float64", NativeType{proto: 4, typ: TypeDouble}, 3.14},
+		{"time.Time", NativeType{proto: 4, typ: TypeTimestamp}, time.Now()},
+	}
+
+	_ = info
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := Marshal(bm.info, bm.value)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func ptrInt64(v int64) *int64    { return &v }
+func ptrString(v string) *string { return &v }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -701,6 +701,18 @@ func TestMarshalNil(t *testing.T) {
 	}
 }
 
+func TestMarshalNilPointerToValueReceiverMarshaler(t *testing.T) {
+	t.Parallel()
+
+	var p *CustomString
+	data, err := Marshal(NativeType{proto: protoVersion3, typ: TypeVarchar}, p)
+	if err != nil {
+		t.Fatalf("unable to marshal nil *CustomString: %v", err)
+	} else if data != nil {
+		t.Errorf("expected nil byte for nil *CustomString, got % X", data)
+	}
+}
+
 func TestUnmarshalInetCopyBytes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Adds a type-switch fast path at the top of `Marshal()` that skips `reflect.ValueOf` for common primitive types and their pointer variants
- The sub-marshalers already handle both pointer and non-pointer types natively (including nil pointer checks), making the reflect-based dereference+recurse path unnecessary for these types
- For pointer types this removes an extra interface box that the old path allocated via `Elem().Interface()`, accounting for most of the measured gain

## Benchmarks

| Type | Old (ns/op) | New (ns/op) | Change | Old allocs | New allocs |
|------|-------------|-------------|--------|------------|------------|
| `*int64` | 36.95 | 15.65 | **-57.65%** (p=0.008) | 2 / 16B | 1 / 8B |
| `*string` | 51.78 | 21.03 | **-59.39%** (p=0.008) | 2 / 32B | 1 / 16B |
| `bool` | 13.77 | 12.96 | -5.88% (p=0.008) | 1 / 1B | 1 / 1B |
| `time.Time` | 22.22 | 20.76 | -6.57% (p=0.008) | 1 / 8B | 1 / 8B |
| **geomean** | 19.95 | 15.45 | **-22.55%** | | |

For a query with 10 pointer parameters, this saves ~300ns and 10 allocations per execution.

## Risk
Low — falls through to existing reflect path for any type not in the fast-path list. All unit tests pass with `-race`.

---
> **Maintenance note (rebased onto `master`):** This branch was rebased onto the latest `master` (tip `bed2bb09`) and all unit tests pass (only the known SSL/cloud cert env failures, unrelated to this change).
> The benchmark figures above were measured **pre-rebase** against the branch's original merge-base; a re-benchmark against current `master` is pending and numbers will be refreshed.
