### PR TITLE
Draft: [DRIVER-785] Validate SELECT without FROM support

### DIFF
--- a/select_without_from_test.go
+++ b/select_without_from_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+// +build integration
+
+package gocql
+
+import "testing"
+
+func isSelectWithoutFromUnsupported(err error) bool {
+	requestErr, ok := err.(RequestError)
+	if !ok {
+		return false
+	}
+	return requestErr.Code() == ErrCodeSyntax || requestErr.Code() == ErrCodeInvalid
+}
+
+func TestSelectWithoutFrom(t *testing.T) {
+	t.Parallel()
+
+	session := createSession(t)
+	defer session.Close()
+
+	var one int
+	if err := unpreparedQuery(session, "SELECT 1").Scan(&one); err != nil {
+		if isSelectWithoutFromUnsupported(err) {
+			t.Skip("server does not support SELECT without FROM")
+		}
+		t.Fatalf("SELECT 1 failed: %v", err)
+	}
+	if one != 1 {
+		t.Fatalf("expected SELECT 1 to return 1, got %d", one)
+	}
+
+	var now UUID
+	if err := unpreparedQuery(session, "SELECT now()").Scan(&now); err != nil {
+		t.Fatalf("SELECT now() failed: %v", err)
+	}
+
+	var preparedOne int
+	if err := session.Query("SELECT 1").Bind().Scan(&preparedOne); err != nil {
+		t.Fatalf("prepared SELECT 1 failed: %v", err)
+	}
+	if preparedOne != 1 {
+		t.Fatalf("expected prepared SELECT 1 to return 1, got %d", preparedOne)
+	}
+
+	var preparedNow UUID
+	if err := session.Query("SELECT now()").Bind().Scan(&preparedNow); err != nil {
+		t.Fatalf("prepared SELECT now() failed: %v", err)
+	}
+}
+
+func unpreparedQuery(session *Session, stmt string) *Query {
+	query := session.Query(stmt)
+	query.skipPrepare = true
+	return query
+}


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-785
GitHub issue: https://github.com/scylladb/gocql/issues/931
Parent epic: https://scylladb.atlassian.net/browse/DRIVER-782

Draft PR for validating SELECT without FROM support in this driver.

Refs #931.

Scope:
- Add or update integration tests for SELECT 1.
- Add or update integration tests for SELECT now().
- Cover prepared and non-prepared execution paths where relevant.
- Feature-detect or skip cleanly against servers that do not support SELECT without FROM.
- Document any driver-specific limitation found during implementation.

This draft currently contains an empty setup commit so work can start from a linked branch without adding placeholder source changes.