### PR TITLE
fix(scylla): detect ScyllaDB via SUPPORTED protocol extensions

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -571,7 +571,8 @@ func (pool *hostConnPool) initConnPicker(conn *Conn) {
 		return
 	}
 
-	if conn.isScyllaConn() {
+	// Use the shard-aware picker only when the server enabled shard awareness (nrShards != 0).
+	if conn.isScyllaConn() && conn.getScyllaSupported().nrShards != 0 {
 		pool.connPicker = newScyllaConnPicker(conn, pool.logger)
 		return
 	}

--- a/scylla.go
+++ b/scylla.go
@@ -333,7 +333,11 @@ func parseSupported(supported map[string][]string, logger StdLogger) ScyllaConne
 			logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d",
 				si.partitioner, si.shardingAlgorithm, si.nrShards, si.msbIgnore)
 		}
-		return ScyllaConnectionFeatures{}
+		// Clear shard-routing fields only; host-wide features are preserved.
+		si.shard = 0
+		si.nrShards = 0
+		si.msbIgnore = 0
+		si.shardingAlgorithm = ""
 	}
 
 	return si

--- a/scylla.go
+++ b/scylla.go
@@ -52,10 +52,14 @@ type ScyllaHostFeatures struct {
 	// https://github.com/scylladb/scylladb/issues/20860
 	// https://github.com/scylladb/scylladb/pull/23292
 	isMetadataIDSupported bool
+	// True when the node is identified as ScyllaDB; stays true even when
+	// shard awareness is disabled on the server.
+	isScylla bool
 }
 
+// IsPresent reports whether the host is a ScyllaDB node.
 func (f ScyllaHostFeatures) IsPresent() bool {
-	return f.nrShards != 0
+	return f.isScylla
 }
 
 func (f ScyllaHostFeatures) Partitioner() string {
@@ -328,6 +332,10 @@ func parseSupported(supported map[string][]string, logger StdLogger) ScyllaConne
 		si.isMetadataIDSupported = true
 	}
 
+	_, hasLWT := supported[lwtAddMetadataMarkKey]
+	_, hasRateLimit := supported[rateLimitError]
+	si.isScylla = hasLWT || hasRateLimit || si.isMetadataIDSupported || si.nrShards != 0
+
 	if si.partitioner != "org.apache.cassandra.dht.Murmur3Partitioner" || si.shardingAlgorithm != "biased-token-round-robin" || si.nrShards == 0 || si.msbIgnore == 0 {
 		if debug.Enabled {
 			logger.Printf("scylla: unsupported sharding configuration, partitioner=%s, algorithm=%s, no_shards=%d, msb_ignore=%d",
@@ -364,9 +372,9 @@ func parseCQLProtocolExtensions(supported map[string][]string, logger StdLogger)
 	return exts
 }
 
-// isScyllaConn checks if conn is suitable for scyllaConnPicker.
+// isScyllaConn checks if conn is connected to a ScyllaDB node.
 func (c *Conn) isScyllaConn() bool {
-	return c.getScyllaSupported().nrShards != 0
+	return c.getScyllaSupported().IsPresent()
 }
 
 // scyllaConnPicker is a specialised ConnPicker that selects connections based

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -264,6 +264,93 @@ func TestScyllaLWTExtParsing(t *testing.T) {
 	})
 }
 
