### PR TITLE
test: use ephemeral ports for test servers

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -195,8 +195,9 @@ func TestDNSLookupConnected(t *testing.T) {
 	defer srv.Stop()
 
 	// Use bare IP (no port) so all entries are portless; the driver falls back
-	// to port 9042, which is where the test server is bound.
+	// to cfg.Port, which is where the test server is bound.
 	cluster := NewCluster("cassandra1.invalid", "127.0.0.1", "cassandra2.invalid")
+	cluster.Port = srv.port()
 	cluster.Logger = log
 	cluster.ProtoVersion = int(defaultProto)
 	cluster.disableControlConn = true
@@ -1720,7 +1721,7 @@ func (nts newTestServerOpts) newServer(t testing.TB, ctx context.Context) *TestS
 }
 
 func NewTestServer(t testing.TB, protocol uint8, ctx context.Context) *TestServer {
-	return NewTestServerWithAddress("127.0.0.1:9042", t, protocol, ctx)
+	return NewTestServerWithAddress("127.0.0.1:0", t, protocol, ctx)
 }
 
 func NewSSLTestServer(t testing.TB, protocol uint8, ctx context.Context) *TestServer {
@@ -1787,6 +1788,10 @@ type TestServer struct {
 }
 
 type testSupportedFactory func(conn net.Conn) map[string][]string
+
+func (srv *TestServer) port() int {
+	return srv.listen.Addr().(*net.TCPAddr).Port
+}
 
 func (srv *TestServer) session() (*Session, error) {
 	return testCluster(frm.ProtoVersion(srv.protocol), srv.Address).CreateSession()

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -102,10 +102,11 @@ func TestAsyncSessionInit(t *testing.T) {
 	}
 	// only build 1 of the servers so that we can test not connecting to the last
 	// one
-	srv := NewTestServerWithAddress(addresses[0]+":9042", t, defaultProto, context.Background())
+	srv := NewTestServerWithAddress(addresses[0]+":0", t, defaultProto, context.Background())
 	defer srv.Stop()
 
-	cluster := testCluster(defaultProto, srv.Address, addresses[1]+":9042", addresses[2]+":9042")
+	cluster := testCluster(defaultProto, addresses[0], addresses[1], addresses[2])
+	cluster.Port = srv.port()
 	cluster.PoolConfig.HostSelectionPolicy = SingleHostReadyPolicy(RoundRobinHostPolicy())
 	db, err := cluster.CreateSession()
 	if err != nil {


### PR DESCRIPTION
Split out from #863.

## Summary
- bind default test servers on ephemeral ports instead of fixed 127.0.0.1:9042
- configure tests to use the bound port where needed

## Validation
- go test -tags unit -run 'TestDNSLookupConnected|TestAsyncSessionInit' .