### PR TITLE
perf: remove unused sync.Mutex from writeCoalescer

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1139,7 +1139,6 @@ type writeCoalescer struct {
 	testEnqueuedHook func()
 	testFlushedHook  func()
 	timeout          atomic.Int64
-	mu               sync.Mutex
 }
 
 func (w *writeCoalescer) setWriteTimeout(timeout time.Duration) {


### PR DESCRIPTION
The `mu sync.Mutex` field in `writeCoalescer` (conn.go) was never referenced by any method. Remove it.