### PR TITLE
perf: index host info snapshots by host id

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -136,7 +136,7 @@ func TestHostFilterDiscovery(t *testing.T) {
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
 
-	tests.AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
+	tests.AssertEqual(t, "len(clusterHosts)-1 != rr.hosts.get().len()", len(clusterHosts)-1, rr.hosts.get().len())
 }
 
 // TestHostFilterInitial ensures that host filtering works for the initial
@@ -162,7 +162,7 @@ func TestHostFilterInitial(t *testing.T) {
 	session := createSessionFromCluster(cluster, t)
 	defer session.Close()
 
-	tests.AssertEqual(t, "len(clusterHosts)-1 != len(rr.hosts.get())", len(clusterHosts)-1, len(rr.hosts.get()))
+	tests.AssertEqual(t, "len(clusterHosts)-1 != rr.hosts.get().len()", len(clusterHosts)-1, rr.hosts.get().len())
 }
 
 func TestApplicationInformation(t *testing.T) {

--- a/policies.go
+++ b/policies.go
@@ -38,29 +38,97 @@ import (
 	"time"
 )
 
-// cowHostList implements a copy on write host list, its equivalent type is []*HostInfo
+const hostInfoListMapThreshold = 20
+
+// hostInfoList is an immutable host list snapshot with optional indexed lookup.
+type hostInfoList struct {
+	hosts     []*HostInfo
+	hostsByID map[UUID]*HostInfo
+	hostIDs   []UUID
+}
+
+func newHostInfoList(hosts []*HostInfo) *hostInfoList {
+	hosts = hosts[:len(hosts):len(hosts)]
+	l := &hostInfoList{
+		hosts: hosts,
+	}
+
+	if len(hosts) >= hostInfoListMapThreshold {
+		hostsByID := make(map[UUID]*HostInfo, len(hosts))
+		l.hostsByID = hostsByID
+		for _, host := range hosts {
+			hostID := host.hostUUID()
+			if hostID.IsEmpty() {
+				continue
+			}
+			if _, ok := hostsByID[hostID]; !ok {
+				hostsByID[hostID] = host
+			}
+		}
+		return l
+	}
+
+	hostIDs := make([]UUID, len(hosts))
+	for i, host := range hosts {
+		hostIDs[i] = host.hostUUID()
+	}
+	l.hostIDs = hostIDs
+
+	return l
+}
+
+// allHosts returns hosts in this snapshot. Callers must treat the returned slice as read-only.
+func (l *hostInfoList) allHosts() []*HostInfo {
+	if l == nil {
+		return nil
+	}
+	return l.hosts
+}
+
+// len returns the number of hosts in this snapshot.
+func (l *hostInfoList) len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.hosts)
+}
+
+// hostByID finds a host in this snapshot by host_id.
+func (l *hostInfoList) hostByID(hostID UUID) *HostInfo {
+	if l == nil || hostID.IsEmpty() {
+		return nil
+	}
+	if l.hostsByID != nil {
+		return l.hostsByID[hostID]
+	}
+	for i, id := range l.hostIDs {
+		if id == hostID {
+			return l.hosts[i]
+		}
+	}
+	return nil
+}
+
+// cowHostList implements a copy-on-write host list.
 type cowHostList struct {
-	list atomic.Pointer[[]*HostInfo]
+	list atomic.Pointer[hostInfoList]
 	mu   sync.Mutex
 }
 
 func (c *cowHostList) String() string {
-	return fmt.Sprintf("%+v", c.get())
+	return fmt.Sprintf("%+v", c.get().allHosts())
 }
 
