### PR TITLE
policies: treat SERIAL/LOCAL_SERIAL consistency as LWT for routing

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -119,6 +119,7 @@ type RetryableQuery interface {
 	Attempts() int
 	SetConsistency(c Consistency)
 	GetConsistency() Consistency
+	IsLWT() bool
 	Context() context.Context
 }
 
@@ -279,6 +280,11 @@ func (d *DowngradingConsistencyRetryPolicy) Attempt(q RetryableQuery) bool {
 	if currentAttempt > len(d.ConsistencyLevelsToTry) {
 		return false
 	} else if currentAttempt > 0 {
+		// Never downgrade LWT queries (including serial consistency reads),
+		// as that would break Paxos/serial read guarantees.
+		if q.IsLWT() {
+			return false
+		}
 		q.SetConsistency(d.ConsistencyLevelsToTry[currentAttempt-1])
 	}
 	return true

--- a/policies_test.go
+++ b/policies_test.go
@@ -277,6 +277,105 @@ func TestHostPolicy_TokenAware_LWT_DisablesHostShuffling(t *testing.T) {
 	}
 }
 
+func TestHostPolicy_TokenAware_SerialConsistency_DisablesHostShuffling(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cons    Consistency
+		shuffle bool
+	}{
+		"LOCAL_SERIAL with shuffling": {cons: LocalSerial, shuffle: true},
+		"SERIAL with shuffling":       {cons: Serial, shuffle: true},
+		"LOCAL_SERIAL no shuffling":   {cons: LocalSerial, shuffle: false},
+		"SERIAL no shuffling":         {cons: Serial, shuffle: false},
+	}
+
+	const keyspace = "myKeyspace"
+	hosts := []*HostInfo{
+		{hostId: tUUID(0), connectAddress: net.IPv4(10, 0, 0, 1), tokens: []string{"00", "10", "20"}},
+		{hostId: tUUID(1), connectAddress: net.IPv4(10, 0, 0, 3), tokens: []string{"25", "35", "45"}},
+		{hostId: tUUID(2), connectAddress: net.IPv4(10, 0, 0, 2), tokens: []string{"00", "10", "20"}},
+		{hostId: tUUID(3), connectAddress: net.IPv4(10, 0, 0, 4), tokens: []string{"25", "35", "45"}},
+		{hostId: tUUID(4), connectAddress: net.IPv4(10, 0, 0, 3), tokens: []string{"50", "60", "70"}},
+		{hostId: tUUID(5), connectAddress: net.IPv4(10, 0, 0, 4), tokens: []string{"50", "60", "70"}},
+	}
+
+	// Expected replica order for token "8" - same as the LWT test above.
+	// Replicas for token 08 are hosts 0 and 2 (they share tokens "00","10","20").
+	wantReplicas := []string{tID(0), tID(2)}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			policy := createPolicy(keyspace, tc.shuffle)
+			for _, host := range hosts {
+				policy.AddHost(host)
+			}
+			query := &Query{
+				cons:        tc.cons,
+				routingKey:  []byte("8"),
+				routingInfo: &queryRoutingInfo{lwt: false}, // NOT marked as LWT by server
+			}
+			query.getKeyspace = func() string { return keyspace }
+
+			// Verify the query is treated as LWT due to serial consistency
+			if !query.IsLWT() {
+				t.Fatalf("expected IsLWT()=true for consistency %v", tc.cons)
+			}
+
+			// Run Pick multiple times - the first two hosts (replicas) should
+			// always be deterministic (no shuffling applied).
+			for i := 0; i < 20; i++ {
+				got := pickHosts(policy, query)
+				if len(got) < 2 {
+					t.Fatalf("iteration %d: expected at least 2 hosts, got %d", i, len(got))
+				}
+				gotReplicas := got[:2]
+				if diff := cmp.Diff(gotReplicas, wantReplicas); diff != "" {
+					t.Errorf("iteration %d: replica order not deterministic for serial consistency query, diff: %s", i, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestQuery_IsLWT_SerialConsistency(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cons      Consistency
+		lwtFlag   bool
+		wantIsLWT bool
+	}{
+		"SERIAL consistency, no LWT flag":       {cons: Serial, lwtFlag: false, wantIsLWT: true},
+		"LOCAL_SERIAL consistency, no LWT flag": {cons: LocalSerial, lwtFlag: false, wantIsLWT: true},
+		"QUORUM consistency, no LWT flag":       {cons: Quorum, lwtFlag: false, wantIsLWT: false},
+		"ONE consistency, no LWT flag":          {cons: One, lwtFlag: false, wantIsLWT: false},
+		"QUORUM consistency, LWT flag set":      {cons: Quorum, lwtFlag: true, wantIsLWT: true},
+		"LOCAL_ONE consistency, no LWT flag":    {cons: LocalOne, lwtFlag: false, wantIsLWT: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			query := &Query{
+				cons:        tc.cons,
+				routingInfo: &queryRoutingInfo{lwt: tc.lwtFlag},
+			}
+			if got := query.IsLWT(); got != tc.wantIsLWT {
+				t.Errorf("IsLWT() = %v, want %v", got, tc.wantIsLWT)
+			}
+		})
+	}
+}
+
+func pickHosts(policy HostSelectionPolicy, query *Query) []string {
+	iter := policy.Pick(query)
+	var hostIds []string
+	for host := iter(); host != nil; host = iter() {
+		hostIds = append(hostIds, host.Info().HostID())
+	}
+	return hostIds
+}
+
 func createPolicy(keyspace string, shuffle bool) HostSelectionPolicy {
 	policy := TokenAwareHostPolicy(RoundRobinHostPolicy())
 	policyInternal := policy.(*tokenAwareHostPolicy)

--- a/policies_test.go
+++ b/policies_test.go
@@ -708,6 +708,26 @@ func TestDowngradingConsistencyRetryPolicy(t *testing.T) {
 	}
 }
 
+func TestDowngradingConsistencyRetryPolicy_NoDowngradeFromSerial(t *testing.T) {
+	t.Parallel()
+
+	consistencyLevels := []Consistency{Quorum, One}
+	rt := &DowngradingConsistencyRetryPolicy{ConsistencyLevelsToTry: consistencyLevels}
+
+	for _, serial := range []Consistency{Serial, LocalSerial} {
+		q := &Query{cons: serial, routingInfo: &queryRoutingInfo{}}
+		q.metrics = preFilledQueryMetrics(map[UUID]*hostMetrics{TimeUUID(): {Attempts: 1}})
+
+		if rt.Attempt(q) {
+			t.Fatalf("DowngradingConsistencyRetryPolicy should not allow downgrade from %v to non-serial", serial)
+		}
+		// Consistency must remain unchanged
+		if q.GetConsistency() != serial {
+			t.Fatalf("expected consistency to remain %v, got %v", serial, q.GetConsistency())
+		}
+	}
+}
+
 // expectHosts makes sure that the next len(hostIDs) returned from iter is a permutation of hostIDs.
 func expectHosts(t *testing.T, msg string, iter NextHost, hostIDs ...string) {
 	t.Helper()

--- a/session.go
+++ b/session.go
@@ -1634,7 +1634,7 @@ func (q *Query) IsIdempotent() bool {
 }
 
 func (q *Query) IsLWT() bool {
-	return q.routingInfo.isLWT()
+	return q.routingInfo.isLWT() || q.cons.IsSerial()
 }
 
 func (q *Query) GetCustomPartitioner() Partitioner {
@@ -2623,7 +2623,7 @@ func (b *Batch) IsIdempotent() bool {
 }
 
 func (b *Batch) IsLWT() bool {
-	return b.routingInfo.isLWT()
+	return b.routingInfo.isLWT() || b.Cons.IsSerial()
 }
 
 func (b *Batch) GetCustomPartitioner() Partitioner {


### PR DESCRIPTION
## Summary

- Queries with `SERIAL` or `LOCAL_SERIAL` as their primary consistency level now receive LWT routing treatment (no replica shuffling, no slow-replica avoidance, deterministic shard selection)
- Previously, only queries flagged as LWT by Scylla's prepare metadata got this treatment, but serial reads (e.g., `SELECT ... WHERE ...` with `LOCAL_SERIAL`) are not flagged by the server despite participating in Paxos

## Changes

- `Query.IsLWT()` and `Batch.IsLWT()` now also check if the primary consistency is serial
- Added `TestHostPolicy_TokenAware_SerialConsistency_DisablesHostShuffling` — verifies replica ordering is deterministic for serial consistency queries
- Added `TestQuery_IsLWT_SerialConsistency` — unit tests for the `IsLWT()` logic with various consistency/flag combinations

Fixes: https://github.com/scylladb/gocql/issues/874
Fixes: https://scylladb.atlassian.net/browse/DRIVER-614

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>