### PR TITLE
Use atomic.Pointer for typed atomic values

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -104,7 +104,7 @@ type ClusterConfig struct {
 	Compressor Compressor
 	// Default: nil
 	Authenticator Authenticator
-	actualSslOpts atomic.Value
+	actualSslOpts *atomic.Pointer[tls.Config]
 	// PoolConfig configures the underlying connection pool, allowing the
 	// configuration of host selection and connection selection policies.
 	PoolConfig PoolConfig
@@ -445,6 +445,7 @@ func (cfg *ClusterConfig) filterHost(host *HostInfo) bool {
 }
 
 func (cfg *ClusterConfig) ValidateAndInitSSL() error {
+	cfg.actualSslOpts = nil
 	if cfg.SslOpts == nil {
 		return nil
 	}
@@ -453,13 +454,17 @@ func (cfg *ClusterConfig) ValidateAndInitSSL() error {
 		return fmt.Errorf("failed to initialize ssl configuration: %s", err.Error())
 	}
 
+	cfg.actualSslOpts = new(atomic.Pointer[tls.Config])
 	cfg.actualSslOpts.Store(actualTLSConfig)
 	return nil
 }
 
 func (cfg *ClusterConfig) getActualTLSConfig() *tls.Config {
-	val, ok := cfg.actualSslOpts.Load().(*tls.Config)
-	if !ok {
+	if cfg.actualSslOpts == nil {
+		return nil
+	}
+	val := cfg.actualSslOpts.Load()
+	if val == nil {
 		return nil
 	}
 	return val.Clone()

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -28,6 +28,7 @@
 package gocql
 
 import (
+	"crypto/tls"
 	"net"
 	"reflect"
 	"testing"
@@ -64,6 +65,37 @@ func TestNewCluster_WithHosts(t *testing.T) {
 	tests.AssertEqual(t, "cluster config hosts length", 2, len(cfg.Hosts))
 	tests.AssertEqual(t, "cluster config host 0", "addr1", cfg.Hosts[0])
 	tests.AssertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
+}
+
+func TestValidateAndInitSSLDoesNotShareTLSConfigBetweenConfigCopies(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewCluster("127.0.0.1")
+	cfg.SslOpts = &SslOptions{
+		Config: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	tlsCfg := *cfg
+	if err := tlsCfg.ValidateAndInitSSL(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsCfg.getActualTLSConfig() == nil {
+		t.Fatal("expected copied TLS config to initialize TLS")
+	}
+	if cfg.getActualTLSConfig() != nil {
+		t.Fatal("expected original config not to retain copied TLS state")
+	}
+
+	noTLSCfg := *cfg
+	noTLSCfg.SslOpts = nil
+	if err := noTLSCfg.ValidateAndInitSSL(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if noTLSCfg.getActualTLSConfig() != nil {
+		t.Fatal("expected copied config with nil SslOpts not to use TLS")
+	}
 }
 
 // TestValidate_HostPortNormalization covers the port-learning logic in Validate():

--- a/control.go
+++ b/control.go
@@ -74,10 +74,8 @@ type controlConnection interface {
 	reconnect() error
 }
 
-// Ensure that the atomic variable is aligned to a 64bit boundary
-// so that atomic operations can be applied on 32bit architectures.
 type controlConn struct {
-	conn         atomic.Value
+	conn         atomic.Pointer[connHost]
 	retry        RetryPolicy
 	session      *Session
 	quit         chan struct{}
@@ -96,8 +94,6 @@ func createControlConn(session *Session) *controlConn {
 		quit:    make(chan struct{}),
 		retry:   &SimpleRetryPolicy{NumRetries: 3},
 	}
-
-	control.conn.Store((*connHost)(nil))
 
 	return control
 }
@@ -334,7 +330,7 @@ func (c *controlConn) setupConn(conn *Conn) error {
 		conn: conn,
 		host: host,
 	}
-	old, _ := c.conn.Swap(ch).(*connHost)
+	old := c.conn.Swap(ch)
 	var oldHost events.HostInfo
 	if old != nil && old.host != nil {
 		oldHost.HostID = old.host.HostID()
@@ -508,7 +504,7 @@ func (c *controlConn) HandleError(conn *Conn, err error, closed bool) {
 }
 
 func (c *controlConn) getConn() *connHost {
-	return c.conn.Load().(*connHost)
+	return c.conn.Load()
 }
 
 // writeFrame sends frame w on the control connection and returns the parsed

--- a/debounce/refresh_debouncer_test.go
+++ b/debounce/refresh_debouncer_test.go
@@ -192,7 +192,10 @@ func TestErrorBroadcaster_MultipleListeners(t *testing.T) {
 
 	err := errors.New("expected error")
 	wg := sync.WaitGroup{}
-	result := atomic.Value{}
+	var result atomic.Pointer[error]
+	storeResult := func(err error) {
+		result.Store(&err)
+	}
 	for _, listener := range listeners {
 		currentListener := listener
 		wg.Add(1)
@@ -200,9 +203,9 @@ func TestErrorBroadcaster_MultipleListeners(t *testing.T) {
 			defer wg.Done()
 			receivedErr, ok := <-currentListener
 			if !ok {
-				result.Store(errors.New("listener was closed"))
+				storeResult(errors.New("listener was closed"))
 			} else if receivedErr != err {
-				result.Store(errors.New("expected received error to be the same as the one that was broadcasted"))
+				storeResult(errors.New("expected received error to be the same as the one that was broadcasted"))
 			}
 		}()
 	}
@@ -214,7 +217,7 @@ func TestErrorBroadcaster_MultipleListeners(t *testing.T) {
 	}()
 	wg.Wait()
 	if loadedVal := result.Load(); loadedVal != nil {
-		t.Error(loadedVal.(error).Error())
+		t.Error((*loadedVal).Error())
 	}
 }
 
@@ -228,7 +231,10 @@ func TestErrorBroadcaster_StopWithoutBroadcast(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
-	result := atomic.Value{}
+	var result atomic.Pointer[error]
+	storeResult := func(err error) {
+		result.Store(&err)
+	}
 	for _, listener := range listeners {
 		currentListener := listener
 		wg.Add(1)
@@ -237,7 +243,7 @@ func TestErrorBroadcaster_StopWithoutBroadcast(t *testing.T) {
 			// broadcaster stopped, expect listener to be closed
 			_, ok := <-currentListener
 			if ok {
-				result.Store(errors.New("expected listener to be closed"))
+				storeResult(errors.New("expected listener to be closed"))
 			}
 		}()
 	}
@@ -249,6 +255,6 @@ func TestErrorBroadcaster_StopWithoutBroadcast(t *testing.T) {
 	}()
 	wg.Wait()
 	if loadedVal := result.Load(); loadedVal != nil {
-		t.Error(loadedVal.(error).Error())
+		t.Error((*loadedVal).Error())
 	}
 }

--- a/metadata_scylla.go
+++ b/metadata_scylla.go
@@ -343,24 +343,24 @@ func compareInterfaceMaps(a, b map[string]any) bool {
 
 // cowTabletList implements a copy on write keyspace metadata map, its equivalent type is map[string]*KeyspaceMetadata
 type cowKeyspaceMetadataMap struct {
-	keyspaceMap atomic.Value
+	keyspaceMap atomic.Pointer[map[string]*KeyspaceMetadata]
 	mu          sync.Mutex
 }
 
 func (c *cowKeyspaceMetadataMap) get() map[string]*KeyspaceMetadata {
-	l, ok := c.keyspaceMap.Load().(map[string]*KeyspaceMetadata)
-	if !ok {
+	l := c.keyspaceMap.Load()
+	if l == nil {
 		return nil
 	}
-	return l
+	return *l
 }
 
 func (c *cowKeyspaceMetadataMap) getKeyspace(keyspaceName string) (*KeyspaceMetadata, bool) {
-	m, ok := c.keyspaceMap.Load().(map[string]*KeyspaceMetadata)
-	if !ok {
-		return nil, ok
+	m := c.keyspaceMap.Load()
+	if m == nil {
+		return nil, false
 	}
-	val, ok := m[keyspaceName]
+	val, ok := (*m)[keyspaceName]
 	return val, ok
 }
 
@@ -376,7 +376,7 @@ func (c *cowKeyspaceMetadataMap) set(keyspaceName string, keyspaceMetadata *Keys
 	}
 	newM[keyspaceName] = keyspaceMetadata
 
-	c.keyspaceMap.Store(newM)
+	c.keyspaceMap.Store(&newM)
 	return true
 }
 
@@ -394,7 +394,7 @@ func (c *cowKeyspaceMetadataMap) removeKeyspace(keyspaceName string) {
 	newM := maps.Clone(m)
 	delete(newM, keyspaceName)
 
-	c.keyspaceMap.Store(newM)
+	c.keyspaceMap.Store(&newM)
 }
 
 // updateKeyspace atomically clones a keyspace's mutable maps, applies fn to
@@ -416,7 +416,7 @@ func (c *cowKeyspaceMetadataMap) updateKeyspace(keyspaceName string, fn func(ks 
 
 	newM := maps.Clone(m)
 	newM[keyspaceName] = cloned
-	c.keyspaceMap.Store(newM)
+	c.keyspaceMap.Store(&newM)
 	return true
 }
 

--- a/policies.go
+++ b/policies.go
@@ -40,7 +40,7 @@ import (
 
 // cowHostList implements a copy on write host list, its equivalent type is []*HostInfo
 type cowHostList struct {
-	list atomic.Value
+	list atomic.Pointer[[]*HostInfo]
 	mu   sync.Mutex
 }
 
@@ -50,8 +50,8 @@ func (c *cowHostList) String() string {
 
 func (c *cowHostList) get() []*HostInfo {
 	// TODO(zariel): should we replace this with []*HostInfo?
-	l, ok := c.list.Load().(*[]*HostInfo)
-	if !ok {
+	l := c.list.Load()
+	if l == nil {
 		return nil
 	}
 	return *l
@@ -517,7 +517,7 @@ func TokenAwareHostPolicy(fallback HostSelectionPolicy, opts ...func(*tokenAware
 }
 
 // clusterMeta holds metadata about cluster topology.
-// It is used inside atomic.Value and shallow copies are used when replacing it,
+// It is used inside atomic.Pointer and shallow copies are used when replacing it,
 // so fields should not be modified in-place. Instead, to modify a field a copy of the field should be made
 // and the pointer in clusterMeta updated to point to the new value.
 type clusterMeta struct {
@@ -531,7 +531,7 @@ var MAX_IN_FLIGHT_THRESHOLD int = 10
 type tokenAwareHostPolicy struct {
 	fallback HostSelectionPolicy
 	// atomic store for *clusterMeta
-	metadata            atomic.Value
+	metadata            atomic.Pointer[clusterMeta]
 	logger              StdLogger
 	getKeyspaceMetadata func(keyspace string) (*KeyspaceMetadata, error)
 	getKeyspaceName     func() string
@@ -689,8 +689,7 @@ func (t *tokenAwareHostPolicy) HostDown(host *HostInfo) {
 // Metadata uses copy on write, so the returned value should be only used for reading.
 // To obtain a copy that could be updated, use getMetadataForUpdate instead.
 func (t *tokenAwareHostPolicy) getMetadataReadOnly() *clusterMeta {
-	meta, _ := t.metadata.Load().(*clusterMeta)
-	return meta
+	return t.metadata.Load()
 }
 
 // getMetadataForUpdate returns clusterMeta suitable for updating.

--- a/scylla.go
+++ b/scylla.go
@@ -392,7 +392,7 @@ func (c *Conn) isScyllaConn() bool {
 type scyllaConnPicker struct {
 	logger StdLogger
 	// disableShardAwarePortUntil is used to temporarily disable new connections to the shard-aware port temporarily
-	disableShardAwarePortUntil *atomic.Value
+	disableShardAwarePortUntil *atomic.Pointer[time.Time]
 	address                    string
 	excessConns                []*Conn
 	conns                      []*Conn
@@ -428,7 +428,7 @@ func newScyllaConnPicker(conn *Conn, logger StdLogger) *scyllaConnPicker {
 		logger:                 logger,
 		excessConnsLimitRate:   conn.session.cfg.MaxExcessShardConnectionsRate,
 
-		disableShardAwarePortUntil: new(atomic.Value),
+		disableShardAwarePortUntil: new(atomic.Pointer[time.Time]),
 	}
 }
 
@@ -570,7 +570,7 @@ func (p *scyllaConnPicker) Put(conn *Conn) error {
 				scyllaShardAwarePortFallbackDuration,
 			)
 			until := time.Now().Add(scyllaShardAwarePortFallbackDuration)
-			p.disableShardAwarePortUntil.Store(until)
+			p.disableShardAwarePortUntil.Store(&until)
 
 			return fmt.Errorf("connection landed on %d shard that already has connection", shard)
 		} else {
@@ -769,8 +769,7 @@ func (p *scyllaConnPicker) NextShard() (shardID, nrShards int) {
 		return 0, 0
 	}
 
-	disableUntil, _ := p.disableShardAwarePortUntil.Load().(time.Time)
-	if time.Now().Before(disableUntil) {
+	if disableUntil := p.disableShardAwarePortUntil.Load(); disableUntil != nil && time.Now().Before(*disableUntil) {
 		// There is suspicion that the shard-aware-port is not reachable
 		// or misconfigured, fall back to the non-shard-aware port
 		return 0, 0

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -543,7 +543,7 @@ func TestScyllaConnPickerHandleShardCountChange(t *testing.T) {
 			logger := &testLogger{}
 			picker := &scyllaConnPicker{
 				logger:                     logger,
-				disableShardAwarePortUntil: new(atomic.Value),
+				disableShardAwarePortUntil: new(atomic.Pointer[time.Time]),
 				hostId:                     tUUID(99),
 				address:                    "192.168.1.1:9042", // Regular port
 				conns:                      make([]*Conn, tt.initialShards),
@@ -556,7 +556,6 @@ func TestScyllaConnPickerHandleShardCountChange(t *testing.T) {
 				shardAwarePortDisabled:     false,
 				excessConnsLimitRate:       0.1,
 			}
-			picker.disableShardAwarePortUntil.Store(time.Time{})
 
 			var connectionsToCheck []*Conn
 


### PR DESCRIPTION
## Summary
- replace remaining atomic.Value fields and test slots with typed atomic.Pointer usage
- keep ClusterConfig copyable by storing a pointer to the typed TLS config atomic
- update Scylla shard-aware fallback timestamp handling for pointer loads/stores

## Testing
- GOTOOLCHAIN=go1.25.0 make check
- GOTOOLCHAIN=go1.25.0 make test-unit
- GOTOOLCHAIN=go1.25.0 go test ./...