### PR TITLE
Fix: peer discovery ignores explicit port from `cfg.Hosts`, always uses `cfg.Port`

### DIFF
--- a/control.go
+++ b/control.go
@@ -317,7 +317,11 @@ type connHost struct {
 func (c *controlConn) setupConn(conn *Conn) error {
 	// we need up-to-date host info for the filterHost call below
 	iter := conn.querySystem(context.TODO(), qrySystemLocal)
-	host, err := hostInfoFromIter(iter, c.session.cfg.Port)
+	// Use the port of the host the control connection was actually established on
+	// as the default, so that peers discovered without an explicit port inherit it
+	// (e.g. when cfg.Hosts specifies a non-default port such as the CQL TLS port).
+	defaultPort := controlConnDefaultPort(conn.host, c.session.cfg.Port)
+	host, err := hostInfoFromIter(iter, defaultPort)
 	if err != nil {
 		return err
 	}

--- a/host_port_discovery_integration_test.go
+++ b/host_port_discovery_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+// +build integration
+
+package gocql
+
+import (
+	"net"
+	"strconv"
+	"testing"
+)
+
+// TestHostPortDiscoveryExplicitPort is a regression test for
+// https://github.com/scylladb/gocql/issues/900.
+//
+// It reproduces the scenario where a ScyllaDB cluster exposes CQL on a
+// non-default port (e.g. the TLS port 9142) while cfg.Port is left at its
+// default value (9042). The port is supplied explicitly via cfg.Hosts entries
+// using the host:port form. After the regression, peer discovery from
+// system.local/system.peers assigned cfg.Port (9042) to all discovered hosts
+// instead of the port the control connection was actually established on,
+// causing subsequent data connections to fail.
+func TestHostPortDiscoveryExplicitPort(t *testing.T) {
+	if *flagDistribution == "cassandra" {
+		t.Skip("skipping; the separate CQL TLS port scenario is ScyllaDB-specific")
+	}
+	t.Parallel()
+
+	const (
+		sslPort       = 9142
+		plaintextPort = 9042
+	)
+
+	// sslOpts mirrors the client material the Makefile provisions under
+	// testdata/pki for the ScyllaDB cluster (client auth is required).
+	newSslOpts := func() *SslOptions {
+		return &SslOptions{
+			CertPath:               "testdata/pki/gocql.crt",
+			KeyPath:                "testdata/pki/gocql.key",
+			CaPath:                 "testdata/pki/ca.crt",
+			EnableHostVerification: false,
+		}
+	}
+
+	hostsWithPort := func(hosts []string, port int) []string {
+		out := make([]string, 0, len(hosts))
+		for _, h := range hosts {
+			host := h
+			if hostOnly, _, err := net.SplitHostPort(h); err == nil {
+				host = hostOnly
+			}
+			out = append(out, net.JoinHostPort(host, strconv.Itoa(port)))
+		}
+		return out
+	}
+
+	baseHosts := getClusterHosts()
+
+	// Probe: verify the cluster is reachable over TLS on 9142 using a correct
+	// configuration. If it is not (e.g. a node started without
+	// native_transport_port_ssl / client encryption), skip rather than fail, so
+	// the test does not produce false negatives in non-TLS environments.
+	probe := createCluster()
+	probe.Port = sslPort
+	probe.Hosts = hostsWithPort(baseHosts, sslPort)
+	probe.SslOpts = newSslOpts()
+	probeSession, err := probe.CreateSession()
+	if err != nil {
+		t.Skipf("skipping; cluster not reachable over TLS on port %d: %v", sslPort, err)
+	}
+	probeSession.Close()
+
+	// Buggy scenario: cfg.Port stays at the default plaintext port while the
+	// explicit TLS port is provided only through cfg.Hosts entries. With the
+	// regression present, discovered hosts get cfg.Port (9042) and data
+	// connections fail; with the fix they inherit the control connection's port.
+	cluster := createCluster()
+	cluster.Port = plaintextPort
+	cluster.Hosts = hostsWithPort(baseHosts, sslPort)
+	cluster.SslOpts = newSslOpts()
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("CreateSession failed; the explicit port from cfg.Hosts was likely not propagated to discovered hosts: %v", err)
+	}
+	defer session.Close()
+
+	ringHosts := session.hostSource.getHostsList()
+	if len(ringHosts) == 0 {
+		t.Fatal("expected at least one host in the ring")
+	}
+
+	for _, host := range ringHosts {
+		if host.Port() != sslPort {
+			t.Errorf("host %s discovered with port %d, expected %d (port from cfg.Hosts must be propagated, not cfg.Port)",
+				host.ConnectAddress(), host.Port(), sslPort)
+		}
+	}
+
+	// Exercise the data plane to confirm pool connections succeed on the TLS
+	// port. Before the fix, data connections went to cfg.Port (9042) with TLS
+	// enabled and failed with a TLS handshake error.
+	var releaseVersion string
+	if err := session.Query("SELECT release_version FROM system.local").
+		Consistency(One).Scan(&releaseVersion); err != nil {
+		t.Fatalf("data-plane query failed (connections likely used the wrong port): %v", err)
+	}
+}

--- a/ring_describer.go
+++ b/ring_describer.go
@@ -29,14 +29,14 @@ func (r *ringDescriber) setControlConn(c controlConnection) {
 }
 
 // Ask the control node for the local host info
-func (r *ringDescriber) getLocalHostInfo(conn ConnInterface) (*HostInfo, error) {
+func (r *ringDescriber) getLocalHostInfo(conn ConnInterface, defaultPort int) (*HostInfo, error) {
 	iter := conn.querySystem(context.TODO(), qrySystemLocal)
 
 	if iter == nil {
 		return nil, errNoControl
 	}
 
-	host, err := hostInfoFromIter(iter, r.cfg.Port)
+	host, err := hostInfoFromIter(iter, defaultPort)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve local host info: %w", err)
 	}
@@ -44,7 +44,7 @@ func (r *ringDescriber) getLocalHostInfo(conn ConnInterface) (*HostInfo, error) 
 }
 
 // Ask the control node for host info on all it's known peers
-func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo, c ConnInterface) ([]*HostInfo, error) {
+func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo, c ConnInterface, defaultPort int) ([]*HostInfo, error) {
 	var iter *Iter
 	if c.getIsSchemaV2() {
 		iter = c.querySystem(context.TODO(), qrySystemPeersV2)
@@ -65,7 +65,7 @@ func (r *ringDescriber) getClusterPeerInfo(localHost *HostInfo, c ConnInterface)
 		return nil, fmt.Errorf("unable to fetch peer host info: %s", err)
 	}
 
-	return getPeersFromQuerySystemPeers(rows, r.cfg.Port, r.logger)
+	return getPeersFromQuerySystemPeers(rows, defaultPort, r.logger)
 }
 
 func getPeersFromQuerySystemPeers(querySystemPeerRows []map[string]any, defaultPort int, logger StdLogger) ([]*HostInfo, error) {
@@ -103,6 +103,18 @@ func isZeroToken(host *HostInfo) bool {
 	return len(host.tokens) == 0
 }
 
+// controlConnDefaultPort returns the port that should be used as the default
+// for hosts discovered via system.local/system.peers that do not carry an
+// explicit port. It prefers the port the control connection was actually
+// established on (e.g. when cfg.Hosts specifies a non-default port such as the
+// CQL TLS port), falling back to cfgPort when unavailable.
+func controlConnDefaultPort(host *HostInfo, cfgPort int) int {
+	if host != nil && host.Port() != 0 {
+		return host.Port()
+	}
+	return cfgPort
+}
+
 // GetHostsFromSystem returns a list of hosts found via queries to system.local and system.peers
 func (r *ringDescriber) GetHostsFromSystem() ([]*HostInfo, string, error) {
 	r.mu.Lock()
@@ -113,12 +125,17 @@ func (r *ringDescriber) GetHostsFromSystem() ([]*HostInfo, string, error) {
 	}
 
 	ch := r.control.getConn()
-	localHost, err := r.getLocalHostInfo(ch.conn)
+	// Use the port of the host the control connection was actually established on
+	// as the default, so that hosts discovered without an explicit port inherit it
+	// (e.g. when cfg.Hosts specifies a non-default port such as the CQL TLS port).
+	defaultPort := controlConnDefaultPort(ch.host, r.cfg.Port)
+
+	localHost, err := r.getLocalHostInfo(ch.conn, defaultPort)
 	if err != nil {
 		return r.prevHosts, r.prevPartitioner, err
 	}
 
-	peerHosts, err := r.getClusterPeerInfo(localHost, ch.conn)
+	peerHosts, err := r.getClusterPeerInfo(localHost, ch.conn, defaultPort)
 	if err != nil {
 		return r.prevHosts, r.prevPartitioner, err
 	}

--- a/ring_describer_test.go
+++ b/ring_describer_test.go
@@ -327,6 +327,53 @@ func TestMockGetHostsFromSystem(t *testing.T) {
 	tests.AssertEqual(t, "host token length", 2, len(hosts[0].tokens))
 }
 
+// portMockControlConn behaves like mockControlConn but reports a configurable
+// port for the host the control connection was established on.
+type portMockControlConn struct {
+	mockControlConn
+	port int
+}
+
+func (m *portMockControlConn) getConn() *connHost {
+	return &connHost{
+		conn: &mockConnection{},
+		host: &HostInfo{port: m.port},
+	}
+}
+
+// TestGetHostsFromSystemUsesControlConnPort verifies that hosts discovered via
+// system.local/system.peers without an explicit native_port inherit the port of
+// the host the control connection was actually established on, rather than
+// cfg.Port. This is a regression test for
+// https://github.com/scylladb/gocql/issues/900 where an explicit non-default
+// port from cfg.Hosts (e.g. the CQL TLS port 9142) was ignored and cfg.Port
+// (9042) was used for all discovered hosts.
+func TestGetHostsFromSystemUsesControlConnPort(t *testing.T) {
+	t.Parallel()
+
+	const controlConnPort = 9142
+
+	r := &ringDescriber{
+		control: &portMockControlConn{port: controlConnPort},
+		// cfg.Port is the default plaintext port, which must NOT be used when the
+		// control connection was established on a different port.
+		cfg: &ClusterConfig{Port: 9042},
+	}
+
+	hosts, _, err := r.GetHostsFromSystem()
+	if err != nil {
+		t.Fatalf("unable to get hosts: %v", err)
+	}
+
+	if len(hosts) == 0 {
+		t.Fatal("expected at least one host")
+	}
+
+	for _, h := range hosts {
+		tests.AssertEqual(t, fmt.Sprintf("port for host %s", h.ConnectAddress()), controlConnPort, h.Port())
+	}
+}
+
 func TestRingDescriberGetClusterPeerInfoClosesIter(t *testing.T) {
 	t.Parallel()
 
@@ -352,7 +399,7 @@ func TestRingDescriberGetClusterPeerInfoClosesIter(t *testing.T) {
 			framer:  framer,
 			numRows: 1,
 		},
-	})
+	}, r.cfg.Port)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -386,7 +433,7 @@ func TestGetClusterPeerInfoQueryRouting(t *testing.T) {
 			}
 			r := &ringDescriber{cfg: &ClusterConfig{}}
 			// iter is nil so getClusterPeerInfo returns errNoControl, but the query is still recorded
-			_, _ = r.getClusterPeerInfo(&HostInfo{}, conn)
+			_, _ = r.getClusterPeerInfo(&HostInfo{}, conn, r.cfg.Port)
 			if conn.lastQuery != tt.wantQuery {
 				t.Errorf("got query %q, want %q", conn.lastQuery, tt.wantQuery)
 			}


### PR DESCRIPTION
When the control connection was established on a port supplied explicitly via
`cfg.Hosts` (e.g. the CQL TLS port `9142`) while `cfg.Port` was left at its
default (`9042`), peer discovery assigned `cfg.Port` to all hosts read from
`system.local` / `system.peers`. Subsequent data connections then targeted the
wrong port. With TLS enabled this surfaced as:

```
tls: first record does not look like a TLS handshake
```

This PR makes discovery use the port the control connection was actually
established on as the default, restoring the pre-regression behavior.

Unit and integration tests added.

Fixes: #900 