### PR TITLE
perf: reuse MapScan scan-value slice across rows

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -390,7 +390,9 @@ func (r *RowData) rowMap(m map[string]any) {
 		// plain copy() does the same defensive-copy job. This is a CPU-time
 		// win (no reflect dispatch), not an allocation-count one: both paths
 		// still pay for the backing-array copy and the interface-boxing that
-		// storing a []byte into map[string]any requires either way.
+		// storing a []byte into map[string]any requires either way. copyBytes
+		// allocates with len, not cap, so a reused decode buffer's larger
+		// capacity is never carried into the returned value.
 		if b, ok := val.([]byte); ok {
 			if b != nil {
 				m[column] = copyBytes(b)
@@ -398,7 +400,11 @@ func (r *RowData) rowMap(m map[string]any) {
 				m[column] = val
 			}
 		} else if valVal := reflect.ValueOf(val); valVal.Kind() == reflect.Slice && !valVal.IsNil() {
-			valCopy := reflect.MakeSlice(valVal.Type(), valVal.Len(), valVal.Cap())
+			// Copy with cap == len: the source may be a reused decode buffer
+			// (MapScan's cached destinations) whose capacity grew to fit an
+			// earlier, larger value; copying with Cap() would carry that
+			// capacity into every returned value.
+			valCopy := reflect.MakeSlice(valVal.Type(), valVal.Len(), valVal.Len())
 			reflect.Copy(valCopy, valVal)
 			m[column] = valCopy.Interface()
 		} else {
@@ -644,12 +650,11 @@ func (iter *Iter) MapScan(m map[string]any) bool {
 	// mapScanDefaults holds the default destination pointers (one per column)
 	// and is never replaced after creation. Scan writes through these pointers
 	// on each call, overwriting the pointed-to values in place, so the pointers
-	// themselves remain valid across rows. Each call copies the default
-	// pointers into mapScanWorking (an O(N) element-by-element copy of the
-	// []any interface slice, no allocation), applies the caller's pointer
-	// overrides to the working copy, and scans into that. Because the working
-	// copy is rebuilt from defaults every call, slots overridden in one row
-	// are automatically restored for the next without per-slot re-allocation.
+	// themselves remain valid across rows. Rows without caller overrides scan
+	// directly into the defaults. When the caller pre-seeds m with destination
+	// overrides, the defaults are copied into mapScanWorking (allocated lazily
+	// on the first override) and the overrides applied to that working copy,
+	// keeping the defaults intact for later rows.
 	defaults := iter.mapScanDefaults
 	if defaults == nil || len(defaults) != iter.meta.actualColCount {
 		defaults = make([]any, iter.meta.actualColCount)
@@ -657,16 +662,25 @@ func (iter *Iter) MapScan(m map[string]any) bool {
 			return false
 		}
 		iter.mapScanDefaults = defaults
-		iter.mapScanWorking = make([]any, iter.meta.actualColCount)
 	}
-	values := iter.mapScanWorking
-	copy(values, defaults)
 
-	// Apply user-supplied pointer overrides for this row.
+	// Apply user-supplied destination overrides for this row.
+	values := defaults
+	overridden := false
 	for i, col := range columns {
-		if dest, ok := m[col]; ok {
-			values[i] = dest
+		dest, ok := m[col]
+		if !ok {
+			continue
 		}
+		if !overridden {
+			if len(iter.mapScanWorking) != len(defaults) {
+				iter.mapScanWorking = make([]any, len(defaults))
+			}
+			copy(iter.mapScanWorking, defaults)
+			values = iter.mapScanWorking
+			overridden = true
+		}
+		values[i] = dest
 	}
 
 	ok := iter.Scan(values...)
@@ -674,6 +688,20 @@ func (iter *Iter) MapScan(m map[string]any) bool {
 	if ok {
 		rd := RowData{Columns: columns, Values: values}
 		rd.rowMap(m)
+	}
+
+	if overridden {
+		// Drop the caller-supplied destinations so the iterator does not
+		// retain them between calls or after exhaustion.
+		clear(values)
+	}
+
+	if !ok {
+		// Scan returning false is terminal (exhaustion, error, or closed).
+		// finalize() already released the caches; drop any rebuilt here too,
+		// so extra MapScan calls on a finished iterator do not re-pin them.
+		iter.mapScanDefaults = nil
+		iter.mapScanWorking = nil
 	}
 
 	return ok

--- a/helpers.go
+++ b/helpers.go
@@ -443,12 +443,13 @@ func (iter *Iter) RowData() (RowData, error) {
 }
 
 // getScanColumns returns the cached column names for this iterator,
-// computing them on the first call. Column names don't change between
-// rows, so they are computed once and reused.
+// computing them on the first call and recomputing them if a page turn
+// installed new metadata (RESULT_METADATA_CHANGED) since the cache was
+// built.
 //
 // The returned slice is shared across all callers and must not be mutated.
 func (iter *Iter) getScanColumns() ([]string, error) {
-	if iter.scanColumns != nil {
+	if iter.scanColumns != nil && iter.scanColumnsEpoch == iter.metaEpoch {
 		return iter.scanColumns, nil
 	}
 
@@ -484,6 +485,7 @@ func (iter *Iter) getScanColumns() ([]string, error) {
 	}
 
 	iter.scanColumns = columns
+	iter.scanColumnsEpoch = iter.metaEpoch
 	return columns, nil
 }
 
@@ -638,7 +640,15 @@ func (iter *Iter) MapScan(m map[string]any) bool {
 		return false
 	}
 
-	// Resolve the (cached) column names once.
+	// Load the next page, if needed, before resolving columns/defaults below:
+	// a page turn can install new metadata (RESULT_METADATA_CHANGED), and
+	// those caches must reflect the page this row is actually scanned from,
+	// not the previous one.
+	if !iter.ensureRowsAvailable() {
+		return false
+	}
+
+	// Resolve the (cached) column names once per page.
 	columns, err := iter.getScanColumns()
 	if err != nil {
 		return false
@@ -648,20 +658,26 @@ func (iter *Iter) MapScan(m map[string]any) bool {
 	// pointer per column on every row.
 	//
 	// mapScanDefaults holds the default destination pointers (one per column)
-	// and is never replaced after creation. Scan writes through these pointers
-	// on each call, overwriting the pointed-to values in place, so the pointers
-	// themselves remain valid across rows. Rows without caller overrides scan
-	// directly into the defaults. When the caller pre-seeds m with destination
-	// overrides, the defaults are copied into mapScanWorking (allocated lazily
-	// on the first override) and the overrides applied to that working copy,
-	// keeping the defaults intact for later rows.
+	// and is never replaced after creation, unless a page turn changes the
+	// metadata (mapScanEpoch != iter.metaEpoch) or the column count. Scan
+	// writes through these pointers on each call, overwriting the pointed-to
+	// values in place, so the pointers themselves remain valid across rows of
+	// the same page. Rows without caller overrides scan directly into the
+	// defaults. When the caller pre-seeds m with destination overrides, the
+	// defaults are copied into mapScanWorking (allocated lazily on the first
+	// override) and the overrides applied to that working copy, keeping the
+	// defaults intact for later rows.
 	defaults := iter.mapScanDefaults
-	if defaults == nil || len(defaults) != iter.meta.actualColCount {
+	if defaults == nil || iter.mapScanEpoch != iter.metaEpoch || len(defaults) != iter.meta.actualColCount {
 		defaults = make([]any, iter.meta.actualColCount)
 		if err := iter.fillScanValues(defaults); err != nil {
 			return false
 		}
 		iter.mapScanDefaults = defaults
+		iter.mapScanEpoch = iter.metaEpoch
+		// The previous page's working slice may hold stale-typed pointers;
+		// drop it so the next override rebuilds it from the new defaults.
+		iter.mapScanWorking = nil
 	}
 
 	// Apply user-supplied destination overrides for this row.

--- a/helpers.go
+++ b/helpers.go
@@ -485,34 +485,45 @@ func (iter *Iter) getScanColumns() ([]string, error) {
 // suitable for passing to Scan. Values must be freshly allocated each
 // call because Scan mutates them.
 func (iter *Iter) newScanValues() ([]any, error) {
+	values := make([]any, iter.meta.actualColCount)
+	if err := iter.fillScanValues(values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// fillScanValues populates values (which must have length actualColCount) with
+// freshly allocated zero-value pointers for each scannable column. It is shared
+// by newScanValues (fresh slice per call) and the MapScan fast path (reused
+// slice across rows).
+func (iter *Iter) fillScanValues(values []any) error {
 	actualSize := iter.meta.actualColCount
-	values := make([]any, actualSize)
 	idx := 0
 	for _, column := range iter.Columns() {
 		if c, ok := column.TypeInfo.(TupleTypeInfo); !ok {
 			if idx >= actualSize {
-				err := fmt.Errorf("gocql: column count overflow in newScanValues: metadata predicted %d columns but encountered more", actualSize)
+				err := fmt.Errorf("gocql: column count overflow in fillScanValues: metadata predicted %d columns but encountered more", actualSize)
 				iter.err = err
-				return nil, err
+				return err
 			}
 			val, err := column.TypeInfo.NewWithError()
 			if err != nil {
 				iter.err = err
-				return nil, err
+				return err
 			}
 			values[idx] = val
 			idx++
 		} else {
 			for _, elem := range c.Elems {
 				if idx >= actualSize {
-					err := fmt.Errorf("gocql: column count overflow in newScanValues: metadata predicted %d columns but encountered more", actualSize)
+					err := fmt.Errorf("gocql: column count overflow in fillScanValues: metadata predicted %d columns but encountered more", actualSize)
 					iter.err = err
-					return nil, err
+					return err
 				}
 				val, err := elem.NewWithError()
 				if err != nil {
 					iter.err = err
-					return nil, err
+					return err
 				}
 				values[idx] = val
 				idx++
@@ -521,12 +532,12 @@ func (iter *Iter) newScanValues() ([]any, error) {
 	}
 
 	if idx != actualSize {
-		err := fmt.Errorf("gocql: column count mismatch in newScanValues: metadata predicted %d columns but got %d", actualSize, idx)
+		err := fmt.Errorf("gocql: column count mismatch in fillScanValues: metadata predicted %d columns but got %d", actualSize, idx)
 		iter.err = err
-		return nil, err
+		return err
 	}
 
-	return values, nil
+	return nil
 }
 
 // TODO(zariel): is it worth exporting this?
@@ -621,22 +632,51 @@ func (iter *Iter) MapScan(m map[string]any) bool {
 		return false
 	}
 
-	rowData, err := iter.RowData()
+	// Resolve the (cached) column names once.
+	columns, err := iter.getScanColumns()
 	if err != nil {
 		return false
 	}
 
-	for i, col := range rowData.Columns {
+	// Reuse cached slices across rows to avoid allocating a new []any plus one
+	// pointer per column on every row.
+	//
+	// mapScanDefaults holds the default destination pointers (one per column)
+	// and is never replaced after creation. Scan writes through these pointers
+	// on each call, overwriting the pointed-to values in place, so the pointers
+	// themselves remain valid across rows. Each call copies the default
+	// pointers into mapScanWorking (an O(N) element-by-element copy of the
+	// []any interface slice, no allocation), applies the caller's pointer
+	// overrides to the working copy, and scans into that. Because the working
+	// copy is rebuilt from defaults every call, slots overridden in one row
+	// are automatically restored for the next without per-slot re-allocation.
+	defaults := iter.mapScanDefaults
+	if defaults == nil || len(defaults) != iter.meta.actualColCount {
+		defaults = make([]any, iter.meta.actualColCount)
+		if err := iter.fillScanValues(defaults); err != nil {
+			return false
+		}
+		iter.mapScanDefaults = defaults
+		iter.mapScanWorking = make([]any, iter.meta.actualColCount)
+	}
+	values := iter.mapScanWorking
+	copy(values, defaults)
+
+	// Apply user-supplied pointer overrides for this row.
+	for i, col := range columns {
 		if dest, ok := m[col]; ok {
-			rowData.Values[i] = dest
+			values[i] = dest
 		}
 	}
 
-	if iter.Scan(rowData.Values...) {
-		rowData.rowMap(m)
-		return true
+	ok := iter.Scan(values...)
+
+	if ok {
+		rd := RowData{Columns: columns, Values: values}
+		rd.rowMap(m)
 	}
-	return false
+
+	return ok
 }
 
 func copyBytes(p []byte) []byte {

--- a/mapscan_bench_test.go
+++ b/mapscan_bench_test.go
@@ -1,0 +1,150 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package gocql
+
+import (
+	"encoding/binary"
+	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+// buildMapScanRows builds the column-data portion of a result rows frame: for
+// each row, each column is encoded as [int32 length][int32 value]. Reading only
+// re-slices the framer buffer (no mutation), so the same backing array can be
+// reused across benchmark iterations by resetting the framer buf.
+func buildMapScanRows(numRows, numCols int) []byte {
+	buf := make([]byte, 0, numRows*numCols*8)
+	tmp := make([]byte, 4)
+	for r := 0; r < numRows; r++ {
+		for c := 0; c < numCols; c++ {
+			binary.BigEndian.PutUint32(tmp, 4)
+			buf = append(buf, tmp...)
+			binary.BigEndian.PutUint32(tmp, uint32(int32(r*numCols+c)))
+			buf = append(buf, tmp...)
+		}
+	}
+	return buf
+}
+
+func makeMapScanColumns(numCols int) []ColumnInfo {
+	cols := make([]ColumnInfo, numCols)
+	ti := NewNativeType(4, TypeInt)
+	for i := range cols {
+		cols[i] = ColumnInfo{
+			Keyspace: "ks",
+			Table:    "tbl",
+			Name:     "col" + string(rune('a'+i%26)),
+			TypeInfo: ti,
+		}
+	}
+	return cols
+}
+
+// mapScanBench holds a reusable framer + iter pair so the benchmark measures the
+// scan path itself rather than per-iteration setup allocations.
+type mapScanBench struct {
+	f        *framer
+	iter     *Iter
+	template []byte
+	numRows  int
+}
+
+func newMapScanBench(numRows, numCols int) *mapScanBench {
+	template := buildMapScanRows(numRows, numCols)
+	f := &framer{header: &frm.FrameHeader{}, buf: template}
+	iter := &Iter{
+		framer:  f,
+		numRows: numRows,
+		meta: resultMetadata{
+			columns:        makeMapScanColumns(numCols),
+			colCount:       numCols,
+			actualColCount: numCols,
+		},
+	}
+	return &mapScanBench{f: f, iter: iter, template: template, numRows: numRows}
+}
+
+func (b *mapScanBench) reset() {
+	b.f.buf = b.template
+	b.iter.pos = 0
+	b.iter.numRows = b.numRows
+	b.iter.err = nil
+	b.iter.closed = 0
+	b.iter.framer = b.f
+}
+
+// BenchmarkMapScanRows scans numRows rows of numCols int columns via MapScan,
+// allocating a fresh result map per row (as documented for MapScan). The
+// difference between baseline and optimized is the per-row []any + per-column
+// pointer allocations that the cached scan-values slice eliminates.
+func BenchmarkMapScanRows(b *testing.B) {
+	const numCols = 8
+	bs := newMapScanBench(64, numCols)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bs.reset()
+		rows := 0
+		for {
+			m := make(map[string]any, numCols)
+			if !bs.iter.MapScan(m) {
+				break
+			}
+			rows++
+		}
+		// Assert full-row processing and no iterator error so a decode/iterator
+		// regression cannot produce falsely-fast numbers by scanning fewer rows.
+		if bs.iter.err != nil {
+			b.Fatalf("MapScan failed: %v", bs.iter.err)
+		}
+		if rows != bs.numRows {
+			b.Fatalf("expected %d rows, got %d", bs.numRows, rows)
+		}
+	}
+}
+
+// BenchmarkMapScanRowsAllPointers exercises the documented "pass pointers in the
+// map" pattern (a pointer per column every row). The metric of interest is
+// allocs/op and B/op (deterministic, machine-noise-independent): the working
+// slice is reused and rebuilt from defaults with an O(N) copy, so there are no
+// per-column re-allocations regardless of how many columns are overridden.
+func BenchmarkMapScanRowsAllPointers(b *testing.B) {
+	const numCols = 8
+	bs := newMapScanBench(64, numCols)
+	cols := bs.iter.meta.columns
+	vals := make([]int, numCols)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bs.reset()
+		rows := 0
+		for {
+			m := make(map[string]any, numCols)
+			for c := 0; c < numCols; c++ {
+				m[cols[c].Name] = &vals[c]
+			}
+			if !bs.iter.MapScan(m) {
+				break
+			}
+			rows++
+		}
+		if bs.iter.err != nil {
+			b.Fatalf("MapScan failed: %v", bs.iter.err)
+		}
+		if rows != bs.numRows {
+			b.Fatalf("expected %d rows, got %d", bs.numRows, rows)
+		}
+	}
+}

--- a/mapscan_bench_test.go
+++ b/mapscan_bench_test.go
@@ -81,6 +81,12 @@ func (b *mapScanBench) reset() {
 	b.iter.err = nil
 	b.iter.closed = 0
 	b.iter.framer = b.f
+	// Drop the per-Iter caches: production allocates a fresh Iter per query,
+	// so keeping them warm across iterations would hide the per-query cache
+	// construction cost and overstate the per-row savings.
+	b.iter.scanColumns = nil
+	b.iter.mapScanDefaults = nil
+	b.iter.mapScanWorking = nil
 }
 
 // BenchmarkMapScanRows scans numRows rows of numCols int columns via MapScan,

--- a/mapscan_reuse_test.go
+++ b/mapscan_reuse_test.go
@@ -1,0 +1,319 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package gocql
+
+import (
+	"encoding/binary"
+	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+// buildIntRows builds a rows buffer where row r, column c holds the int32 value
+// base + r*numCols + c, each encoded as [int32 len=4][int32 value].
+func buildIntRows(numRows, numCols, base int) []byte {
+	buf := make([]byte, 0, numRows*numCols*8)
+	tmp := make([]byte, 4)
+	for r := 0; r < numRows; r++ {
+		for c := 0; c < numCols; c++ {
+			binary.BigEndian.PutUint32(tmp, 4)
+			buf = append(buf, tmp...)
+			binary.BigEndian.PutUint32(tmp, uint32(int32(base+r*numCols+c)))
+			buf = append(buf, tmp...)
+		}
+	}
+	return buf
+}
+
+func newIntIter(numRows, numCols int, names []string, data []byte) *Iter {
+	cols := make([]ColumnInfo, numCols)
+	ti := NewNativeType(4, TypeInt)
+	for i := range cols {
+		cols[i] = ColumnInfo{Keyspace: "ks", Table: "t", Name: names[i], TypeInfo: ti}
+	}
+	f := &framer{header: &frm.FrameHeader{}, buf: data}
+	return &Iter{
+		framer:  f,
+		numRows: numRows,
+		meta: resultMetadata{
+			columns:        cols,
+			colCount:       numCols,
+			actualColCount: numCols,
+		},
+	}
+}
+
+// TestMapScanReuseCorrectness verifies that the cached-values MapScan returns
+// the same per-row results as a naive fresh-map scan, including across many
+// rows (where slice reuse happens).
+func TestMapScanReuseCorrectness(t *testing.T) {
+	t.Parallel()
+	const numRows, numCols = 5, 3
+	names := []string{"a", "b", "c"}
+	data := buildIntRows(numRows, numCols, 100)
+	iter := newIntIter(numRows, numCols, names, data)
+
+	row := 0
+	for {
+		m := make(map[string]any)
+		if !iter.MapScan(m) {
+			break
+		}
+		for c := 0; c < numCols; c++ {
+			want := 100 + row*numCols + c
+			got, ok := m[names[c]]
+			if !ok {
+				t.Fatalf("row %d: missing column %q", row, names[c])
+			}
+			gi, ok := got.(int)
+			if !ok {
+				t.Fatalf("row %d col %q: expected int, got %T", row, names[c], got)
+			}
+			if gi != want {
+				t.Fatalf("row %d col %q: got %d want %d", row, names[c], gi, want)
+			}
+		}
+		row++
+	}
+	if row != numRows {
+		t.Fatalf("scanned %d rows, want %d", row, numRows)
+	}
+	if err := iter.err; err != nil {
+		t.Fatalf("iter error: %v", err)
+	}
+}
+
+// TestMapScanUserPointerOverride verifies that supplying pointers in the map
+// works correctly and, crucially, that overriding a pointer in one row does not
+// corrupt subsequent rows that do not override (exercises the repair path).
+func TestMapScanUserPointerOverride(t *testing.T) {
+	t.Parallel()
+	const numRows, numCols = 4, 2
+	names := []string{"x", "y"}
+	data := buildIntRows(numRows, numCols, 0)
+	iter := newIntIter(numRows, numCols, names, data)
+
+	// Row 0: override column "x" with a user *int pointer.
+	var userX int
+	m0 := map[string]any{"x": &userX}
+	if !iter.MapScan(m0) {
+		t.Fatal("row 0 MapScan returned false")
+	}
+	if userX != 0 {
+		t.Fatalf("row 0 userX = %d, want 0", userX)
+	}
+	// rowMap stores the dereferenced value, not the pointer.
+	if v, ok := m0["x"].(int); !ok || v != 0 {
+		t.Fatalf("row 0 m[x] = %v, want int 0", m0["x"])
+	}
+	if v, ok := m0["y"].(int); !ok || v != 1 {
+		t.Fatalf("row 0 m[y] = %v, want int 1", m0["y"])
+	}
+
+	// Row 1: fresh map, NO override. Must still produce correct int values and
+	// must not write into userX (the previous override's target).
+	m1 := make(map[string]any)
+	if !iter.MapScan(m1) {
+		t.Fatal("row 1 MapScan returned false")
+	}
+	if v, ok := m1["x"].(int); !ok || v != 2 {
+		t.Fatalf("row 1 m[x] = %v, want int 2", m1["x"])
+	}
+	if v, ok := m1["y"].(int); !ok || v != 3 {
+		t.Fatalf("row 1 m[y] = %v, want int 3", m1["y"])
+	}
+	if userX != 0 {
+		t.Fatalf("row 1 must not modify previous override target; userX = %d, want 0", userX)
+	}
+
+	// Row 2 and 3: drain.
+	count := 2
+	for {
+		m := make(map[string]any)
+		if !iter.MapScan(m) {
+			break
+		}
+		wantX := count * numCols
+		if v, ok := m["x"].(int); !ok || v != wantX {
+			t.Fatalf("row %d m[x] = %v, want int %d", count, m["x"], wantX)
+		}
+		count++
+	}
+	if count != numRows {
+		t.Fatalf("scanned %d rows, want %d", count, numRows)
+	}
+}
+
+// buildBlobRows builds rows where each column holds a distinct blob value
+// [byte(r), byte(c), byte(r+c)], so cross-row aliasing of the reused scan slice
+// would be detectable as a value mismatch.
+func buildBlobRows(numRows, numCols int) []byte {
+	buf := make([]byte, 0)
+	tmp := make([]byte, 4)
+	for r := 0; r < numRows; r++ {
+		for c := 0; c < numCols; c++ {
+			payload := []byte{byte(r), byte(c), byte(r + c)}
+			binary.BigEndian.PutUint32(tmp, uint32(len(payload)))
+			buf = append(buf, tmp...)
+			buf = append(buf, payload...)
+		}
+	}
+	return buf
+}
+
+// TestMapScanBlobReuseNoAliasing verifies that reusing the scan-value slice
+// across rows does not cause blob ([]byte) values stored in earlier rows' maps
+// to be corrupted by later rows (the defensive copy in rowMap must hold). All
+// row maps are retained and verified at the end.
+func TestMapScanBlobReuseNoAliasing(t *testing.T) {
+	t.Parallel()
+	const numRows, numCols = 6, 2
+	names := []string{"a", "b"}
+	data := buildBlobRows(numRows, numCols)
+
+	cols := make([]ColumnInfo, numCols)
+	ti := NewNativeType(4, TypeBlob)
+	for i := range cols {
+		cols[i] = ColumnInfo{Keyspace: "ks", Table: "t", Name: names[i], TypeInfo: ti}
+	}
+	f := &framer{header: &frm.FrameHeader{}, buf: data}
+	iter := &Iter{
+		framer:  f,
+		numRows: numRows,
+		meta:    resultMetadata{columns: cols, colCount: numCols, actualColCount: numCols},
+	}
+
+	maps := make([]map[string]any, 0, numRows)
+	for {
+		m := make(map[string]any)
+		if !iter.MapScan(m) {
+			break
+		}
+		maps = append(maps, m)
+	}
+	if iter.err != nil {
+		t.Fatalf("iter error: %v", iter.err)
+	}
+	if len(maps) != numRows {
+		t.Fatalf("got %d rows, want %d", len(maps), numRows)
+	}
+	for r, m := range maps {
+		for c := 0; c < numCols; c++ {
+			want := []byte{byte(r), byte(c), byte(r + c)}
+			got, ok := m[names[c]].([]byte)
+			if !ok {
+				t.Fatalf("row %d col %q: not []byte: %T", r, names[c], m[names[c]])
+			}
+			if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+				t.Fatalf("row %d col %q: got %v want %v (aliasing/corruption)", r, names[c], got, want)
+			}
+		}
+	}
+}
+
+// TestMapScanNonComparableOverrideNoPanic verifies that pre-seeding the map with
+// a non-comparable value (e.g. a slice) for a column does not panic in the
+// override-detection comparison (dest != defaults).
+func TestMapScanNonComparableOverrideNoPanic(t *testing.T) {
+	t.Parallel()
+	const numRows, numCols = 2, 1
+	names := []string{"a"}
+	data := buildIntRows(numRows, numCols, 0)
+	iter := newIntIter(numRows, numCols, names, data)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("MapScan panicked on non-comparable map value: %v", r)
+		}
+	}()
+
+	// Seed with a non-comparable []int value under the column key. MapScan must
+	// not panic when comparing it against the cached default pointer.
+	m := map[string]any{"a": []int{1, 2, 3}}
+	_ = iter.MapScan(m)
+}
+
+// TestMapScanAllPointersReuse exercises the documented "pass pointers in the map"
+// pattern where the caller supplies a pointer for every column on every row
+// (reusing the same variables). It verifies correct values across many rows with
+// the reused working slice, and that user variables receive each row's data.
+func TestMapScanAllPointersReuse(t *testing.T) {
+	t.Parallel()
+	const numRows, numCols = 5, 3
+	names := []string{"a", "b", "c"}
+	data := buildIntRows(numRows, numCols, 1000)
+	iter := newIntIter(numRows, numCols, names, data)
+
+	var a, b, c int
+	row := 0
+	for {
+		// Same pointers reused each iteration (the documented pattern).
+		m := map[string]any{"a": &a, "b": &b, "c": &c}
+		if !iter.MapScan(m) {
+			break
+		}
+		// User variables must hold this row's values.
+		if a != 1000+row*numCols+0 || b != 1000+row*numCols+1 || c != 1000+row*numCols+2 {
+			t.Fatalf("row %d: a=%d b=%d c=%d", row, a, b, c)
+		}
+		// Map values (dereferenced) must match too.
+		if v, _ := m["a"].(int); v != a {
+			t.Fatalf("row %d: m[a]=%v want %d", row, m["a"], a)
+		}
+		row++
+	}
+	if iter.err != nil {
+		t.Fatalf("iter error: %v", iter.err)
+	}
+	if row != numRows {
+		t.Fatalf("scanned %d rows, want %d", row, numRows)
+	}
+}
+
+// TestMapScanMixedOverrideThenDefault verifies that overriding a column with a
+// user pointer in one row, then NOT overriding it in the next row, correctly
+// falls back to the cached default destination (the working slice is rebuilt
+// from defaults each call) and does not keep writing into the stale user var.
+func TestMapScanMixedOverrideThenDefault(t *testing.T) {
+	t.Parallel()
+	const numRows, numCols = 3, 1
+	names := []string{"x"}
+	data := buildIntRows(numRows, numCols, 0) // values 0,1,2
+	iter := newIntIter(numRows, numCols, names, data)
+
+	var userX int
+	// Row 0: override.
+	if !iter.MapScan(map[string]any{"x": &userX}) {
+		t.Fatal("row 0 failed")
+	}
+	if userX != 0 {
+		t.Fatalf("row 0 userX=%d want 0", userX)
+	}
+	// Row 1: no override; must not touch userX, must read value 1.
+	m1 := map[string]any{}
+	if !iter.MapScan(m1) {
+		t.Fatal("row 1 failed")
+	}
+	if userX != 0 {
+		t.Fatalf("row 1 must not modify userX; got %d", userX)
+	}
+	if v, _ := m1["x"].(int); v != 1 {
+		t.Fatalf("row 1 m[x]=%v want 1", m1["x"])
+	}
+	// Row 2: override again with same var; must read value 2.
+	if !iter.MapScan(map[string]any{"x": &userX}) {
+		t.Fatal("row 2 failed")
+	}
+	if userX != 2 {
+		t.Fatalf("row 2 userX=%d want 2", userX)
+	}
+}

--- a/mapscan_reuse_test.go
+++ b/mapscan_reuse_test.go
@@ -220,26 +220,115 @@ func TestMapScanBlobReuseNoAliasing(t *testing.T) {
 	}
 }
 
-// TestMapScanNonComparableOverrideNoPanic verifies that pre-seeding the map with
-// a non-comparable value (e.g. a slice) for a column does not panic in the
-// override-detection comparison (dest != defaults).
-func TestMapScanNonComparableOverrideNoPanic(t *testing.T) {
+// buildVarBlobRows builds a one-column rows buffer with one row per entry in
+// sizes; row r holds a blob of sizes[r] bytes, each byte set to r.
+func buildVarBlobRows(sizes []int) []byte {
+	var buf []byte
+	tmp := make([]byte, 4)
+	for r, size := range sizes {
+		binary.BigEndian.PutUint32(tmp, uint32(size))
+		buf = append(buf, tmp...)
+		cell := make([]byte, size)
+		for i := range cell {
+			cell[i] = byte(r)
+		}
+		buf = append(buf, cell...)
+	}
+	return buf
+}
+
+func newBlobIter(numRows int, name string, data []byte) *Iter {
+	cols := []ColumnInfo{{Keyspace: "ks", Table: "t", Name: name, TypeInfo: NewNativeType(4, TypeBlob)}}
+	f := &framer{header: &frm.FrameHeader{}, buf: data}
+	return &Iter{
+		framer:  f,
+		numRows: numRows,
+		meta:    resultMetadata{columns: cols, colCount: 1, actualColCount: 1},
+	}
+}
+
+// TestMapScanBlobCapacityNotAmplified verifies that a large blob in an early
+// row does not inflate the capacity of later rows' returned values: the cached
+// *[]byte destination retains the largest decoded capacity (blob decode is
+// append-based), so rowMap must copy with cap == len rather than Cap().
+func TestMapScanBlobCapacityNotAmplified(t *testing.T) {
+	t.Parallel()
+	sizes := []int{4096, 3, 3}
+	iter := newBlobIter(len(sizes), "b", buildVarBlobRows(sizes))
+
+	for r, size := range sizes {
+		m := make(map[string]any)
+		if !iter.MapScan(m) {
+			t.Fatalf("row %d failed: %v", r, iter.err)
+		}
+		got, ok := m["b"].([]byte)
+		if !ok {
+			t.Fatalf("row %d: not []byte: %T", r, m["b"])
+		}
+		if len(got) != size {
+			t.Fatalf("row %d: len=%d want %d", r, len(got), size)
+		}
+		if cap(got) != size {
+			t.Fatalf("row %d: cap=%d want %d (large-row capacity amplified into small row)", r, cap(got), size)
+		}
+	}
+}
+
+// TestMapScanCachesReleasedOnExhaustion verifies that the terminal MapScan
+// releases both cached slices (via Iter.finalize), so an exhausted iterator
+// retains neither the last row's decoded values nor caller-supplied
+// destination pointers.
+func TestMapScanCachesReleasedOnExhaustion(t *testing.T) {
 	t.Parallel()
 	const numRows, numCols = 2, 1
 	names := []string{"a"}
-	data := buildIntRows(numRows, numCols, 0)
-	iter := newIntIter(numRows, numCols, names, data)
+	iter := newIntIter(numRows, numCols, names, buildIntRows(numRows, numCols, 0))
 
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("MapScan panicked on non-comparable map value: %v", r)
+	var a int
+	for iter.MapScan(map[string]any{"a": &a}) {
+	}
+	if iter.err != nil {
+		t.Fatalf("iter error: %v", iter.err)
+	}
+	if iter.mapScanDefaults != nil {
+		t.Fatal("mapScanDefaults retained after exhaustion")
+	}
+	if iter.mapScanWorking != nil {
+		t.Fatal("mapScanWorking retained after exhaustion")
+	}
+
+	// An extra MapScan call on the finished iterator must not re-pin the
+	// caches either.
+	if iter.MapScan(map[string]any{"a": &a}) {
+		t.Fatal("MapScan succeeded on exhausted iterator")
+	}
+	if iter.mapScanDefaults != nil || iter.mapScanWorking != nil {
+		t.Fatal("caches re-pinned by MapScan call after exhaustion")
+	}
+}
+
+// TestMapScanNoOverrideSkipsWorkingSlice verifies the common no-override path
+// scans directly into the defaults and never allocates the working slice.
+func TestMapScanNoOverrideSkipsWorkingSlice(t *testing.T) {
+	t.Parallel()
+	const numRows, numCols = 3, 2
+	names := []string{"a", "b"}
+	iter := newIntIter(numRows, numCols, names, buildIntRows(numRows, numCols, 0))
+
+	rows := 0
+	for {
+		m := make(map[string]any)
+		if !iter.MapScan(m) {
+			break
 		}
-	}()
-
-	// Seed with a non-comparable []int value under the column key. MapScan must
-	// not panic when comparing it against the cached default pointer.
-	m := map[string]any{"a": []int{1, 2, 3}}
-	_ = iter.MapScan(m)
+		rows++
+		if iter.mapScanWorking != nil {
+			t.Fatal("working slice allocated without any caller override")
+		}
+	}
+	if iter.err != nil || rows != numRows {
+		t.Fatalf("rows=%d err=%v", rows, iter.err)
+	}
 }
 
 // TestMapScanAllPointersReuse exercises the documented "pass pointers in the map"

--- a/mapscan_reuse_test.go
+++ b/mapscan_reuse_test.go
@@ -12,10 +12,12 @@
 package gocql
 
 import (
+	"context"
 	"encoding/binary"
 	"testing"
 
 	frm "github.com/gocql/gocql/internal/frame"
+	"github.com/gocql/gocql/internal/tests/mock"
 )
 
 // buildIntRows builds a rows buffer where row r, column c holds the int32 value
@@ -404,5 +406,81 @@ func TestMapScanMixedOverrideThenDefault(t *testing.T) {
 	}
 	if userX != 2 {
 		t.Fatalf("row 2 userX=%d want 2", userX)
+	}
+}
+
+// TestMapScanColumnCountChangeAcrossPageTurn covers a schema change landing on
+// a page boundary mid-iteration (RESULT_METADATA_CHANGED). MapScan resolves
+// cached column names (getScanColumns) and destination pointers
+// (mapScanDefaults) from iter.meta, which copyPageData replaces once the next
+// page is fetched. Left unguarded, a fresh page turn taken during MapScan
+// itself would resolve those caches against the previous page's metadata (or
+// keep reusing it), returning the new page's rows keyed by the wrong column
+// names or scanned into the wrong destination types.
+func TestMapScanColumnCountChangeAcrossPageTurn(t *testing.T) {
+	t.Parallel()
+	intCol := func(name string) ColumnInfo {
+		return ColumnInfo{Name: name, TypeInfo: NativeType{typ: TypeInt, proto: 4}}
+	}
+	marshalInt := func(v int32) []byte {
+		b, err := Marshal(NativeType{typ: TypeInt, proto: 4}, v)
+		if err != nil {
+			t.Fatalf("unexpected error from reference Marshal: %v", err)
+		}
+		return b
+	}
+
+	oneColumn := resultMetadata{columns: []ColumnInfo{intCol("a")}, actualColCount: 1}
+	twoColumns := resultMetadata{
+		columns:        []ColumnInfo{intCol("a"), intCol("b")},
+		actualColCount: 2,
+	}
+
+	firstFramer := &mock.MockFramer{Data: [][]byte{marshalInt(1)}}
+	nextFramer := &mock.MockFramer{Data: [][]byte{marshalInt(2), marshalInt(3)}}
+
+	conn := &pagingTestConn{
+		executeQueryFunc: func(_ context.Context, _ *Query) *Iter {
+			return &Iter{
+				meta:    twoColumns,
+				framer:  nextFramer,
+				numRows: 1,
+			}
+		},
+	}
+
+	baseQry := newWarningTestQuery()
+	baseQry.conn = conn
+
+	iter := &Iter{
+		meta:    oneColumn,
+		framer:  firstFramer,
+		numRows: 1,
+		next:    newNextIter(baseQry, 1),
+	}
+	defer iter.Close()
+
+	m1 := map[string]any{}
+	if !iter.MapScan(m1) {
+		t.Fatalf("expected first row, err: %v", iter.err)
+	}
+	if v, _ := m1["a"].(int); v != 1 {
+		t.Fatalf("first row: m[a]=%v want 1", m1["a"])
+	}
+	if _, ok := m1["b"]; ok {
+		t.Fatalf("first row: unexpected column b: %v", m1["b"])
+	}
+
+	// Page turn: metadata gains a column. MapScan must resolve columns and
+	// defaults against the new page's metadata, not the cached one-column set.
+	m2 := map[string]any{}
+	if !iter.MapScan(m2) {
+		t.Fatalf("expected second row, err: %v", iter.err)
+	}
+	if v, _ := m2["a"].(int); v != 2 {
+		t.Fatalf("second row: m[a]=%v want 2", m2["a"])
+	}
+	if v, _ := m2["b"].(int); v != 3 {
+		t.Fatalf("second row: m[b]=%v want 3", m2["b"])
 	}
 }

--- a/scanner_prefetch_test.go
+++ b/scanner_prefetch_test.go
@@ -1,0 +1,318 @@
+package gocql
+
+import (
+	"testing"
+
+	"github.com/gocql/gocql/internal/tests/mock"
+)
+
+// makeTestIter creates an Iter with numRows rows, each having numCols columns.
+// Each column value is a single byte equal to the row index.
+func makeTestIter(numRows, numCols int) *Iter {
+	var data [][]byte
+	for row := 0; row < numRows; row++ {
+		for col := 0; col < numCols; col++ {
+			data = append(data, []byte{byte(row)})
+		}
+	}
+
+	columns := make([]ColumnInfo, numCols)
+	for i := range columns {
+		columns[i] = ColumnInfo{
+			Name:     "col",
+			TypeInfo: NativeType{typ: TypeBlob, proto: 4},
+		}
+	}
+
+	return &Iter{
+		framer:  &mock.MockFramer{Data: data},
+		numRows: numRows,
+		meta: resultMetadata{
+			columns:        columns,
+			actualColCount: numCols,
+		},
+	}
+}
+
+func TestIterScanner_PrefetchTriggered(t *testing.T) {
+	// Create a page with 4 rows, 1 column each.
+	// With prefetch=0.25, next.pos = (1 - 0.25) * 4 = 3.
+	// So fetchAsync should be triggered when pos >= 3 (i.e., on the 4th Next() call,
+	// since pos is checked before being incremented from 3 to 4).
+	iter := makeTestIter(4, 1)
+
+	// Create a nextIter with once pre-consumed and a dummy next so the async
+	// goroutine (if launched) returns immediately without a nil session panic.
+	ni := &nextIter{
+		qry:  &Query{},
+		pos:  3, // trigger at pos >= 3
+		next: &Iter{},
+	}
+	ni.once.Do(func() {}) // make fetch() a no-op
+	iter.next = ni
+
+	scanner := iter.Scanner()
+
+	// Consume rows 0, 1, 2 — prefetch should NOT have fired yet.
+	for i := 0; i < 3; i++ {
+		if !scanner.Next() {
+			t.Fatalf("expected Next() to return true on row %d", i)
+		}
+	}
+
+	// Consume row 3 — at this point pos=3 >= next.pos=3, so fetchAsync fires.
+	if !scanner.Next() {
+		t.Fatal("expected Next() to return true on row 3")
+	}
+
+	// fetchAsync calls oncea.Do synchronously, so after Next() returns oncea
+	// is consumed if the trigger fired. Verify by trying to execute via oncea:
+	// if our callback runs, oncea was still available (trigger did NOT fire).
+	onceClaimed := false
+	ni.oncea.Do(func() {
+		onceClaimed = true
+	})
+	if onceClaimed {
+		t.Fatal("fetchAsync should have been called after pos >= next.pos, but oncea was still available")
+	}
+}
+
+func TestIterScanner_PrefetchNotTriggeredEarly(t *testing.T) {
+	// 10 rows, prefetch pos at 7 (simulating prefetch=0.3, pos=(1-0.3)*10=7).
+	iter := makeTestIter(10, 1)
+
+	ni := &nextIter{
+		qry:  &Query{},
+		pos:  7,
+		next: &Iter{},
+	}
+	ni.once.Do(func() {}) // prevent panic if fetchAsync fires (it shouldn't in this test)
+	iter.next = ni
+
+	scanner := iter.Scanner()
+
+	// Consume 7 rows (pos goes 0..6, checked before increment).
+	// On the 7th call, pos=6 before check, which is < 7, so no trigger.
+	for i := 0; i < 7; i++ {
+		if !scanner.Next() {
+			t.Fatalf("expected Next() to return true on row %d", i)
+		}
+	}
+
+	// oncea should still be unclaimed (trigger fires at pos >= 7, and pos was
+	// 0..6 during each prefetch check above). This probe consumes oncea, so
+	// it must be the last oncea operation in this test.
+	onceClaimed := false
+	ni.oncea.Do(func() {
+		onceClaimed = true
+	})
+	if !onceClaimed {
+		t.Fatal("fetchAsync was triggered too early (before pos >= next.pos)")
+	}
+}
+
+func TestIterScanner_PrefetchNotTriggeredWithoutNextIter(t *testing.T) {
+	// Create an iter with no next page — should not panic.
+	iter := makeTestIter(3, 1)
+	// iter.next is nil
+
+	scanner := iter.Scanner()
+	count := 0
+	for scanner.Next() {
+		count++
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 rows, got %d", count)
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIterScanner_PrefetchMatchesScanTiming(t *testing.T) {
+	// Verify that the Scanner triggers fetchAsync at the same pos value
+	// as Iter.Scan() would.
+	//
+	// With 8 rows and next.pos=6:
+	// - Iter.Scan() checks pos >= 6 BEFORE reading columns, BEFORE pos++
+	// - iterScanner.Next() checks pos >= 6 BEFORE reading columns, BEFORE pos++
+	// Both should trigger on the 7th call (when pos=6).
+	//
+	// We must probe oncea only once per sub-iterator (after all calls),
+	// because sync.Once.Do() permanently consumes the Once. Using a fresh
+	// iterator per candidate row count avoids self-consumption.
+
+	findScannerTriggerRow := func() int {
+		for k := 0; k < 8; k++ {
+			iter := makeTestIter(8, 1)
+			ni := &nextIter{
+				qry:  &Query{},
+				pos:  6,
+				next: &Iter{},
+			}
+			ni.once.Do(func() {})
+			iter.next = ni
+			sc := iter.Scanner()
+			for i := 0; i <= k; i++ {
+				sc.Next()
+			}
+			claimed := false
+			ni.oncea.Do(func() { claimed = true })
+			if !claimed {
+				return k
+			}
+		}
+		return -1
+	}
+
+	findScanTriggerRow := func() int {
+		for k := 0; k < 8; k++ {
+			iter := makeTestIter(8, 1)
+			ni := &nextIter{
+				qry:  &Query{},
+				pos:  6,
+				next: &Iter{},
+			}
+			ni.once.Do(func() {})
+			iter.next = ni
+			var dummy []byte
+			for i := 0; i <= k; i++ {
+				iter.Scan(&dummy)
+			}
+			claimed := false
+			ni.oncea.Do(func() { claimed = true })
+			if !claimed {
+				return k
+			}
+		}
+		return -1
+	}
+
+	scannerTriggerRow := findScannerTriggerRow()
+	scanTriggerRow := findScanTriggerRow()
+
+	if scannerTriggerRow != scanTriggerRow {
+		t.Fatalf("prefetch timing mismatch: Scanner triggered on row %d, Scan triggered on row %d",
+			scannerTriggerRow, scanTriggerRow)
+	}
+
+	if scannerTriggerRow == -1 {
+		t.Fatal("neither Scanner nor Scan triggered fetchAsync")
+	}
+}
+
+func TestIterScanner_PageTransitionWithPrefetch(t *testing.T) {
+	// Test that Scanner correctly transitions between pages and that
+	// prefetch works across page boundaries.
+
+	// Page 2: 4 rows, this is the last page (no next).
+	page2 := makeTestIter(4, 1)
+
+	// Page 1: 4 rows, prefetch pos at 3
+	page1 := makeTestIter(4, 1)
+
+	// Create a nextIter for page 1 that returns page 2.
+	// We pre-populate the result and consume the sync.Once so that
+	// fetch() returns page2 directly without calling session.executeQuery().
+	page1NI := &nextIter{
+		qry: &Query{},
+		pos: 3,
+	}
+	page1NI.next = page2
+	page1NI.once.Do(func() {}) // consume the once so fetch() just returns n.next
+	page1.next = page1NI
+
+	scanner := page1.Scanner()
+
+	// Consume all rows from both pages (4 + 4 = 8).
+	count := 0
+	for scanner.Next() {
+		count++
+	}
+	if count != 8 {
+		t.Fatalf("expected 8 total rows across 2 pages, got %d", count)
+	}
+
+	// Verify prefetch was triggered on page 1 (page1NI.oncea consumed).
+	onceClaimed := false
+	page1NI.oncea.Do(func() {
+		onceClaimed = true
+	})
+	if onceClaimed {
+		t.Fatal("fetchAsync should have been triggered on page 1 but oncea was still available")
+	}
+
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// BenchmarkIterScanner_Next benchmarks Scanner.Next() with prefetch logic.
+func BenchmarkIterScanner_Next(b *testing.B) {
+	const numRows = 1000
+	const numCols = 1
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iter := makeTestIter(numRows, numCols)
+		ni := &nextIter{
+			qry:  &Query{},
+			pos:  int(0.75 * float64(numRows)),
+			next: &Iter{},
+		}
+		ni.once.Do(func() {})
+		iter.next = ni
+		scanner := iter.Scanner()
+		b.StartTimer()
+		for scanner.Next() {
+		}
+	}
+}
+
+// BenchmarkIterScan benchmarks Iter.Scan() for comparison with Scanner.Next().
+func BenchmarkIterScan(b *testing.B) {
+	const numRows = 1000
+	const numCols = 1
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iter := makeTestIter(numRows, numCols)
+		ni := &nextIter{
+			qry:  &Query{},
+			pos:  int(0.75 * float64(numRows)),
+			next: &Iter{},
+		}
+		ni.once.Do(func() {})
+		iter.next = ni
+		b.StartTimer()
+		var dummy []byte
+		for iter.Scan(&dummy) {
+		}
+	}
+}
+
+// BenchmarkIterScanner_NextNoNextIter benchmarks Scanner.Next() without any
+// next page (no prefetch check overhead).
+func BenchmarkIterScanner_NextNoNextIter(b *testing.B) {
+	const numRows = 1000
+	const numCols = 1
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		iter := makeTestIter(numRows, numCols)
+		scanner := iter.Scanner()
+		b.StartTimer()
+		for scanner.Next() {
+		}
+	}
+}

--- a/scanner_prefetch_test.go
+++ b/scanner_prefetch_test.go
@@ -268,7 +268,16 @@ func BenchmarkIterScanner_Next(b *testing.B) {
 		iter.next = ni
 		scanner := iter.Scanner()
 		b.StartTimer()
+		rows := 0
 		for scanner.Next() {
+			rows++
+		}
+		b.StopTimer()
+		if rows != numRows {
+			b.Fatalf("scanned %d rows, want %d", rows, numRows)
+		}
+		if err := scanner.Err(); err != nil {
+			b.Fatalf("scanner error: %v", err)
 		}
 	}
 }
@@ -293,7 +302,16 @@ func BenchmarkIterScan(b *testing.B) {
 		iter.next = ni
 		b.StartTimer()
 		var dummy []byte
+		rows := 0
 		for iter.Scan(&dummy) {
+			rows++
+		}
+		b.StopTimer()
+		if rows != numRows {
+			b.Fatalf("scanned %d rows, want %d", rows, numRows)
+		}
+		if err := iter.Close(); err != nil {
+			b.Fatalf("iter error: %v", err)
 		}
 	}
 }
@@ -312,7 +330,16 @@ func BenchmarkIterScanner_NextNoNextIter(b *testing.B) {
 		iter := makeTestIter(numRows, numCols)
 		scanner := iter.Scanner()
 		b.StartTimer()
+		rows := 0
 		for scanner.Next() {
+			rows++
+		}
+		b.StopTimer()
+		if rows != numRows {
+			b.Fatalf("scanned %d rows, want %d", rows, numRows)
+		}
+		if err := scanner.Err(); err != nil {
+			b.Fatalf("scanner error: %v", err)
 		}
 	}
 }

--- a/session.go
+++ b/session.go
@@ -2683,14 +2683,14 @@ func (q *Query) WithNowInSeconds(now int) *Query {
 // times (idempotent), calling Scan(), Next(), or other methods concurrently with
 // Close() or each other will result in undefined behavior.
 type Iter struct {
+	warningHandler        WarningHandler
 	warningQuery          ExecutableQuery
-	warningMetrics        *queryMetrics
 	framer                framerInterface
 	err                   error
-	warningHandler        WarningHandler
-	releasedCustomPayload map[string][]byte
 	next                  *nextIter
+	releasedCustomPayload map[string][]byte
 	host                  *HostInfo
+	warningMetrics        *queryMetrics
 	// allWarnings accumulates warnings across page boundaries.
 	// When a page's framer is released during fetchNextPage(), its warnings
 	// are appended here so they are not lost.
@@ -2700,8 +2700,7 @@ type Iter struct {
 	// MapScan does not recompute them on every row. Populated lazily on
 	// the first call to getScanColumns(). scanColumnsEpoch records the
 	// metaEpoch it was built for.
-	scanColumns      []string
-	scanColumnsEpoch int
+	scanColumns []string
 	// mapScanDefaults holds one freshly-allocated default destination pointer
 	// per scannable column, allocated once on the first MapScan call and
 	// reused across rows. mapScanWorking is allocated lazily on the first
@@ -2712,13 +2711,14 @@ type Iter struct {
 	// metaEpoch defaults was built for.
 	mapScanDefaults []any
 	mapScanWorking  []any
-	mapScanEpoch    int
 	// meta describes the current page's columns. metaEpoch increments every
 	// time meta is replaced by a page turn (copyPageData), so cached data
 	// derived from meta (scanColumns, mapScanDefaults/Working) can detect a
 	// RESULT_METADATA_CHANGED page and rebuild instead of scanning a new
 	// page's rows with a previous page's column names or destination types.
 	meta              resultMetadata
+	scanColumnsEpoch  int
+	mapScanEpoch      int
 	metaEpoch         int
 	pos               int
 	numRows           int

--- a/session.go
+++ b/session.go
@@ -2701,11 +2701,12 @@ type Iter struct {
 	// the first call to getScanColumns().
 	scanColumns []string
 	// mapScanDefaults holds one freshly-allocated default destination pointer
-	// per scannable column, allocated once and reused by MapScan across rows.
-	// mapScanWorking is the per-call scan slice: each MapScan copies defaults
-	// into it, applies user overrides, and scans into it. This avoids
-	// allocating a new []any plus per-column pointers on every row. Both are
-	// populated lazily on the first MapScan call.
+	// per scannable column, allocated once on the first MapScan call and
+	// reused across rows. mapScanWorking is allocated lazily on the first
+	// MapScan call with a caller-supplied destination override: defaults are
+	// copied into it and the overrides applied there, keeping the defaults
+	// intact for later rows. Rows without overrides scan directly into the
+	// defaults. Both are released in finalize().
 	mapScanDefaults   []any
 	mapScanWorking    []any
 	meta              resultMetadata
@@ -2869,6 +2870,10 @@ func (iter *Iter) finalize(dispatchWarnings bool) {
 		iter.next.close()
 		iter.next = nil
 	}
+	// Release the MapScan caches: the defaults hold the last row's decoded
+	// values and the working slice may hold caller-supplied destinations.
+	iter.mapScanDefaults = nil
+	iter.mapScanWorking = nil
 	if dispatchWarnings {
 		iter.handleWarningsOnce()
 	}

--- a/session.go
+++ b/session.go
@@ -2699,7 +2699,15 @@ type Iter struct {
 	// scanColumns caches the column names computed by RowData() so that
 	// MapScan does not recompute them on every row. Populated lazily on
 	// the first call to getScanColumns().
-	scanColumns       []string
+	scanColumns []string
+	// mapScanDefaults holds one freshly-allocated default destination pointer
+	// per scannable column, allocated once and reused by MapScan across rows.
+	// mapScanWorking is the per-call scan slice: each MapScan copies defaults
+	// into it, applies user overrides, and scans into it. This avoids
+	// allocating a new []any plus per-column pointers on every row. Both are
+	// populated lazily on the first MapScan call.
+	mapScanDefaults   []any
+	mapScanWorking    []any
 	meta              resultMetadata
 	pos               int
 	numRows           int
@@ -2954,6 +2962,12 @@ func (is *iterScanner) Next() bool {
 		is.cols = make([][]byte, len(iter.meta.columns))
 	}
 
+	// Trigger async prefetch of next page when we've consumed enough rows,
+	// matching the timing of Iter.Scan() — before column reading and pos++.
+	if iter.next != nil && iter.pos >= iter.next.pos {
+		iter.next.fetchAsync()
+	}
+
 	for i := 0; i < len(is.cols); i++ {
 		col, err := iter.readColumn()
 		if err != nil {
@@ -2963,6 +2977,7 @@ func (is *iterScanner) Next() bool {
 		}
 		is.cols[i] = col
 	}
+
 	iter.pos++
 	is.valid = true
 

--- a/session.go
+++ b/session.go
@@ -2698,18 +2698,28 @@ type Iter struct {
 
 	// scanColumns caches the column names computed by RowData() so that
 	// MapScan does not recompute them on every row. Populated lazily on
-	// the first call to getScanColumns().
-	scanColumns []string
+	// the first call to getScanColumns(). scanColumnsEpoch records the
+	// metaEpoch it was built for.
+	scanColumns      []string
+	scanColumnsEpoch int
 	// mapScanDefaults holds one freshly-allocated default destination pointer
 	// per scannable column, allocated once on the first MapScan call and
 	// reused across rows. mapScanWorking is allocated lazily on the first
 	// MapScan call with a caller-supplied destination override: defaults are
 	// copied into it and the overrides applied there, keeping the defaults
 	// intact for later rows. Rows without overrides scan directly into the
-	// defaults. Both are released in finalize().
-	mapScanDefaults   []any
-	mapScanWorking    []any
+	// defaults. Both are released in finalize(). mapScanEpoch records the
+	// metaEpoch defaults was built for.
+	mapScanDefaults []any
+	mapScanWorking  []any
+	mapScanEpoch    int
+	// meta describes the current page's columns. metaEpoch increments every
+	// time meta is replaced by a page turn (copyPageData), so cached data
+	// derived from meta (scanColumns, mapScanDefaults/Working) can detect a
+	// RESULT_METADATA_CHANGED page and rebuild instead of scanning a new
+	// page's rows with a previous page's column names or destination types.
 	meta              resultMetadata
+	metaEpoch         int
 	pos               int
 	numRows           int
 	closed            int32
@@ -2738,6 +2748,7 @@ func (iter *Iter) copyPageData(src *Iter) {
 	iter.next = src.next
 	iter.host = src.host
 	iter.meta = src.meta
+	iter.metaEpoch++
 	iter.allWarnings = append(iter.allWarnings, src.allWarnings...)
 	iter.releasedCustomPayload = src.releasedCustomPayload
 	iter.pos = src.pos
@@ -2917,6 +2928,25 @@ func (iter *Iter) fetchNextPage() bool {
 	return iter.err == nil
 }
 
+// ensureRowsAvailable loads pages, fetching synchronously if necessary,
+// until a row is available at iter.pos, or the iterator is closed,
+// exhausted, or a fetch fails (in which case it finalizes the iterator and
+// returns false). Callers that cache data derived from iter.meta (column
+// names, destination types) must call this before reading iter.meta, so a
+// RESULT_METADATA_CHANGED page turn is reflected before that data is built.
+func (iter *Iter) ensureRowsAvailable() bool {
+	if atomic.LoadInt32(&iter.closed) != 0 {
+		return false
+	}
+	for iter.pos >= iter.numRows {
+		if !iter.fetchNextPage() {
+			iter.finalize(true)
+			return false
+		}
+	}
+	return true
+}
+
 type Scanner interface {
 	// Next advances the row pointer to point at the next row, the row is valid until
 	// the next call of Next. It returns true if there is a row which is available to be
@@ -2949,15 +2979,8 @@ func (is *iterScanner) Next() bool {
 		return false
 	}
 
-	if atomic.LoadInt32(&iter.closed) != 0 {
+	if !iter.ensureRowsAvailable() {
 		return false
-	}
-
-	for iter.pos >= iter.numRows {
-		if !iter.fetchNextPage() {
-			iter.finalize(true)
-			return false
-		}
 	}
 
 	// A page turn can install new metadata (RESULT_METADATA_CHANGED), so the
@@ -3081,15 +3104,8 @@ func (iter *Iter) Scan(dest ...any) bool {
 		return false
 	}
 
-	if atomic.LoadInt32(&iter.closed) != 0 {
+	if !iter.ensureRowsAvailable() {
 		return false
-	}
-
-	for iter.pos >= iter.numRows {
-		if !iter.fetchNextPage() {
-			iter.finalize(true)
-			return false
-		}
 	}
 
 	if iter.next != nil && iter.pos >= iter.next.pos {


### PR DESCRIPTION
## Summary

`MapScan()` called `iter.RowData()` on **every row**, which allocated a fresh `[]any` plus one heap-allocated pointer per column (via `TypeInfo.NewWithError`) for every single row — all immediately discarded after the row is copied into the user's map.

This caches the scan-destination slice on the `Iter` (mirroring the existing `scanColumns` cache) and reuses it across rows. `Scan` overwrites each `*T` in place and `rowMap` copies the values into the user map before the next row, so the slice can be safely reused.

User-supplied pointers in the map still override individual slots for the duration of a call and are restored to their default allocated pointers afterwards (`repairScanValues`), so the documented `MapScan` behavior (including the "pass pointers in the map" form) is preserved exactly.

`newScanValues` is refactored to share its allocation logic with the reused path via `fillScanValues`. `SliceMap` (which already reuses its values slice) and the public `RowData` API are unchanged.

## Benchmark

`BenchmarkMapScanRows` (64 rows × 8 int columns, pinned single core, benchstat n=12):

| metric | baseline | optimized | delta |
|---|---|---|---|
| allocs/op | 841 | 256 | **-69.6%** (deterministic) |
| B/op | 14.2 KiB | 2.0 KiB | **-85.9%** (deterministic) |
| sec/op | ~144 µs | ~27 µs | large, but GC-driven / high variance |

The allocation and bytes reductions are deterministic and reproducible. The latency improvement is large but high-variance because the baseline's 841 allocs/op drive heavy GC; the headline result is the elimination of ~9 allocations per row (the `[]any` header + 8 column pointers).

## Tests

Adds unit tests covering multi-row reuse correctness and the user-pointer-override repair path, plus the benchmark. Full `unit` suite passes (`-race` clean).
