### PR TITLE
Gate control-connection port override when AddressTranslator is configured

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -135,12 +136,17 @@ type ClusterConfig struct {
 	Keyspace string
 	// CQL version (default: 3.0.0)
 	CQLVersion string
-	// addresses for the initial connections. It is recommended to use the value set in
+	// Addresses for the initial connections. It is recommended to use the value set in
 	// the Cassandra config for broadcast_address or listen_address, an IP address not
 	// a domain name. This is because events from Cassandra will use the configured IP
 	// address, which is used to index connected hosts. If the domain name specified
 	// resolves to more than 1 IP address then the driver may connect multiple times to
 	// the same host, and will not mark the node being down or up from events.
+	//
+	// Each entry may optionally include a port in host:port format. cfg.Port is
+	// overridden only when every entry carries an explicit port and all ports are
+	// equal. If any entry omits the port, or entries disagree on the port, cfg.Port
+	// is left unchanged and is used for peer discovery.
 	Hosts []string
 	// The time to wait for frames before flushing the frames connection to Cassandra.
 	// Can help reduce syscall overhead by making less calls to write. Set to 0 to
@@ -547,6 +553,34 @@ func (cfg *ClusterConfig) Validate() error {
 
 	if cfg.NumConns < 0 {
 		return errors.New("NumConns should be positive non-zero number or zero")
+	}
+
+	// Parse and normalise any ports embedded in cfg.Hosts.
+	// cfg.Port is overridden only when every entry carries an explicit port and
+	// they all agree on the same value. Any entry without a port, or any
+	// disagreement between entries, leaves cfg.Port unchanged.
+	var explicitPort int // 0 means "not yet seen"
+	allHavePorts := true
+	portsConsistent := true
+	for _, addr := range cfg.Hosts {
+		_, portStr, err := net.SplitHostPort(addr)
+		if err != nil {
+			// No port in this entry.
+			allHavePorts = false
+			continue
+		}
+		p, err := strconv.Atoi(portStr)
+		if err != nil || p <= 0 || p > 65535 {
+			return fmt.Errorf("invalid port %q in host entry %q: port must be a number between 1 and 65535", portStr, addr)
+		}
+		if explicitPort == 0 {
+			explicitPort = p
+		} else if explicitPort != p {
+			portsConsistent = false
+		}
+	}
+	if allHavePorts && portsConsistent && explicitPort != 0 {
+		cfg.Port = explicitPort
 	}
 
 	if cfg.Port <= 0 || cfg.Port > 65535 {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -66,6 +66,76 @@ func TestNewCluster_WithHosts(t *testing.T) {
 	tests.AssertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
 }
 
+// TestValidate_HostPortNormalization covers the port-in-hosts feature added to
+// Validate(): a port embedded in a cfg.Hosts entry should be adopted as cfg.Port
+// so that peer discovery uses the correct port for all nodes.
+func TestValidate_HostPortNormalization(t *testing.T) {
+	t.Parallel()
+
+	makeValid := func(hosts ...string) *ClusterConfig {
+		cfg := NewCluster(hosts...)
+		// Supply just enough mandatory fields for Validate to reach the port
+		// check rather than failing on an earlier guard.
+		return cfg
+	}
+
+	t.Run("single host with explicit port overrides cfg.Port", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9142, cfg.Port)
+	})
+
+	t.Run("multiple hosts with the same explicit port", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "10.0.0.2:9142")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9142, cfg.Port)
+	})
+
+	t.Run("hosts without explicit port use cfg.Port unchanged", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1", "10.0.0.2")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9042, cfg.Port)
+	})
+
+	t.Run("mixed: some hosts with port, some without – leaves cfg.Port unchanged", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "10.0.0.2")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Not all hosts have a port → cfg.Port is left at the default
+		tests.AssertEqual(t, "cfg.Port after Validate", 9042, cfg.Port)
+	})
+
+	t.Run("hosts with conflicting explicit ports leaves cfg.Port unchanged", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "10.0.0.2:9043")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Inconsistent ports → fallback to the default cfg.Port (9042)
+		tests.AssertEqual(t, "cfg.Port after Validate", 9042, cfg.Port)
+	})
+
+	t.Run("host with invalid port string returns error", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:notaport")
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("expected an error for invalid port, got nil")
+		}
+	})
+}
+
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {
 	t.Parallel()
 	hh := HostInfoBuilder{


### PR DESCRIPTION
The previous commit propagated the control connection's port to all discovered
hosts that lack an explicit `native_port`. That is correct for the #900
scenario (direct connections, non-default CQL-TLS port). However, when an
`AddressTranslator` or `ClientRoutesConfig` is set — for example, nodes exposed
through a TCP proxy where the translator is built around `cfg.Port` — the driver
must not let the control connection's port bleed into the default. If `cfg.Hosts`
uses heterogeneous ports, different contact points would produce different
defaults, making the port handed to the translator non-deterministic.

When an `AddressTranslator` or `ClientRoutesConfig` is set, `controlConnDefaultPort` now falls back to `cfg.Port` unconditionally instead of using the control connection's port, preventing non-deterministic port defaults when `cfg.Hosts` entries carry heterogeneous ports. A new `usesAddressTranslation()` helper on `ClusterConfig` centralises this check, and the `Port` field doc is updated to explain the behaviour for translator users. The change is covered by three new unit tests (`TestGetHostsFromSystemTranslatorKeepsCfgPort`, `TestControlConnDefaultPort`, `TestUsesAddressTranslation`) and a shared `assertAllHostsPort` test helper.
