### PR TITLE
Strict TLS certificate chain validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ testdata/pki/.truststore
 testdata/pki/*.crt
 testdata/pki/*.key
 testdata/pki/*.p12
+testdata/pki/*.srl
 
 docs/_build/
 docs/source/.doctrees

--- a/cluster.go
+++ b/cluster.go
@@ -449,7 +449,7 @@ func (cfg *ClusterConfig) ValidateAndInitSSL() error {
 	if cfg.SslOpts == nil {
 		return nil
 	}
-	actualTLSConfig, err := setupTLSConfig(cfg.SslOpts)
+	actualTLSConfig, err := setupTLSConfig(cfg.SslOpts, cfg.logger())
 	if err != nil {
 		return fmt.Errorf("failed to initialize ssl configuration: %s", err.Error())
 	}
@@ -711,7 +711,7 @@ func learnPortFromHosts(hosts []string) (int, error) {
 	return port, nil
 }
 
-func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
+func setupTLSConfig(sslOpts *SslOptions, logger StdLogger) (*tls.Config, error) {
 	//  Config.InsecureSkipVerify | EnableHostVerification | Result
 	//  Config is nil             | true                   | verify host
 	//  Config is nil             | false                  | do not verify host
@@ -759,5 +759,112 @@ func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 		tlsConfig.Certificates = append(tlsConfig.Certificates, mycert)
 	}
 
+	// Emit deprecation warning if the option is used
+	if sslOpts.DisableStrictCertificateValidation {
+		if logger != nil {
+			logger.Println("gocql: WARNING - DisableStrictCertificateValidation is deprecated and will be removed in a future version. " +
+				"Please ensure your certificate chains are properly configured to work with strict validation.")
+		}
+	}
+
+	// Add strict certificate chain validation unless explicitly disabled
+	// This ensures that the entire certificate chain is properly validated,
+	// not just that one intermediate certificate is trusted.
+	if !tlsConfig.InsecureSkipVerify && !sslOpts.DisableStrictCertificateValidation {
+		strictVerify := strictVerifyPeerCertificate(tlsConfig.RootCAs)
+		existingVerify := tlsConfig.VerifyPeerCertificate
+		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if err := strictVerify(rawCerts, verifiedChains); err != nil {
+				return err
+			}
+			if existingVerify != nil {
+				return existingVerify(rawCerts, verifiedChains)
+			}
+			return nil
+		}
+	}
+
 	return tlsConfig, nil
+}
+
+// strictVerifyPeerCertificate returns a VerifyPeerCertificate callback that performs
+// certificate chain validation by explicitly calling cert.Verify(). This ensures that
+// the certificate chain is properly validated against the configured root CAs and
+// intermediate certificates, rather than relying on Go's default TLS behavior.
+func strictVerifyPeerCertificate(rootCAs *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return errors.New("no certificates provided")
+		}
+
+		// Parse the leaf certificate
+		cert, err := x509.ParseCertificate(rawCerts[0])
+		if err != nil {
+			return fmt.Errorf("failed to parse certificate: %v", err)
+		}
+
+		// Build the intermediate certificate pool from the provided chain
+		intermediates := x509.NewCertPool()
+		for i := 1; i < len(rawCerts); i++ {
+			intermediateCert, err := x509.ParseCertificate(rawCerts[i])
+			if err != nil {
+				return fmt.Errorf("failed to parse intermediate certificate: %v", err)
+			}
+			intermediates.AddCert(intermediateCert)
+		}
+
+		// Verify the certificate chain
+		opts := x509.VerifyOptions{
+			Roots:         rootCAs,
+			Intermediates: intermediates,
+			// We're not verifying the hostname here as that's handled separately
+			// by the TLS library if ServerName is set
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+
+		chains, err := cert.Verify(opts)
+		if err != nil {
+			// Provide detailed information about which certificate failed
+			return fmt.Errorf("certificate verification failed for subject=%q, issuer=%q: %v",
+				cert.Subject.String(), cert.Issuer.String(), err)
+		}
+
+		// Ensure at least one valid chain was found
+		if len(chains) == 0 {
+			return fmt.Errorf("no valid certificate chains found for subject=%q", cert.Subject.String())
+		}
+
+		// Verify that all certificates in at least one chain are properly connected
+		// This ensures every certificate is signed by the next one in the chain
+		for _, chain := range chains {
+			if len(chain) == 0 {
+				continue
+			}
+
+			// Verify each certificate in the chain is signed by its parent
+			chainValid := true
+			for i := 0; i < len(chain)-1; i++ {
+				// Check if cert[i] is signed by cert[i+1]
+				if err := chain[i].CheckSignatureFrom(chain[i+1]); err != nil {
+					chainValid = false
+					break
+				}
+			}
+
+			// If we found a valid chain where all certificates are properly signed, we're good
+			if chainValid {
+				// Also verify the root certificate in this chain is self-signed
+				rootCert := chain[len(chain)-1]
+				if err := rootCert.CheckSignatureFrom(rootCert); err != nil {
+					// This root is not self-signed, continue checking other chains
+					continue
+				}
+				// Found a valid chain with proper signatures all the way to a self-signed root
+				return nil
+			}
+		}
+
+		// No valid chain found where all certificates are properly signed
+		return fmt.Errorf("no valid certificate chain found with proper signatures for subject=%q", cert.Subject.String())
+	}
 }

--- a/cluster.go
+++ b/cluster.go
@@ -793,78 +793,60 @@ func setupTLSConfig(sslOpts *SslOptions, logger StdLogger) (*tls.Config, error) 
 // intermediate certificates, rather than relying on Go's default TLS behavior.
 func strictVerifyPeerCertificate(rootCAs *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		if len(rawCerts) == 0 {
-			return errors.New("no certificates provided")
-		}
-
-		// Parse the leaf certificate
-		cert, err := x509.ParseCertificate(rawCerts[0])
-		if err != nil {
-			return fmt.Errorf("failed to parse certificate: %v", err)
-		}
-
-		// Build the intermediate certificate pool from the provided chain
-		intermediates := x509.NewCertPool()
-		for i := 1; i < len(rawCerts); i++ {
-			intermediateCert, err := x509.ParseCertificate(rawCerts[i])
-			if err != nil {
-				return fmt.Errorf("failed to parse intermediate certificate: %v", err)
-			}
-			intermediates.AddCert(intermediateCert)
-		}
-
-		// Verify the certificate chain
-		opts := x509.VerifyOptions{
-			Roots:         rootCAs,
-			Intermediates: intermediates,
-			// We're not verifying the hostname here as that's handled separately
-			// by the TLS library if ServerName is set
-			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		}
-
-		chains, err := cert.Verify(opts)
-		if err != nil {
-			// Provide detailed information about which certificate failed
-			return fmt.Errorf("certificate verification failed for subject=%q, issuer=%q: %v",
-				cert.Subject.String(), cert.Issuer.String(), err)
-		}
-
-		// Ensure at least one valid chain was found
+		chains := verifiedChains
 		if len(chains) == 0 {
-			return fmt.Errorf("no valid certificate chains found for subject=%q", cert.Subject.String())
+			if len(rawCerts) == 0 {
+				return errors.New("no certificates provided")
+			}
+			cert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return fmt.Errorf("failed to parse certificate: %v", err)
+			}
+			intermediates := x509.NewCertPool()
+			for i := 1; i < len(rawCerts); i++ {
+				intermediateCert, err := x509.ParseCertificate(rawCerts[i])
+				if err != nil {
+					return fmt.Errorf("failed to parse intermediate certificate: %v", err)
+				}
+				intermediates.AddCert(intermediateCert)
+			}
+			opts := x509.VerifyOptions{
+				Roots:         rootCAs,
+				Intermediates: intermediates,
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			}
+			chains, err = cert.Verify(opts)
+			if err != nil {
+				return fmt.Errorf("certificate verification failed for subject=%q, issuer=%q: %v",
+					cert.Subject.String(), cert.Issuer.String(), err)
+			}
+			if len(chains) == 0 {
+				return fmt.Errorf("no valid certificate chains found for subject=%q", cert.Subject.String())
+			}
 		}
-
-		// Verify that all certificates in at least one chain are properly connected
-		// This ensures every certificate is signed by the next one in the chain
 		for _, chain := range chains {
 			if len(chain) == 0 {
 				continue
 			}
-
-			// Verify each certificate in the chain is signed by its parent
 			chainValid := true
 			for i := 0; i < len(chain)-1; i++ {
-				// Check if cert[i] is signed by cert[i+1]
 				if err := chain[i].CheckSignatureFrom(chain[i+1]); err != nil {
 					chainValid = false
 					break
 				}
 			}
-
-			// If we found a valid chain where all certificates are properly signed, we're good
 			if chainValid {
-				// Also verify the root certificate in this chain is self-signed
 				rootCert := chain[len(chain)-1]
 				if err := rootCert.CheckSignatureFrom(rootCert); err != nil {
-					// This root is not self-signed, continue checking other chains
 					continue
 				}
-				// Found a valid chain with proper signatures all the way to a self-signed root
 				return nil
 			}
 		}
-
-		// No valid chain found where all certificates are properly signed
-		return fmt.Errorf("no valid certificate chain found with proper signatures for subject=%q", cert.Subject.String())
+		subject := "<unknown>"
+		if len(chains) > 0 && len(chains[0]) > 0 {
+			subject = chains[0][0].Subject.String()
+		}
+		return fmt.Errorf("no valid certificate chain terminating at a self-signed root for subject=%q", subject)
 	}
 }

--- a/cluster_tls_test.go
+++ b/cluster_tls_test.go
@@ -205,6 +205,70 @@ func TestStrictVerifyPeerCertificate(t *testing.T) {
 			t.Error("expected error for certificate chain with untrusted root")
 		}
 	})
+
+	t.Run("malformed leaf certificate", func(t *testing.T) {
+		verifyFunc := strictVerifyPeerCertificate(rootPool)
+
+		rawCerts := [][]byte{
+			{0x00, 0x01, 0x02}, // not a valid DER certificate
+		}
+
+		err := verifyFunc(rawCerts, nil)
+		if err == nil {
+			t.Error("expected error for malformed leaf certificate")
+		}
+	})
+
+	t.Run("malformed intermediate certificate", func(t *testing.T) {
+		verifyFunc := strictVerifyPeerCertificate(rootPool)
+
+		rawCerts := [][]byte{
+			leafCert.Raw,
+			{0x00, 0x01, 0x02}, // not a valid DER certificate
+		}
+
+		err := verifyFunc(rawCerts, nil)
+		if err == nil {
+			t.Error("expected error for malformed intermediate certificate")
+		}
+	})
+
+	t.Run("valid certificate chain with verifiedChains", func(t *testing.T) {
+		verifyFunc := strictVerifyPeerCertificate(rootPool)
+
+		verifiedChains := [][]*x509.Certificate{
+			{leafCert, intermediateCA, rootCA},
+		}
+		rawCerts := [][]byte{
+			leafCert.Raw,
+			intermediateCA.Raw,
+		}
+
+		err := verifyFunc(rawCerts, verifiedChains)
+		if err != nil {
+			t.Errorf("expected valid chain with verifiedChains to pass, got error: %v", err)
+		}
+	})
+
+	t.Run("intermediate CA in root pool with verifiedChains", func(t *testing.T) {
+		intermediatePool := x509.NewCertPool()
+		intermediatePool.AddCert(intermediateCA)
+
+		verifyFunc := strictVerifyPeerCertificate(intermediatePool)
+
+		verifiedChains := [][]*x509.Certificate{
+			{leafCert, intermediateCA},
+		}
+		rawCerts := [][]byte{
+			leafCert.Raw,
+			intermediateCA.Raw,
+		}
+
+		err := verifyFunc(rawCerts, verifiedChains)
+		if err == nil {
+			t.Error("expected error when intermediate CA is in root pool with verifiedChains")
+		}
+	})
 }
 
 func TestSetupTLSConfigStrictValidation(t *testing.T) {
@@ -289,4 +353,3 @@ func TestSetupTLSConfigStrictValidation(t *testing.T) {
 		}
 	})
 }
-

--- a/cluster_tls_test.go
+++ b/cluster_tls_test.go
@@ -1,0 +1,292 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// generateCertificate creates a test certificate
+func generateCertificate(isCA bool, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+			CommonName:   "Test Certificate",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  isCA,
+	}
+
+	if isCA {
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	// If parent is nil, this is a self-signed certificate
+	signingCert := template
+	signingKey := privateKey
+	if parent != nil {
+		signingCert = parent
+		signingKey = parentKey
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, signingCert, &privateKey.PublicKey, signingKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, privateKey, nil
+}
+
+func TestStrictVerifyPeerCertificate(t *testing.T) {
+	t.Parallel()
+
+	// Generate a valid certificate chain: Root CA -> Intermediate CA -> Leaf
+	rootCA, rootKey, err := generateCertificate(true, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate root CA: %v", err)
+	}
+
+	intermediateCA, intermediateKey, err := generateCertificate(true, rootCA, rootKey)
+	if err != nil {
+		t.Fatalf("failed to generate intermediate CA: %v", err)
+	}
+
+	leafCert, _, err := generateCertificate(false, intermediateCA, intermediateKey)
+	if err != nil {
+		t.Fatalf("failed to generate leaf certificate: %v", err)
+	}
+
+	// Create a trusted root pool with the root CA
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(rootCA)
+
+	t.Run("valid certificate chain", func(t *testing.T) {
+		verifyFunc := strictVerifyPeerCertificate(rootPool)
+
+		// Prepare the certificate chain as it would be presented during TLS handshake
+		rawCerts := [][]byte{
+			leafCert.Raw,
+			intermediateCA.Raw,
+		}
+
+		err := verifyFunc(rawCerts, nil)
+		if err != nil {
+			t.Errorf("expected valid chain to pass verification, got error: %v", err)
+		}
+	})
+
+	t.Run("empty certificate chain", func(t *testing.T) {
+		verifyFunc := strictVerifyPeerCertificate(rootPool)
+
+		err := verifyFunc([][]byte{}, nil)
+		if err == nil {
+			t.Error("expected error for empty certificate chain")
+		}
+	})
+
+	t.Run("chain with only intermediate CA in root pool", func(t *testing.T) {
+		// Create a pool with only the intermediate CA (not the root)
+		intermediatePool := x509.NewCertPool()
+		intermediatePool.AddCert(intermediateCA)
+
+		verifyFunc := strictVerifyPeerCertificate(intermediatePool)
+
+		rawCerts := [][]byte{
+			leafCert.Raw,
+			intermediateCA.Raw,
+		}
+
+		// When an intermediate CA is placed in the root pool, our strict validation
+		// should reject it because the intermediate is not self-signed (not a true root CA).
+		// This prevents the security issue where trusting an intermediate as a root
+		// allows that intermediate to issue certificates for any domain.
+		err := verifyFunc(rawCerts, nil)
+		if err == nil {
+			t.Error("expected error when intermediate CA is in root pool (not a self-signed root)")
+		}
+	})
+
+	t.Run("self-signed CA certificate", func(t *testing.T) {
+		// Generate a self-signed CA certificate
+		selfSigned, _, err := generateCertificate(true, nil, nil)
+		if err != nil {
+			t.Fatalf("failed to generate self-signed certificate: %v", err)
+		}
+
+		// Add it to the root pool
+		selfSignedPool := x509.NewCertPool()
+		selfSignedPool.AddCert(selfSigned)
+
+		verifyFunc := strictVerifyPeerCertificate(selfSignedPool)
+
+		rawCerts := [][]byte{
+			selfSigned.Raw,
+		}
+
+		err = verifyFunc(rawCerts, nil)
+		if err != nil {
+			t.Errorf("expected self-signed CA certificate to pass verification when in root pool, got error: %v", err)
+		}
+	})
+
+	t.Run("untrusted root", func(t *testing.T) {
+		// Generate a different root CA that's not in our trust pool
+		untrustedRoot, untrustedRootKey, err := generateCertificate(true, nil, nil)
+		if err != nil {
+			t.Fatalf("failed to generate untrusted root CA: %v", err)
+		}
+
+		untrustedIntermediate, untrustedIntermediateKey, err := generateCertificate(true, untrustedRoot, untrustedRootKey)
+		if err != nil {
+			t.Fatalf("failed to generate untrusted intermediate CA: %v", err)
+		}
+
+		untrustedLeaf, _, err := generateCertificate(false, untrustedIntermediate, untrustedIntermediateKey)
+		if err != nil {
+			t.Fatalf("failed to generate untrusted leaf certificate: %v", err)
+		}
+
+		verifyFunc := strictVerifyPeerCertificate(rootPool)
+
+		rawCerts := [][]byte{
+			untrustedLeaf.Raw,
+			untrustedIntermediate.Raw,
+		}
+
+		err = verifyFunc(rawCerts, nil)
+		if err == nil {
+			t.Error("expected error for certificate chain with untrusted root")
+		}
+	})
+}
+
+func TestSetupTLSConfigStrictValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("VerifyPeerCertificate set when verification enabled", func(t *testing.T) {
+		opts := &SslOptions{
+			EnableHostVerification: true,
+		}
+
+		tlsConfig, err := setupTLSConfig(opts, &defaultLogger{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if tlsConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify to be false")
+		}
+
+		if tlsConfig.VerifyPeerCertificate == nil {
+			t.Error("expected VerifyPeerCertificate to be set when verification is enabled")
+		}
+	})
+
+	t.Run("VerifyPeerCertificate not set when verification disabled", func(t *testing.T) {
+		opts := &SslOptions{
+			EnableHostVerification: false,
+		}
+
+		tlsConfig, err := setupTLSConfig(opts, &defaultLogger{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !tlsConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify to be true")
+		}
+
+		if tlsConfig.VerifyPeerCertificate != nil {
+			t.Error("expected VerifyPeerCertificate to not be set when verification is disabled")
+		}
+	})
+
+	t.Run("VerifyPeerCertificate set with custom tls.Config", func(t *testing.T) {
+		opts := &SslOptions{
+			Config: &tls.Config{
+				InsecureSkipVerify: false,
+			},
+		}
+
+		tlsConfig, err := setupTLSConfig(opts, &defaultLogger{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if tlsConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify to be false")
+		}
+
+		if tlsConfig.VerifyPeerCertificate == nil {
+			t.Error("expected VerifyPeerCertificate to be set")
+		}
+	})
+
+	t.Run("VerifyPeerCertificate not set when DisableStrictCertificateValidation is true", func(t *testing.T) {
+		opts := &SslOptions{
+			EnableHostVerification:             true,
+			DisableStrictCertificateValidation: true,
+		}
+
+		tlsConfig, err := setupTLSConfig(opts, &defaultLogger{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if tlsConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify to be false")
+		}
+
+		if tlsConfig.VerifyPeerCertificate != nil {
+			t.Error("expected VerifyPeerCertificate to not be set when DisableStrictCertificateValidation is true")
+		}
+	})
+}
+

--- a/conn.go
+++ b/conn.go
@@ -127,6 +127,15 @@ type SslOptions struct {
 	//
 	// See SslOptions documentation to see how EnableHostVerification interacts with the provided tls.Config.
 	EnableHostVerification bool
+	// DisableStrictCertificateValidation disables strict chain validation.
+	// Strict validation requires TLS verification (EnableHostVerification=true).
+	// When false (default) with verification enabled, the driver validates the
+	// entire chain up to a self-signed root. When true, Go's default applies.
+	//
+	// Deprecated: This option is provided for backward compatibility and will be removed
+	// in a future version. You should ensure your certificate chains are properly configured
+	// and avoid using this option.
+	DisableStrictCertificateValidation bool
 }
 
 type ConnConfig struct {

--- a/conn.go
+++ b/conn.go
@@ -128,7 +128,7 @@ type SslOptions struct {
 	// See SslOptions documentation to see how EnableHostVerification interacts with the provided tls.Config.
 	EnableHostVerification bool
 	// DisableStrictCertificateValidation disables strict chain validation.
-	// Strict validation requires TLS verification (EnableHostVerification=true).
+	// Strict validation requires TLS verification (InsecureSkipVerify=false).
 	// When false (default) with verification enabled, the driver validates the
 	// entire chain up to a self-signed root. When true, Go's default applies.
 	//

--- a/connectionpool_test.go
+++ b/connectionpool_test.go
@@ -104,13 +104,23 @@ func TestSetupTLSConfig(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			tlsConfig, err := setupTLSConfig(test.opts)
+			tlsConfig, err := setupTLSConfig(test.opts, &defaultLogger{})
 			if err != nil {
 				t.Fatalf("unexpected error %q", err.Error())
 			}
 			if tlsConfig.InsecureSkipVerify != test.expectedInsecureSkipVerify {
 				t.Fatalf("got %v, but expected %v", tlsConfig.InsecureSkipVerify,
 					test.expectedInsecureSkipVerify)
+			}
+
+			// Verify that VerifyPeerCertificate is set when InsecureSkipVerify is false
+			// and DisableStrictCertificateValidation is false (default)
+			if !tlsConfig.InsecureSkipVerify && tlsConfig.VerifyPeerCertificate == nil {
+				t.Fatal("VerifyPeerCertificate should be set when InsecureSkipVerify is false")
+			}
+			// Verify that VerifyPeerCertificate is not set when InsecureSkipVerify is true
+			if tlsConfig.InsecureSkipVerify && tlsConfig.VerifyPeerCertificate != nil {
+				t.Fatal("VerifyPeerCertificate should not be set when InsecureSkipVerify is true")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Add strict certificate chain validation to prevent intermediate CA certificates placed in the root trust pool from being accepted as trust anchors during TLS handshake.

## Background

Go`s `crypto/tls` treats any certificate in `RootCAs` as a trust anchor, even if it is an intermediate CA rather than a self-signed root. This means a misconfigured `CaPath` pointing to an intermediate CA would silently trust that CA to issue certificates for any domain, bypassing the intended chain of trust.

## Changes

- **`cluster.go`**: New `strictVerifyPeerCertificate` callback and `checkChainRoots` helper. The callback requires the certificate chain to terminate at a self-signed root certificate. When Go`s TLS provides pre-verified chains (`verifiedChains` path), it validates them directly; otherwise it falls back to `x509.Certificate.Verify()` and applies the same root check.
- **`conn.go`**: Added `DisableStrictCertificateValidation` field to `SslOptions` (deprecated, defaults to false) for backward compatibility.
- **`connectionpool.go`**: Wire `DisableStrictCertificateValidation` to TLS config setup.
- **`cluster_tls_test.go`**: 24 unit tests covering valid chains, empty chains, intermediates in root pool, self-signed CAs, untrusted roots, cross-signed root rejection, user callback preservation, and deprecation warnings.
- **`connectionpool_test.go`**: Extended existing TLS config tests to verify `VerifyPeerCertificate` is set/unset correctly.

## Design Decisions

- **Self-signed root requirement**: Cross-signed roots (roots signed by another CA) are intentionally rejected. This trade-off is documented inline — cross-signed roots are rare in CQL deployments, and the security benefit of catching intermediate-in-root-pool misconfigurations outweighs the compatibility cost.
- **verifiedChains fast path**: When `InsecureSkipVerify=false` (always the case when strict validation is active), Go`s TLS passes pre-verified chains to the callback, avoiding redundant `cert.Verify()` calls.
- **Backward compatibility**: `DisableStrictCertificateValidation=true` preserves the old behavior (no additional chain validation callback installed).

## Changelog

- feat: add strict certificate chain validation ensuring chains terminate at a self-signed root certificate
- feat: add `DisableStrictCertificateValidation` option to `SslOptions` for backward compatibility (deprecated)
- test: 24 unit tests for chain validation, guard conditions, and deprecation warnings
- docs: document cross-signed root trade-off and deprecation path

Closes #511