### PR TITLE
test: retry TRUNCATE on transient Scylla topology contention (#895)

### DIFF
--- a/integration_serialization_scylla_test.go
+++ b/integration_serialization_scylla_test.go
@@ -5,6 +5,7 @@ package gocql
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -17,6 +18,109 @@ import (
 
 	"github.com/gocql/gocql/internal/tests/serialization/valcases"
 )
+
+// truncateTable executes a TRUNCATE on the given fully-qualified table, retrying
+// transient ScyllaDB topology contention ("Another global topology request is
+// ongoing, please retry."). TRUNCATE is a global topology operation, so when
+// several parallel tests issue DDL/TRUNCATE concurrently Scylla rejects the
+// overlapping request with an invalid_request_exception that SimpleRetryPolicy
+// does not retry. See scylladb/gocql#895.
+func truncateTable(t *testing.T, session *Session, fqTable string) error {
+	t.Helper()
+	return retryOnTopologyBusy(func() error {
+		return session.Query("TRUNCATE " + fqTable).Exec()
+	})
+}
+
+// retryOnTopologyBusy runs exec, retrying (with a short backoff) only while it
+// returns the transient ScyllaDB "Another global topology request is ongoing"
+// error. Any other error (or success) is returned immediately.
+func retryOnTopologyBusy(exec func() error) error {
+	const maxAttempts = 10
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		err = exec()
+		if err == nil || !isTopologyBusyErr(err) {
+			return err
+		}
+		// Small backoff capped at ~0.5s; topology requests are short.
+		time.Sleep(time.Duration(50*(attempt+1)) * time.Millisecond)
+	}
+	return err
+}
+
+// isTopologyBusyErr reports whether err is the transient ScyllaDB error returned
+// when another global topology request is already in progress.
+func isTopologyBusyErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Another global topology request is ongoing")
+}
+
+// TestRetryOnTopologyBusy verifies the retry logic deterministically (no
+// cluster required): topology-busy errors are retried until success, other
+// errors are returned immediately, and retries are bounded.
+func TestRetryOnTopologyBusy(t *testing.T) {
+	t.Parallel()
+
+	busy := errors.New("Error during truncate: exceptions::invalid_request_exception (Another global topology request is ongoing, please retry.)")
+	other := errors.New("some other error")
+
+	t.Run("retries busy then succeeds", func(t *testing.T) {
+		calls := 0
+		err := retryOnTopologyBusy(func() error {
+			calls++
+			if calls < 3 {
+				return busy
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected 3 calls, got %d", calls)
+		}
+	})
+
+	t.Run("does not retry non-busy errors", func(t *testing.T) {
+		calls := 0
+		err := retryOnTopologyBusy(func() error {
+			calls++
+			return other
+		})
+		if err != other {
+			t.Fatalf("expected the original error, got %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call (no retry), got %d", calls)
+		}
+	})
+
+	t.Run("gives up after max attempts", func(t *testing.T) {
+		calls := 0
+		err := retryOnTopologyBusy(func() error {
+			calls++
+			return busy
+		})
+		if !isTopologyBusyErr(err) {
+			t.Fatalf("expected the busy error after exhausting retries, got %v", err)
+		}
+		if calls != 10 {
+			t.Fatalf("expected 10 attempts, got %d", calls)
+		}
+	})
+
+	t.Run("isTopologyBusyErr classification", func(t *testing.T) {
+		if !isTopologyBusyErr(busy) {
+			t.Error("busy error should be classified as topology-busy")
+		}
+		if isTopologyBusyErr(other) {
+			t.Error("other error should not be classified as topology-busy")
+		}
+		if isTopologyBusyErr(nil) {
+			t.Error("nil should not be classified as topology-busy")
+		}
+	})
+}
 
 func TestSerializationSimpleTypesCassandra(t *testing.T) {
 	t.Parallel()
@@ -343,7 +447,7 @@ func TestSliceMapMapScanTypes(t *testing.T) {
 		t.Fatal("Failed to create test table:", err)
 	}
 
-	if err := session.Query(fmt.Sprintf("TRUNCATE gocql_test.%s", table)).Exec(); err != nil {
+	if err := truncateTable(t, session, fmt.Sprintf("gocql_test.%s", table)); err != nil {
 		t.Fatal("Failed to truncate test table:", err)
 	}
 
@@ -509,7 +613,7 @@ func TestSliceMapMapScanCounterTypes(t *testing.T) {
 	}
 
 	// Clear existing data
-	if err := session.Query(fmt.Sprintf("TRUNCATE gocql_test_tablets_disabled.%s", table)).Exec(); err != nil {
+	if err := truncateTable(t, session, fmt.Sprintf("gocql_test_tablets_disabled.%s", table)); err != nil {
 		t.Fatal("Failed to truncate counter test table:", err)
 	}
 
@@ -572,7 +676,7 @@ func TestSliceMapMapScanTupleTypes(t *testing.T) {
 	}
 
 	// Clear existing data
-	if err := session.Query(fmt.Sprintf("TRUNCATE gocql_test.%s", table)).Exec(); err != nil {
+	if err := truncateTable(t, session, fmt.Sprintf("gocql_test.%s", table)); err != nil {
 		t.Fatal("Failed to truncate tuple test table:", err)
 	}
 
@@ -700,7 +804,7 @@ func TestSliceMapMapScanVectorTypes(t *testing.T) {
 	}
 
 	// Clear existing data
-	if err := session.Query(fmt.Sprintf("TRUNCATE gocql_test.%s", table)).Exec(); err != nil {
+	if err := truncateTable(t, session, fmt.Sprintf("gocql_test.%s", table)); err != nil {
 		t.Fatal("Failed to truncate vector test table:", err)
 	}
 
@@ -820,7 +924,7 @@ func TestSliceMapMapScanCollectionTypes(t *testing.T) {
 	}
 
 	// Clear existing data
-	if err := session.Query(fmt.Sprintf("TRUNCATE gocql_test.%s", table)).Exec(); err != nil {
+	if err := truncateTable(t, session, fmt.Sprintf("gocql_test.%s", table)); err != nil {
 		t.Fatal("Failed to truncate collection test table:", err)
 	}
 

--- a/integration_serialization_scylla_test.go
+++ b/integration_serialization_scylla_test.go
@@ -36,6 +36,12 @@ func truncateTable(t *testing.T, session *Session, fqTable string) error {
 // returns the transient ScyllaDB "Another global topology request is ongoing"
 // error. Any other error (or success) is returned immediately.
 func retryOnTopologyBusy(exec func() error) error {
+	return retryOnTopologyBusyWithSleep(exec, time.Sleep)
+}
+
+// retryOnTopologyBusyWithSleep is retryOnTopologyBusy with an injectable sleep
+// function so tests can avoid real backoff delays.
+func retryOnTopologyBusyWithSleep(exec func() error, sleep func(time.Duration)) error {
 	const maxAttempts = 10
 	var err error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
@@ -44,7 +50,7 @@ func retryOnTopologyBusy(exec func() error) error {
 			return err
 		}
 		// Small backoff capped at ~0.5s; topology requests are short.
-		time.Sleep(time.Duration(50*(attempt+1)) * time.Millisecond)
+		sleep(time.Duration(50*(attempt+1)) * time.Millisecond)
 	}
 	return err
 }
@@ -64,15 +70,18 @@ func TestRetryOnTopologyBusy(t *testing.T) {
 	busy := errors.New("Error during truncate: exceptions::invalid_request_exception (Another global topology request is ongoing, please retry.)")
 	other := errors.New("some other error")
 
+	// noSleep avoids real backoff so these subtests stay fast and deterministic.
+	noSleep := func(time.Duration) {}
+
 	t.Run("retries busy then succeeds", func(t *testing.T) {
 		calls := 0
-		err := retryOnTopologyBusy(func() error {
+		err := retryOnTopologyBusyWithSleep(func() error {
 			calls++
 			if calls < 3 {
 				return busy
 			}
 			return nil
-		})
+		}, noSleep)
 		if err != nil {
 			t.Fatalf("expected success, got %v", err)
 		}
@@ -83,10 +92,10 @@ func TestRetryOnTopologyBusy(t *testing.T) {
 
 	t.Run("does not retry non-busy errors", func(t *testing.T) {
 		calls := 0
-		err := retryOnTopologyBusy(func() error {
+		err := retryOnTopologyBusyWithSleep(func() error {
 			calls++
 			return other
-		})
+		}, noSleep)
 		if err != other {
 			t.Fatalf("expected the original error, got %v", err)
 		}
@@ -97,10 +106,10 @@ func TestRetryOnTopologyBusy(t *testing.T) {
 
 	t.Run("gives up after max attempts", func(t *testing.T) {
 		calls := 0
-		err := retryOnTopologyBusy(func() error {
+		err := retryOnTopologyBusyWithSleep(func() error {
 			calls++
 			return busy
-		})
+		}, noSleep)
 		if !isTopologyBusyErr(err) {
 			t.Fatalf("expected the busy error after exhausting retries, got %v", err)
 		}


### PR DESCRIPTION
## Summary

Fixes the flaky Scylla CI failure where `TestSliceMapMapScanTypes` / `TupleTypes` / `CollectionTypes` / `CounterTypes` / vector fail with:

```
Failed to truncate test table: Error during truncate: exceptions::invalid_request_exception
  (Another global topology request is ongoing, please retry.)
```

## Root cause

These tests run with `t.Parallel()` and each does `CREATE TABLE` immediately followed by `TRUNCATE` on a tablets keyspace. `TRUNCATE` is a global **topology** operation; concurrent topology requests from parallel tests make Scylla reject the overlapping one with an `invalid_request_exception` that `SimpleRetryPolicy` does not retry.

## Fix

Add a `truncateTable` test helper that retries `TRUNCATE` specifically on the *"Another global topology request is ongoing"* error (short backoff, bounded attempts); other errors fail fast as before. Route the five `TRUNCATE` call sites through it.

Closes #895. This is a CI-stability fix; the affected feature PRs (#893, #879, #875, #775, #753) will pick it up on rebase.