+func TestParseSupported(t *testing.T) {
+	t.Parallel()
+
+	const (
+		lwtMask        = 8
+		rateLimitCode  = 42
+		shardAwarePort = 19042
+	)
+
+	validSharding := map[string][]string{
+		"SCYLLA_SHARD":               {"3"},
+		"SCYLLA_NR_SHARDS":           {"12"},
+		"SCYLLA_PARTITIONER":         {"org.apache.cassandra.dht.Murmur3Partitioner"},
+		"SCYLLA_SHARDING_ALGORITHM":  {"biased-token-round-robin"},
+		"SCYLLA_SHARDING_IGNORE_MSB": {"12"},
+		"SCYLLA_SHARD_AWARE_PORT":    {fmt.Sprintf("%d", shardAwarePort)},
+		lwtAddMetadataMarkKey:        {fmt.Sprintf("LWT_OPTIMIZATION_META_BIT_MASK=%d", lwtMask)},
+		rateLimitError:               {fmt.Sprintf("ERROR_CODE=%d", rateLimitCode)},
+	}
+
+	tests := []struct {
+		name               string
+		supported          map[string][]string
+		nrShards           int
+		msbIgnore          uint64
+		shardingAlgorithm  string
+		partitioner        string
+		lwtFlagMask        int
+		rateLimitErrorCode int
+		shardAwarePort     uint16
+	}{
+		{
+			name:               "full valid Scylla with sharding",
+			supported:          validSharding,
+			nrShards:           12,
+			msbIgnore:          12,
+			shardingAlgorithm:  "biased-token-round-robin",
+			partitioner:        "org.apache.cassandra.dht.Murmur3Partitioner",
+			lwtFlagMask:        lwtMask,
+			rateLimitErrorCode: rateLimitCode,
+			shardAwarePort:     shardAwarePort,
+		},
+		{
+			name: "Scylla without sharding (allow_shard_aware_drivers: false)",
+			supported: map[string][]string{
+				lwtAddMetadataMarkKey:     {fmt.Sprintf("LWT_OPTIMIZATION_META_BIT_MASK=%d", lwtMask)},
+				rateLimitError:            {fmt.Sprintf("ERROR_CODE=%d", rateLimitCode)},
+				"SCYLLA_SHARD_AWARE_PORT": {fmt.Sprintf("%d", shardAwarePort)},
+			},
+			lwtFlagMask:        lwtMask,
+			rateLimitErrorCode: rateLimitCode,
+			shardAwarePort:     shardAwarePort,
+		},
+		{
+			name: "invalid sharding (msbIgnore missing) with ports and LWT",
+			supported: map[string][]string{
+				"SCYLLA_NR_SHARDS":          {"12"},
+				"SCYLLA_PARTITIONER":        {"org.apache.cassandra.dht.Murmur3Partitioner"},
+				"SCYLLA_SHARDING_ALGORITHM": {"biased-token-round-robin"},
+				"SCYLLA_SHARD_AWARE_PORT":   {fmt.Sprintf("%d", shardAwarePort)},
+				lwtAddMetadataMarkKey:       {fmt.Sprintf("LWT_OPTIMIZATION_META_BIT_MASK=%d", lwtMask)},
+			},
+			partitioner:    "org.apache.cassandra.dht.Murmur3Partitioner",
+			lwtFlagMask:    lwtMask,
+			shardAwarePort: shardAwarePort,
+		},
+		{
+			name:      "pure Cassandra (no SCYLLA keys)",
+			supported: map[string][]string{"CQL_VERSION": {"3.0.0"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseSupported(tt.supported, &testLogger{})
+			assert.Equal(t, tt.nrShards, got.nrShards, "nrShards")
+			assert.Equal(t, tt.msbIgnore, got.msbIgnore, "msbIgnore")
+			assert.Equal(t, tt.shardingAlgorithm, got.shardingAlgorithm, "shardingAlgorithm")
+			assert.Equal(t, tt.partitioner, got.partitioner, "partitioner")
+			assert.Equal(t, tt.lwtFlagMask, got.lwtFlagMask, "lwtFlagMask")
+			assert.Equal(t, tt.rateLimitErrorCode, got.rateLimitErrorCode, "rateLimitErrorCode")
+			assert.Equal(t, tt.shardAwarePort, got.shardAwarePort, "shardAwarePort")
+		})
+	}
+}
+
 func TestScyllaPortIterator(t *testing.T) {
 	t.Parallel()
 

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -285,15 +285,17 @@ func TestParseSupported(t *testing.T) {
 	}
 
 	tests := []struct {
-		name               string
-		supported          map[string][]string
-		nrShards           int
-		msbIgnore          uint64
-		shardingAlgorithm  string
-		partitioner        string
-		lwtFlagMask        int
-		rateLimitErrorCode int
-		shardAwarePort     uint16
+		name                  string
+		supported             map[string][]string
+		nrShards              int
+		msbIgnore             uint64
+		shardingAlgorithm     string
+		partitioner           string
+		lwtFlagMask           int
+		rateLimitErrorCode    int
+		shardAwarePort        uint16
+		isMetadataIDSupported bool
+		isScylla              bool
 	}{
 		{
 			name:               "full valid Scylla with sharding",
@@ -305,6 +307,7 @@ func TestParseSupported(t *testing.T) {
 			lwtFlagMask:        lwtMask,
 			rateLimitErrorCode: rateLimitCode,
 			shardAwarePort:     shardAwarePort,
+			isScylla:           true,
 		},
 		{
 			name: "Scylla without sharding (allow_shard_aware_drivers: false)",
@@ -313,9 +316,13 @@ func TestParseSupported(t *testing.T) {
 				rateLimitError:            {fmt.Sprintf("ERROR_CODE=%d", rateLimitCode)},
 				"SCYLLA_SHARD_AWARE_PORT": {fmt.Sprintf("%d", shardAwarePort)},
 			},
+			nrShards:           0,
+			msbIgnore:          0,
+			shardingAlgorithm:  "",
 			lwtFlagMask:        lwtMask,
 			rateLimitErrorCode: rateLimitCode,
 			shardAwarePort:     shardAwarePort,
+			isScylla:           true,
 		},
 		{
 			name: "invalid sharding (msbIgnore missing) with ports and LWT",
@@ -326,13 +333,30 @@ func TestParseSupported(t *testing.T) {
 				"SCYLLA_SHARD_AWARE_PORT":   {fmt.Sprintf("%d", shardAwarePort)},
 				lwtAddMetadataMarkKey:       {fmt.Sprintf("LWT_OPTIMIZATION_META_BIT_MASK=%d", lwtMask)},
 			},
-			partitioner:    "org.apache.cassandra.dht.Murmur3Partitioner",
-			lwtFlagMask:    lwtMask,
+			nrShards:          0,
+			msbIgnore:         0,
+			shardingAlgorithm: "",
+			partitioner:       "org.apache.cassandra.dht.Murmur3Partitioner",
+			lwtFlagMask:       lwtMask,
+			shardAwarePort:    shardAwarePort,
+			isScylla:          true,
+		},
+		{
+			name:                  "Scylla detected via SCYLLA_USE_METADATA_ID only",
+			supported:             map[string][]string{"SCYLLA_USE_METADATA_ID": {""}},
+			isMetadataIDSupported: true,
+			isScylla:              true,
+		},
+		{
+			name:           "shard-aware port only, no detection keys",
+			supported:      map[string][]string{"SCYLLA_SHARD_AWARE_PORT": {fmt.Sprintf("%d", shardAwarePort)}},
 			shardAwarePort: shardAwarePort,
+			isScylla:       false,
 		},
 		{
 			name:      "pure Cassandra (no SCYLLA keys)",
 			supported: map[string][]string{"CQL_VERSION": {"3.0.0"}},
+			isScylla:  false,
 		},
 	}
 
@@ -347,8 +371,69 @@ func TestParseSupported(t *testing.T) {
 			assert.Equal(t, tt.lwtFlagMask, got.lwtFlagMask, "lwtFlagMask")
 			assert.Equal(t, tt.rateLimitErrorCode, got.rateLimitErrorCode, "rateLimitErrorCode")
 			assert.Equal(t, tt.shardAwarePort, got.shardAwarePort, "shardAwarePort")
+			assert.Equal(t, tt.isMetadataIDSupported, got.isMetadataIDSupported, "isMetadataIDSupported")
+			assert.Equal(t, tt.isScylla, got.isScylla, "isScylla")
 		})
 	}
+}
+
+func TestIsScyllaConn(t *testing.T) {
+	t.Parallel()
+
+	makeConn := func(supported map[string][]string) *Conn {
+		conn := mockConn(0)
+		conn.supported = supported
+		conn.scyllaSupported = parseSupported(supported, &testLogger{})
+		return conn
+	}
+
+	t.Run("Scylla with sharding", func(t *testing.T) {
+		t.Parallel()
+		conn := makeConn(map[string][]string{
+			"SCYLLA_NR_SHARDS":           {"12"},
+			"SCYLLA_PARTITIONER":         {"org.apache.cassandra.dht.Murmur3Partitioner"},
+			"SCYLLA_SHARDING_ALGORITHM":  {"biased-token-round-robin"},
+			"SCYLLA_SHARDING_IGNORE_MSB": {"12"},
+			lwtAddMetadataMarkKey:        {"LWT_OPTIMIZATION_META_BIT_MASK=8"},
+		})
+		assert.True(t, conn.isScyllaConn())
+	})
+
+	t.Run("Scylla without sharding (allow_shard_aware_drivers: false)", func(t *testing.T) {
+		t.Parallel()
+		conn := makeConn(map[string][]string{
+			lwtAddMetadataMarkKey: {"LWT_OPTIMIZATION_META_BIT_MASK=8"},
+			rateLimitError:        {"ERROR_CODE=42"},
+		})
+		assert.True(t, conn.isScyllaConn())
+	})
+
+	t.Run("pure Cassandra", func(t *testing.T) {
+		t.Parallel()
+		conn := makeConn(map[string][]string{"CQL_VERSION": {"3.0.0"}})
+		assert.False(t, conn.isScyllaConn())
+	})
+}
+
+func TestInitConnPickerNonShardAwareScylla(t *testing.T) {
+	t.Parallel()
+
+	conn := mockConn(0)
+	conn.scyllaSupported = parseSupported(map[string][]string{
+		lwtAddMetadataMarkKey: {"LWT_OPTIMIZATION_META_BIT_MASK=8"},
+	}, &testLogger{})
+	require.True(t, conn.isScyllaConn())
+	require.Zero(t, conn.getScyllaSupported().nrShards)
+
+	pool := &hostConnPool{
+		size:       1,
+		connPicker: nopConnPicker{},
+		logger:     &testLogger{},
+	}
+	pool.initConnPicker(conn)
+
+	_, isScyllaPicker := pool.connPicker.(*scyllaConnPicker)
+	assert.False(t, isScyllaPicker, "must not build scyllaConnPicker without shards")
 }
 
 func TestScyllaPortIterator(t *testing.T) {


### PR DESCRIPTION
## Problem

ScyllaDB was recognized only by a non-zero shard count (`nrShards != 0`) derived from the `SUPPORTED` response. That signal is fragile: when a node runs with `allow_shard_aware_drivers: false`, the server suppresses the entire intranode-sharding block (`SCYLLA_SHARD`, `SCYLLA_NR_SHARDS`, `SCYLLA_PARTITIONER`, `SCYLLA_SHARDING_ALGORITHM`, `SCYLLA_SHARDING_IGNORE_MSB`), so the driver misidentified ScyllaDB as Cassandra. That broke `system.peers_v2` avoidance, `USING TIMEOUT`, peer-query routing, and `scylla_tables` metadata lookups.

A related root cause: `parseSupported()` returned a fully zeroed `ScyllaConnectionFeatures{}` on invalid/absent sharding config, discarding host-wide features (LWT mask, rate-limit code, metadata-id flag, shard-aware ports, partitioner) that ScyllaDB advertises independently of shard awareness.

## Why not `SCYLLA_PARTITIONER`?

`SCYLLA_PARTITIONER` lives inside the same `if (allow_shard_aware_drivers)` block on the server, so it is suppressed together with the shard count — it does not solve the fragility. The reliable signals are the protocol-extension keys emitted via `supported_cql_protocol_extensions()` (returns `::full()`, no config gate): `SCYLLA_LWT_ADD_METADATA_MARK` (since ScyllaDB ~4.1), `SCYLLA_RATE_LIMIT_ERROR`, and `SCYLLA_USE_METADATA_ID`.

## Changes

Two commits:

1. **`fix(scylla): preserve host features when sharding config is unsupported`** — on invalid/absent sharding config, clear only the shard-routing fields (`shard`, `nrShards`, `msbIgnore`, `shardingAlgorithm`) instead of the whole struct. Host-wide features, including the partitioner, are preserved.

2. **`fix(scylla): detect ScyllaDB via SUPPORTED protocol extensions`** — add an `isScylla` marker to `ScyllaHostFeatures`, set in `parseSupported()` before the sharding gate, true when the node advertises any unconditional `SCYLLA_*` extension key or a non-zero shard count. `isScyllaConn()` now returns this marker. Because the marker no longer implies shard awareness, `initConnPicker()` additionally checks `nrShards != 0` before building a `scyllaConnPicker`, avoiding a panic for a non-shard-aware ScyllaDB node.

## Result

ScyllaDB is detected reliably even when shard awareness is disabled, while shard-aware connection picking still requires real shard data.

## Tests

- `TestParseSupported` — full sharding, extensions-only, invalid sharding, metadata-id-only, shard-aware-port-only, and pure Cassandra inputs.
- `TestIsScyllaConn` — detection with sharding, without sharding (`allow_shard_aware_drivers: false`), and pure Cassandra.
- `TestInitConnPickerNonShardAwareScylla` — a non-shard-aware ScyllaDB connection does not build a `scyllaConnPicker` (no panic) and falls back to the default picker.

Full unit suite passes (`go test -tags unit ./...`).

Fixes: https://github.com/scylladb/gocql/issues/902
