### PR TITLE
improvement: targeted schema invalidation for type/function/aggregate events

### DIFF
--- a/events.go
+++ b/events.go
@@ -152,11 +152,11 @@ func (s *Session) handleSchemaEvent(frames []frame) {
 			s.metadataDescriber.invalidateTableSchema(f.Keyspace, f.Object)
 			s.handleTableChange(f.Keyspace, f.Object, f.Change)
 		case *frm.SchemaChangeAggregate:
-			s.metadataDescriber.invalidateKeyspaceSchema(f.Keyspace)
+			s.metadataDescriber.invalidateAggregatesSchema(f.Keyspace)
 		case *frm.SchemaChangeFunction:
-			s.metadataDescriber.invalidateKeyspaceSchema(f.Keyspace)
+			s.metadataDescriber.invalidateFunctionsSchema(f.Keyspace)
 		case *frm.SchemaChangeType:
-			s.metadataDescriber.invalidateKeyspaceSchema(f.Keyspace)
+			s.metadataDescriber.invalidateTypesSchema(f.Keyspace)
 		}
 	}
 }

--- a/events_unit_test.go
+++ b/events_unit_test.go
@@ -540,25 +540,25 @@ func TestHandleSchemaEvent(t *testing.T) {
 				wantTablets: 2,
 			},
 			{
-				name:        "type/CREATED clears entire keyspace",
-				keyspaces:   map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
-				event:       &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
-				wantKsGone:  []string{"test_ks"},
-				wantTablets: -1,
+				name:          "type/CREATED marks types dirty but keeps keyspace",
+				keyspaces:     map[string][]string{"test_ks": {"tbl_a", "tbl_b"}},
+				event:         &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				wantKsPresent: []string{"test_ks"},
+				wantTablets:   -1,
 			},
 			{
-				name:        "function/CREATED clears entire keyspace",
-				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
-				event:       &frm.SchemaChangeFunction{Change: "CREATED", Keyspace: "test_ks", Name: "fn", Args: []string{"int"}},
-				wantKsGone:  []string{"test_ks"},
-				wantTablets: -1,
+				name:          "function/CREATED marks functions dirty but keeps keyspace",
+				keyspaces:     map[string][]string{"test_ks": {"tbl_a"}},
+				event:         &frm.SchemaChangeFunction{Change: "CREATED", Keyspace: "test_ks", Name: "fn", Args: []string{"int"}},
+				wantKsPresent: []string{"test_ks"},
+				wantTablets:   -1,
 			},
 			{
-				name:        "aggregate/CREATED clears entire keyspace",
-				keyspaces:   map[string][]string{"test_ks": {"tbl_a"}},
-				event:       &frm.SchemaChangeAggregate{Change: "CREATED", Keyspace: "test_ks", Name: "agg", Args: []string{"int"}},
-				wantKsGone:  []string{"test_ks"},
-				wantTablets: -1,
+				name:          "aggregate/CREATED marks aggregates dirty but keeps keyspace",
+				keyspaces:     map[string][]string{"test_ks": {"tbl_a"}},
+				event:         &frm.SchemaChangeAggregate{Change: "CREATED", Keyspace: "test_ks", Name: "agg", Args: []string{"int"}},
+				wantKsPresent: []string{"test_ks"},
+				wantTablets:   -1,
 			},
 			// Cross-isolation
 			{
@@ -771,6 +771,7 @@ func TestHandleSchemaEvent(t *testing.T) {
 			knownKeyspaces      map[string][]tableInfo
 			populateKs          map[string][]string
 			disableSystemSchema bool
+			enableFunctions     bool  // session.hasAggregatesAndFunctions
 			event               frame // nil = no event
 			getKeyspace         string
 			wantError           bool
@@ -796,15 +797,47 @@ func TestHandleSchemaEvent(t *testing.T) {
 				expectedQueries: noQueries,
 			},
 			{
-				name: "after type event: refreshes and caches",
+				name: "after type event: refreshes only types and caches",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs:  map[string][]string{"test_ks": {"tbl_a"}},
+				event:       &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				getKeyspace: "test_ks",
+				expectedQueries: map[string]int{
+					"SELECT * FROM system_schema.types WHERE keyspace_name = ?": 1,
+				},
+				wantNoRequery: true,
+			},
+			{
+				name: "after function event: refreshes functions and aggregates and caches",
 				knownKeyspaces: map[string][]tableInfo{
 					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
 				},
 				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
-				event:           &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				enableFunctions: true,
+				event:           &frm.SchemaChangeFunction{Change: "CREATED", Keyspace: "test_ks", Name: "fn", Args: []string{"int"}},
 				getKeyspace:     "test_ks",
-				expectedQueries: fullRefresh("test_ks"),
-				wantNoRequery:   true,
+				expectedQueries: map[string]int{
+					"SELECT * FROM system_schema.functions WHERE keyspace_name = ?":  1,
+					"SELECT * FROM system_schema.aggregates WHERE keyspace_name = ?": 1,
+				},
+				wantNoRequery: true,
+			},
+			{
+				name: "after aggregate event: refreshes functions and aggregates and caches",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
+				enableFunctions: true,
+				event:           &frm.SchemaChangeAggregate{Change: "CREATED", Keyspace: "test_ks", Name: "agg", Args: []string{"int"}},
+				getKeyspace:     "test_ks",
+				expectedQueries: map[string]int{
+					"SELECT * FROM system_schema.functions WHERE keyspace_name = ?":  1,
+					"SELECT * FROM system_schema.aggregates WHERE keyspace_name = ?": 1,
+				},
+				wantNoRequery: true,
 			},
 			{
 				name:            "uncached keyspace: refreshes and caches",
@@ -838,6 +871,9 @@ func TestHandleSchemaEvent(t *testing.T) {
 				defer s.Close()
 				if tt.disableSystemSchema {
 					s.useSystemSchema = false
+				}
+				if tt.enableFunctions {
+					s.hasAggregatesAndFunctions = true
 				}
 				for ks, tables := range tt.populateKs {
 					populateKeyspace(s, ks, tables...)
@@ -882,6 +918,7 @@ func TestHandleSchemaEvent(t *testing.T) {
 			name            string
 			knownKeyspaces  map[string][]tableInfo
 			populateKs      map[string][]string
+			enableFunctions bool // session.hasAggregatesAndFunctions
 			event           frame
 			getTable        [2]string // [ks, table]
 			wantError       bool
@@ -921,14 +958,47 @@ func TestHandleSchemaEvent(t *testing.T) {
 				expectNoRequery: true,
 			},
 			{
-				name: "after type event: refreshes full keyspace",
+				name: "after type event: refreshes only types",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs: map[string][]string{"test_ks": {"tbl_a"}},
+				event:      &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				getTable:   [2]string{"test_ks", "tbl_a"},
+				expectedQueries: map[string]int{
+					"SELECT * FROM system_schema.types WHERE keyspace_name = ?": 1,
+				},
+				expectNoRequery: true,
+			},
+			{
+				name: "after function event: refreshes functions and aggregates",
 				knownKeyspaces: map[string][]tableInfo{
 					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
 				},
 				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
-				event:           &frm.SchemaChangeType{Change: "CREATED", Keyspace: "test_ks", Object: "my_type"},
+				enableFunctions: true,
+				event:           &frm.SchemaChangeFunction{Change: "CREATED", Keyspace: "test_ks", Name: "fn", Args: []string{"int"}},
 				getTable:        [2]string{"test_ks", "tbl_a"},
-				expectedQueries: fullRefresh("test_ks"),
+				expectedQueries: map[string]int{
+					"SELECT * FROM system_schema.functions WHERE keyspace_name = ?":  1,
+					"SELECT * FROM system_schema.aggregates WHERE keyspace_name = ?": 1,
+				},
+				expectNoRequery: true,
+			},
+			{
+				name: "after aggregate event: refreshes functions and aggregates",
+				knownKeyspaces: map[string][]tableInfo{
+					"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+				},
+				populateKs:      map[string][]string{"test_ks": {"tbl_a"}},
+				enableFunctions: true,
+				event:           &frm.SchemaChangeAggregate{Change: "CREATED", Keyspace: "test_ks", Name: "agg", Args: []string{"int"}},
+				getTable:        [2]string{"test_ks", "tbl_a"},
+				expectedQueries: map[string]int{
+					"SELECT * FROM system_schema.functions WHERE keyspace_name = ?":  1,
+					"SELECT * FROM system_schema.aggregates WHERE keyspace_name = ?": 1,
+				},
+				expectNoRequery: true,
 			},
 			{
 				name: "unknown table: returns error",
@@ -956,6 +1026,9 @@ func TestHandleSchemaEvent(t *testing.T) {
 				ctrl := &schemaDataMock{knownKeyspaces: knownKs}
 				s := newSchemaEventTestSessionWithMock(ctrl)
 				defer s.Close()
+				if tt.enableFunctions {
+					s.hasAggregatesAndFunctions = true
+				}
 				for ks, tables := range tt.populateKs {
 					populateKeyspace(s, ks, tables...)
 				}
@@ -1052,6 +1125,57 @@ func TestHandleSchemaEvent(t *testing.T) {
 		}
 		if got := ctrl.getQueryCount(); got != 0 {
 			t.Fatalf("tbl_c not invalidated, expected 0 queries, got %d", got)
+		}
+	})
+
+	t.Run("function event without UDF/UDA support: clears flag without wiping data", func(t *testing.T) {
+		t.Parallel()
+		ctrl := &schemaDataMock{
+			knownKeyspaces: map[string][]tableInfo{
+				"test_ks": {{name: "tbl_a", columns: []columnInfo{{name: "id", kind: "partition_key", position: 0}}}},
+			},
+		}
+		s := newSchemaEventTestSessionWithMock(ctrl) // hasAggregatesAndFunctions = false
+		defer s.Close()
+		populateKeyspace(s, "test_ks", "tbl_a")
+
+		// Simulate a keyspace that already carries function/aggregate
+		// metadata, to prove a spurious invalidation on a server without
+		// UDF/UDA support (pre-Cassandra-2.2) does not wipe it with an
+		// empty map.
+		ks, ok := s.metadataDescriber.metadata.keyspaceMetadata.getKeyspace("test_ks")
+		if !ok {
+			t.Fatal("test_ks should be cached")
+		}
+		ks = ks.Clone()
+		ks.Functions = map[string]*FunctionMetadata{"fn": {Name: "fn"}}
+		ks.Aggregates = map[string]*AggregateMetadata{"agg": {Name: "agg"}}
+		s.metadataDescriber.metadata.keyspaceMetadata.set("test_ks", ks)
+
+		s.handleSchemaEvent([]frame{
+			&frm.SchemaChangeFunction{Change: "CREATED", Keyspace: "test_ks", Name: "fn2", Args: []string{"int"}},
+		})
+
+		ctrl.resetQueries()
+
+		ksAfter, err := s.metadataDescriber.GetKeyspace("test_ks")
+		if err != nil {
+			t.Fatalf("GetKeyspace failed: %v", err)
+		}
+		if n := ctrl.getQueryCount(); n != 0 {
+			t.Fatalf("expected no functions/aggregates queries on a server without UDF/UDA support, got %d", n)
+		}
+		if _, ok := ksAfter.Functions["fn"]; !ok {
+			t.Fatal("pre-existing Functions data was wiped despite hasAggregatesAndFunctions=false")
+		}
+		if _, ok := ksAfter.Aggregates["agg"]; !ok {
+			t.Fatal("pre-existing Aggregates data was wiped despite hasAggregatesAndFunctions=false")
+		}
+
+		// The dirty flags must still be cleared, otherwise GetKeyspace would
+		// keep retrying a refresh that can never succeed on this server.
+		if ksAfter.needsPartialRefresh() {
+			t.Fatal("expected needsPartialRefresh to be false after handling the event")
 		}
 	})
 

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -22,18 +22,24 @@ import (
 
 // schema metadata for a keyspace
 type KeyspaceMetadata struct {
-	StrategyOptions   map[string]any
-	Tables            map[string]*TableMetadata
-	Functions         map[string]*FunctionMetadata
-	Aggregates        map[string]*AggregateMetadata
-	Types             map[string]*TypeMetadata
-	Indexes           map[string]*IndexMetadata
-	Views             map[string]*ViewMetadata
-	tablesInvalidated map[string]struct{}
-	Name              string
-	StrategyClass     string
-	CreateStmts       string
-	DurableWrites     bool
+	StrategyOptions           map[string]any
+	Tables                    map[string]*TableMetadata
+	Functions                 map[string]*FunctionMetadata
+	Aggregates                map[string]*AggregateMetadata
+	Types                     map[string]*TypeMetadata
+	Indexes                   map[string]*IndexMetadata
+	Views                     map[string]*ViewMetadata
+	tablesInvalidated         map[string]struct{}
+	Name                      string
+	StrategyClass             string
+	CreateStmts               string
+	DurableWrites             bool
+	typesInvalidated          bool
+	functionsInvalidated      bool
+	aggregatesInvalidated     bool
+	typesInvalidationGen      uint64
+	functionsInvalidationGen  uint64
+	aggregatesInvalidationGen uint64
 }
 
 // Clone returns a shallow copy of the keyspace metadata with
@@ -41,17 +47,23 @@ type KeyspaceMetadata struct {
 // do not race with concurrent readers of the original.
 func (ks *KeyspaceMetadata) Clone() *KeyspaceMetadata {
 	cloned := &KeyspaceMetadata{
-		Name:            ks.Name,
-		DurableWrites:   ks.DurableWrites,
-		StrategyClass:   ks.StrategyClass,
-		StrategyOptions: maps.Clone(ks.StrategyOptions),
-		Tables:          maps.Clone(ks.Tables),
-		Functions:       maps.Clone(ks.Functions),
-		Aggregates:      maps.Clone(ks.Aggregates),
-		Types:           maps.Clone(ks.Types),
-		Indexes:         maps.Clone(ks.Indexes),
-		Views:           maps.Clone(ks.Views),
-		CreateStmts:     ks.CreateStmts,
+		Name:                      ks.Name,
+		DurableWrites:             ks.DurableWrites,
+		StrategyClass:             ks.StrategyClass,
+		StrategyOptions:           maps.Clone(ks.StrategyOptions),
+		Tables:                    maps.Clone(ks.Tables),
+		Functions:                 maps.Clone(ks.Functions),
+		Aggregates:                maps.Clone(ks.Aggregates),
+		Types:                     maps.Clone(ks.Types),
+		Indexes:                   maps.Clone(ks.Indexes),
+		Views:                     maps.Clone(ks.Views),
+		CreateStmts:               ks.CreateStmts,
+		typesInvalidated:          ks.typesInvalidated,
+		functionsInvalidated:      ks.functionsInvalidated,
+		aggregatesInvalidated:     ks.aggregatesInvalidated,
+		typesInvalidationGen:      ks.typesInvalidationGen,
+		functionsInvalidationGen:  ks.functionsInvalidationGen,
+		aggregatesInvalidationGen: ks.aggregatesInvalidationGen,
 	}
 	if ks.tablesInvalidated != nil {
 		cloned.tablesInvalidated = maps.Clone(ks.tablesInvalidated)
@@ -88,6 +100,29 @@ func (ks *KeyspaceMetadata) removeTable(tableName string) {
 	if ks.tablesInvalidated != nil {
 		delete(ks.tablesInvalidated, tableName)
 	}
+}
+
+func (ks *KeyspaceMetadata) needsPartialRefresh() bool {
+	return ks.typesInvalidated || ks.functionsInvalidated || ks.aggregatesInvalidated
+}
+
+func (ks *KeyspaceMetadata) invalidateTypes() {
+	ks.typesInvalidated = true
+	ks.typesInvalidationGen++
+}
+
+func (ks *KeyspaceMetadata) invalidateFunctions() {
+	ks.functionsInvalidated = true
+	ks.aggregatesInvalidated = true
+	ks.functionsInvalidationGen++
+	// Aggregates embed copies of function metadata, so they must be refreshed
+	// whenever functions change.
+	ks.aggregatesInvalidationGen++
+}
+
+func (ks *KeyspaceMetadata) invalidateAggregates() {
+	ks.aggregatesInvalidated = true
+	ks.aggregatesInvalidationGen++
 }
 
 // schema metadata for a table (a.k.a. column family)
@@ -380,9 +415,69 @@ func (c *cowKeyspaceMetadataMap) set(keyspaceName string, keyspaceMetadata *Keys
 	return true
 }
 
+// replaceKeyspace atomically publishes replacement as the keyspace's new
+// metadata, first carrying forward any types/functions/aggregates that were
+// invalidated more recently than the generations refreshKeyspaceSchema
+// started from (invalidations concurrent with its fetch), so the replacement
+// doesn't clobber them with the older values it fetched.
+func (c *cowKeyspaceMetadataMap) replaceKeyspace(keyspaceName string, replacement *KeyspaceMetadata, startTypesGeneration, startFunctionsGeneration, startAggregatesGeneration uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	m := c.get()
+	if current, ok := m[keyspaceName]; ok && current != nil {
+		if current.typesInvalidationGen > startTypesGeneration {
+			replacement.typesInvalidationGen = current.typesInvalidationGen
+			replacement.typesInvalidated = current.typesInvalidated
+			replacement.Types = current.Types
+		}
+		if current.functionsInvalidationGen > startFunctionsGeneration {
+			replacement.functionsInvalidationGen = current.functionsInvalidationGen
+			replacement.functionsInvalidated = current.functionsInvalidated
+			replacement.Functions = current.Functions
+		}
+		if current.aggregatesInvalidationGen > startAggregatesGeneration {
+			replacement.aggregatesInvalidationGen = current.aggregatesInvalidationGen
+			replacement.aggregatesInvalidated = current.aggregatesInvalidated
+			replacement.Aggregates = current.Aggregates
+		}
+		if replacement.typesInvalidated || replacement.functionsInvalidated || replacement.aggregatesInvalidated {
+			// Stale maps were preserved over the freshly fetched ones, so the
+			// fresh DESCRIBE/ToCQL output may reference data not present in the
+			// merged maps. Invalidate it so ToCQL regenerates from the maps.
+			replacement.CreateStmts = ""
+		}
+	}
+
+	newM := maps.Clone(m)
+	if newM == nil {
+		newM = make(map[string]*KeyspaceMetadata)
+	}
+	newM[keyspaceName] = replacement
+	c.keyspaceMap.Store(&newM)
+}
+
 func (c *cowKeyspaceMetadataMap) invalidateTable(keyspaceName, tableName string) {
 	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
 		ks.invalidateTable(tableName)
+	})
+}
+
+func (c *cowKeyspaceMetadataMap) invalidateTypes(keyspaceName string) {
+	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		ks.invalidateTypes()
+	})
+}
+
+func (c *cowKeyspaceMetadataMap) invalidateFunctions(keyspaceName string) {
+	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		ks.invalidateFunctions()
+	})
+}
+
+func (c *cowKeyspaceMetadataMap) invalidateAggregates(keyspaceName string) {
+	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		ks.invalidateAggregates()
 	})
 }
 
@@ -527,10 +622,11 @@ type Metadata struct {
 
 // queries the cluster for schema information for a specific keyspace and for tablets
 type metadataDescriber struct {
-	keyspaceGroup singleflight.Group
-	tableGroup    singleflight.Group
-	session       *Session
-	metadata      *Metadata
+	keyspaceGroup       singleflight.Group
+	partialRefreshGroup singleflight.Group
+	tableGroup          singleflight.Group
+	session             *Session
+	metadata            *Metadata
 
 	// mu serialises refreshAllSchema calls so the snapshot-compare-refresh
 	// cycle runs as an atomic batch.  Individual keyspace/table refreshes
@@ -565,6 +661,35 @@ func (s *metadataDescriber) getKeyspaceInternal(keyspaceName string) (metadata *
 		metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
 		if !found {
 			return nil, true, fmt.Errorf("keyspace %s: %w", keyspaceName, ErrNotFound)
+		}
+	}
+
+	// Genuine partial refreshes converge within a couple of iterations. Under
+	// a sustained invalidation burst the generation counters keep advancing
+	// during the fetch/apply cycle, so bound the loop and fall back to a full
+	// refresh rather than spinning forever.
+	const maxPartialRefreshAttempts = 3
+	for attempt := 0; attempt < maxPartialRefreshAttempts && metadata.needsPartialRefresh(); attempt++ {
+		err = s.deduplicatedPartialRefreshKeyspace(keyspaceName)
+		if err != nil {
+			return metadata, wasReloaded, err
+		}
+		metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+		if !found {
+			return nil, wasReloaded, fmt.Errorf("keyspace %s: %w", keyspaceName, ErrNotFound)
+		}
+	}
+
+	if metadata.needsPartialRefresh() {
+		// Still dirty after the bounded partial-refresh loop: the invalidation
+		// burst outran us. A full refresh covers every category at once and
+		// clears the remaining flags when it lands on a quiet instant.
+		if err := s.deduplicatedRefreshKeyspace(keyspaceName); err != nil {
+			return metadata, wasReloaded, err
+		}
+		metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+		if !found {
+			return nil, wasReloaded, fmt.Errorf("keyspace %s: %w", keyspaceName, ErrNotFound)
 		}
 	}
 
@@ -686,11 +811,42 @@ func (s *metadataDescriber) invalidateTableSchema(keyspaceName, tableName string
 	s.metadata.keyspaceMetadata.invalidateTable(keyspaceName, tableName)
 }
 
+func (s *metadataDescriber) invalidateTypesSchema(keyspaceName string) {
+	s.metadata.keyspaceMetadata.invalidateTypes(keyspaceName)
+}
+
+func (s *metadataDescriber) invalidateFunctionsSchema(keyspaceName string) {
+	s.metadata.keyspaceMetadata.invalidateFunctions(keyspaceName)
+}
+
+func (s *metadataDescriber) invalidateAggregatesSchema(keyspaceName string) {
+	s.metadata.keyspaceMetadata.invalidateAggregates(keyspaceName)
+}
+
 // deduplicatedRefreshKeyspace collapses concurrent refreshKeyspaceSchema calls
 // for the same keyspace into a single in-flight operation.
 func (s *metadataDescriber) deduplicatedRefreshKeyspace(keyspaceName string) error {
 	_, err, _ := s.keyspaceGroup.Do(keyspaceName, func() (any, error) {
 		return nil, s.refreshKeyspaceSchema(keyspaceName)
+	})
+	return err
+}
+
+// deduplicatedPartialRefreshKeyspace collapses concurrent partial refreshes
+// for the same keyspace into a single in-flight operation. Without this, every
+// caller that observes a dirty snapshot (its own generation counters) would
+// fire its own set of metadata queries, flooding the cluster during an
+// invalidation burst.
+func (s *metadataDescriber) deduplicatedPartialRefreshKeyspace(keyspaceName string) error {
+	_, err, _ := s.partialRefreshGroup.Do(keyspaceName, func() (any, error) {
+		// Re-read the latest published snapshot inside the single shared
+		// flight so all concurrent callers act on the newest generation
+		// counters rather than their potentially stale individual ones.
+		snapshot, ok := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+		if !ok {
+			return nil, s.deduplicatedRefreshKeyspace(keyspaceName)
+		}
+		return nil, s.refreshPartialKeyspaceSchema(keyspaceName, snapshot)
 	})
 	return err
 }
@@ -761,6 +917,17 @@ func (s *metadataDescriber) refreshAllSchema() error {
 // compileMetadata after all queries complete.
 func (s *metadataDescriber) refreshKeyspaceSchema(keyspaceName string) error {
 	var (
+		startTypesGeneration      uint64
+		startFunctionsGeneration  uint64
+		startAggregatesGeneration uint64
+	)
+	if current, found := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName); found && current != nil {
+		startTypesGeneration = current.typesInvalidationGen
+		startFunctionsGeneration = current.functionsInvalidationGen
+		startAggregatesGeneration = current.aggregatesInvalidationGen
+	}
+
+	var (
 		keyspace    *KeyspaceMetadata
 		tables      []TableMetadata
 		columns     []ColumnMetadata
@@ -827,8 +994,11 @@ func (s *metadataDescriber) refreshKeyspaceSchema(keyspaceName string) error {
 	}
 
 	compileMetadata(keyspace, tables, columns, functions, aggregates, types, indexes, views, createStmts)
+	keyspace.typesInvalidationGen = startTypesGeneration
+	keyspace.functionsInvalidationGen = startFunctionsGeneration
+	keyspace.aggregatesInvalidationGen = startAggregatesGeneration
 
-	s.metadata.keyspaceMetadata.set(keyspaceName, keyspace)
+	s.metadata.keyspaceMetadata.replaceKeyspace(keyspaceName, keyspace, startTypesGeneration, startFunctionsGeneration, startAggregatesGeneration)
 
 	return nil
 }
@@ -875,6 +1045,120 @@ func (s *metadataDescriber) refreshTableSchema(keyspaceName, tableName string) e
 	if !applied {
 		// Keyspace was removed between the initial check and the update.
 		// Fall back to a full keyspace refresh to recover.
+		return s.deduplicatedRefreshKeyspace(keyspaceName)
+	}
+	return nil
+}
+
+// refreshPartialKeyspaceSchema fetches only the metadata categories that have
+// been invalidated (types, functions, aggregates) and atomically updates the
+// cached keyspace. This avoids a full keyspace refresh when only these
+// lightweight schema objects changed.
+func (s *metadataDescriber) refreshPartialKeyspaceSchema(keyspaceName string, snapshot *KeyspaceMetadata) error {
+	typesGeneration := snapshot.typesInvalidationGen
+	functionsGeneration := snapshot.functionsInvalidationGen
+	aggregatesGeneration := snapshot.aggregatesInvalidationGen
+
+	needTypes := snapshot.typesInvalidated
+	needFunctions := snapshot.functionsInvalidated
+	needAggregates := snapshot.aggregatesInvalidated
+
+	// A server that predates Cassandra 2.2 has no UDF/UDA support at all, so
+	// it can never have functions or aggregates to change; any invalidation
+	// for them is a no-op. Skip the network round trip and, below, only clear
+	// the dirty flags instead of replacing the (already empty) maps.
+	hasFunctions := s.session.hasAggregatesAndFunctions
+
+	var (
+		types      []TypeMetadata
+		functions  []FunctionMetadata
+		aggregates []AggregateMetadata
+	)
+
+	var g errgroup.Group
+
+	if needTypes {
+		g.Go(func() error {
+			var err error
+			types, err = getTypeMetadata(s.session, keyspaceName)
+			return err
+		})
+	}
+	// Aggregates depend on functions, so if aggregates are invalidated we
+	// must also refresh functions to compile aggregate metadata correctly.
+	if (needFunctions || needAggregates) && hasFunctions {
+		g.Go(func() error {
+			var err error
+			functions, err = getFunctionsMetadata(s.session, keyspaceName)
+			return err
+		})
+	}
+	if needAggregates && hasFunctions {
+		g.Go(func() error {
+			var err error
+			aggregates, err = getAggregatesMetadata(s.session, keyspaceName)
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	applied := s.metadata.keyspaceMetadata.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		changed := false
+
+		applyFunctions := false
+		if needFunctions {
+			applyFunctions = ks.functionsInvalidated && ks.functionsInvalidationGen == functionsGeneration
+		} else if needAggregates {
+			// When functions are fetched only to recompile aggregates, avoid
+			// overwriting a concurrently full-refreshed function map.
+			applyFunctions = ks.aggregatesInvalidated && ks.aggregatesInvalidationGen == aggregatesGeneration
+		}
+
+		if needTypes && ks.typesInvalidated && ks.typesInvalidationGen == typesGeneration {
+			ks.Types = make(map[string]*TypeMetadata, len(types))
+			for i := range types {
+				ks.Types[types[i].Name] = &types[i]
+			}
+			ks.typesInvalidated = false
+			changed = true
+		}
+		if applyFunctions {
+			if hasFunctions {
+				ks.Functions = make(map[string]*FunctionMetadata, len(functions))
+				for i := range functions {
+					ks.Functions[functions[i].Name] = &functions[i]
+				}
+				changed = true
+			}
+			ks.functionsInvalidated = false
+		}
+		if needAggregates && ks.aggregatesInvalidated && ks.aggregatesInvalidationGen == aggregatesGeneration {
+			if hasFunctions {
+				ks.Aggregates = make(map[string]*AggregateMetadata, len(aggregates))
+				for i := range aggregates {
+					aggregate := &aggregates[i]
+					if fn, ok := ks.Functions[aggregate.finalFunc]; ok {
+						aggregate.FinalFunc = *fn
+					}
+					if fn, ok := ks.Functions[aggregate.stateFunc]; ok {
+						aggregate.StateFunc = *fn
+					}
+					ks.Aggregates[aggregate.Name] = aggregate
+				}
+				changed = true
+			}
+			ks.aggregatesInvalidated = false
+		}
+		if changed {
+			// The partial refresh replaced at least one metadata category, so
+			// the cached DESCRIBE/ToCQL output no longer matches the maps.
+			ks.CreateStmts = ""
+		}
+	})
+	if !applied {
 		return s.deduplicatedRefreshKeyspace(keyspaceName)
 	}
 	return nil

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -22,18 +22,24 @@ import (
 
 // schema metadata for a keyspace
 type KeyspaceMetadata struct {
-	StrategyOptions   map[string]any
-	Tables            map[string]*TableMetadata
-	Functions         map[string]*FunctionMetadata
-	Aggregates        map[string]*AggregateMetadata
-	Types             map[string]*TypeMetadata
-	Indexes           map[string]*IndexMetadata
-	Views             map[string]*ViewMetadata
-	tablesInvalidated map[string]struct{}
-	Name              string
-	StrategyClass     string
-	CreateStmts       string
-	DurableWrites     bool
+	StrategyOptions           map[string]any
+	Tables                    map[string]*TableMetadata
+	Functions                 map[string]*FunctionMetadata
+	Aggregates                map[string]*AggregateMetadata
+	Types                     map[string]*TypeMetadata
+	Indexes                   map[string]*IndexMetadata
+	Views                     map[string]*ViewMetadata
+	tablesInvalidated         map[string]struct{}
+	Name                      string
+	StrategyClass             string
+	CreateStmts               string
+	DurableWrites             bool
+	typesInvalidated          bool
+	functionsInvalidated      bool
+	aggregatesInvalidated     bool
+	typesInvalidationGen      uint64
+	functionsInvalidationGen  uint64
+	aggregatesInvalidationGen uint64
 }
 
 // Clone returns a shallow copy of the keyspace metadata with
@@ -41,17 +47,23 @@ type KeyspaceMetadata struct {
 // do not race with concurrent readers of the original.
 func (ks *KeyspaceMetadata) Clone() *KeyspaceMetadata {
 	cloned := &KeyspaceMetadata{
-		Name:            ks.Name,
-		DurableWrites:   ks.DurableWrites,
-		StrategyClass:   ks.StrategyClass,
-		StrategyOptions: maps.Clone(ks.StrategyOptions),
-		Tables:          maps.Clone(ks.Tables),
-		Functions:       maps.Clone(ks.Functions),
-		Aggregates:      maps.Clone(ks.Aggregates),
-		Types:           maps.Clone(ks.Types),
-		Indexes:         maps.Clone(ks.Indexes),
-		Views:           maps.Clone(ks.Views),
-		CreateStmts:     ks.CreateStmts,
+		Name:                      ks.Name,
+		DurableWrites:             ks.DurableWrites,
+		StrategyClass:             ks.StrategyClass,
+		StrategyOptions:           maps.Clone(ks.StrategyOptions),
+		Tables:                    maps.Clone(ks.Tables),
+		Functions:                 maps.Clone(ks.Functions),
+		Aggregates:                maps.Clone(ks.Aggregates),
+		Types:                     maps.Clone(ks.Types),
+		Indexes:                   maps.Clone(ks.Indexes),
+		Views:                     maps.Clone(ks.Views),
+		CreateStmts:               ks.CreateStmts,
+		typesInvalidated:          ks.typesInvalidated,
+		functionsInvalidated:      ks.functionsInvalidated,
+		aggregatesInvalidated:     ks.aggregatesInvalidated,
+		typesInvalidationGen:      ks.typesInvalidationGen,
+		functionsInvalidationGen:  ks.functionsInvalidationGen,
+		aggregatesInvalidationGen: ks.aggregatesInvalidationGen,
 	}
 	if ks.tablesInvalidated != nil {
 		cloned.tablesInvalidated = maps.Clone(ks.tablesInvalidated)
@@ -88,6 +100,29 @@ func (ks *KeyspaceMetadata) removeTable(tableName string) {
 	if ks.tablesInvalidated != nil {
 		delete(ks.tablesInvalidated, tableName)
 	}
+}
+
+func (ks *KeyspaceMetadata) needsPartialRefresh() bool {
+	return ks.typesInvalidated || ks.functionsInvalidated || ks.aggregatesInvalidated
+}
+
+func (ks *KeyspaceMetadata) invalidateTypes() {
+	ks.typesInvalidated = true
+	ks.typesInvalidationGen++
+}
+
+func (ks *KeyspaceMetadata) invalidateFunctions() {
+	ks.functionsInvalidated = true
+	ks.aggregatesInvalidated = true
+	ks.functionsInvalidationGen++
+	// Aggregates embed copies of function metadata, so they must be refreshed
+	// whenever functions change.
+	ks.aggregatesInvalidationGen++
+}
+
+func (ks *KeyspaceMetadata) invalidateAggregates() {
+	ks.aggregatesInvalidated = true
+	ks.aggregatesInvalidationGen++
 }
 
 // schema metadata for a table (a.k.a. column family)
@@ -380,9 +415,47 @@ func (c *cowKeyspaceMetadataMap) set(keyspaceName string, keyspaceMetadata *Keys
 	return true
 }
 
+// replaceKeyspace atomically merges the current keyspace metadata into the
+// replacement before publishing it. If the keyspace does not exist, the
+// replacement is still published as-is.
+func (c *cowKeyspaceMetadataMap) replaceKeyspace(keyspaceName string, replacement *KeyspaceMetadata, merge func(current, replacement *KeyspaceMetadata)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	m := c.get()
+	if current, ok := m[keyspaceName]; ok && current != nil {
+		merge(current, replacement)
+	}
+
+	newM := maps.Clone(m)
+	if newM == nil {
+		newM = make(map[string]*KeyspaceMetadata)
+	}
+	newM[keyspaceName] = replacement
+	c.keyspaceMap.Store(&newM)
+}
+
 func (c *cowKeyspaceMetadataMap) invalidateTable(keyspaceName, tableName string) {
 	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
 		ks.invalidateTable(tableName)
+	})
+}
+
+func (c *cowKeyspaceMetadataMap) invalidateTypes(keyspaceName string) {
+	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		ks.invalidateTypes()
+	})
+}
+
+func (c *cowKeyspaceMetadataMap) invalidateFunctions(keyspaceName string) {
+	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		ks.invalidateFunctions()
+	})
+}
+
+func (c *cowKeyspaceMetadataMap) invalidateAggregates(keyspaceName string) {
+	c.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		ks.invalidateAggregates()
 	})
 }
 
@@ -527,10 +600,11 @@ type Metadata struct {
 
 // queries the cluster for schema information for a specific keyspace and for tablets
 type metadataDescriber struct {
-	keyspaceGroup singleflight.Group
-	tableGroup    singleflight.Group
-	session       *Session
-	metadata      *Metadata
+	keyspaceGroup       singleflight.Group
+	partialRefreshGroup singleflight.Group
+	tableGroup          singleflight.Group
+	session             *Session
+	metadata            *Metadata
 
 	// mu serialises refreshAllSchema calls so the snapshot-compare-refresh
 	// cycle runs as an atomic batch.  Individual keyspace/table refreshes
@@ -565,6 +639,35 @@ func (s *metadataDescriber) getKeyspaceInternal(keyspaceName string) (metadata *
 		metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
 		if !found {
 			return nil, true, fmt.Errorf("keyspace %s: %w", keyspaceName, ErrNotFound)
+		}
+	}
+
+	// Genuine partial refreshes converge within a couple of iterations. Under
+	// a sustained invalidation burst the generation counters keep advancing
+	// during the fetch/apply cycle, so bound the loop and fall back to a full
+	// refresh rather than spinning forever.
+	const maxPartialRefreshAttempts = 3
+	for attempt := 0; attempt < maxPartialRefreshAttempts && metadata.needsPartialRefresh(); attempt++ {
+		err = s.deduplicatedPartialRefreshKeyspace(keyspaceName)
+		if err != nil {
+			return metadata, wasReloaded, err
+		}
+		metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+		if !found {
+			return nil, wasReloaded, fmt.Errorf("keyspace %s: %w", keyspaceName, ErrNotFound)
+		}
+	}
+
+	if metadata.needsPartialRefresh() {
+		// Still dirty after the bounded partial-refresh loop: the invalidation
+		// burst outran us. A full refresh covers every category at once and
+		// clears the remaining flags when it lands on a quiet instant.
+		if err := s.deduplicatedRefreshKeyspace(keyspaceName); err != nil {
+			return metadata, wasReloaded, err
+		}
+		metadata, found = s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+		if !found {
+			return nil, wasReloaded, fmt.Errorf("keyspace %s: %w", keyspaceName, ErrNotFound)
 		}
 	}
 
@@ -686,11 +789,42 @@ func (s *metadataDescriber) invalidateTableSchema(keyspaceName, tableName string
 	s.metadata.keyspaceMetadata.invalidateTable(keyspaceName, tableName)
 }
 
+func (s *metadataDescriber) invalidateTypesSchema(keyspaceName string) {
+	s.metadata.keyspaceMetadata.invalidateTypes(keyspaceName)
+}
+
+func (s *metadataDescriber) invalidateFunctionsSchema(keyspaceName string) {
+	s.metadata.keyspaceMetadata.invalidateFunctions(keyspaceName)
+}
+
+func (s *metadataDescriber) invalidateAggregatesSchema(keyspaceName string) {
+	s.metadata.keyspaceMetadata.invalidateAggregates(keyspaceName)
+}
+
 // deduplicatedRefreshKeyspace collapses concurrent refreshKeyspaceSchema calls
 // for the same keyspace into a single in-flight operation.
 func (s *metadataDescriber) deduplicatedRefreshKeyspace(keyspaceName string) error {
 	_, err, _ := s.keyspaceGroup.Do(keyspaceName, func() (any, error) {
 		return nil, s.refreshKeyspaceSchema(keyspaceName)
+	})
+	return err
+}
+
+// deduplicatedPartialRefreshKeyspace collapses concurrent partial refreshes
+// for the same keyspace into a single in-flight operation. Without this, every
+// caller that observes a dirty snapshot (its own generation counters) would
+// fire its own set of metadata queries, flooding the cluster during an
+// invalidation burst.
+func (s *metadataDescriber) deduplicatedPartialRefreshKeyspace(keyspaceName string) error {
+	_, err, _ := s.partialRefreshGroup.Do(keyspaceName, func() (any, error) {
+		// Re-read the latest published snapshot inside the single shared
+		// flight so all concurrent callers act on the newest generation
+		// counters rather than their potentially stale individual ones.
+		snapshot, ok := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName)
+		if !ok {
+			return nil, s.deduplicatedRefreshKeyspace(keyspaceName)
+		}
+		return nil, s.refreshPartialKeyspaceSchema(keyspaceName, snapshot)
 	})
 	return err
 }
@@ -761,6 +895,17 @@ func (s *metadataDescriber) refreshAllSchema() error {
 // compileMetadata after all queries complete.
 func (s *metadataDescriber) refreshKeyspaceSchema(keyspaceName string) error {
 	var (
+		startTypesGeneration      uint64
+		startFunctionsGeneration  uint64
+		startAggregatesGeneration uint64
+	)
+	if current, found := s.metadata.keyspaceMetadata.getKeyspace(keyspaceName); found && current != nil {
+		startTypesGeneration = current.typesInvalidationGen
+		startFunctionsGeneration = current.functionsInvalidationGen
+		startAggregatesGeneration = current.aggregatesInvalidationGen
+	}
+
+	var (
 		keyspace    *KeyspaceMetadata
 		tables      []TableMetadata
 		columns     []ColumnMetadata
@@ -827,8 +972,33 @@ func (s *metadataDescriber) refreshKeyspaceSchema(keyspaceName string) error {
 	}
 
 	compileMetadata(keyspace, tables, columns, functions, aggregates, types, indexes, views, createStmts)
+	keyspace.typesInvalidationGen = startTypesGeneration
+	keyspace.functionsInvalidationGen = startFunctionsGeneration
+	keyspace.aggregatesInvalidationGen = startAggregatesGeneration
 
-	s.metadata.keyspaceMetadata.set(keyspaceName, keyspace)
+	s.metadata.keyspaceMetadata.replaceKeyspace(keyspaceName, keyspace, func(current, replacement *KeyspaceMetadata) {
+		if current.typesInvalidationGen > startTypesGeneration {
+			replacement.typesInvalidationGen = current.typesInvalidationGen
+			replacement.typesInvalidated = current.typesInvalidated
+			replacement.Types = current.Types
+		}
+		if current.functionsInvalidationGen > startFunctionsGeneration {
+			replacement.functionsInvalidationGen = current.functionsInvalidationGen
+			replacement.functionsInvalidated = current.functionsInvalidated
+			replacement.Functions = current.Functions
+		}
+		if current.aggregatesInvalidationGen > startAggregatesGeneration {
+			replacement.aggregatesInvalidationGen = current.aggregatesInvalidationGen
+			replacement.aggregatesInvalidated = current.aggregatesInvalidated
+			replacement.Aggregates = current.Aggregates
+		}
+		if replacement.typesInvalidated || replacement.functionsInvalidated || replacement.aggregatesInvalidated {
+			// Stale maps were preserved over the freshly fetched ones, so the
+			// fresh DESCRIBE/ToCQL output may reference data not present in the
+			// merged maps. Invalidate it so ToCQL regenerates from the maps.
+			replacement.CreateStmts = ""
+		}
+	})
 
 	return nil
 }
@@ -875,6 +1045,120 @@ func (s *metadataDescriber) refreshTableSchema(keyspaceName, tableName string) e
 	if !applied {
 		// Keyspace was removed between the initial check and the update.
 		// Fall back to a full keyspace refresh to recover.
+		return s.deduplicatedRefreshKeyspace(keyspaceName)
+	}
+	return nil
+}
+
+// refreshPartialKeyspaceSchema fetches only the metadata categories that have
+// been invalidated (types, functions, aggregates) and atomically updates the
+// cached keyspace. This avoids a full keyspace refresh when only these
+// lightweight schema objects changed.
+func (s *metadataDescriber) refreshPartialKeyspaceSchema(keyspaceName string, snapshot *KeyspaceMetadata) error {
+	typesGeneration := snapshot.typesInvalidationGen
+	functionsGeneration := snapshot.functionsInvalidationGen
+	aggregatesGeneration := snapshot.aggregatesInvalidationGen
+
+	needTypes := snapshot.typesInvalidated
+	needFunctions := snapshot.functionsInvalidated
+	needAggregates := snapshot.aggregatesInvalidated
+
+	// A server that predates Cassandra 2.2 has no UDF/UDA support at all, so
+	// it can never have functions or aggregates to change; any invalidation
+	// for them is a no-op. Skip the network round trip and, below, only clear
+	// the dirty flags instead of replacing the (already empty) maps.
+	hasFunctions := s.session.hasAggregatesAndFunctions
+
+	var (
+		types      []TypeMetadata
+		functions  []FunctionMetadata
+		aggregates []AggregateMetadata
+	)
+
+	var g errgroup.Group
+
+	if needTypes {
+		g.Go(func() error {
+			var err error
+			types, err = getTypeMetadata(s.session, keyspaceName)
+			return err
+		})
+	}
+	// Aggregates depend on functions, so if aggregates are invalidated we
+	// must also refresh functions to compile aggregate metadata correctly.
+	if (needFunctions || needAggregates) && hasFunctions {
+		g.Go(func() error {
+			var err error
+			functions, err = getFunctionsMetadata(s.session, keyspaceName)
+			return err
+		})
+	}
+	if needAggregates && hasFunctions {
+		g.Go(func() error {
+			var err error
+			aggregates, err = getAggregatesMetadata(s.session, keyspaceName)
+			return err
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	applied := s.metadata.keyspaceMetadata.updateKeyspace(keyspaceName, func(ks *KeyspaceMetadata) {
+		changed := false
+
+		applyFunctions := false
+		if needFunctions {
+			applyFunctions = ks.functionsInvalidated && ks.functionsInvalidationGen == functionsGeneration
+		} else if needAggregates {
+			// When functions are fetched only to recompile aggregates, avoid
+			// overwriting a concurrently full-refreshed function map.
+			applyFunctions = ks.aggregatesInvalidated && ks.aggregatesInvalidationGen == aggregatesGeneration
+		}
+
+		if needTypes && ks.typesInvalidated && ks.typesInvalidationGen == typesGeneration {
+			ks.Types = make(map[string]*TypeMetadata, len(types))
+			for i := range types {
+				ks.Types[types[i].Name] = &types[i]
+			}
+			ks.typesInvalidated = false
+			changed = true
+		}
+		if applyFunctions {
+			if hasFunctions {
+				ks.Functions = make(map[string]*FunctionMetadata, len(functions))
+				for i := range functions {
+					ks.Functions[functions[i].Name] = &functions[i]
+				}
+				changed = true
+			}
+			ks.functionsInvalidated = false
+		}
+		if needAggregates && ks.aggregatesInvalidated && ks.aggregatesInvalidationGen == aggregatesGeneration {
+			if hasFunctions {
+				ks.Aggregates = make(map[string]*AggregateMetadata, len(aggregates))
+				for i := range aggregates {
+					aggregate := &aggregates[i]
+					if fn, ok := ks.Functions[aggregate.finalFunc]; ok {
+						aggregate.FinalFunc = *fn
+					}
+					if fn, ok := ks.Functions[aggregate.stateFunc]; ok {
+						aggregate.StateFunc = *fn
+					}
+					ks.Aggregates[aggregate.Name] = aggregate
+				}
+				changed = true
+			}
+			ks.aggregatesInvalidated = false
+		}
+		if changed {
+			// The partial refresh replaced at least one metadata category, so
+			// the cached DESCRIBE/ToCQL output no longer matches the maps.
+			ks.CreateStmts = ""
+		}
+	})
+	if !applied {
 		return s.deduplicatedRefreshKeyspace(keyspaceName)
 	}
 	return nil

--- a/metadata_scylla_test.go
+++ b/metadata_scylla_test.go
@@ -504,3 +504,247 @@ func assertKeyspaceMetadata(t *testing.T, actual, expected *KeyspaceMetadata) {
 	assertViewsMetadata(t, expected.Name, actual.Views, expected.Views)
 	assertIndicesMetadata(t, expected.Name, actual.Indexes, expected.Indexes)
 }
+
+func TestCowKeyspaceMetadataMapInvalidateTypes(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	ks := &KeyspaceMetadata{
+		Name:  "test_ks",
+		Types: map[string]*TypeMetadata{"mytype": {Name: "mytype"}},
+	}
+	m.set("test_ks", ks)
+
+	m.invalidateTypes("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after invalidateTypes")
+	}
+	if got.typesInvalidationGen != 1 {
+		t.Fatalf("expected typesInvalidationGen to be 1, got %d", got.typesInvalidationGen)
+	}
+	if !got.typesInvalidated {
+		t.Fatal("expected typesInvalidated to be true")
+	}
+	// Types map should still be present (not removed)
+	if got.Types == nil {
+		t.Fatal("Types map should not be nil")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateFunctions(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	ks := &KeyspaceMetadata{
+		Name:      "test_ks",
+		Functions: map[string]*FunctionMetadata{"myfunc": {Name: "myfunc"}},
+	}
+	m.set("test_ks", ks)
+
+	m.invalidateFunctions("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after invalidateFunctions")
+	}
+	if got.functionsInvalidationGen != 1 {
+		t.Fatalf("expected functionsInvalidationGen to be 1, got %d", got.functionsInvalidationGen)
+	}
+	if got.aggregatesInvalidationGen != 1 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 1, got %d", got.aggregatesInvalidationGen)
+	}
+	if !got.functionsInvalidated {
+		t.Fatal("expected functionsInvalidated to be true")
+	}
+	if !got.aggregatesInvalidated {
+		t.Fatal("expected aggregatesInvalidated to be true")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateAggregates(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	ks := &KeyspaceMetadata{
+		Name:       "test_ks",
+		Aggregates: map[string]*AggregateMetadata{"myagg": {Name: "myagg"}},
+	}
+	m.set("test_ks", ks)
+
+	m.invalidateAggregates("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after invalidateAggregates")
+	}
+	if got.aggregatesInvalidationGen != 1 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 1, got %d", got.aggregatesInvalidationGen)
+	}
+	if !got.aggregatesInvalidated {
+		t.Fatal("expected aggregatesInvalidated to be true")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateFunctionsBumpsGeneration(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	m.set("test_ks", &KeyspaceMetadata{Name: "test_ks"})
+
+	m.invalidateFunctions("test_ks")
+	m.invalidateFunctions("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after repeated invalidateFunctions")
+	}
+	if got.functionsInvalidationGen != 2 {
+		t.Fatalf("expected functionsInvalidationGen to be 2, got %d", got.functionsInvalidationGen)
+	}
+	if got.aggregatesInvalidationGen != 2 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 2, got %d", got.aggregatesInvalidationGen)
+	}
+	if !got.functionsInvalidated || !got.aggregatesInvalidated {
+		t.Fatal("expected repeated invalidation to keep dirty flags set")
+	}
+}
+
+func TestCowKeyspaceMetadataMapReplaceKeyspaceOnEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	replacement := &KeyspaceMetadata{Name: "test_ks"}
+
+	m.replaceKeyspace("test_ks", replacement, func(current, replacement *KeyspaceMetadata) {
+		t.Fatal("merge should not be called when the keyspace is absent")
+	})
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("expected keyspace to be stored")
+	}
+	if got != replacement {
+		t.Fatal("expected replacement keyspace to be stored as-is")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateNonexistentKeyspace(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+
+	// Should not panic on non-existent keyspace
+	m.invalidateTypes("nonexistent")
+	m.invalidateFunctions("nonexistent")
+	m.invalidateAggregates("nonexistent")
+}
+
+func TestKeyspaceMetadataNeedsPartialRefresh(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{Name: "test_ks"}
+	if ks.needsPartialRefresh() {
+		t.Fatal("fresh keyspace should not need partial refresh")
+	}
+
+	ks.typesInvalidated = true
+	ks.typesInvalidationGen = 1
+	if !ks.needsPartialRefresh() {
+		t.Fatal("should need partial refresh when types invalidated")
+	}
+
+	ks.typesInvalidated = false
+	ks.typesInvalidationGen = 0
+	ks.functionsInvalidated = true
+	ks.functionsInvalidationGen = 1
+	if !ks.needsPartialRefresh() {
+		t.Fatal("should need partial refresh when functions invalidated")
+	}
+
+	ks.functionsInvalidated = false
+	ks.functionsInvalidationGen = 0
+	ks.aggregatesInvalidated = true
+	ks.aggregatesInvalidationGen = 1
+	if !ks.needsPartialRefresh() {
+		t.Fatal("should need partial refresh when aggregates invalidated")
+	}
+}
+
+func TestKeyspaceMetadataInvalidateFunctionsCascadesToAggregates(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{}
+	ks.invalidateFunctions()
+
+	if ks.functionsInvalidationGen != 1 {
+		t.Fatalf("expected functionsInvalidationGen to be 1, got %d", ks.functionsInvalidationGen)
+	}
+	if ks.aggregatesInvalidationGen != 1 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 1, got %d", ks.aggregatesInvalidationGen)
+	}
+	if !ks.functionsInvalidated || !ks.aggregatesInvalidated {
+		t.Fatal("invalidateFunctions should set both dirty flags")
+	}
+}
+
+func TestKeyspaceMetadataInvalidateTypesOnlyBumpsTypesGeneration(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{}
+	ks.invalidateTypes()
+
+	if ks.typesInvalidationGen != 1 {
+		t.Fatalf("expected typesInvalidationGen to be 1, got %d", ks.typesInvalidationGen)
+	}
+	if !ks.typesInvalidated {
+		t.Fatal("invalidateTypes should set types dirty flag")
+	}
+	if ks.functionsInvalidationGen != 0 {
+		t.Fatalf("expected functionsInvalidationGen to remain 0, got %d", ks.functionsInvalidationGen)
+	}
+	if ks.aggregatesInvalidationGen != 0 {
+		t.Fatalf("expected aggregatesInvalidationGen to remain 0, got %d", ks.aggregatesInvalidationGen)
+	}
+}
+
+func TestKeyspaceMetadataClonePreservesInvalidationFlags(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{
+		Name:                      "test_ks",
+		Tables:                    map[string]*TableMetadata{},
+		Functions:                 map[string]*FunctionMetadata{},
+		Aggregates:                map[string]*AggregateMetadata{},
+		Types:                     map[string]*TypeMetadata{},
+		Indexes:                   map[string]*IndexMetadata{},
+		Views:                     map[string]*ViewMetadata{},
+		typesInvalidated:          true,
+		functionsInvalidated:      true,
+		aggregatesInvalidated:     true,
+		typesInvalidationGen:      3,
+		functionsInvalidationGen:  4,
+		aggregatesInvalidationGen: 5,
+	}
+
+	cloned := ks.Clone()
+	if cloned.typesInvalidationGen != 3 {
+		t.Fatalf("Clone should preserve typesInvalidationGen, got %d", cloned.typesInvalidationGen)
+	}
+	if !cloned.typesInvalidated {
+		t.Fatal("Clone should preserve typesInvalidated")
+	}
+	if cloned.functionsInvalidationGen != 4 {
+		t.Fatalf("Clone should preserve functionsInvalidationGen, got %d", cloned.functionsInvalidationGen)
+	}
+	if !cloned.functionsInvalidated {
+		t.Fatal("Clone should preserve functionsInvalidated")
+	}
+	if cloned.aggregatesInvalidationGen != 5 {
+		t.Fatalf("Clone should preserve aggregatesInvalidationGen, got %d", cloned.aggregatesInvalidationGen)
+	}
+	if !cloned.aggregatesInvalidated {
+		t.Fatal("Clone should preserve aggregatesInvalidated")
+	}
+}

--- a/metadata_scylla_test.go
+++ b/metadata_scylla_test.go
@@ -504,3 +504,245 @@ func assertKeyspaceMetadata(t *testing.T, actual, expected *KeyspaceMetadata) {
 	assertViewsMetadata(t, expected.Name, actual.Views, expected.Views)
 	assertIndicesMetadata(t, expected.Name, actual.Indexes, expected.Indexes)
 }
+
+func TestCowKeyspaceMetadataMapInvalidateTypes(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	ks := &KeyspaceMetadata{
+		Name:  "test_ks",
+		Types: map[string]*TypeMetadata{"mytype": {Name: "mytype"}},
+	}
+	m.set("test_ks", ks)
+
+	m.invalidateTypes("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after invalidateTypes")
+	}
+	if got.typesInvalidationGen != 1 {
+		t.Fatalf("expected typesInvalidationGen to be 1, got %d", got.typesInvalidationGen)
+	}
+	if !got.typesInvalidated {
+		t.Fatal("expected typesInvalidated to be true")
+	}
+	// Types map should still be present (not removed)
+	if got.Types == nil {
+		t.Fatal("Types map should not be nil")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateFunctions(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	ks := &KeyspaceMetadata{
+		Name:      "test_ks",
+		Functions: map[string]*FunctionMetadata{"myfunc": {Name: "myfunc"}},
+	}
+	m.set("test_ks", ks)
+
+	m.invalidateFunctions("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after invalidateFunctions")
+	}
+	if got.functionsInvalidationGen != 1 {
+		t.Fatalf("expected functionsInvalidationGen to be 1, got %d", got.functionsInvalidationGen)
+	}
+	if got.aggregatesInvalidationGen != 1 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 1, got %d", got.aggregatesInvalidationGen)
+	}
+	if !got.functionsInvalidated {
+		t.Fatal("expected functionsInvalidated to be true")
+	}
+	if !got.aggregatesInvalidated {
+		t.Fatal("expected aggregatesInvalidated to be true")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateAggregates(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	ks := &KeyspaceMetadata{
+		Name:       "test_ks",
+		Aggregates: map[string]*AggregateMetadata{"myagg": {Name: "myagg"}},
+	}
+	m.set("test_ks", ks)
+
+	m.invalidateAggregates("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after invalidateAggregates")
+	}
+	if got.aggregatesInvalidationGen != 1 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 1, got %d", got.aggregatesInvalidationGen)
+	}
+	if !got.aggregatesInvalidated {
+		t.Fatal("expected aggregatesInvalidated to be true")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateFunctionsBumpsGeneration(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	m.set("test_ks", &KeyspaceMetadata{Name: "test_ks"})
+
+	m.invalidateFunctions("test_ks")
+	m.invalidateFunctions("test_ks")
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("keyspace should still exist after repeated invalidateFunctions")
+	}
+	if got.functionsInvalidationGen != 2 {
+		t.Fatalf("expected functionsInvalidationGen to be 2, got %d", got.functionsInvalidationGen)
+	}
+	if got.aggregatesInvalidationGen != 2 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 2, got %d", got.aggregatesInvalidationGen)
+	}
+	if !got.functionsInvalidated || !got.aggregatesInvalidated {
+		t.Fatal("expected repeated invalidation to keep dirty flags set")
+	}
+}
+
+func TestCowKeyspaceMetadataMapReplaceKeyspaceOnEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+	replacement := &KeyspaceMetadata{Name: "test_ks"}
+
+	m.replaceKeyspace("test_ks", replacement, 0, 0, 0)
+
+	got, found := m.getKeyspace("test_ks")
+	if !found {
+		t.Fatal("expected keyspace to be stored")
+	}
+	if got != replacement {
+		t.Fatal("expected replacement keyspace to be stored as-is")
+	}
+}
+
+func TestCowKeyspaceMetadataMapInvalidateNonexistentKeyspace(t *testing.T) {
+	t.Parallel()
+
+	m := &cowKeyspaceMetadataMap{}
+
+	// Should not panic on non-existent keyspace
+	m.invalidateTypes("nonexistent")
+	m.invalidateFunctions("nonexistent")
+	m.invalidateAggregates("nonexistent")
+}
+
+func TestKeyspaceMetadataNeedsPartialRefresh(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{Name: "test_ks"}
+	if ks.needsPartialRefresh() {
+		t.Fatal("fresh keyspace should not need partial refresh")
+	}
+
+	ks.typesInvalidated = true
+	ks.typesInvalidationGen = 1
+	if !ks.needsPartialRefresh() {
+		t.Fatal("should need partial refresh when types invalidated")
+	}
+
+	ks.typesInvalidated = false
+	ks.typesInvalidationGen = 0
+	ks.functionsInvalidated = true
+	ks.functionsInvalidationGen = 1
+	if !ks.needsPartialRefresh() {
+		t.Fatal("should need partial refresh when functions invalidated")
+	}
+
+	ks.functionsInvalidated = false
+	ks.functionsInvalidationGen = 0
+	ks.aggregatesInvalidated = true
+	ks.aggregatesInvalidationGen = 1
+	if !ks.needsPartialRefresh() {
+		t.Fatal("should need partial refresh when aggregates invalidated")
+	}
+}
+
+func TestKeyspaceMetadataInvalidateFunctionsCascadesToAggregates(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{}
+	ks.invalidateFunctions()
+
+	if ks.functionsInvalidationGen != 1 {
+		t.Fatalf("expected functionsInvalidationGen to be 1, got %d", ks.functionsInvalidationGen)
+	}
+	if ks.aggregatesInvalidationGen != 1 {
+		t.Fatalf("expected aggregatesInvalidationGen to be 1, got %d", ks.aggregatesInvalidationGen)
+	}
+	if !ks.functionsInvalidated || !ks.aggregatesInvalidated {
+		t.Fatal("invalidateFunctions should set both dirty flags")
+	}
+}
+
+func TestKeyspaceMetadataInvalidateTypesOnlyBumpsTypesGeneration(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{}
+	ks.invalidateTypes()
+
+	if ks.typesInvalidationGen != 1 {
+		t.Fatalf("expected typesInvalidationGen to be 1, got %d", ks.typesInvalidationGen)
+	}
+	if !ks.typesInvalidated {
+		t.Fatal("invalidateTypes should set types dirty flag")
+	}
+	if ks.functionsInvalidationGen != 0 {
+		t.Fatalf("expected functionsInvalidationGen to remain 0, got %d", ks.functionsInvalidationGen)
+	}
+	if ks.aggregatesInvalidationGen != 0 {
+		t.Fatalf("expected aggregatesInvalidationGen to remain 0, got %d", ks.aggregatesInvalidationGen)
+	}
+}
+
+func TestKeyspaceMetadataClonePreservesInvalidationFlags(t *testing.T) {
+	t.Parallel()
+
+	ks := &KeyspaceMetadata{
+		Name:                      "test_ks",
+		Tables:                    map[string]*TableMetadata{},
+		Functions:                 map[string]*FunctionMetadata{},
+		Aggregates:                map[string]*AggregateMetadata{},
+		Types:                     map[string]*TypeMetadata{},
+		Indexes:                   map[string]*IndexMetadata{},
+		Views:                     map[string]*ViewMetadata{},
+		typesInvalidated:          true,
+		functionsInvalidated:      true,
+		aggregatesInvalidated:     true,
+		typesInvalidationGen:      3,
+		functionsInvalidationGen:  4,
+		aggregatesInvalidationGen: 5,
+	}
+
+	cloned := ks.Clone()
+	if cloned.typesInvalidationGen != 3 {
+		t.Fatalf("Clone should preserve typesInvalidationGen, got %d", cloned.typesInvalidationGen)
+	}
+	if !cloned.typesInvalidated {
+		t.Fatal("Clone should preserve typesInvalidated")
+	}
+	if cloned.functionsInvalidationGen != 4 {
+		t.Fatalf("Clone should preserve functionsInvalidationGen, got %d", cloned.functionsInvalidationGen)
+	}
+	if !cloned.functionsInvalidated {
+		t.Fatal("Clone should preserve functionsInvalidated")
+	}
+	if cloned.aggregatesInvalidationGen != 5 {
+		t.Fatalf("Clone should preserve aggregatesInvalidationGen, got %d", cloned.aggregatesInvalidationGen)
+	}
+	if !cloned.aggregatesInvalidated {
+		t.Fatal("Clone should preserve aggregatesInvalidated")
+	}
+}

--- a/recreate_test.go
+++ b/recreate_test.go
@@ -315,9 +315,17 @@ func trimQueries(in []string) []string {
 }
 
 var schemaVersion = regexp.MustCompile(` WITH ID = [0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}[ \t\n]+AND`)
+var tabletsClause = regexp.MustCompile(` AND tablets = \{[^}]*\}`)
 
 func trimSchema(s string) string {
 	// Remove temporary items from the scheme, in particular schema version:
 	// ) WITH ID = cf0364d0-3b85-11ef-b79d-80a2ee1928c0
-	return strings.ReplaceAll(schemaVersion.ReplaceAllString(s, " WITH"), "\n\n", "\n")
+	s = strings.ReplaceAll(schemaVersion.ReplaceAllString(s, " WITH"), "\n\n", "\n")
+	// The client rebuilds CREATE KEYSPACE from cached metadata and can't
+	// reproduce the server's fully-qualified strategy class name or its
+	// tablets clause (not modeled by KeyspaceMetadata); normalize both away
+	// since neither affects the recreated schema's meaning.
+	s = strings.ReplaceAll(s, "org.apache.cassandra.locator.", "")
+	s = tabletsClause.ReplaceAllString(s, "")
+	return s
 }


### PR DESCRIPTION
Previously, schema change events for types, functions, and aggregates invalidated the entire keyspace cache, forcing a full schema reload. This was unnecessary and expensive.

Now each category has its own dirty flag and monotonic generation counter. Only the affected metadata (types, functions, aggregates) is re-fetched on the next `GetKeyspace` call, while tables, views, and indexes remain cached.

Key design points:
- Generation counters prevent clearing invalidations that arrived during an in-flight partial refresh.
- Function invalidation cascades to aggregates since `AggregateMetadata` embeds `FunctionMetadata` by value.
- Full keyspace refresh merges newer invalidation state to avoid dropping concurrent events.

Fixes: https://github.com/scylladb/gocql/issues/730