### PR TITLE
Support uniform port in cfg.Hosts entries

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -135,12 +136,18 @@ type ClusterConfig struct {
 	Keyspace string
 	// CQL version (default: 3.0.0)
 	CQLVersion string
-	// addresses for the initial connections. It is recommended to use the value set in
+	// Addresses for the initial connections. It is recommended to use the value set in
 	// the Cassandra config for broadcast_address or listen_address, an IP address not
 	// a domain name. This is because events from Cassandra will use the configured IP
 	// address, which is used to index connected hosts. If the domain name specified
 	// resolves to more than 1 IP address then the driver may connect multiple times to
 	// the same host, and will not mark the node being down or up from events.
+	//
+	// Each entry may optionally include a port in host:port format. When cfg.Port
+	// is 0 (not explicitly set) and ClientRoutesConfig is nil, the driver learns
+	// the port from these entries (see cfg.Port for details). When cfg.Port is
+	// set to a non-zero value, embedded ports in host strings are ignored for
+	// the purpose of peer discovery.
 	Hosts []string
 	// The time to wait for frames before flushing the frames connection to Cassandra.
 	// Can help reduce syscall overhead by making less calls to write. Set to 0 to
@@ -197,7 +204,19 @@ type ClusterConfig struct {
 	// ConnectTimeout has a default value of 11 seconds.
 	ConnectTimeout time.Duration
 	// Port used when dialing.
-	// Default: 9042
+	//
+	// When left at 0 (the zero value, i.e. not explicitly set) and
+	// ClientRoutesConfig is nil, the driver attempts to learn the port from
+	// cfg.Hosts: if every host entry embeds the same port, that port is used;
+	// if no entry embeds a port, the default 9042 is used; any inconsistency
+	// (some entries have a port, some don't, or they differ) is an error.
+	//
+	// When set to a non-zero value the driver uses that port for all
+	// connections — including peer-discovered nodes — and never learns from
+	// cfg.Hosts. Set to 9042 explicitly if you want the default port and
+	// also want to prevent any learning from host strings.
+	//
+	// Default: 0 (auto-detect; effectively 9042 when no port is in Hosts)
 	Port int
 	// The size of the connection pool for each host.
 	// The pool filling runs in separate gourutine during the session initialization phase.
@@ -375,7 +394,6 @@ func NewCluster(hosts ...string) *ClusterConfig {
 		ConnectTimeout:                60 * time.Second,
 		ReadTimeout:                   11 * time.Second,
 		WriteTimeout:                  11 * time.Second,
-		Port:                          9042,
 		MaxExcessShardConnectionsRate: 2,
 		NumConns:                      2,
 		Consistency:                   Quorum,
@@ -549,6 +567,30 @@ func (cfg *ClusterConfig) Validate() error {
 		return errors.New("NumConns should be positive non-zero number or zero")
 	}
 
+	// Resolve cfg.Port: when the user has not set it explicitly (Port == 0),
+	// attempt to learn it from the host strings (unless client routes are in
+	// use, which manage their own addressing). Fall back to defaultCQLPort when
+	// no port is embedded in the host strings.
+	if cfg.Port == 0 {
+		// When ClientRoutesConfig is set we skip learning from cfg.Hosts because
+		// Private Service Connect (PSC) discovery entry points have different
+		// ports by design, so a uniform port derived from the initial contact
+		// points would be incorrect for peer-discovered nodes.
+		if cfg.ClientRoutesConfig == nil {
+			learned, err := learnPortFromHosts(cfg.Hosts)
+			if err != nil {
+				return err
+			}
+			if learned != 0 {
+				cfg.Port = learned
+			} else {
+				cfg.Port = defaultCQLPort
+			}
+		} else {
+			cfg.Port = defaultCQLPort
+		}
+	}
+
 	if cfg.Port <= 0 || cfg.Port > 65535 {
 		return errors.New("Port should be a valid port number: a number between 1 and 65535")
 	}
@@ -613,11 +655,56 @@ func (cfg *ClusterConfig) Validate() error {
 	return cfg.ValidateAndInitSSL()
 }
 
+const defaultCQLPort = 9042
+
 var (
 	ErrNoHosts              = errors.New("no hosts provided")
 	ErrNoConnectionsStarted = errors.New("no connections were made when creating the session")
 	ErrHostQueryFailed      = errors.New("unable to populate Hosts")
 )
+
+// learnPortFromHosts inspects the host entries for embedded ports.
+// It returns the common port (> 0) if every entry carries the same explicit
+// port, 0 if no entry carries a port, or an error as soon as inconsistency
+// is detected: some entries have a port while others don't, or two entries
+// carry different port values.
+func learnPortFromHosts(hosts []string) (int, error) {
+	var port int // 0 = not yet seen
+	sawPortless := false
+	for _, addr := range hosts {
+		_, portStr, err := net.SplitHostPort(addr)
+		if err != nil {
+			// No port in this entry.
+			if port != 0 {
+				// Already saw a ported entry – return immediately.
+				return 0, errors.New(
+					"cfg.Hosts entries must either all include a port or none: " +
+						"use cfg.Port to set a uniform port instead")
+			}
+			sawPortless = true
+			continue
+		}
+		p, err := strconv.Atoi(portStr)
+		if err != nil || p <= 0 || p > 65535 {
+			return 0, fmt.Errorf("invalid port %q in host entry %q: port must be a number between 1 and 65535", portStr, addr)
+		}
+		if sawPortless {
+			// Already saw a portless entry – return immediately.
+			return 0, errors.New(
+				"cfg.Hosts entries must either all include a port or none: " +
+					"use cfg.Port to set a uniform port instead")
+		}
+		if port == 0 {
+			port = p
+		} else if port != p {
+			return 0, fmt.Errorf(
+				"all cfg.Hosts entries must use the same port, got %d and %d: "+
+					"use cfg.Port to set a uniform port instead",
+				port, p)
+		}
+	}
+	return port, nil
+}
 
 func setupTLSConfig(sslOpts *SslOptions) (*tls.Config, error) {
 	//  Config.InsecureSkipVerify | EnableHostVerification | Result

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -42,7 +42,7 @@ func TestNewCluster_Defaults(t *testing.T) {
 	cfg := NewCluster()
 	tests.AssertEqual(t, "cluster config cql version", "3.0.0", cfg.CQLVersion)
 	tests.AssertEqual(t, "cluster config timeout", 11*time.Second, cfg.Timeout)
-	tests.AssertEqual(t, "cluster config port", 9042, cfg.Port)
+	tests.AssertEqual(t, "cluster config port", 0, cfg.Port)
 	tests.AssertEqual(t, "cluster config num-conns", 2, cfg.NumConns)
 	tests.AssertEqual(t, "cluster config consistency", Quorum, cfg.Consistency)
 	tests.AssertEqual(t, "cluster config max prepared statements", defaultMaxPreparedStmts, cfg.MaxPreparedStmts)
@@ -64,6 +64,140 @@ func TestNewCluster_WithHosts(t *testing.T) {
 	tests.AssertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
 	tests.AssertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
 	tests.AssertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
+}
+
+// TestValidate_HostPortNormalization covers the port-learning logic in Validate():
+// when cfg.Port is 0 (not explicitly set) the driver learns it from cfg.Hosts.
+func TestValidate_HostPortNormalization(t *testing.T) {
+	t.Parallel()
+
+	makeValid := func(hosts ...string) *ClusterConfig {
+		cfg := NewCluster(hosts...)
+		return cfg
+	}
+
+	t.Run("single host with explicit port sets cfg.Port", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9142, cfg.Port)
+	})
+
+	t.Run("multiple hosts with the same explicit port", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "10.0.0.2:9142")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9142, cfg.Port)
+	})
+
+	t.Run("hosts without explicit port default to 9042", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1", "10.0.0.2")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9042, cfg.Port)
+	})
+
+	t.Run("mixed: some hosts with port, some without returns error", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "10.0.0.2")
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("expected an error for mixed port/no-port hosts, got nil")
+		}
+	})
+
+	t.Run("hosts with conflicting explicit ports returns error", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "10.0.0.2:9043")
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("expected an error for conflicting host ports, got nil")
+		}
+	})
+
+	t.Run("host with invalid port string returns error", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:notaport")
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("expected an error for invalid port, got nil")
+		}
+	})
+
+	t.Run("IPv6 bare address without port defaults to 9042", func(t *testing.T) {
+		t.Parallel()
+		// A bare IPv6 address (no brackets, no port) is not parseable by
+		// net.SplitHostPort, so it is treated as a portless entry and the
+		// driver falls back to the default port 9042.
+		cfg := makeValid("::1")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9042, cfg.Port)
+	})
+
+	t.Run("IPv6 bracketed address with port sets cfg.Port", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("[::1]:9142")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9142, cfg.Port)
+	})
+
+	t.Run("multiple IPv6 hosts with the same explicit port", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("[::1]:9142", "[::2]:9142")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9142, cfg.Port)
+	})
+
+	t.Run("mixed IPv4 and IPv6 hosts with the same port", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "[::1]:9142")
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9142, cfg.Port)
+	})
+
+	t.Run("mixed IPv4 and IPv6 hosts with conflicting ports returns error", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142", "[::1]:9043")
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("expected an error for conflicting IPv4/IPv6 host ports, got nil")
+		}
+	})
+
+	t.Run("user-set Port skips learning from hosts", func(t *testing.T) {
+		t.Parallel()
+		// User explicitly sets Port=9042 (same as default) while hosts say 9142.
+		// The driver must NOT override the explicit Port.
+		cfg := makeValid("10.0.0.1:9142")
+		cfg.Port = 9042
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9042, cfg.Port)
+	})
+
+	t.Run("client routes enabled skips learning from hosts", func(t *testing.T) {
+		t.Parallel()
+		cfg := makeValid("10.0.0.1:9142")
+		cfg.ClientRoutesConfig = &ClientRoutesConfig{
+			TableName: "system.client_routes",
+			Endpoints: []ClientRoutesEndpoint{{ConnectionID: "conn-1", ConnectionAddr: "10.0.0.1:9142"}},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertEqual(t, "cfg.Port after Validate", 9042, cfg.Port)
+	})
 }
 
 func TestClusterConfig_translateAddressAndPort_NilTranslator(t *testing.T) {

--- a/conn_test.go
+++ b/conn_test.go
@@ -193,14 +193,16 @@ func TestDNSLookupConnected(t *testing.T) {
 	srv := NewTestServer(t, defaultProto, context.Background())
 	defer srv.Stop()
 
-	cluster := NewCluster("cassandra1.invalid", srv.Address, "cassandra2.invalid")
+	// Use bare IP (no port) so all entries are portless; the driver falls back
+	// to port 9042, which is where the test server is bound.
+	cluster := NewCluster("cassandra1.invalid", "127.0.0.1", "cassandra2.invalid")
 	cluster.Logger = log
 	cluster.ProtoVersion = int(defaultProto)
 	cluster.disableControlConn = true
 	cluster.DNSResolver = brokenDNSResolver{}
 
 	// CreateSession() should attempt to resolve the DNS name "cassandraX.invalid"
-	// and fail, but continue to connect via srv.Address
+	// and fail, but continue to connect via 127.0.0.1
 	_, err := cluster.CreateSession()
 	if err != nil {
 		t.Fatal("CreateSession() should have connected")
@@ -433,7 +435,7 @@ func TestQueryMultinodeWithMetrics(t *testing.T) {
 	// Can do with 1 context for all servers
 	ctx := context.Background()
 	for _, ip := range addresses {
-		srv := NewTestServerWithAddress(ip+":0", t, defaultProto, ctx)
+		srv := NewTestServerWithAddress(ip+":9042", t, defaultProto, ctx)
 		defer srv.Stop()
 		nodes = append(nodes, srv)
 	}
@@ -522,7 +524,7 @@ func TestSpeculativeExecution(t *testing.T) {
 	// Can do with 1 context for all servers
 	ctx := context.Background()
 	for _, ip := range addresses {
-		srv := NewTestServerWithAddress(ip+":0", t, defaultProto, ctx)
+		srv := NewTestServerWithAddress(ip+":9042", t, defaultProto, ctx)
 		defer srv.Stop()
 		nodes = append(nodes, srv)
 	}
@@ -1715,7 +1717,7 @@ func (nts newTestServerOpts) newServer(t testing.TB, ctx context.Context) *TestS
 }
 
 func NewTestServer(t testing.TB, protocol uint8, ctx context.Context) *TestServer {
-	return NewTestServerWithAddress("127.0.0.1:0", t, protocol, ctx)
+	return NewTestServerWithAddress("127.0.0.1:9042", t, protocol, ctx)
 }
 
 func NewSSLTestServer(t testing.TB, protocol uint8, ctx context.Context) *TestServer {

--- a/exec.go
+++ b/exec.go
@@ -69,7 +69,10 @@ func NewSingleHostQueryExecutor(cfg *ClusterConfig) (e SingleHostQueryExecutor, 
 	}
 
 	var hosts []*HostInfo
-	if hosts, err = resolveInitialEndpoints(c.DNSResolver, c.Hosts, c.Port, c.Logger); err != nil {
+	// Use the port resolved by Validate() (stored in the session config) rather
+	// than the original c.Port which may still be 0 if the user did not set it
+	// explicitly.
+	if hosts, err = resolveInitialEndpoints(c.DNSResolver, c.Hosts, e.session.cfg.Port, c.Logger); err != nil {
 		err = fmt.Errorf("addrs to hosts: %w", err)
 		return
 	}

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -102,11 +102,10 @@ func TestAsyncSessionInit(t *testing.T) {
 	}
 	// only build 1 of the servers so that we can test not connecting to the last
 	// one
-	srv := NewTestServerWithAddress(addresses[0]+":0", t, defaultProto, context.Background())
+	srv := NewTestServerWithAddress(addresses[0]+":9042", t, defaultProto, context.Background())
 	defer srv.Stop()
 
-	// just choose any port
-	cluster := testCluster(defaultProto, srv.Address, addresses[1]+":9999", addresses[2]+":9999")
+	cluster := testCluster(defaultProto, srv.Address, addresses[1]+":9042", addresses[2]+":9042")
 	cluster.PoolConfig.HostSelectionPolicy = SingleHostReadyPolicy(RoundRobinHostPolicy())
 	db, err := cluster.CreateSession()
 	if err != nil {


### PR DESCRIPTION
When cfg.Port is not explicitly set (zero value) and ClientRoutesConfig
is nil, the driver now learns the effective port from cfg.Hosts entries:

- All entries carry the same explicit port → that port is used for all
  connections including peer-discovered nodes.
- No entry carries a port → falls back to the default CQL port 9042.
- Any inconsistency (mixed port/no-port entries, or differing port
  values) → Validate() returns an error immediately.

When cfg.Port is set to any non-zero value (including 9042 explicitly)
or when ClientRoutesConfig is used, the host strings are never consulted
for the port.