### PR TITLE
scylla: fix data race in scyllaConnPicker

### DIFF
--- a/scylla.go
+++ b/scylla.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -383,6 +384,7 @@ type scyllaConnPicker struct {
 	address                    string
 	excessConns                []*Conn
 	conns                      []*Conn
+	mu                         sync.RWMutex
 	nrShards                   int
 	pos                        uint64
 	lastAttemptedShard         int
@@ -419,6 +421,9 @@ func newScyllaConnPicker(conn *Conn, logger StdLogger) *scyllaConnPicker {
 }
 
 func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
 	if len(p.conns) == 0 {
 		return nil
 	}
@@ -524,6 +529,9 @@ func (p *scyllaConnPicker) Put(conn *Conn) error {
 		return errors.New("server reported that it has no shards")
 	}
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if nrShards != p.nrShards {
 		if debug.Enabled {
 			p.logger.Printf("scylla: %s shard count changed from %d to %d, rebuilding connection pool",
@@ -568,7 +576,7 @@ func (p *scyllaConnPicker) Put(conn *Conn) error {
 	}
 
 	if p.shouldCloseExcessConns() {
-		p.closeExcessConns()
+		p.closeExcessConnsLocked()
 	}
 
 	return nil
@@ -622,14 +630,20 @@ func (p *scyllaConnPicker) shouldCloseExcessConns() bool {
 }
 
 func (p *scyllaConnPicker) GetConnectionCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.nrConns
 }
 
 func (p *scyllaConnPicker) GetExcessConnectionCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return len(p.excessConns)
 }
 
 func (p *scyllaConnPicker) GetShardCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.nrShards
 }
 
@@ -648,6 +662,9 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
 		p.logger.Printf("scylla: %s remove shard %d connection", p.address, shard)
 	}
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if p.conns[shard] != nil {
 		p.conns[shard] = nil
 		p.nrConns--
@@ -655,6 +672,8 @@ func (p *scyllaConnPicker) Remove(conn *Conn) {
 }
 
 func (p *scyllaConnPicker) InFlight() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	result := 0
 	for _, conn := range p.conns {
 		if conn != nil {
@@ -665,33 +684,44 @@ func (p *scyllaConnPicker) InFlight() int {
 }
 
 func (p *scyllaConnPicker) Size() (int, int) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.nrConns, p.nrShards - p.nrConns
 }
 
 func (p *scyllaConnPicker) Close() {
-	p.closeConns()
-	p.closeExcessConns()
-}
-
-func (p *scyllaConnPicker) closeConns() {
-	if len(p.conns) == 0 {
-		if debug.Enabled {
-			p.logger.Printf("scylla: %s no connections to close", p.address)
-		}
-		return
-	}
-
+	p.mu.Lock()
 	conns := p.conns
 	p.conns = nil
 	p.nrConns = 0
+	excessConns := p.excessConns
+	p.excessConns = nil
+	p.mu.Unlock()
 
-	if debug.Enabled {
-		p.logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
+	// Close connections outside of the lock to avoid deadlocks when a
+	// connection close triggers HandleError. See scylladb/gocql#53.
+	if len(conns) > 0 {
+		if debug.Enabled {
+			p.logger.Printf("scylla: %s closing %d connections", p.address, len(conns))
+		}
+		go closeConns(conns...)
+	} else if debug.Enabled {
+		p.logger.Printf("scylla: %s no connections to close", p.address)
 	}
-	go closeConns(conns...)
+
+	if len(excessConns) > 0 {
+		if debug.Enabled {
+			p.logger.Printf("scylla: %s closing %d excess connections", p.address, len(excessConns))
+		}
+		go closeConns(excessConns...)
+	} else if debug.Enabled {
+		p.logger.Printf("scylla: %s no excess connections to close", p.address)
+	}
 }
 
-func (p *scyllaConnPicker) closeExcessConns() {
+// closeExcessConnsLocked closes excess connections. Must be called with p.mu held.
+// The actual connection closing happens asynchronously outside the lock.
+func (p *scyllaConnPicker) closeExcessConnsLocked() {
 	if len(p.excessConns) == 0 {
 		if debug.Enabled {
 			p.logger.Printf("scylla: %s no excess connections to close", p.address)
@@ -708,8 +738,8 @@ func (p *scyllaConnPicker) closeExcessConns() {
 	go closeConns(conns...)
 }
 
-// Closing must be done outside of hostConnPool lock. If holding a lock
-// a deadlock can occur when closing one of the connections returns error on close.
+// closeConns closes a list of connections. Must be called outside of any lock
+// to avoid deadlocks when a connection close triggers HandleError.
 // See scylladb/gocql#53.
 func closeConns(conns ...*Conn) {
 	for _, conn := range conns {
@@ -733,6 +763,9 @@ func (p *scyllaConnPicker) NextShard() (shardID, nrShards int) {
 		// or misconfigured, fall back to the non-shard-aware port
 		return 0, 0
 	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	// Find the shard without a connection
 	// It's important to start counting from 1 here because we want


### PR DESCRIPTION
## 🐛 Problem

`scyllaConnPicker` has no internal synchronization, causing a data race between `Close()` and concurrent `fill()` goroutines during session shutdown.

### 🏁 The race window

`hostConnPool.Close()` (`connectionpool.go:342`) releases `pool.mu` **before** calling `connPicker.Close()`:

```go
pool.mu.Lock()
pool.closed = true
pool.mu.Unlock()          // ← pool.mu released

pool.connPicker.Close()   // ← writes p.conns, p.nrConns with NO lock
```

Between these two lines, other goroutines can still acquire `pool.mu` and call into the unprotected picker:

| Goroutine | Acquires `pool.mu` | Calls | Accesses |
|---|---|---|---|
| `fillingStopped()` | ✅ `Lock()` | `connPicker.Size()` | **reads** `p.nrConns` |
| `connect()` | ✅ `Lock()` | `connPicker.NextShard()` | **reads** `p.conns`, `p.nrShards`; **writes** `p.lastAttemptedShard` |
| `Pick()` | ✅ `RLock()` | `connPicker.Pick()` | **reads** `p.conns` |

Meanwhile `Close()` → `closeConns()` **writes** `p.conns = nil`, `p.nrConns = 0` — with no lock at all.

`pool.mu` does not help here because `Close()` already released it. The picker itself has no internal synchronization.

> 📝 **Note:** `defaultConnPicker` already has an internal `sync.RWMutex` protecting every method. `scyllaConnPicker` was simply missing the equivalent — this is a gap, not a design choice.

### 💥 Impact

**With `-race` (CI):** Fatal — the race detector aborts the process on any unsynchronized concurrent access. This was exposed by v1.18.0 adding `t.Parallel()` to integration tests, causing **79 test failures** (21 on proto v3, 58 on proto v4) in the driver matrix — all reported as `DATA RACE`.

**Without `-race` (production):** `p.conns` is a slice header (3 words: ptr, len, cap). A torn read during `Close()` can produce an inconsistent state — e.g., `ptr=nil` with `len > 0` — leading to a **nil-pointer dereference and panic** in `Pick()` or `NextShard()`. This can occur whenever `Session.Close()` runs while queries are still in-flight or pool filling is active. It's a shutdown-time crash, not a data corruption issue.

## ✅ Fix

Add `sync.RWMutex` to `scyllaConnPicker`, mirroring `defaultConnPicker`'s existing pattern:

- **`RLock`** for read-only methods: `Pick()`, `Size()`, `InFlight()`, `GetConnectionCount()`, `GetExcessConnectionCount()`, `GetShardCount()`
- **`Lock`** for mutating methods: `Put()`, `Remove()`, `NextShard()`, `Close()`

### 🔒 Deadlock safety

`Close()` is restructured to acquire `p.mu` once, extract both slices (`conns` + `excessConns`), nil them out, release the lock, then close connections asynchronously via `go closeConns(...)` — preserving the guarantee from #53 that `conn.Close()` is never called while holding a lock.

This matters because `conn.Close()` can trigger `HandleError()` → `pool.mu.Lock()`. If `p.mu` were held during `conn.Close()`, any concurrent `connect()` path acquiring `pool.mu` → `p.mu` would create a lock-ordering inversion (deadlock).

The lock order is strictly **`pool.mu` → `p.mu`** at every call site, with no inversion paths.

### 📊 Changes

- **+51 / -18** lines in `scylla.go` (single file)
- `closeExcessConns()` renamed to `closeExcessConnsLocked()` for internal calls under lock
- No API or behavior changes

## 🧪 Testing

- ✅ All unit tests pass with `-race`: `go test -race -count=1 -tags unit ./...`
- ✅ Driver matrix [staging build #3](https://jenkins.scylladb.com/job/scylla-staging/job/mhradovich/job/gocql-driver-matrix-master/3/) — **all 6 runs pass, 0 failures** against Scylla 2026.3.0~dev:

| Driver | Protocol | Tests | Passed | Failed | Skipped |
|---|---|---|---|---|---|
| 🦎 scylla v1.18.0 | v3 | 458 | 442 | 0 | 16 |
| 🦎 scylla v1.18.0 | v4 | 454 | 441 | 0 | 13 |
| 🐿️ upstream v2.1.1 | v3 | 211 | 208 | 0 | 3 |
| 🐿️ upstream v2.1.1 | v4 | 210 | 208 | 0 | 2 |
| 🐿️ upstream v2.0.0 | v3 | 210 | 207 | 0 | 3 |
| 🐿️ upstream v2.0.0 | v4 | 209 | 207 | 0 | 2 |

> 📈 **Before this fix:** scylla v1.18.0 had **79 DATA RACE failures** (21 on proto v3, 58 on proto v4). After: **0**.