-func (c *cowHostList) get() []*HostInfo {
-	// TODO(zariel): should we replace this with []*HostInfo?
-	l := c.list.Load()
-	if l == nil {
-		return nil
-	}
-	return *l
+func (c *cowHostList) get() *hostInfoList {
+	return c.list.Load()
 }
 
 // add will add a host if it not already in the list
 func (c *cowHostList) add(host *HostInfo) bool {
 	c.mu.Lock()
-	l := c.get()
+	defer c.mu.Unlock()
+
+	l := c.get().allHosts()
 
 	if n := len(l); n == 0 {
 		l = []*HostInfo{host}
@@ -68,7 +136,6 @@ func (c *cowHostList) add(host *HostInfo) bool {
 		newL := make([]*HostInfo, n+1)
 		for i := 0; i < n; i++ {
 			if host.Equal(l[i]) {
-				c.mu.Unlock()
 				return false
 			}
 			newL[i] = l[i]
@@ -77,17 +144,48 @@ func (c *cowHostList) add(host *HostInfo) bool {
 		l = newL
 	}
 
-	c.list.Store(&l)
-	c.mu.Unlock()
+	c.list.Store(newHostInfoList(l))
+	return true
+}
+
+func (c *cowHostList) addAll(hosts []*HostInfo) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	l := c.get().allHosts()
+	newL := make([]*HostInfo, len(l), len(l)+len(hosts))
+	copy(newL, l)
+
+	added := false
+	for _, host := range hosts {
+		exists := false
+		for _, existing := range newL {
+			if host.Equal(existing) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			newL = append(newL, host)
+			added = true
+		}
+	}
+
+	if !added {
+		return false
+	}
+
+	c.list.Store(newHostInfoList(newL))
 	return true
 }
 
 func (c *cowHostList) remove(host *HostInfo) bool {
 	c.mu.Lock()
-	l := c.get()
+	defer c.mu.Unlock()
+
+	l := c.get().allHosts()
 	size := len(l)
 	if size == 0 {
-		c.mu.Unlock()
 		return false
 	}
 
@@ -102,13 +200,10 @@ func (c *cowHostList) remove(host *HostInfo) bool {
 	}
 
 	if !found {
-		c.mu.Unlock()
 		return false
 	}
 
-	newL = newL[: size-1 : size-1]
-	c.list.Store(&newL)
-	c.mu.Unlock()
+	c.list.Store(newHostInfoList(newL))
 
 	return true
 }
@@ -448,7 +543,7 @@ func (r *roundRobinHostPolicy) IsOperational(*Session) error        { return nil
 
 func (r *roundRobinHostPolicy) Pick(qry ExecutableQuery) NextHost {
 	nextStartOffset := atomic.AddUint64(&r.lastUsedHostIdx, 1)
-	return roundRobbin(int(nextStartOffset), r.hosts.get())
+	return roundRobbin(int(nextStartOffset), r.hosts.get().allHosts())
 }
 
 func (r *roundRobinHostPolicy) AddHost(host *HostInfo) {
@@ -626,7 +721,7 @@ func (t *tokenAwareHostPolicy) SetPartitioner(partitioner string) {
 		t.fallback.SetPartitioner(partitioner)
 		t.partitioner = partitioner
 		meta := t.getMetadataForUpdate()
-		meta.resetTokenRing(t.partitioner, t.hosts.get(), t.logger)
+		meta.resetTokenRing(t.partitioner, t.hosts.get().allHosts(), t.logger)
 		t.updateReplicas(meta, t.getKeyspaceName())
 		t.metadata.Store(meta)
 	}
@@ -636,7 +731,7 @@ func (t *tokenAwareHostPolicy) AddHost(host *HostInfo) {
 	t.mu.Lock()
 	if t.hosts.add(host) {
 		meta := t.getMetadataForUpdate()
-		meta.resetTokenRing(t.partitioner, t.hosts.get(), t.logger)
+		meta.resetTokenRing(t.partitioner, t.hosts.get().allHosts(), t.logger)
 		t.updateReplicas(meta, t.getKeyspaceName())
 		t.metadata.Store(meta)
 	}
@@ -648,12 +743,10 @@ func (t *tokenAwareHostPolicy) AddHost(host *HostInfo) {
 func (t *tokenAwareHostPolicy) AddHosts(hosts []*HostInfo) {
 	t.mu.Lock()
 
-	for _, host := range hosts {
-		t.hosts.add(host)
-	}
+	t.hosts.addAll(hosts)
 
 	meta := t.getMetadataForUpdate()
-	meta.resetTokenRing(t.partitioner, t.hosts.get(), t.logger)
+	meta.resetTokenRing(t.partitioner, t.hosts.get().allHosts(), t.logger)
 	t.updateReplicas(meta, t.getKeyspaceName())
 	t.metadata.Store(meta)
 
@@ -668,7 +761,7 @@ func (t *tokenAwareHostPolicy) RemoveHost(host *HostInfo) {
 	t.mu.Lock()
 	if t.hosts.remove(host) {
 		meta := t.getMetadataForUpdate()
-		meta.resetTokenRing(t.partitioner, t.hosts.get(), t.logger)
+		meta.resetTokenRing(t.partitioner, t.hosts.get().allHosts(), t.logger)
 		t.updateReplicas(meta, t.getKeyspaceName())
 		t.metadata.Store(meta)
 	}
@@ -850,11 +943,8 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		if len(tabletReplicas) != 0 {
 			hosts := t.hosts.get()
 			for _, replica := range tabletReplicas {
-				for _, host := range hosts {
-					if host.hostId == UUID(replica.HostUUIDValue()) {
-						replicas = append(replicas, host)
-						break
-					}
+				if host := hosts.hostByID(UUID(replica.HostUUIDValue())); host != nil {
+					replicas = append(replicas, host)
 				}
 			}
 		}
@@ -1090,9 +1180,9 @@ func roundRobbin(shift int, hosts ...[]*HostInfo) NextHost {
 func (d *dcAwareRR) Pick(q ExecutableQuery) NextHost {
 	nextStartOffset := atomic.AddUint64(&d.lastUsedHostIdx, 1)
 	if d.disableDCFailover {
-		return roundRobbin(int(nextStartOffset), d.localHosts.get())
+		return roundRobbin(int(nextStartOffset), d.localHosts.get().allHosts())
 	}
-	return roundRobbin(int(nextStartOffset), d.localHosts.get(), d.remoteHosts.get())
+	return roundRobbin(int(nextStartOffset), d.localHosts.get().allHosts(), d.remoteHosts.get().allHosts())
 }
 
 // RackAwareRoundRobinPolicy is a host selection policies which will prioritize and
@@ -1180,9 +1270,9 @@ func (d *rackAwareRR) HostDown(host *HostInfo) { d.RemoveHost(host) }
 func (d *rackAwareRR) Pick(q ExecutableQuery) NextHost {
 	nextStartOffset := atomic.AddUint64(&d.lastUsedHostIdx, 1)
 	if d.disableDCFailover {
-		return roundRobbin(int(nextStartOffset), d.hosts[0].get(), d.hosts[1].get())
+		return roundRobbin(int(nextStartOffset), d.hosts[0].get().allHosts(), d.hosts[1].get().allHosts())
 	}
-	return roundRobbin(int(nextStartOffset), d.hosts[0].get(), d.hosts[1].get(), d.hosts[2].get())
+	return roundRobbin(int(nextStartOffset), d.hosts[0].get().allHosts(), d.hosts[1].get().allHosts(), d.hosts[2].get().allHosts())
 }
 
 // ReadyPolicy defines a policy for when a HostSelectionPolicy can be used. After

--- a/policies_test.go
+++ b/policies_test.go
@@ -492,7 +492,7 @@ func TestCOWList_Add(t *testing.T) {
 		}
 	}
 
-	hosts := cow.get()
+	hosts := cow.get().allHosts()
 	if len(hosts) != len(toAdd) {
 		t.Fatalf("expected to have %d hosts got %d", len(toAdd), len(hosts))
 	}
@@ -507,6 +507,117 @@ func TestCOWList_Add(t *testing.T) {
 			t.Errorf("addr was not in the host list: %q", addr)
 		}
 	}
+}
+
+func TestHostInfoList_HostByID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		hosts   []*HostInfo
+		wantMap bool
+	}{
+		{
+			name:    "linear below threshold",
+			hosts:   makeHostInfoListTestHosts(hostInfoListMapThreshold - 1),
+			wantMap: false,
+		},
+		{
+			name:    "map at threshold",
+			hosts:   makeHostInfoListTestHosts(hostInfoListMapThreshold),
+			wantMap: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hosts := newHostInfoList(tt.hosts)
+			if (hosts.hostsByID != nil) != tt.wantMap {
+				t.Fatalf("hostsByID presence = %v, want %v", hosts.hostsByID != nil, tt.wantMap)
+			}
+			if tt.wantMap {
+				if hosts.hostIDs != nil {
+					t.Fatalf("hostIDs = %v, want nil when hostsByID is used", hosts.hostIDs)
+				}
+			} else if len(hosts.hostIDs) != len(tt.hosts) {
+				t.Fatalf("len(hostIDs) = %d, want %d", len(hosts.hostIDs), len(tt.hosts))
+			}
+
+			for _, host := range tt.hosts {
+				if got := hosts.hostByID(host.hostUUID()); got != host {
+					t.Fatalf("hostByID(%s) = %v, want %v", host.HostID(), got, host)
+				}
+			}
+
+			if got := hosts.hostByID(tUUID(9999)); got != nil {
+				t.Fatalf("hostByID(missing) = %v, want nil", got)
+			}
+			if got := hosts.hostByID(UUID{}); got != nil {
+				t.Fatalf("hostByID(zero) = %v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestHostInfoList_AllHostsClipsCapacity(t *testing.T) {
+	t.Parallel()
+
+	original := makeHostInfoListTestHosts(2)
+	withSpareCapacity := make([]*HostInfo, len(original), len(original)+1)
+	copy(withSpareCapacity, original)
+
+	hosts := newHostInfoList(withSpareCapacity)
+	snapshot := hosts.allHosts()
+	appended := append(snapshot, &HostInfo{hostId: tUUID(100)})
+
+	if len(snapshot) != len(original) {
+		t.Fatalf("len(allHosts()) = %d, want %d", len(snapshot), len(original))
+	}
+	if len(appended) != len(original)+1 {
+		t.Fatalf("len(appended) = %d, want %d", len(appended), len(original)+1)
+	}
+	if &snapshot[0] == &appended[0] {
+		t.Fatal("append reused allHosts backing array")
+	}
+}
+
+func TestCOWList_AddAll(t *testing.T) {
+	t.Parallel()
+
+	var cow cowHostList
+	hosts := makeHostInfoListTestHosts(hostInfoListMapThreshold)
+
+	if !cow.addAll(hosts) {
+		t.Fatal("did not add hosts which were not in the set")
+	}
+	if got := cow.get().len(); got != len(hosts) {
+		t.Fatalf("len() = %d, want %d", got, len(hosts))
+	}
+	if cow.get().hostsByID == nil {
+		t.Fatal("expected host ID map at threshold")
+	}
+	for _, host := range hosts {
+		if got := cow.get().hostByID(host.hostUUID()); got != host {
+			t.Fatalf("hostByID(%s) = %v, want %v", host.HostID(), got, host)
+		}
+	}
+	if cow.addAll(hosts) {
+		t.Fatal("added duplicate hosts")
+	}
+}
+
+func makeHostInfoListTestHosts(n int) []*HostInfo {
+	hosts := make([]*HostInfo, n)
+	for i := range hosts {
+		hosts[i] = &HostInfo{
+			hostId:         tUUID(i + 1),
+			connectAddress: net.IPv4(10, 0, byte(i>>8), byte(i)),
+			port:           9042,
+		}
+	}
+	return hosts
 }
 
 // TestSimpleRetryPolicy makes sure that we only allow 1 + numRetries attempts


### PR DESCRIPTION
## Summary

- Add immutable HostInfoList snapshots behind cowHostList, published with atomic.Pointer.
- Precompute host UUIDs and build a host_id map only at 20+ hosts based on BenchmarkHostInfoListHostByIDStrategies.
- Use HostInfoList.HostByID() in tablet replica host resolution, replacing nested host scans.

## Benchmark notes

- BenchmarkHostInfoListHostByIDStrategies: list faster through 18 hosts; map slightly ahead at 20 and clearly ahead at 22+.
- BenchmarkTabletAwarePick stayed roughly flat across 10/50/100 hosts after the change.

## Testing

- go test -tags unit ./...
- go test -race -tags unit ./ -run 'Test(COWList|HostInfoList|HostPolicy_TokenAware_Tablets)'
- go test -tags unit ./ -run '^$' -bench '^BenchmarkHostInfoListHostByIDStrategies/Hosts(18|20|22|24)/(List|Map)$' -benchtime=500ms -count=7
- go test -tags unit ./ -run '^$' -bench '^BenchmarkTabletAwarePick($|/)' -benchtime=300ms -count=3
