### PR TITLE
fix: handle ECONNRESET/EPIPE in TestServer to fix flaky shard-aware test (TestShardAwarePortMockedUnreachable)

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -43,6 +43,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1822,7 +1823,7 @@ func (srv *TestServer) serve() {
 			for !srv.isClosed() {
 				framer, err := srv.readFrame(conn)
 				if err != nil {
-					if err == io.EOF || errors.Is(err, net.ErrClosed) {
+					if err == io.EOF || errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.ECONNRESET) {
 						return
 					}
 					srv.errorLocked(err)
@@ -2086,7 +2087,7 @@ func (srv *TestServer) process(conn net.Conn, reqFrame *framer, exts map[string]
 	}
 
 	if err := respFrame.writeTo(conn); err != nil {
-		if !errors.Is(err, net.ErrClosed) {
+		if !errors.Is(err, net.ErrClosed) && !errors.Is(err, syscall.ECONNRESET) && !errors.Is(err, syscall.EPIPE) {
 			srv.errorLocked(err)
 		}
 	}


### PR DESCRIPTION
TestShardAwarePortMockedUnreachable/without_TLS is flaky because the
mock TestServer fails the test on transient TCP errors during normal
connection teardown. When the driver closes a connection and the
server's async process() goroutine writes a response after the close,
the driver's kernel sends RST (ECONNRESET) because data arrived at a
closed socket. Writing to a half-closed connection can also produce
EPIPE.

Handle ECONNRESET alongside io.EOF and net.ErrClosed in the serve()
readFrame error path, and ECONNRESET/EPIPE alongside net.ErrClosed in
the process() writeTo error path.
