### PR TITLE
perf/marshal: combined merge of #826 + #839 + #881: optimize collection, vector, lists marshal/unmarshal performance

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -2426,6 +2426,13 @@ func marshalQueryValue(typ TypeInfo, value any, dst *queryValues) error {
 		value = named.value
 	}
 
+	// Capture user-Marshaler handling BEFORE Marshal consumes value, so we can
+	// skip the pool even if the user implements Marshaler for a CQL type that
+	// would otherwise be a pooled fast path. This avoids handing back user-owned
+	// memory to the pool, where a later getMarshalOutput could overwrite it while
+	// the user is still reading it.
+	_, userMarshaler := value.(Marshaler)
+
 	if _, ok := value.(unsetColumn); !ok {
 		val, err := Marshal(typ, value)
 		if err != nil {
@@ -2433,6 +2440,7 @@ func marshalQueryValue(typ TypeInfo, value any, dst *queryValues) error {
 		}
 
 		dst.value = val
+		dst.pooled = !userMarshaler && pooledMarshalValue(typ, value) && cap(val) <= marshalBufMaxCap
 	} else {
 		dst.isUnset = true
 	}
@@ -2533,6 +2541,11 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 		info  *preparedStatment
 	)
 
+	// pooledBufs collects marshalled byte slices from fast-path marshal
+	// functions so they can be returned to marshalOutputPool after the
+	// framer copies them (before putQueryValues clears params.values).
+	var pooledBufs [][]byte
+
 	// The keyspace and table this attempt routes by, used below to attribute a
 	// tablet-routing hint. Held in locals rather than read back out of
 	// qry.routingInfo: one *Query (and one *queryRoutingInfo) is shared by every
@@ -2569,13 +2582,20 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 		}
 
 		params.values = getQueryValues(len(values))
+
 		for i := 0; i < len(values); i++ {
 			v := &params.values[i]
 			value := values[i]
 			typ := info.request.columns[i].TypeInfo
 			if err := marshalQueryValue(typ, value, v); err != nil {
+				for _, buf := range pooledBufs {
+					putMarshalOutput(buf)
+				}
 				putQueryValues(params.values)
 				return &Iter{err: err}
+			}
+			if v.pooled {
+				pooledBufs = append(pooledBufs, v.value)
 			}
 		}
 
@@ -2614,8 +2634,12 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 	}
 
 	framer, err := c.exec(ctx, frame, qry.trace, qry.GetRequestTimeout())
-	// Return pooled values; consumed by buildFrame at the start of c.exec().
-	// Returned after round-trip (not right after serialization) for simplicity.
+	// Return pooled marshal buffers and query values; consumed by buildFrame
+	// at the start of c.exec(). Returned after round-trip (not right after
+	// serialization) for simplicity.
+	for _, buf := range pooledBufs {
+		putMarshalOutput(buf)
+	}
 	putQueryValues(params.values)
 	if err != nil {
 		return &Iter{err: err}
@@ -2879,6 +2903,17 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 
 	hasLwtEntries := false
 
+	// pooledBufs collects marshalled byte slices from fast-path marshal
+	// functions so they can be returned to marshalOutputPool after the
+	// framer copies them. The defer is installed before the loop so that
+	// buffers are returned even if a later marshalQueryValue call fails.
+	var pooledBufs [][]byte
+	defer func() {
+		for _, buf := range pooledBufs {
+			putMarshalOutput(buf)
+		}
+	}()
+
 	for i := 0; i < n; i++ {
 		entry := &batch.Entries[i]
 		b := &req.statements[i]
@@ -2923,6 +2958,9 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 				if err := marshalQueryValue(typ, value, v); err != nil {
 					putBatchQueryValues(req.statements)
 					return &Iter{err: err}
+				}
+				if v.pooled {
+					pooledBufs = append(pooledBufs, v.value)
 				}
 			}
 

--- a/conn.go
+++ b/conn.go
@@ -2420,6 +2420,25 @@ func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer,
 	}
 }
 
+// putPooledOutput returns a buffer to marshalOutputPool. Indirected so tests
+// can observe exactly which buffers the release paths hand back.
+var putPooledOutput = putMarshalOutput
+
+// releasePooledValues returns the buffers that the generic marshal path took
+// from marshalOutputPool. The gate is the per-value pooled flag, never the
+// column's TypeInfo: poolability is a property of the code path that produced
+// the bytes, so predicting it from the schema would recycle reflect-path,
+// pointer and user-Marshaler buffers that were never pooled. Clearing the flag
+// makes a second call a no-op.
+func releasePooledValues(vals []queryValues) {
+	for i := range vals {
+		if vals[i].pooled {
+			putPooledOutput(vals[i].value)
+			vals[i].pooled = false
+		}
+	}
+}
+
 func marshalQueryValue(typ TypeInfo, value any, dst *queryValues) error {
 	if named, ok := value.(*namedValue); ok {
 		dst.name = named.name
@@ -2541,11 +2560,6 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 		info  *preparedStatment
 	)
 
-	// pooledBufs collects marshalled byte slices from fast-path marshal
-	// functions so they can be returned to marshalOutputPool after the
-	// framer copies them (before putQueryValues clears params.values).
-	var pooledBufs [][]byte
-
 	// The keyspace and table this attempt routes by, used below to attribute a
 	// tablet-routing hint. Held in locals rather than read back out of
 	// qry.routingInfo: one *Query (and one *queryRoutingInfo) is shared by every
@@ -2588,14 +2602,11 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 			value := values[i]
 			typ := info.request.columns[i].TypeInfo
 			if err := marshalQueryValue(typ, value, v); err != nil {
-				for _, buf := range pooledBufs {
-					putMarshalOutput(buf)
-				}
+				// Return pooled marshal buffers before putQueryValues clears the
+				// pooled flags below.
+				releasePooledValues(params.values)
 				putQueryValues(params.values)
 				return &Iter{err: err}
-			}
-			if v.pooled {
-				pooledBufs = append(pooledBufs, v.value)
 			}
 		}
 
@@ -2637,9 +2648,7 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 	// Return pooled marshal buffers and query values; consumed by buildFrame
 	// at the start of c.exec(). Returned after round-trip (not right after
 	// serialization) for simplicity.
-	for _, buf := range pooledBufs {
-		putMarshalOutput(buf)
-	}
+	releasePooledValues(params.values)
 	putQueryValues(params.values)
 	if err != nil {
 		return &Iter{err: err}
@@ -2910,7 +2919,7 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 	var pooledBufs [][]byte
 	defer func() {
 		for _, buf := range pooledBufs {
-			putMarshalOutput(buf)
+			putPooledOutput(buf)
 		}
 	}()
 

--- a/cql_list_wire_test_helpers.go
+++ b/cql_list_wire_test_helpers.go
@@ -1,0 +1,63 @@
+//go:build all || unit
+// +build all unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import "encoding/binary"
+
+// buildCQLList and buildCQLListWithNulls live under `all || unit` (rather
+// than marshal_test.go's `unit`-only tag) because list_fastpath_test.go and
+// marshal_edgecases_test.go, which build under `all || unit`, call them too.
+
+func buildCQLList(elems ...[]byte) []byte {
+	var buf []byte
+	countBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(countBytes, uint32(len(elems)))
+	buf = append(buf, countBytes...)
+	for _, e := range elems {
+		lenBytes := make([]byte, 4)
+		binary.BigEndian.PutUint32(lenBytes, uint32(len(e)))
+		buf = append(buf, lenBytes...)
+		buf = append(buf, e...)
+	}
+	return buf
+}
+
+// buildCQLListWithNulls builds a CQL binary list where a nil entry encodes a
+// null element (length -1), matching the wire format the server emits.
+func buildCQLListWithNulls(elems ...[]byte) []byte {
+	var buf []byte
+	countBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(countBytes, uint32(len(elems)))
+	buf = append(buf, countBytes...)
+	for _, e := range elems {
+		lenBytes := make([]byte, 4)
+		if e == nil {
+			binary.BigEndian.PutUint32(lenBytes, uint32(0xFFFFFFFF)) // -1
+			buf = append(buf, lenBytes...)
+			continue
+		}
+		binary.BigEndian.PutUint32(lenBytes, uint32(len(e)))
+		buf = append(buf, lenBytes...)
+		buf = append(buf, e...)
+	}
+	return buf
+}

--- a/frame.go
+++ b/frame.go
@@ -1345,6 +1345,11 @@ type queryValues struct {
 	name    string
 	value   []byte
 	isUnset bool
+	// pooled reports whether value was returned from marshalOutputPool (the
+	// buffer-pool fast path) and is safe to return to the pool after the
+	// framer has copied it. False when the bytes came from a user Marshaler,
+	// the reflection path, or any non-pooled allocation site.
+	pooled bool
 }
 
 // queryValuesPools is a set of size-bucketed sync.Pools for []queryValues slices.

--- a/list_fastpath_test.go
+++ b/list_fastpath_test.go
@@ -24,6 +24,7 @@ package gocql
 import (
 	"encoding/binary"
 	"math"
+	"reflect"
 	"testing"
 )
 
@@ -257,9 +258,9 @@ func TestUnmarshalListFastPath_Int32_NilData(t *testing.T) {
 	}
 }
 
-// --- Slice reuse tests (unmarshal into existing capacity) ---
+// --- Decoding into a pre-sized destination ---
 
-func TestUnmarshalListFastPath_Float32_SliceReuse(t *testing.T) {
+func TestUnmarshalListFastPath_Float32_PreSizedDestination(t *testing.T) {
 	info := listTypeInfo(TypeFloat)
 	input := []float32{1.0, 2.0, 3.0}
 
@@ -277,9 +278,6 @@ func TestUnmarshalListFastPath_Float32_SliceReuse(t *testing.T) {
 	if len(existing) != 3 {
 		t.Fatalf("length mismatch: got %d, want 3", len(existing))
 	}
-	if cap(existing) != 10 {
-		t.Fatalf("expected capacity to be preserved at 10, got %d", cap(existing))
-	}
 	for i := range input {
 		if existing[i] != input[i] {
 			t.Errorf("index %d: got %v, want %v", i, existing[i], input[i])
@@ -287,7 +285,7 @@ func TestUnmarshalListFastPath_Float32_SliceReuse(t *testing.T) {
 	}
 }
 
-func TestUnmarshalListFastPath_Int64_SliceReuse(t *testing.T) {
+func TestUnmarshalListFastPath_Int64_PreSizedDestination(t *testing.T) {
 	info := listTypeInfo(TypeBigInt)
 	input := []int64{100, 200, 300, 400}
 
@@ -380,7 +378,8 @@ func TestMarshalListFastPath_Float32_SpecialValues(t *testing.T) {
 	nan := float32(math.NaN())
 	inf := float32(math.Inf(1))
 	negInf := float32(math.Inf(-1))
-	input := []float32{nan, inf, negInf, 0, -0}
+	negZero := math.Float32frombits(0x80000000)
+	input := []float32{nan, inf, negInf, 0, negZero}
 
 	data, err := marshalList(info, input)
 	if err != nil {
@@ -404,6 +403,12 @@ func TestMarshalListFastPath_Float32_SpecialValues(t *testing.T) {
 	}
 	if output[2] != negInf {
 		t.Errorf("-Inf: got %v, want %v", output[2], negInf)
+	}
+	if output[3] != 0 {
+		t.Errorf("+0: got %v, want 0", output[3])
+	}
+	if math.Float32bits(output[4]) != 0x80000000 {
+		t.Errorf("-0 bits mismatch: got %08x, want 80000000", math.Float32bits(output[4]))
 	}
 }
 
@@ -450,26 +455,60 @@ func TestMarshalListFastPath_Int64_BoundaryValues(t *testing.T) {
 }
 
 // --- Wrong-type fallback tests ---
-// Verify that passing a non-matching Go type falls through to the reflect path.
+// Verify that passing a genuinely non-matching Go type falls through to the
+// reflect path. (Earlier revisions used []int for TypeInt, but Go's marshalList
+// has an explicit []int fast-path branch for TypeInt, so []int is no longer a
+// "wrong type" — it hits the fast path. Use a custom named type to actually
+// exercise the reflect fallback.)
 
-func TestMarshalListFastPath_WrongType_FallsToReflect(t *testing.T) {
+type namedInt32 int32
+
+func TestMarshalListFastPath_NonMatchingType_FallsToReflect(t *testing.T) {
 	info := listTypeInfo(TypeInt)
-	// Pass []int instead of []int32 — should fall through to reflect path
-	input := []int{1, 2, 3}
+	// namedInt32 does not match any concrete-type fast path; falls through
+	// to the reflect marshal/unmarshal.
+	input := []namedInt32{namedInt32(1), namedInt32(2), namedInt32(3)}
 
 	data, err := marshalList(info, input)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Verify the data is valid by unmarshaling via reflect path
-	var output []int
+	var output []namedInt32
 	if err := unmarshalList(info, data, &output); err != nil {
 		t.Fatal(err)
 	}
 
-	if len(output) != 3 || output[0] != 1 || output[1] != 2 || output[2] != 3 {
+	if len(output) != 3 ||
+		output[0] != namedInt32(1) || output[1] != namedInt32(2) || output[2] != namedInt32(3) {
 		t.Errorf("reflect fallback: got %v, want [1 2 3]", output)
+	}
+}
+
+// TestUnmarshalListFastPath_NonMatchingType_ReflectPath verifies that the
+// reflect fallback path in unmarshalList handles unmarshal targets without a
+// fast-path match. We use *[]any to force the reflect path even on the typed
+// unmarshal side.
+func TestUnmarshalListFastPath_NonMatchingType_ReflectPath(t *testing.T) {
+	info := listTypeInfo(TypeVarchar)
+	// Wire: [count=2][len=5][hello][len=5][world]
+	data := buildCQLList([]byte("hello"), []byte("world"))
+	var output []any
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output) != 2 {
+		t.Fatalf("expected length 2, got %d", len(output))
+	}
+	// The reflect path decodes VARCHAR elements as []byte (not string) when
+	// the destination is []any; verify the byte content matches.
+	got0, ok := output[0].([]byte)
+	if !ok || string(got0) != "hello" {
+		t.Errorf("output[0]: got %v, want hello (as []byte)", output[0])
+	}
+	got1, ok := output[1].([]byte)
+	if !ok || string(got1) != "world" {
+		t.Errorf("output[1]: got %v, want world (as []byte)", output[1])
 	}
 }
 
@@ -589,22 +628,37 @@ func TestMarshalListFastPath_CrossPathCompat_Int32(t *testing.T) {
 	info := listTypeInfo(TypeInt)
 	input := []int32{100, 200, 300}
 
-	// Fast path marshal
+	// Fast-path marshal
 	data, err := marshalList(info, input)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Reflect path unmarshal (use []int which doesn't match fast path)
-	var reflectOutput []int
-	if err := unmarshalList(info, data, &reflectOutput); err != nil {
+	// Fast-path unmarshal: round-trip is consistent.
+	var fast []int32
+	if err := unmarshalList(info, data, &fast); err != nil {
 		t.Fatal(err)
 	}
+	if !reflect.DeepEqual(fast, input) {
+		t.Errorf("round-trip mismatch: got %v, want %v", fast, input)
+	}
 
-	for i := range input {
-		if int32(reflectOutput[i]) != input[i] {
-			t.Errorf("index %d: got %d, want %d", i, reflectOutput[i], input[i])
-		}
+	// Reverse: emit via the reflect marshal path, then consume via the fast
+	// path. We build a []any to force the reflect marshal.
+	anyOut := make([]any, len(input))
+	for i, v := range input {
+		anyOut[i] = v
+	}
+	wireBytes, err := Marshal(info, anyOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fastReflect []int32
+	if err := unmarshalList(info, wireBytes, &fastReflect); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fastReflect, input) {
+		t.Errorf("reflect→fast round-trip mismatch: got %v, want %v", fastReflect, input)
 	}
 }
 

--- a/list_fastpath_test.go
+++ b/list_fastpath_test.go
@@ -1,0 +1,1231 @@
+//go:build all || unit
+// +build all unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// --- Helper to create list CollectionType ---
+
+func listTypeInfo(elemType Type) CollectionType {
+	return CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: elemType},
+	}
+}
+
+func setTypeInfo(elemType Type) CollectionType {
+	return CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeSet},
+		Elem:       NativeType{proto: protoVersion4, typ: elemType},
+	}
+}
+
+// --- Round-trip correctness tests ---
+
+func TestMarshalListFastPath_Float32_RoundTrip(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	input := []float32{1.5, -2.5, 3.14, 0, math.MaxFloat32, math.SmallestNonzeroFloat32}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []float32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Float64_RoundTrip(t *testing.T) {
+	info := listTypeInfo(TypeDouble)
+	input := []float64{1.5, -2.5, math.Pi, 0, math.MaxFloat64, math.SmallestNonzeroFloat64}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []float64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Int32_RoundTrip(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	input := []int32{0, 1, -1, math.MaxInt32, math.MinInt32, 42}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Int64_RoundTrip(t *testing.T) {
+	info := listTypeInfo(TypeBigInt)
+	input := []int64{0, 1, -1, math.MaxInt64, math.MinInt64, 42}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Int64Timestamp_RoundTrip(t *testing.T) {
+	info := listTypeInfo(TypeTimestamp)
+	input := []int64{0, 1714000000000, -1, math.MaxInt64}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+// --- Empty list tests ---
+
+func TestMarshalListFastPath_Float32_Empty(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	input := []float32{}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []float32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != 0 {
+		t.Fatalf("expected empty slice, got length %d", len(output))
+	}
+}
+
+func TestMarshalListFastPath_Int32_Empty(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	input := []int32{}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != 0 {
+		t.Fatalf("expected empty slice, got length %d", len(output))
+	}
+}
+
+// --- Nil list tests ---
+
+func TestMarshalListFastPath_Float32_Nil(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	var input []float32 // nil
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil data for nil input, got %v", data)
+	}
+}
+
+func TestMarshalListFastPath_Int32_Nil(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	var input []int32 // nil
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil data for nil input, got %v", data)
+	}
+}
+
+func TestUnmarshalListFastPath_Float32_NilData(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	var output []float32
+
+	if err := unmarshalList(info, nil, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output != nil {
+		t.Fatalf("expected nil output, got %v", output)
+	}
+}
+
+func TestUnmarshalListFastPath_Int32_NilData(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	var output []int32
+
+	if err := unmarshalList(info, nil, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output != nil {
+		t.Fatalf("expected nil output, got %v", output)
+	}
+}
+
+// --- Slice reuse tests (unmarshal into existing capacity) ---
+
+func TestUnmarshalListFastPath_Float32_SliceReuse(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	input := []float32{1.0, 2.0, 3.0}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-allocate a slice with extra capacity
+	existing := make([]float32, 0, 10)
+	if err := unmarshalList(info, data, &existing); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(existing) != 3 {
+		t.Fatalf("length mismatch: got %d, want 3", len(existing))
+	}
+	if cap(existing) != 10 {
+		t.Fatalf("expected capacity to be preserved at 10, got %d", cap(existing))
+	}
+	for i := range input {
+		if existing[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, existing[i], input[i])
+		}
+	}
+}
+
+func TestUnmarshalListFastPath_Int64_SliceReuse(t *testing.T) {
+	info := listTypeInfo(TypeBigInt)
+	input := []int64{100, 200, 300, 400}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-allocate with exact capacity
+	existing := make([]int64, 0, 4)
+	if err := unmarshalList(info, data, &existing); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(existing) != 4 {
+		t.Fatalf("length mismatch: got %d, want 4", len(existing))
+	}
+	for i := range input {
+		if existing[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, existing[i], input[i])
+		}
+	}
+}
+
+// --- Wire format compatibility test ---
+// Verify the fast-path produces identical bytes to the reflect path.
+
+func TestMarshalListFastPath_WireCompatibility_Int32(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	input := []int32{1, 2, 3}
+
+	// Expected wire format: [count=3] + 3 × ([len=4] + [big-endian int32])
+	// Total = 4 + 3*8 = 28 bytes
+	expected := make([]byte, 28)
+	binary.BigEndian.PutUint32(expected[0:], 3)  // count
+	binary.BigEndian.PutUint32(expected[4:], 4)  // elem 0 length
+	binary.BigEndian.PutUint32(expected[8:], 1)  // elem 0 value
+	binary.BigEndian.PutUint32(expected[12:], 4) // elem 1 length
+	binary.BigEndian.PutUint32(expected[16:], 2) // elem 1 value
+	binary.BigEndian.PutUint32(expected[20:], 4) // elem 2 length
+	binary.BigEndian.PutUint32(expected[24:], 3) // elem 2 value
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(data) != len(expected) {
+		t.Fatalf("wire size mismatch: got %d, want %d", len(data), len(expected))
+	}
+	for i := range expected {
+		if data[i] != expected[i] {
+			t.Errorf("byte %d: got %02x, want %02x", i, data[i], expected[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_WireCompatibility_Float64(t *testing.T) {
+	info := listTypeInfo(TypeDouble)
+	input := []float64{1.5, -2.5}
+
+	// Expected wire format: [count=2] + 2 × ([len=8] + [big-endian float64])
+	// Total = 4 + 2*12 = 28 bytes
+	expected := make([]byte, 28)
+	binary.BigEndian.PutUint32(expected[0:], 2)                       // count
+	binary.BigEndian.PutUint32(expected[4:], 8)                       // elem 0 length
+	binary.BigEndian.PutUint64(expected[8:], math.Float64bits(1.5))   // elem 0 value
+	binary.BigEndian.PutUint32(expected[16:], 8)                      // elem 1 length
+	binary.BigEndian.PutUint64(expected[20:], math.Float64bits(-2.5)) // elem 1 value
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(data) != len(expected) {
+		t.Fatalf("wire size mismatch: got %d, want %d", len(data), len(expected))
+	}
+	for i := range expected {
+		if data[i] != expected[i] {
+			t.Errorf("byte %d: got %02x, want %02x", i, data[i], expected[i])
+		}
+	}
+}
+
+// --- Boundary value tests ---
+
+func TestMarshalListFastPath_Float32_SpecialValues(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	nan := float32(math.NaN())
+	inf := float32(math.Inf(1))
+	negInf := float32(math.Inf(-1))
+	input := []float32{nan, inf, negInf, 0, -0}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []float32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	// NaN != NaN, check bits
+	if math.Float32bits(output[0]) != math.Float32bits(nan) {
+		t.Errorf("NaN bits mismatch: got %08x, want %08x", math.Float32bits(output[0]), math.Float32bits(nan))
+	}
+	if output[1] != inf {
+		t.Errorf("Inf: got %v, want %v", output[1], inf)
+	}
+	if output[2] != negInf {
+		t.Errorf("-Inf: got %v, want %v", output[2], negInf)
+	}
+}
+
+func TestMarshalListFastPath_Int32_BoundaryValues(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	input := []int32{math.MaxInt32, math.MinInt32, 0, 1, -1}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %d, want %d", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Int64_BoundaryValues(t *testing.T) {
+	info := listTypeInfo(TypeBigInt)
+	input := []int64{math.MaxInt64, math.MinInt64, 0, 1, -1}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %d, want %d", i, output[i], input[i])
+		}
+	}
+}
+
+// --- Wrong-type fallback tests ---
+// Verify that passing a non-matching Go type falls through to the reflect path.
+
+func TestMarshalListFastPath_WrongType_FallsToReflect(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	// Pass []int instead of []int32 — should fall through to reflect path
+	input := []int{1, 2, 3}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the data is valid by unmarshaling via reflect path
+	var output []int
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != 3 || output[0] != 1 || output[1] != 2 || output[2] != 3 {
+		t.Errorf("reflect fallback: got %v, want [1 2 3]", output)
+	}
+}
+
+// --- Set type tests (sets use the same code path as lists) ---
+
+func TestMarshalSetFastPath_Int32_RoundTrip(t *testing.T) {
+	info := setTypeInfo(TypeInt)
+	input := []int32{10, 20, 30}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalSetFastPath_Float64_RoundTrip(t *testing.T) {
+	info := setTypeInfo(TypeDouble)
+	input := []float64{1.1, 2.2, 3.3}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []float64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+// --- Large list test ---
+
+func TestMarshalListFastPath_Float32_Large(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	n := 10000
+	input := make([]float32, n)
+	for i := range input {
+		input[i] = float32(i) * 0.1
+	}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []float32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != n {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), n)
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %v, want %v", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Int64_Large(t *testing.T) {
+	info := listTypeInfo(TypeBigInt)
+	n := 10000
+	input := make([]int64, n)
+	for i := range input {
+		input[i] = int64(i) * 1000000
+	}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != n {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), n)
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %d, want %d", i, output[i], input[i])
+		}
+	}
+}
+
+// --- Cross-path compatibility test ---
+// Verify fast-path marshal produces data that the reflect-path unmarshal can read,
+// and vice versa.
+
+func TestMarshalListFastPath_CrossPathCompat_Int32(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	input := []int32{100, 200, 300}
+
+	// Fast path marshal
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reflect path unmarshal (use []int which doesn't match fast path)
+	var reflectOutput []int
+	if err := unmarshalList(info, data, &reflectOutput); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range input {
+		if int32(reflectOutput[i]) != input[i] {
+			t.Errorf("index %d: got %d, want %d", i, reflectOutput[i], input[i])
+		}
+	}
+}
+
+// --- listByteSize overflow test ---
+
+func TestListByteSize_Overflow(t *testing.T) {
+	_, err := listByteSize(math.MaxInt/2, 8)
+	if err == nil {
+		t.Error("expected overflow error, got nil")
+	}
+}
+
+func TestListByteSize_Zero(t *testing.T) {
+	size, err := listByteSize(0, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != 4 {
+		t.Errorf("expected 4 (header only), got %d", size)
+	}
+}
+
+// --- Unmarshal error cases ---
+
+func TestUnmarshalListFastPath_Float32_TruncatedData(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	// Valid header saying 3 elements, but not enough data
+	data := make([]byte, 10) // needs 4 + 3*8 = 28 bytes
+	binary.BigEndian.PutUint32(data, 3)
+
+	var output []float32
+	err := unmarshalList(info, data, &output)
+	if err == nil {
+		t.Error("expected error for truncated data, got nil")
+	}
+}
+
+func TestUnmarshalListFastPath_Int32_TruncatedHeader(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	data := make([]byte, 2) // needs at least 4 bytes for header
+
+	var output []int32
+	err := unmarshalList(info, data, &output)
+	if err == nil {
+		t.Error("expected error for truncated header, got nil")
+	}
+}
+
+func TestUnmarshalListFastPath_NegativeCount(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	// Craft a payload with high bit set in count (0x80000000 = -2147483648 as int32)
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, 0x80000000)
+
+	var output []int32
+	err := unmarshalList(info, data, &output)
+	if err == nil {
+		t.Error("expected error for negative count, got nil")
+	}
+}
+
+// --- Null element tests ---
+// CQL lists can contain null elements (represented by -1 length prefix).
+// The fast path should handle these by writing the zero value, matching the slow path.
+
+func TestUnmarshalListFastPath_Int32_NullElement(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	// Wire format: count=3, elem0=1, elem1=null, elem2=3
+	// [count=3] [len=4][1] [len=-1] [len=4][3]
+	// Total = 4 + 8 + 4 + 8 = 24 bytes
+	data := make([]byte, 24)
+	binary.BigEndian.PutUint32(data[0:], 3)           // count
+	binary.BigEndian.PutUint32(data[4:], 4)           // elem 0 length
+	binary.BigEndian.PutUint32(data[8:], 1)           // elem 0 value
+	binary.BigEndian.PutUint32(data[12:], 0xFFFFFFFF) // elem 1 length = -1 (null)
+	binary.BigEndian.PutUint32(data[16:], 4)          // elem 2 length
+	binary.BigEndian.PutUint32(data[20:], 3)          // elem 2 value
+
+	var output []int32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []int32{1, 0, 3}
+	if len(output) != len(expected) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(expected))
+	}
+	for i := range expected {
+		if output[i] != expected[i] {
+			t.Errorf("index %d: got %d, want %d", i, output[i], expected[i])
+		}
+	}
+}
+
+func TestUnmarshalListFastPath_Float32_NullElement(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	// Wire format: count=2, elem0=null, elem1=1.5
+	data := make([]byte, 16)
+	binary.BigEndian.PutUint32(data[0:], 2)                      // count
+	binary.BigEndian.PutUint32(data[4:], 0xFFFFFFFF)             // elem 0 = null
+	binary.BigEndian.PutUint32(data[8:], 4)                      // elem 1 length
+	binary.BigEndian.PutUint32(data[12:], math.Float32bits(1.5)) // elem 1 value
+
+	var output []float32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != 2 {
+		t.Fatalf("length mismatch: got %d, want 2", len(output))
+	}
+	if output[0] != 0 {
+		t.Errorf("null element: got %v, want 0", output[0])
+	}
+	if output[1] != 1.5 {
+		t.Errorf("normal element: got %v, want 1.5", output[1])
+	}
+}
+
+func TestUnmarshalListFastPath_Int64_NullElement(t *testing.T) {
+	info := listTypeInfo(TypeBigInt)
+	// Wire format: count=2, elem0=100, elem1=null
+	data := make([]byte, 20)
+	binary.BigEndian.PutUint32(data[0:], 2)           // count
+	binary.BigEndian.PutUint32(data[4:], 8)           // elem 0 length
+	binary.BigEndian.PutUint64(data[8:], 100)         // elem 0 value
+	binary.BigEndian.PutUint32(data[16:], 0xFFFFFFFF) // elem 1 = null
+
+	var output []int64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != 2 || output[0] != 100 || output[1] != 0 {
+		t.Errorf("got %v, want [100 0]", output)
+	}
+}
+
+// --- TypeCounter test ---
+
+func TestMarshalListFastPath_Counter_RoundTrip(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeCounter},
+	}
+	input := []int64{10, 20, 30}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output []int64
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("index %d: got %d, want %d", i, output[i], input[i])
+		}
+	}
+}
+
+// --- Benchmarks ---
+
+func BenchmarkMarshalListFastPathInt32(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeInt)
+
+	for _, s := range sizes {
+		input := make([]int32, s.n)
+		for i := range input {
+			input[i] = int32(i)
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 4))
+			for i := 0; i < b.N; i++ {
+				_, err := marshalList(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalListFastPathInt32(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeInt)
+
+	for _, s := range sizes {
+		input := make([]int32, s.n)
+		for i := range input {
+			input[i] = int32(i)
+		}
+		data, err := marshalList(info, input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 4))
+			var output []int32
+			for i := 0; i < b.N; i++ {
+				err := unmarshalList(info, data, &output)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalListFastPathFloat32(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeFloat)
+
+	for _, s := range sizes {
+		input := make([]float32, s.n)
+		for i := range input {
+			input[i] = float32(i) * 0.1
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 4))
+			for i := 0; i < b.N; i++ {
+				_, err := marshalList(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalListFastPathFloat32(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeFloat)
+
+	for _, s := range sizes {
+		input := make([]float32, s.n)
+		for i := range input {
+			input[i] = float32(i) * 0.1
+		}
+		data, err := marshalList(info, input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 4))
+			var output []float32
+			for i := 0; i < b.N; i++ {
+				err := unmarshalList(info, data, &output)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalListFastPathFloat64(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeDouble)
+
+	for _, s := range sizes {
+		input := make([]float64, s.n)
+		for i := range input {
+			input[i] = float64(i) * 0.1
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 8))
+			for i := 0; i < b.N; i++ {
+				_, err := marshalList(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalListFastPathFloat64(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeDouble)
+
+	for _, s := range sizes {
+		input := make([]float64, s.n)
+		for i := range input {
+			input[i] = float64(i) * 0.1
+		}
+		data, err := marshalList(info, input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 8))
+			var output []float64
+			for i := 0; i < b.N; i++ {
+				err := unmarshalList(info, data, &output)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalListFastPathInt64(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeBigInt)
+
+	for _, s := range sizes {
+		input := make([]int64, s.n)
+		for i := range input {
+			input[i] = int64(i) * 1000000
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 8))
+			for i := 0; i < b.N; i++ {
+				_, err := marshalList(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalListFastPathInt64(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := listTypeInfo(TypeBigInt)
+
+	for _, s := range sizes {
+		input := make([]int64, s.n)
+		for i := range input {
+			input[i] = int64(i) * 1000000
+		}
+		data, err := marshalList(info, input)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 8))
+			var output []int64
+			for i := 0; i < b.N; i++ {
+				err := unmarshalList(info, data, &output)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// --- Fix: oversized count guard ---
+// A malformed count that exceeds (len(data)-4)/4 must be rejected before make().
+
+func TestUnmarshalListFastPath_Float32_OversizedCount(t *testing.T) {
+	info := listTypeInfo(TypeFloat)
+	// 4-byte header claiming 1 element, no element bytes follow.
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, 1)
+	var out []float32
+	if err := unmarshalList(info, data, &out); err == nil {
+		t.Error("expected error for oversized count, got nil")
+	}
+}
+
+func TestUnmarshalListFastPath_Float64_OversizedCount(t *testing.T) {
+	info := listTypeInfo(TypeDouble)
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, 1)
+	var out []float64
+	if err := unmarshalList(info, data, &out); err == nil {
+		t.Error("expected error for oversized count, got nil")
+	}
+}
+
+func TestUnmarshalListFastPath_Int32_OversizedCount(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, 1)
+	var out []int32
+	if err := unmarshalList(info, data, &out); err == nil {
+		t.Error("expected error for oversized count, got nil")
+	}
+}
+
+func TestUnmarshalListFastPath_Int64_OversizedCount(t *testing.T) {
+	info := listTypeInfo(TypeBigInt)
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, 1)
+	var out []int64
+	if err := unmarshalList(info, data, &out); err == nil {
+		t.Error("expected error for oversized count, got nil")
+	}
+}
+
+// --- Fix: TypeInt []int / *[]int fast path ---
+
+func TestMarshalListFastPath_Int_RoundTrip(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	input := []int{0, 1, -1, math.MaxInt32, math.MinInt32, 42}
+
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output []int
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatal(err)
+	}
+	if len(output) != len(input) {
+		t.Fatalf("length mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if output[i] != input[i] {
+			t.Errorf("[%d]: got %d, want %d", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Int_WireCompatibility(t *testing.T) {
+	// []int and []int32 must produce identical wire bytes for values in int32 range.
+	info := listTypeInfo(TypeInt)
+	d32, err := marshalList(info, []int32{0, 1, -1, math.MaxInt32, math.MinInt32})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dInt, err := marshalList(info, []int{0, 1, -1, math.MaxInt32, math.MinInt32})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d32) != len(dInt) {
+		t.Fatalf("wire length mismatch: int32=%d int=%d", len(d32), len(dInt))
+	}
+	for i := range d32 {
+		if d32[i] != dInt[i] {
+			t.Errorf("byte[%d]: int32=0x%02x int=0x%02x", i, d32[i], dInt[i])
+		}
+	}
+}
+
+func TestMarshalListFastPath_Int_OutOfRange(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	if _, err := marshalList(info, []int{int(math.MaxInt32) + 1}); err == nil {
+		t.Error("expected error for out-of-range int, got nil")
+	}
+}
+
+func TestMarshalListFastPath_Int_Nil(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	data, err := marshalList(info, []int(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data != nil {
+		t.Errorf("expected nil for nil slice, got %v", data)
+	}
+}
+
+func TestUnmarshalListFastPath_Int_NilData(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	dst := []int{1, 2, 3}
+	if err := unmarshalList(info, nil, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if dst != nil {
+		t.Errorf("expected nil after nil data, got %v", dst)
+	}
+}
+
+func TestUnmarshalListFastPath_Int_PreSizedDestination(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	input := []int{10, 20, 30}
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := make([]int, 0, 10)
+	if err := unmarshalList(info, data, &dst); err != nil {
+		t.Fatal(err)
+	}
+	for i, v := range input {
+		if dst[i] != v {
+			t.Errorf("[%d]: got %d, want %d", i, dst[i], v)
+		}
+	}
+}
+
+func TestUnmarshalListFastPath_Int_NullElement(t *testing.T) {
+	info := listTypeInfo(TypeInt)
+	// [count=2] [len=4][7] [len=-1(null)]
+	data := make([]byte, 4+8+4)
+	binary.BigEndian.PutUint32(data[0:], 2)
+	binary.BigEndian.PutUint32(data[4:], 4)
+	binary.BigEndian.PutUint32(data[8:], 7)
+	binary.BigEndian.PutUint32(data[12:], 0xFFFFFFFF)
+	var dst []int
+	if err := unmarshalList(info, data, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != 2 || dst[0] != 7 || dst[1] != 0 {
+		t.Errorf("got %v, want [7 0]", dst)
+	}
+}
+
+func TestMarshalListFastPath_Int_CrossPathCompat(t *testing.T) {
+	// Fast-path marshal bytes must be consumable by the reflect slow path.
+	info := listTypeInfo(TypeInt)
+	fast, err := marshalList(info, []int{1, 2, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var iface any
+	if err := unmarshalList(info, fast, &iface); err != nil {
+		t.Fatalf("reflect unmarshal of fast-path bytes: %v", err)
+	}
+}
+
+func TestUnmarshalListFastPath_Int_EmptyElement(t *testing.T) {
+	// A zero-length (non-null) element is Cassandra's legacy empty-value
+	// convention; it decodes to zero like a null does, on both paths.
+	info := listTypeInfo(TypeInt)
+	// [count=2] [len=0] [len=4][7]
+	data := make([]byte, 4+4+8)
+	binary.BigEndian.PutUint32(data[0:], 2)
+	binary.BigEndian.PutUint32(data[4:], 0)
+	binary.BigEndian.PutUint32(data[8:], 4)
+	binary.BigEndian.PutUint32(data[12:], 7)
+
+	var dst []int
+	if err := unmarshalList(info, data, &dst); err != nil {
+		t.Fatalf("fast path rejected an empty element the generic path accepts: %v", err)
+	}
+	if len(dst) != 2 || dst[0] != 0 || dst[1] != 7 {
+		t.Errorf("got %v, want [0 7]", dst)
+	}
+
+	// The generic path (forced via a named type) must agree.
+	type namedIntsEmptyElem []int
+	var gen namedIntsEmptyElem
+	if err := unmarshalList(info, data, &gen); err != nil {
+		t.Fatalf("generic path: %v", err)
+	}
+	if len(gen) != 2 || gen[0] != 0 || gen[1] != 7 {
+		t.Errorf("generic path got %v, want [0 7]", gen)
+	}
+}

--- a/marshal.go
+++ b/marshal.go
@@ -888,6 +888,9 @@ func marshalList(info CollectionType, value any) ([]byte, error) {
 	if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
+	if value == nil {
+		return nil, nil
+	}
 
 	// Fast path: type-switch on concrete slice types for common fixed-size
 	// CQL element types. These bypass reflect and per-element Marshal entirely.
@@ -983,6 +986,500 @@ func marshalList(info CollectionType, value any) ([]byte, error) {
 	return nil, marshalErrorf("can not marshal %T into %s", value, info)
 }
 
+var errFastPathNotApplicable = errors.New("fast path not applicable")
+
+// unmarshalListFast attempts to unmarshal a CQL list/set directly into
+// common concrete Go slice types without reflection. Returns
+// errFastPathNotApplicable if the type combination is not handled.
+//
+// Every leaf allocates a fresh backing array rather than reusing the one in
+// *dst. Reuse looks free but aliases results the caller kept: the ordinary
+// `for iter.Scan(&v) { out = append(out, v) }` loop would leave every element
+// of out pointing at the last row. Iter.Scan documents that it copies into
+// dest, and there is no RawBytes-style "valid until the next Scan" contract.
+func unmarshalListFast(info CollectionType, data []byte, value any) error {
+	elemTyp := info.Elem.Type()
+
+	switch v := value.(type) {
+	case *[]string:
+		// TypeAscii is excluded: the generic path validates ASCII payloads
+		// (rejecting bytes > 127) via serialization/ascii, whereas this fast
+		// path would decode with string(elem) and silently accept invalid data.
+		if elemTyp != TypeVarchar && elemTyp != TypeText {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListString(info, data, v)
+	case *[]int64:
+		if elemTyp != TypeBigInt && elemTyp != TypeCounter {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListInt64(info, data, v)
+	case *[]int32:
+		if elemTyp != TypeInt {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListInt32(info, data, v)
+	case *[]float64:
+		if elemTyp != TypeDouble {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListFloat64(info, data, v)
+	case *[]float32:
+		if elemTyp != TypeFloat {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListFloat32(info, data, v)
+	case *[]bool:
+		if elemTyp != TypeBoolean {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListBool(info, data, v)
+	case *[][]byte:
+		if elemTyp != TypeBlob {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListBlob(info, data, v)
+	case *[]int16:
+		if elemTyp != TypeSmallInt {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListInt16(info, data, v)
+	case *[]time.Time:
+		if elemTyp != TypeTimestamp && elemTyp != TypeDate {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListTime(info, data, v)
+	case *[]UUID:
+		if elemTyp != TypeUUID && elemTyp != TypeTimeUUID {
+			return errFastPathNotApplicable
+		}
+		return unmarshalListUUID(info, data, v)
+	default:
+		return errFastPathNotApplicable
+	}
+}
+
+// readListHeader reads the collection count and advances past the header.
+// Returns the element count and remaining data, or an error.
+func readListHeader(data []byte) (int, []byte, error) {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return 0, nil, err
+	}
+	if n < 0 {
+		return 0, nil, unmarshalErrorf("unmarshal list: negative size %d", n)
+	}
+	rest := data[p:]
+	// Reject counts that cannot possibly fit in the remaining payload before
+	// allocating: each element carries at least a 4-byte length prefix, so a
+	// valid count is bounded by len(rest)/4. This prevents a malformed frame
+	// with a huge positive size from triggering a massive up-front allocation.
+	if n > len(rest)/4 {
+		return 0, nil, unmarshalErrorf("unmarshal list: invalid size %d", n)
+	}
+	return n, rest, nil
+}
+
+// readListElement reads one element's raw bytes from data.
+// Returns the element bytes (nil if null), remaining data, and any error.
+func readListElement(data []byte) ([]byte, []byte, error) {
+	m, p, err := readCollectionSize(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	data = data[p:]
+	if m < 0 {
+		return nil, data, nil // null element
+	}
+	if len(data) < m {
+		return nil, nil, unmarshalErrorf("unmarshal list: unexpected eof")
+	}
+	return data[:m], data[m:], nil
+}
+
+func unmarshalListString(info CollectionType, data []byte, dst *[]string) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []string
+	if n == 0 {
+		s = make([]string, 0)
+	} else {
+		s = make([]string, n)
+		// Total element data bytes = remaining frame bytes minus n×4-byte length prefixes.
+		// Share one buffer across all strings (avoiding n individual string
+		// allocations), but only up to marshalBufMaxCap: sharing an unbounded
+		// buffer would let a caller keeping one small string pin all of it.
+		total := len(data) - n*4
+		if total > 0 && total <= marshalBufMaxCap {
+			buf := make([]byte, total)
+			offset := 0
+			for i := 0; i < n; i++ {
+				var elem []byte
+				elem, data, err = readListElement(data)
+				if err != nil {
+					return err
+				}
+				if len(elem) > 0 {
+					copy(buf[offset:], elem)
+					s[i] = unsafe.String(&buf[offset], len(elem))
+					offset += len(elem)
+				} else {
+					// Null/empty slot — explicitly clear (don't leave a stale
+					// string from a reused backing array).
+					s[i] = ""
+				}
+			}
+		} else {
+			for i := 0; i < n; i++ {
+				var elem []byte
+				elem, data, err = readListElement(data)
+				if err != nil {
+					return err
+				}
+				s[i] = string(elem) // "" for both nil and empty, matches DecString
+			}
+		}
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListInt64(info CollectionType, data []byte, dst *[]int64) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []int64
+	if n == 0 {
+		s = make([]int64, 0)
+	} else {
+		s = make([]int64, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			s[i] = 0
+			continue
+		}
+		if len(elem) != 8 {
+			return unmarshalErrorf("unmarshal list: invalid bigint size %d", len(elem))
+		}
+		s[i] = int64(elem[0])<<56 | int64(elem[1])<<48 | int64(elem[2])<<40 | int64(elem[3])<<32 |
+			int64(elem[4])<<24 | int64(elem[5])<<16 | int64(elem[6])<<8 | int64(elem[7])
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListInt32(info CollectionType, data []byte, dst *[]int32) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []int32
+	if n == 0 {
+		s = make([]int32, 0)
+	} else {
+		s = make([]int32, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			s[i] = 0
+			continue
+		}
+		if len(elem) != 4 {
+			return unmarshalErrorf("unmarshal list: invalid int size %d", len(elem))
+		}
+		s[i] = int32(elem[0])<<24 | int32(elem[1])<<16 | int32(elem[2])<<8 | int32(elem[3])
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListFloat64(info CollectionType, data []byte, dst *[]float64) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []float64
+	if n == 0 {
+		s = make([]float64, 0)
+	} else {
+		s = make([]float64, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			s[i] = 0
+			continue
+		}
+		if len(elem) != 8 {
+			return unmarshalErrorf("unmarshal list: invalid double size %d", len(elem))
+		}
+		bits := uint64(elem[0])<<56 | uint64(elem[1])<<48 | uint64(elem[2])<<40 | uint64(elem[3])<<32 |
+			uint64(elem[4])<<24 | uint64(elem[5])<<16 | uint64(elem[6])<<8 | uint64(elem[7])
+		s[i] = math.Float64frombits(bits)
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListFloat32(info CollectionType, data []byte, dst *[]float32) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []float32
+	if n == 0 {
+		s = make([]float32, 0)
+	} else {
+		s = make([]float32, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			s[i] = 0
+			continue
+		}
+		if len(elem) != 4 {
+			return unmarshalErrorf("unmarshal list: invalid float size %d", len(elem))
+		}
+		bits := uint32(elem[0])<<24 | uint32(elem[1])<<16 | uint32(elem[2])<<8 | uint32(elem[3])
+		s[i] = math.Float32frombits(bits)
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListBool(info CollectionType, data []byte, dst *[]bool) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []bool
+	if n == 0 {
+		s = make([]bool, 0)
+	} else {
+		s = make([]bool, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			s[i] = false
+			continue
+		}
+		if len(elem) != 1 {
+			return unmarshalErrorf("unmarshal list: invalid boolean size %d", len(elem))
+		}
+		s[i] = elem[0] != 0
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListBlob(info CollectionType, data []byte, dst *[][]byte) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s [][]byte
+	if n == 0 {
+		s = make([][]byte, 0)
+	} else {
+		s = make([][]byte, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if elem == nil {
+			// Null slot — explicitly clear (don't leave stale backing-array
+			// bytes when reusing a caller-provided slice across calls).
+			s[i] = nil
+			continue
+		}
+		// Copy to avoid aliasing the read buffer
+		cp := make([]byte, len(elem))
+		copy(cp, elem)
+		s[i] = cp
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListInt16(info CollectionType, data []byte, dst *[]int16) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []int16
+	if n == 0 {
+		s = make([]int16, 0)
+	} else {
+		s = make([]int16, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			s[i] = 0
+			continue
+		}
+		if len(elem) != 2 {
+			return unmarshalErrorf("unmarshal list: invalid smallint size %d", len(elem))
+		}
+		s[i] = int16(elem[0])<<8 | int16(elem[1])
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListTime(info CollectionType, data []byte, dst *[]time.Time) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []time.Time
+	if n == 0 {
+		s = make([]time.Time, 0)
+	} else {
+		s = make([]time.Time, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			// Null/empty slot — explicitly clear (don't leave a stale
+			// time.Time from a reused backing array).
+			if info.Elem.Type() == TypeDate {
+				s[i] = time.Date(-5877641, 06, 23, 0, 0, 0, 0, time.UTC)
+			} else {
+				s[i] = time.Time{}
+			}
+			continue
+		}
+		if info.Elem.Type() == TypeTimestamp {
+			if len(elem) != 8 {
+				return unmarshalErrorf("unmarshal list: invalid timestamp size %d", len(elem))
+			}
+			msec := int64(elem[0])<<56 | int64(elem[1])<<48 | int64(elem[2])<<40 | int64(elem[3])<<32 |
+				int64(elem[4])<<24 | int64(elem[5])<<16 | int64(elem[6])<<8 | int64(elem[7])
+			s[i] = time.UnixMilli(msec).UTC()
+		} else {
+			if len(elem) != 4 {
+				return unmarshalErrorf("unmarshal list: invalid date size %d", len(elem))
+			}
+			msec := (int64(elem[0])<<24 | int64(elem[1])<<16 | int64(elem[2])<<8 | int64(elem[3]) - (1 << 31)) * 86400000
+			s[i] = time.UnixMilli(msec).UTC()
+		}
+	}
+	*dst = s
+	return nil
+}
+
+func unmarshalListUUID(info CollectionType, data []byte, dst *[]UUID) error {
+	if data == nil {
+		*dst = nil
+		return nil
+	}
+	n, data, err := readListHeader(data)
+	if err != nil {
+		return err
+	}
+	var s []UUID
+	if n == 0 {
+		s = make([]UUID, 0)
+	} else {
+		s = make([]UUID, n)
+	}
+	for i := 0; i < n; i++ {
+		var elem []byte
+		elem, data, err = readListElement(data)
+		if err != nil {
+			return err
+		}
+		if len(elem) == 0 {
+			// Null/empty slot — explicitly clear (don't leave stale backing-array
+			// bytes when reusing a caller-provided slice across calls).
+			s[i] = UUID{}
+			continue
+		}
+		if len(elem) != 16 {
+			return unmarshalErrorf("unmarshal list: invalid uuid size %d", len(elem))
+		}
+		copy(s[i][:], elem)
+	}
+	*dst = s
+	return nil
+}
+
 func readCollectionSize(data []byte) (size, read int, err error) {
 	if len(data) < 4 {
 		return 0, 0, unmarshalErrorf("unmarshal list: unexpected eof")
@@ -996,46 +1493,16 @@ func unmarshalList(info CollectionType, data []byte, value any) error {
 	// Fast path: type-switch on concrete pointer-to-slice types for common
 	// fixed-size CQL element types. Bypasses reflect and per-element Unmarshal.
 	// nil data is handled here; leaf functions assume non-nil data.
-	switch info.Elem.Type() {
-	case TypeFloat:
-		if dst, ok := value.(*[]float32); ok {
-			if data == nil {
-				*dst = nil
-				return nil
-			}
-			return unmarshalListFloat32(data, dst)
+	if dst, ok := value.(*[]int); ok && info.Elem.Type() == TypeInt {
+		if data == nil {
+			*dst = nil
+			return nil
 		}
-	case TypeDouble:
-		if dst, ok := value.(*[]float64); ok {
-			if data == nil {
-				*dst = nil
-				return nil
-			}
-			return unmarshalListFloat64(data, dst)
-		}
-	case TypeInt:
-		if dst, ok := value.(*[]int32); ok {
-			if data == nil {
-				*dst = nil
-				return nil
-			}
-			return unmarshalListInt32(data, dst)
-		}
-		if dst, ok := value.(*[]int); ok {
-			if data == nil {
-				*dst = nil
-				return nil
-			}
-			return unmarshalListInt(data, dst)
-		}
-	case TypeBigInt, TypeTimestamp, TypeCounter:
-		if dst, ok := value.(*[]int64); ok {
-			if data == nil {
-				*dst = nil
-				return nil
-			}
-			return unmarshalListInt64(data, dst)
-		}
+		return unmarshalListInt(data, dst)
+	}
+
+	if err := unmarshalListFast(info, data, value); err != errFastPathNotApplicable {
+		return err
 	}
 
 	rv := reflect.ValueOf(value)
@@ -1120,6 +1587,9 @@ func unmarshalList(info CollectionType, data []byte, value any) error {
 
 func marshalVector(info VectorType, value any) ([]byte, error) {
 	if _, ok := value.(unsetColumn); ok {
+		return nil, nil
+	}
+	if value == nil {
 		return nil, nil
 	}
 
@@ -1886,137 +2356,6 @@ func marshalListInt64(list []int64) ([]byte, error) {
 	return buf, nil
 }
 
-// --- List/Set fast-path unmarshal functions ---
-// List wire format: [4-byte count] + N × ([4-byte elem-length] + [elem-bytes])
-// For fixed-size types, each elem-length must equal the expected element size.
-
-func unmarshalListFloat32(data []byte, dst *[]float32) error {
-	if len(data) < 4 {
-		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
-	}
-	n := int(int32(binary.BigEndian.Uint32(data[:4])))
-	if n < 0 {
-		return unmarshalErrorf("unmarshal list: negative count %d", n)
-	}
-	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
-	if n > (len(data)-4)/4 {
-		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
-	}
-	vec := *dst
-	if cap(vec) >= n {
-		vec = vec[:n]
-	} else {
-		vec = make([]float32, n)
-	}
-	off := 4
-	for i := 0; i < n; i++ {
-		if off+4 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
-		}
-		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
-		off += 4
-		if elemLen < 0 {
-			// Null element: set zero value, matching slow-path behavior
-			vec[i] = 0
-			continue
-		}
-		if elemLen != 4 {
-			return unmarshalErrorf("unmarshal list: expected 4-byte float32 element, got %d bytes at index %d", elemLen, i)
-		}
-		if off+4 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
-		}
-		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[off:]))
-		off += 4
-	}
-	*dst = vec
-	return nil
-}
-
-func unmarshalListFloat64(data []byte, dst *[]float64) error {
-	if len(data) < 4 {
-		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
-	}
-	n := int(int32(binary.BigEndian.Uint32(data[:4])))
-	if n < 0 {
-		return unmarshalErrorf("unmarshal list: negative count %d", n)
-	}
-	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
-	if n > (len(data)-4)/4 {
-		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
-	}
-	vec := *dst
-	if cap(vec) >= n {
-		vec = vec[:n]
-	} else {
-		vec = make([]float64, n)
-	}
-	off := 4
-	for i := 0; i < n; i++ {
-		if off+4 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
-		}
-		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
-		off += 4
-		if elemLen < 0 {
-			vec[i] = 0
-			continue
-		}
-		if elemLen != 8 {
-			return unmarshalErrorf("unmarshal list: expected 8-byte float64 element, got %d bytes at index %d", elemLen, i)
-		}
-		if off+8 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
-		}
-		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[off:]))
-		off += 8
-	}
-	*dst = vec
-	return nil
-}
-
-func unmarshalListInt32(data []byte, dst *[]int32) error {
-	if len(data) < 4 {
-		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
-	}
-	n := int(int32(binary.BigEndian.Uint32(data[:4])))
-	if n < 0 {
-		return unmarshalErrorf("unmarshal list: negative count %d", n)
-	}
-	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
-	if n > (len(data)-4)/4 {
-		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
-	}
-	vec := *dst
-	if cap(vec) >= n {
-		vec = vec[:n]
-	} else {
-		vec = make([]int32, n)
-	}
-	off := 4
-	for i := 0; i < n; i++ {
-		if off+4 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
-		}
-		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
-		off += 4
-		if elemLen < 0 {
-			vec[i] = 0
-			continue
-		}
-		if elemLen != 4 {
-			return unmarshalErrorf("unmarshal list: expected 4-byte int32 element, got %d bytes at index %d", elemLen, i)
-		}
-		if off+4 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
-		}
-		vec[i] = int32(binary.BigEndian.Uint32(data[off:]))
-		off += 4
-	}
-	*dst = vec
-	return nil
-}
-
 func unmarshalListInt(data []byte, dst *[]int) error {
 	if len(data) < 4 {
 		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
@@ -2053,48 +2392,6 @@ func unmarshalListInt(data []byte, dst *[]int) error {
 		}
 		vec[i] = int(int32(binary.BigEndian.Uint32(data[off:])))
 		off += 4
-	}
-	*dst = vec
-	return nil
-}
-
-func unmarshalListInt64(data []byte, dst *[]int64) error {
-	if len(data) < 4 {
-		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
-	}
-	n := int(int32(binary.BigEndian.Uint32(data[:4])))
-	if n < 0 {
-		return unmarshalErrorf("unmarshal list: negative count %d", n)
-	}
-	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
-	if n > (len(data)-4)/4 {
-		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
-	}
-	vec := *dst
-	if cap(vec) >= n {
-		vec = vec[:n]
-	} else {
-		vec = make([]int64, n)
-	}
-	off := 4
-	for i := 0; i < n; i++ {
-		if off+4 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
-		}
-		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
-		off += 4
-		if elemLen < 0 {
-			vec[i] = 0
-			continue
-		}
-		if elemLen != 8 {
-			return unmarshalErrorf("unmarshal list: expected 8-byte int64 element, got %d bytes at index %d", elemLen, i)
-		}
-		if off+8 > len(data) {
-			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
-		}
-		vec[i] = int64(binary.BigEndian.Uint64(data[off:]))
-		off += 8
 	}
 	*dst = vec
 	return nil
@@ -2182,6 +2479,9 @@ func computeUnsignedVIntSize(v uint64) int {
 
 func marshalMap(info CollectionType, value any) ([]byte, error) {
 	if _, ok := value.(unsetColumn); ok {
+		return nil, nil
+	}
+	if value == nil {
 		return nil, nil
 	}
 

--- a/marshal.go
+++ b/marshal.go
@@ -1240,7 +1240,345 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// readMapHeader reads a map's element count, bounded by len(rest)/8 (each
+// entry needs at least two 4-byte length prefixes). Prevents make(map, n)
+// from a bogus huge n causing a massive allocation.
+func readMapHeader(data []byte) (int, []byte, error) {
+	n, p, err := readCollectionSize(data)
+	if err != nil {
+		return 0, nil, err
+	}
+	if n < 0 {
+		return 0, nil, unmarshalErrorf("unmarshal map: negative size %d", n)
+	}
+	rest := data[p:]
+	if n > len(rest)/8 {
+		return 0, nil, unmarshalErrorf("unmarshal map: invalid size %d", n)
+	}
+	return n, rest, nil
+}
+
+// readMapEntryData reads a single collection entry (key or value) from data.
+// Returns the entry bytes (nil if the entry is null, i.e. size < 0),
+// the number of bytes consumed from data, and any error.
+func readMapEntryData(data []byte) (entryData []byte, consumed int, err error) {
+	if len(data) < 4 {
+		return nil, 0, unmarshalErrorf("unmarshal map: unexpected eof")
+	}
+	m := int(int32(data[0])<<24 | int32(data[1])<<16 | int32(data[2])<<8 | int32(data[3]))
+	if m < 0 {
+		return nil, 4, nil
+	}
+	// Compare against len(data)-4 instead of 4+m: on 32-bit targets a large
+	// positive m could overflow 4+m, wrap negative, bypass this guard, and then
+	// panic on the data[4:4+m] slice. len(data) >= 4 and m >= 0 here, so
+	// len(data)-4 is non-negative and the comparison is safe.
+	if m > len(data)-4 {
+		return nil, 0, unmarshalErrorf("unmarshal map: unexpected eof")
+	}
+	return data[4 : 4+m], 4 + m, nil
+}
+
+// isStringKeyType returns true if the CQL type encodes as raw bytes that can be
+// interpreted as a Go string without further validation (text, varchar).
+//
+// TypeAscii is deliberately excluded: the generic path validates ASCII payloads
+// via serialization/ascii.DecString (rejecting bytes > 127), so routing ascii
+// through the raw-string fast path would silently accept invalid data.
+func isStringKeyType(t Type) bool {
+	return t == TypeVarchar || t == TypeText
+}
+
+// unmarshalMapFast attempts to unmarshal a map using type-switch fast paths
+// for common concrete map types, avoiding all reflection. Returns (true, err)
+// if the fast path handled the value, or (false, nil) to fall through to the
+// generic reflect-based path.
+func unmarshalMapFast(info CollectionType, data []byte, value any) (bool, error) {
+	if data == nil {
+		return false, nil
+	}
+
+	keyType := info.Key.Type()
+	elemType := info.Elem.Type()
+
+	// We only fast-path string-keyed maps and int64-keyed maps, which cover
+	// the vast majority of real-world CQL map usage. TypeAscii is excluded so
+	// the generic path can validate ASCII payloads (bytes > 127 are rejected).
+	switch keyType {
+	case TypeVarchar, TypeText:
+		switch v := value.(type) {
+		case *map[string]string:
+			if !isStringKeyType(elemType) {
+				return false, nil
+			}
+			return true, unmarshalMapStringString(data, v)
+		case *map[string][]byte:
+			if elemType != TypeBlob {
+				return false, nil
+			}
+			return true, unmarshalMapStringBytes(data, v)
+		case *map[string]int64:
+			if elemType != TypeBigInt && elemType != TypeCounter {
+				return false, nil
+			}
+			return true, unmarshalMapStringInt64(data, v)
+		case *map[string]int32:
+			if elemType != TypeInt {
+				return false, nil
+			}
+			return true, unmarshalMapStringInt32(data, v)
+		case *map[string]float64:
+			if elemType != TypeDouble {
+				return false, nil
+			}
+			return true, unmarshalMapStringFloat64(data, v)
+		case *map[string]bool:
+			if elemType != TypeBoolean {
+				return false, nil
+			}
+			return true, unmarshalMapStringBool(data, v)
+		}
+	case TypeBigInt, TypeCounter:
+		switch v := value.(type) {
+		case *map[int64]string:
+			if !isStringKeyType(elemType) {
+				return false, nil
+			}
+			return true, unmarshalMapInt64String(data, v)
+		case *map[int64]int64:
+			if elemType != TypeBigInt && elemType != TypeCounter {
+				return false, nil
+			}
+			return true, unmarshalMapInt64Int64(data, v)
+		}
+	}
+	return false, nil
+}
+
+func unmarshalMapStringString(data []byte, dest *map[string]string) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		m[string(keyData)] = string(valData)
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringBytes(data []byte, dest *map[string][]byte) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[string][]byte, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		// Copy the value bytes since the underlying buffer may be reused.
+		var valCopy []byte
+		if valData != nil {
+			valCopy = make([]byte, len(valData))
+			copy(valCopy, valData)
+		}
+		m[string(keyData)] = valCopy
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringInt64(data []byte, dest *map[string]int64) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[string]int64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int64
+		if err := bigint.DecInt64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringInt32(data []byte, dest *map[string]int32) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[string]int32, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int32
+		if err := cqlint.DecInt32(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringFloat64(data []byte, dest *map[string]float64) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[string]float64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v float64
+		if err := double.DecFloat64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapStringBool(data []byte, dest *map[string]bool) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[string]bool, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v bool
+		if err := boolean.DecBool(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[string(keyData)] = v
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapInt64String(data []byte, dest *map[int64]string) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[int64]string, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var k int64
+		if err := bigint.DecInt64(keyData, &k); err != nil {
+			return unmarshalErrorf("unmarshal map key: %v", err)
+		}
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		m[k] = string(valData)
+	}
+	*dest = m
+	return nil
+}
+
+func unmarshalMapInt64Int64(data []byte, dest *map[int64]int64) error {
+	n, data, err := readMapHeader(data)
+	if err != nil {
+		return err
+	}
+	m := make(map[int64]int64, n)
+	for i := 0; i < n; i++ {
+		keyData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var k int64
+		if err := bigint.DecInt64(keyData, &k); err != nil {
+			return unmarshalErrorf("unmarshal map key: %v", err)
+		}
+		valData, c, err := readMapEntryData(data)
+		if err != nil {
+			return err
+		}
+		data = data[c:]
+		var v int64
+		if err := bigint.DecInt64(valData, &v); err != nil {
+			return unmarshalErrorf("unmarshal map value: %v", err)
+		}
+		m[k] = v
+	}
+	*dest = m
+	return nil
+}
+
 func unmarshalMap(info CollectionType, data []byte, value any) error {
+	// Try fast path for common concrete map types (no reflection).
+	if handled, err := unmarshalMapFast(info, data, value); handled {
+		return err
+	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)

--- a/marshal.go
+++ b/marshal.go
@@ -929,33 +929,57 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 		return nil, nil
 	}
 
-	// Fast paths for []float64/[]float32 — skip reflect/per-element dispatch.
-	// dim=0 falls through to the generic path (CQL null semantics).
-	if info.Dimensions > 0 {
+	dim := info.Dimensions
+
+	// Fast path: type-switch on concrete slice types for common fixed-size
+	// CQL element types. These bypass reflect and per-element Marshal entirely.
+	if !isVectorVariableLengthType(info.SubType) {
 		switch info.SubType.Type() {
-		case TypeDouble:
-			if v, ok := value.([]float64); ok {
-				if v == nil {
-					return nil, nil
-				}
-				if len(v) != info.Dimensions {
-					return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, len(v))
-				}
-				return marshalVectorFloat64(info.Dimensions, v)
-			}
 		case TypeFloat:
-			if v, ok := value.([]float32); ok {
-				if v == nil {
+			if vec, ok := value.([]float32); ok {
+				if vec == nil {
 					return nil, nil
 				}
-				if len(v) != info.Dimensions {
-					return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, len(v))
+				return marshalVectorFloat32(vec, dim)
+			}
+		case TypeDouble:
+			if vec, ok := value.([]float64); ok {
+				if vec == nil {
+					return nil, nil
 				}
-				return marshalVectorFloat32(info.Dimensions, v)
+				return marshalVectorFloat64(vec, dim)
+			}
+		case TypeInt:
+			if vec, ok := value.([]int32); ok {
+				if vec == nil {
+					return nil, nil
+				}
+				return marshalVectorInt32(vec, dim)
+			}
+			if vec, ok := value.([]int); ok {
+				if vec == nil {
+					return nil, nil
+				}
+				return marshalVectorInt(vec, dim)
+			}
+		case TypeBigInt, TypeTimestamp:
+			if vec, ok := value.([]int64); ok {
+				if vec == nil {
+					return nil, nil
+				}
+				return marshalVectorInt64(vec, dim)
+			}
+		case TypeUUID, TypeTimeUUID:
+			if vec, ok := value.([]UUID); ok {
+				if vec == nil {
+					return nil, nil
+				}
+				return marshalVectorUUID(vec, dim)
 			}
 		}
 	}
 
+	// Slow path: reflection-based marshal for all other types.
 	rv := reflect.ValueOf(value)
 	t := rv.Type()
 	k := t.Kind()
@@ -966,8 +990,8 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 	switch k {
 	case reflect.Slice, reflect.Array:
 		n := rv.Len()
-		if n != info.Dimensions {
-			return nil, marshalErrorf("expected vector with %d dimensions, received %d", info.Dimensions, n)
+		if n != dim {
+			return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, n)
 		}
 
 		isLengthType := isVectorVariableLengthType(info.SubType)
@@ -996,81 +1020,107 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 	return nil, marshalErrorf("can not marshal %T into %s. Accepted types: slice, array.", value, info)
 }
 
-// vectorSliceReuse reuses *dst's backing array when cap is sufficient.
-func vectorSliceReuse[T any](dst *[]T, dim int) []T {
-	vec := *dst
-	if cap(vec) >= dim {
-		vec = vec[:dim]
-	} else {
-		vec = make([]T, dim)
-	}
-	return vec
-}
-
-// marshalVectorFloat64 encodes []float64 as contiguous big-endian IEEE 754 doubles.
-func marshalVectorFloat64(dim int, vec []float64) ([]byte, error) {
-	buf := make([]byte, dim*8)
-	for i, v := range vec {
-		binary.BigEndian.PutUint64(buf[i*8:], math.Float64bits(v))
-	}
-	return buf, nil
-}
-
-// marshalVectorFloat32 encodes []float32 as contiguous big-endian IEEE 754 floats.
-func marshalVectorFloat32(dim int, vec []float32) ([]byte, error) {
-	buf := make([]byte, dim*4)
-	for i, v := range vec {
-		binary.BigEndian.PutUint32(buf[i*4:], math.Float32bits(v))
-	}
-	return buf, nil
-}
-
-// unmarshalVectorFloat64 decodes contiguous big-endian IEEE 754 doubles into vec.
-// The caller is responsible for ensuring data is dim*8 bytes and vec has length dim.
-func unmarshalVectorFloat64(data []byte, vec []float64) {
-	for i := range vec {
-		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[i*8:]))
-	}
-}
-
-// unmarshalVectorFloat32 decodes contiguous big-endian IEEE 754 floats into vec.
-// The caller is responsible for ensuring data is dim*4 bytes and vec has length dim.
-func unmarshalVectorFloat32(data []byte, vec []float32) {
-	for i := range vec {
-		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[i*4:]))
-	}
-}
-
 func unmarshalVector(info VectorType, data []byte, value any) error {
-	// Fast paths for *[]float64/*[]float32 — skip reflect/per-element dispatch.
-	// nil/empty and dim=0 fall through to the generic path.
-	if info.Dimensions > 0 && data != nil {
+	dim := info.Dimensions
+
+	// Fast path: type-switch on concrete pointer-to-slice types for common
+	// fixed-size CQL element types. These bypass reflect and per-element
+	// Unmarshal entirely.
+	if !isVectorVariableLengthType(info.SubType) {
 		switch info.SubType.Type() {
-		case TypeDouble:
-			if dst, ok := value.(*[]float64); ok {
-				expected := info.Dimensions * 8
-				if len(data) != expected {
-					return unmarshalErrorf("unmarshal vector<double>: expected %d bytes, got %d", expected, len(data))
-				}
-				vec := vectorSliceReuse(dst, info.Dimensions)
-				unmarshalVectorFloat64(data, vec)
-				*dst = vec
-				return nil
-			}
 		case TypeFloat:
 			if dst, ok := value.(*[]float32); ok {
-				expected := info.Dimensions * 4
-				if len(data) != expected {
-					return unmarshalErrorf("unmarshal vector<float>: expected %d bytes, got %d", expected, len(data))
+				if data == nil {
+					*dst = nil
+					return nil
 				}
-				vec := vectorSliceReuse(dst, info.Dimensions)
-				unmarshalVectorFloat32(data, vec)
-				*dst = vec
-				return nil
+				if dim == 0 {
+					if len(data) > 0 {
+						return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+					}
+					*dst = make([]float32, 0)
+					return nil
+				}
+				return unmarshalVectorFloat32(data, dim, dst)
+			}
+		case TypeDouble:
+			if dst, ok := value.(*[]float64); ok {
+				if data == nil {
+					*dst = nil
+					return nil
+				}
+				if dim == 0 {
+					if len(data) > 0 {
+						return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+					}
+					*dst = make([]float64, 0)
+					return nil
+				}
+				return unmarshalVectorFloat64(data, dim, dst)
+			}
+		case TypeInt:
+			if dst, ok := value.(*[]int32); ok {
+				if data == nil {
+					*dst = nil
+					return nil
+				}
+				if dim == 0 {
+					if len(data) > 0 {
+						return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+					}
+					*dst = make([]int32, 0)
+					return nil
+				}
+				return unmarshalVectorInt32(data, dim, dst)
+			}
+			if dst, ok := value.(*[]int); ok {
+				if data == nil {
+					*dst = nil
+					return nil
+				}
+				if dim == 0 {
+					if len(data) > 0 {
+						return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+					}
+					*dst = make([]int, 0)
+					return nil
+				}
+				return unmarshalVectorInt(data, dim, dst)
+			}
+		case TypeBigInt, TypeTimestamp:
+			if dst, ok := value.(*[]int64); ok {
+				if data == nil {
+					*dst = nil
+					return nil
+				}
+				if dim == 0 {
+					if len(data) > 0 {
+						return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+					}
+					*dst = make([]int64, 0)
+					return nil
+				}
+				return unmarshalVectorInt64(data, dim, dst)
+			}
+		case TypeUUID, TypeTimeUUID:
+			if dst, ok := value.(*[]UUID); ok {
+				if data == nil {
+					*dst = nil
+					return nil
+				}
+				if dim == 0 {
+					if len(data) > 0 {
+						return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+					}
+					*dst = make([]UUID, 0)
+					return nil
+				}
+				return unmarshalVectorUUID(data, dim, dst)
 			}
 		}
 	}
 
+	// Slow path: reflection-based unmarshal for all other types.
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -1097,7 +1147,7 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 			rv.Set(reflect.Zero(t))
 			return nil
 		}
-		if info.Dimensions == 0 {
+		if dim == 0 {
 			if len(data) > 0 {
 				return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
 			}
@@ -1111,18 +1161,18 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 			return nil
 		}
 		if k == reflect.Array {
-			if rv.Len() != info.Dimensions {
-				return unmarshalErrorf("unmarshal vector: array of size %d cannot store vector of %d dimensions", rv.Len(), info.Dimensions)
+			if rv.Len() != dim {
+				return unmarshalErrorf("unmarshal vector: array of size %d cannot store vector of %d dimensions", rv.Len(), dim)
 			}
 		} else {
-			rv.Set(reflect.MakeSlice(t, info.Dimensions, info.Dimensions))
+			rv.Set(reflect.MakeSlice(t, dim, dim))
 			if rv.Kind() == reflect.Interface {
 				rv = rv.Elem()
 			}
 		}
-		elemSize := len(data) / info.Dimensions
+		elemSize := len(data) / dim
 		isLengthType := isVectorVariableLengthType(info.SubType)
-		for i := 0; i < info.Dimensions; i++ {
+		for i := 0; i < dim; i++ {
 			offset := 0
 			if isLengthType {
 				m, p, err := readUnsignedVInt(data)
@@ -1168,6 +1218,258 @@ func fixedElemSize(elemType TypeInfo) int {
 		return 16
 	}
 	return 0
+}
+
+// vectorByteSize returns the total byte size of a vector with the given number
+// of dimensions and per-element byte size. It returns an error if the result
+// would overflow int.
+func vectorByteSize(dim, elemSize int) (int, error) {
+	n := int64(dim) * int64(elemSize)
+	if n < 0 || n > math.MaxInt32 {
+		return 0, marshalErrorf("vector byte size overflow: %d * %d", dim, elemSize)
+	}
+	return int(n), nil
+}
+
+// --- Vector fast-path marshal functions ---
+// These use encoding/binary.BigEndian directly, avoiding per-element
+// reflection and the generic Marshal() call for common fixed-size types.
+// Each function validates dimensions, checks for byte-size overflow,
+// and uses a BCE hint to eliminate bounds checks in the hot loop.
+
+func marshalVectorFloat32(vec []float32, dim int) ([]byte, error) {
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	if dim > 0 {
+		_ = buf[dim*4-1] // BCE hint
+	}
+	for i, v := range vec {
+		binary.BigEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	return buf, nil
+}
+
+func marshalVectorFloat64(vec []float64, dim int) ([]byte, error) {
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	if dim > 0 {
+		_ = buf[dim*8-1] // BCE hint
+	}
+	for i, v := range vec {
+		binary.BigEndian.PutUint64(buf[i*8:], math.Float64bits(v))
+	}
+	return buf, nil
+}
+
+func marshalVectorInt32(vec []int32, dim int) ([]byte, error) {
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	if dim > 0 {
+		_ = buf[dim*4-1] // BCE hint
+	}
+	for i, v := range vec {
+		binary.BigEndian.PutUint32(buf[i*4:], uint32(v))
+	}
+	return buf, nil
+}
+
+func marshalVectorInt(vec []int, dim int) ([]byte, error) {
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	if dim > 0 {
+		_ = buf[dim*4-1] // BCE hint
+	}
+	for i, v := range vec {
+		if v > math.MaxInt32 || v < math.MinInt32 {
+			return nil, marshalErrorf("marshal vector: int element value %d out of int32 range", v)
+		}
+		binary.BigEndian.PutUint32(buf[i*4:], uint32(int32(v)))
+	}
+	return buf, nil
+}
+
+func marshalVectorInt64(vec []int64, dim int) ([]byte, error) {
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	if dim > 0 {
+		_ = buf[dim*8-1] // BCE hint
+	}
+	for i, v := range vec {
+		binary.BigEndian.PutUint64(buf[i*8:], uint64(v))
+	}
+	return buf, nil
+}
+
+func marshalVectorUUID(vec []UUID, dim int) ([]byte, error) {
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	size, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	if dim > 0 {
+		_ = buf[dim*16-1] // BCE hint
+	}
+	for i := range vec {
+		copy(buf[i*16:], vec[i][:])
+	}
+	return buf, nil
+}
+
+// --- Vector fast-path unmarshal functions ---
+// These read from raw bytes using encoding/binary.BigEndian directly, into a
+// fresh backing array per decode (see marshal_alias_test.go).
+//
+// Deliberately stricter than the generic path on payload length: each decoder
+// requires len(data) to be exactly the fixed element width times dim, where
+// the reflect path derives the element size as len(data)/dim and silently
+// ignores trailing bytes. Trailing bytes mean a corrupt or misframed value,
+// and an error beats quietly decoding it.
+
+func unmarshalVectorFloat32(data []byte, dim int, dst *[]float32) error {
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return err
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector: expected %d bytes for %d float32 dimensions, got %d", expected, dim, len(data))
+	}
+	vec := make([]float32, dim)
+	if dim > 0 {
+		_ = data[dim*4-1] // BCE hint
+	}
+	for i := 0; i < dim; i++ {
+		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[i*4:]))
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalVectorFloat64(data []byte, dim int, dst *[]float64) error {
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return err
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector: expected %d bytes for %d float64 dimensions, got %d", expected, dim, len(data))
+	}
+	vec := make([]float64, dim)
+	if dim > 0 {
+		_ = data[dim*8-1] // BCE hint
+	}
+	for i := 0; i < dim; i++ {
+		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[i*8:]))
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalVectorInt32(data []byte, dim int, dst *[]int32) error {
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return err
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector: expected %d bytes for %d int32 dimensions, got %d", expected, dim, len(data))
+	}
+	vec := make([]int32, dim)
+	if dim > 0 {
+		_ = data[dim*4-1] // BCE hint
+	}
+	for i := 0; i < dim; i++ {
+		vec[i] = int32(binary.BigEndian.Uint32(data[i*4:]))
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalVectorInt(data []byte, dim int, dst *[]int) error {
+	expected, err := vectorByteSize(dim, 4)
+	if err != nil {
+		return err
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector: expected %d bytes for %d int dimensions, got %d", expected, dim, len(data))
+	}
+	vec := make([]int, dim)
+	if dim > 0 {
+		_ = data[dim*4-1] // BCE hint
+	}
+	for i := 0; i < dim; i++ {
+		vec[i] = int(int32(binary.BigEndian.Uint32(data[i*4:])))
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalVectorInt64(data []byte, dim int, dst *[]int64) error {
+	expected, err := vectorByteSize(dim, 8)
+	if err != nil {
+		return err
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector: expected %d bytes for %d int64 dimensions, got %d", expected, dim, len(data))
+	}
+	vec := make([]int64, dim)
+	if dim > 0 {
+		_ = data[dim*8-1] // BCE hint
+	}
+	for i := 0; i < dim; i++ {
+		vec[i] = int64(binary.BigEndian.Uint64(data[i*8:]))
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalVectorUUID(data []byte, dim int, dst *[]UUID) error {
+	expected, err := vectorByteSize(dim, 16)
+	if err != nil {
+		return err
+	}
+	if len(data) != expected {
+		return unmarshalErrorf("unmarshal vector: expected %d bytes for %d UUID dimensions, got %d", expected, dim, len(data))
+	}
+	vec := make([]UUID, dim)
+	if dim > 0 {
+		_ = data[dim*16-1] // BCE hint
+	}
+	for i := 0; i < dim; i++ {
+		copy(vec[i][:], data[i*16:])
+	}
+	*dst = vec
+	return nil
 }
 
 // isVectorVariableLengthType determines if a type requires explicit length serialization within a vector.
@@ -2408,6 +2710,48 @@ func (v VectorType) Zero() any {
 		return nil
 	}
 	return reflect.Zero(reflect.SliceOf(reflect.TypeOf(t))).Interface()
+}
+
+// NewWithError returns a pointer to an empty slice of the appropriate Go type
+// for common vector element types, avoiding the expensive goType() → asVectorType()
+// re-parse of Java type strings on every call.
+func (v VectorType) NewWithError() (any, error) {
+	if nt, ok := v.SubType.(NativeType); ok {
+		switch nt.typ {
+		case TypeFloat:
+			return new([]float32), nil
+		case TypeDouble:
+			return new([]float64), nil
+		case TypeInt:
+			return new([]int), nil
+		case TypeBigInt, TypeTimestamp:
+			return new([]int64), nil
+		case TypeUUID, TypeTimeUUID:
+			return new([]UUID), nil
+		case TypeText, TypeVarchar, TypeAscii:
+			return new([]string), nil
+		case TypeBlob:
+			return new([][]byte), nil
+		case TypeBoolean:
+			return new([]bool), nil
+		case TypeSmallInt:
+			return new([]int16), nil
+		case TypeTinyInt:
+			return new([]int8), nil
+		case TypeTime:
+			return new([]time.Duration), nil
+		case TypeCounter:
+			return new([]int64), nil
+		case TypeDate:
+			return new([]time.Time), nil
+		}
+	}
+	// Fallback to reflection for complex/nested types
+	typ, err := goType(v)
+	if err != nil {
+		return nil, err
+	}
+	return reflect.New(typ).Interface(), nil
 }
 
 func (t CollectionType) NewWithError() (any, error) {

--- a/marshal.go
+++ b/marshal.go
@@ -220,9 +220,17 @@ func Marshal(info TypeInfo, value any) ([]byte, error) {
 	case TypeTimestamp:
 		return marshalTimestamp(value)
 	case TypeList, TypeSet:
-		return marshalList(info, value)
+		ct, ok := info.(CollectionType)
+		if !ok {
+			return nil, marshalErrorf("can not marshal %T into %s", value, info)
+		}
+		return marshalList(ct, value)
 	case TypeMap:
-		return marshalMap(info, value)
+		ct, ok := info.(CollectionType)
+		if !ok {
+			return nil, marshalErrorf("can not marshal %T into %s", value, info)
+		}
+		return marshalMap(ct, value)
 	case TypeUUID:
 		return marshalUUID(value)
 	case TypeTimeUUID:
@@ -333,9 +341,17 @@ func Unmarshal(info TypeInfo, data []byte, value any) error {
 	case TypeTimestamp:
 		return unmarshalTimestamp(data, value)
 	case TypeList, TypeSet:
-		return unmarshalList(info, data, value)
+		ct, ok := info.(CollectionType)
+		if !ok {
+			return unmarshalErrorf("can not unmarshal %s into %T", info, value)
+		}
+		return unmarshalList(ct, data, value)
 	case TypeMap:
-		return unmarshalMap(info, data, value)
+		ct, ok := info.(CollectionType)
+		if !ok {
+			return unmarshalErrorf("can not unmarshal %s into %T", info, value)
+		}
+		return unmarshalMap(ct, data, value)
 	case TypeTimeUUID:
 		return unmarshalTimeUUID(data, value)
 	case TypeUUID:
@@ -695,28 +711,19 @@ func unmarshalDuration(data []byte, value any) error {
 	return nil
 }
 
-func writeCollectionSize(info CollectionType, n int, buf *bytes.Buffer) error {
+func writeCollectionSize(n int, buf *bytes.Buffer) error {
 	if n > math.MaxInt32 {
 		return marshalErrorf("marshal: collection too large")
 	}
 
-	buf.WriteByte(byte(n >> 24))
-	buf.WriteByte(byte(n >> 16))
-	buf.WriteByte(byte(n >> 8))
-	buf.WriteByte(byte(n))
+	tmp := [4]byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}
+	buf.Write(tmp[:])
 
 	return nil
 }
 
-func marshalList(info TypeInfo, value any) ([]byte, error) {
-	listInfo, ok := info.(CollectionType)
-	if !ok {
-		return nil, marshalErrorf("marshal: can not marshal non collection type into list")
-	}
-
-	if value == nil {
-		return nil, nil
-	} else if _, ok := value.(unsetColumn); ok {
+func marshalList(info CollectionType, value any) ([]byte, error) {
+	if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -732,12 +739,12 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 		buf := &bytes.Buffer{}
 		n := rv.Len()
 
-		if err := writeCollectionSize(listInfo, n, buf); err != nil {
+		if err := writeCollectionSize(n, buf); err != nil {
 			return nil, err
 		}
 
 		for i := 0; i < n; i++ {
-			item, err := Marshal(listInfo.Elem, rv.Index(i).Interface())
+			item, err := Marshal(info.Elem, rv.Index(i).Interface())
 			if err != nil {
 				return nil, err
 			}
@@ -746,7 +753,7 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 			if item == nil {
 				itemLen = -1
 			}
-			if err := writeCollectionSize(listInfo, itemLen, buf); err != nil {
+			if err := writeCollectionSize(itemLen, buf); err != nil {
 				return nil, err
 			}
 			buf.Write(item)
@@ -760,13 +767,13 @@ func marshalList(info TypeInfo, value any) ([]byte, error) {
 			for i := 0; i < len(keys); i++ {
 				keys[i] = rkeys[i].Interface()
 			}
-			return marshalList(listInfo, keys)
+			return marshalList(info, keys)
 		}
 	}
 	return nil, marshalErrorf("can not marshal %T into %s", value, info)
 }
 
-func readCollectionSize(info CollectionType, data []byte) (size, read int, err error) {
+func readCollectionSize(data []byte) (size, read int, err error) {
 	if len(data) < 4 {
 		return 0, 0, unmarshalErrorf("unmarshal list: unexpected eof")
 	}
@@ -775,12 +782,7 @@ func readCollectionSize(info CollectionType, data []byte) (size, read int, err e
 	return
 }
 
-func unmarshalList(info TypeInfo, data []byte, value any) error {
-	listInfo, ok := info.(CollectionType)
-	if !ok {
-		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into list")
-	}
-
+func unmarshalList(info CollectionType, data []byte, value any) error {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -795,7 +797,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
 		}
 		// Create a properly typed slice based on the element type
-		elemGoType, err := goType(listInfo.Elem)
+		elemGoType, err := goType(info.Elem)
 		if err != nil {
 			return unmarshalErrorf("unmarshal list: cannot determine element type: %v", err)
 		}
@@ -815,7 +817,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			rv.Set(reflect.Zero(t))
 			return nil
 		}
-		n, p, err := readCollectionSize(listInfo, data)
+		n, p, err := readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -838,7 +840,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 			}
 		}
 		for i := 0; i < n; i++ {
-			m, p, err := readCollectionSize(listInfo, data)
+			m, p, err := readCollectionSize(data)
 			if err != nil {
 				return err
 			}
@@ -852,7 +854,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 				unmarshalData = data[:m]
 				data = data[m:]
 			}
-			if err := Unmarshal(listInfo.Elem, unmarshalData, rv.Index(i).Addr().Interface()); err != nil {
+			if err := Unmarshal(info.Elem, unmarshalData, rv.Index(i).Addr().Interface()); err != nil {
 				return err
 			}
 		}
@@ -862,9 +864,7 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 }
 
 func marshalVector(info VectorType, value any) ([]byte, error) {
-	if value == nil {
-		return nil, nil
-	} else if _, ok := value.(unsetColumn); ok {
+	if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -1184,15 +1184,8 @@ func computeUnsignedVIntSize(v uint64) int {
 	return (639 - lead0*9) >> 6
 }
 
-func marshalMap(info TypeInfo, value any) ([]byte, error) {
-	mapInfo, ok := info.(CollectionType)
-	if !ok {
-		return nil, marshalErrorf("marshal: can not marshal none collection type into map")
-	}
-
-	if value == nil {
-		return nil, nil
-	} else if _, ok := value.(unsetColumn); ok {
+func marshalMap(info CollectionType, value any) ([]byte, error) {
+	if _, ok := value.(unsetColumn); ok {
 		return nil, nil
 	}
 
@@ -1210,13 +1203,13 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	n := rv.Len()
 
-	if err := writeCollectionSize(mapInfo, n, buf); err != nil {
+	if err := writeCollectionSize(n, buf); err != nil {
 		return nil, err
 	}
 
 	keys := rv.MapKeys()
 	for _, key := range keys {
-		item, err := Marshal(mapInfo.Key, key.Interface())
+		item, err := Marshal(info.Key, key.Interface())
 		if err != nil {
 			return nil, err
 		}
@@ -1225,12 +1218,12 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 		if item == nil {
 			itemLen = -1
 		}
-		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
+		if err := writeCollectionSize(itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
 
-		item, err = Marshal(mapInfo.Elem, rv.MapIndex(key).Interface())
+		item, err = Marshal(info.Elem, rv.MapIndex(key).Interface())
 		if err != nil {
 			return nil, err
 		}
@@ -1239,7 +1232,7 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 		if item == nil {
 			itemLen = -1
 		}
-		if err := writeCollectionSize(mapInfo, itemLen, buf); err != nil {
+		if err := writeCollectionSize(itemLen, buf); err != nil {
 			return nil, err
 		}
 		buf.Write(item)
@@ -1247,12 +1240,7 @@ func marshalMap(info TypeInfo, value any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func unmarshalMap(info TypeInfo, data []byte, value any) error {
-	mapInfo, ok := info.(CollectionType)
-	if !ok {
-		return unmarshalErrorf("unmarshal: can not unmarshal none collection type into map")
-	}
-
+func unmarshalMap(info CollectionType, data []byte, value any) error {
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -1266,11 +1254,11 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			return unmarshalErrorf("can not unmarshal into non-empty interface %T", value)
 		}
 		// Create a properly typed map based on the key and element types
-		keyGoType, err := goType(mapInfo.Key)
+		keyGoType, err := goType(info.Key)
 		if err != nil {
 			return unmarshalErrorf("unmarshal map: cannot determine key type: %v", err)
 		}
-		elemGoType, err := goType(mapInfo.Elem)
+		elemGoType, err := goType(info.Elem)
 		if err != nil {
 			return unmarshalErrorf("unmarshal map: cannot determine element type: %v", err)
 		}
@@ -1284,7 +1272,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 		rv.Set(reflect.Zero(t))
 		return nil
 	}
-	n, p, err := readCollectionSize(mapInfo, data)
+	n, p, err := readCollectionSize(data)
 	if err != nil {
 		return err
 	}
@@ -1301,7 +1289,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 	}
 	data = data[p:]
 	for i := 0; i < n; i++ {
-		m, p, err := readCollectionSize(mapInfo, data)
+		m, p, err := readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -1316,11 +1304,11 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			unmarshalData = data[:m]
 			data = data[m:]
 		}
-		if err := Unmarshal(mapInfo.Key, unmarshalData, key.Interface()); err != nil {
+		if err := Unmarshal(info.Key, unmarshalData, key.Interface()); err != nil {
 			return err
 		}
 
-		m, p, err = readCollectionSize(mapInfo, data)
+		m, p, err = readCollectionSize(data)
 		if err != nil {
 			return err
 		}
@@ -1336,7 +1324,7 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 			unmarshalData = data[:m]
 			data = data[m:]
 		}
-		if err := Unmarshal(mapInfo.Elem, unmarshalData, val.Interface()); err != nil {
+		if err := Unmarshal(info.Elem, unmarshalData, val.Interface()); err != nil {
 			return err
 		}
 

--- a/marshal.go
+++ b/marshal.go
@@ -33,6 +33,7 @@ import (
 	"math/big"
 	"math/bits"
 	"reflect"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -68,6 +69,58 @@ var (
 var (
 	ErrorUDTUnavailable = errors.New("UDT are not available on protocols less than 3, please update config")
 )
+
+// marshalBufPool is a sync.Pool of *bytes.Buffer used by collection and vector
+// marshal functions to avoid allocating a new Buffer on every call.
+//
+// Lifecycle: marshalList/marshalMap/marshalVector call getMarshalBuf to get a
+// pooled buffer, write the serialized data into it, then call finishMarshalBuf
+// which copies the data into a new []byte and returns the buffer to the pool.
+// This ensures the returned slice never aliases pooled storage.
+var marshalBufPool = sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
+
+// marshalBufMaxCap is the maximum capacity of a buffer that will be returned
+// to the pool. Buffers larger than this are left for GC to avoid holding
+// excessive memory in the pool from occasional large payloads.
+const marshalBufMaxCap = 64 * 1024 // 64 KiB
+
+// getMarshalBuf returns a *bytes.Buffer from the pool, reset and optionally
+// pre-grown to the given size hint. If sizeHint <= 0, no pre-grow is done.
+func getMarshalBuf(sizeHint int) *bytes.Buffer {
+	buf := marshalBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	if sizeHint > 0 {
+		buf.Grow(sizeHint)
+	}
+	return buf
+}
+
+// putMarshalBuf returns a *bytes.Buffer to the pool. Buffers whose capacity
+// exceeds marshalBufMaxCap are discarded to prevent the pool from holding
+// oversized allocations.
+func putMarshalBuf(buf *bytes.Buffer) {
+	if buf == nil {
+		return
+	}
+	if buf.Cap() > marshalBufMaxCap {
+		return // let GC collect oversized buffers
+	}
+	marshalBufPool.Put(buf)
+}
+
+// finishMarshalBuf copies the contents of buf into a new []byte and returns
+// the buffer to the pool. This ensures the returned slice does not alias the
+// pooled buffer's internal storage.
+func finishMarshalBuf(buf *bytes.Buffer) []byte {
+	result := make([]byte, buf.Len())
+	copy(result, buf.Bytes())
+	putMarshalBuf(buf)
+	return result
+}
 
 // Marshaler is an interface for custom unmarshaler.
 // Each value of the 'CQL binary protocol' consist of <value_len> and <value_data>.
@@ -736,16 +789,23 @@ func marshalList(info CollectionType, value any) ([]byte, error) {
 
 	switch k {
 	case reflect.Slice, reflect.Array:
-		buf := &bytes.Buffer{}
 		n := rv.Len()
 
+		sizeHint := 4
+		if elemSize := fixedElemSize(info.Elem); elemSize > 0 {
+			sizeHint += n * (4 + elemSize)
+		}
+		buf := getMarshalBuf(sizeHint)
+
 		if err := writeCollectionSize(n, buf); err != nil {
+			putMarshalBuf(buf)
 			return nil, err
 		}
 
 		for i := 0; i < n; i++ {
 			item, err := Marshal(info.Elem, rv.Index(i).Interface())
 			if err != nil {
+				putMarshalBuf(buf)
 				return nil, err
 			}
 			itemLen := len(item)
@@ -754,11 +814,12 @@ func marshalList(info CollectionType, value any) ([]byte, error) {
 				itemLen = -1
 			}
 			if err := writeCollectionSize(itemLen, buf); err != nil {
+				putMarshalBuf(buf)
 				return nil, err
 			}
 			buf.Write(item)
 		}
-		return buf.Bytes(), nil
+		return finishMarshalBuf(buf), nil
 	case reflect.Map:
 		elem := t.Elem()
 		if elem.Kind() == reflect.Struct && elem.NumField() == 0 {
@@ -910,17 +971,19 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 		}
 
 		isLengthType := isVectorVariableLengthType(info.SubType)
-		buf := &bytes.Buffer{}
+		sizeHint := 0
 		if !isLengthType {
-			if elemSize := vectorFixedElemSize(info.SubType); elemSize > 0 {
+			if elemSize := fixedElemSize(info.SubType); elemSize > 0 {
 				if needed := int64(n) * int64(elemSize); needed > 0 && needed <= math.MaxInt32 {
-					buf.Grow(int(needed))
+					sizeHint = int(needed)
 				}
 			}
 		}
+		buf := getMarshalBuf(sizeHint)
 		for i := 0; i < n; i++ {
 			item, err := Marshal(info.SubType, rv.Index(i).Interface())
 			if err != nil {
+				putMarshalBuf(buf)
 				return nil, err
 			}
 			if isLengthType {
@@ -928,7 +991,7 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 			}
 			buf.Write(item)
 		}
-		return buf.Bytes(), nil
+		return finishMarshalBuf(buf), nil
 	}
 	return nil, marshalErrorf("can not marshal %T into %s. Accepted types: slice, array.", value, info)
 }
@@ -1090,13 +1153,16 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 	return unmarshalErrorf("can not unmarshal %s into %T. Accepted types: *slice, *array, *any.", info, value)
 }
 
-func vectorFixedElemSize(elemType TypeInfo) int {
+// fixedElemSize returns the wire-format byte size for fixed-length CQL types.
+// Returns 0 for variable-length or unknown types.
+// Note: TypeBoolean/TypeTinyInt (1B) and TypeSmallInt (2B) are intentionally
+// excluded — Cassandra's vector implementation treats them as variable-length,
+// and the pre-sizing benefit for such small types is negligible.
+func fixedElemSize(elemType TypeInfo) int {
 	switch elemType.Type() {
-	case TypeBoolean:
-		return 1
-	case TypeInt, TypeFloat:
+	case TypeInt, TypeFloat, TypeDate:
 		return 4
-	case TypeBigInt, TypeDouble, TypeTimestamp:
+	case TypeBigInt, TypeDouble, TypeTimestamp, TypeCounter, TypeTime:
 		return 8
 	case TypeUUID, TypeTimeUUID:
 		return 16
@@ -1200,10 +1266,18 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 		return nil, nil
 	}
 
-	buf := &bytes.Buffer{}
 	n := rv.Len()
 
+	sizeHint := 4
+	keySize := fixedElemSize(info.Key)
+	valSize := fixedElemSize(info.Elem)
+	if keySize > 0 && valSize > 0 {
+		sizeHint += n * (4 + keySize + 4 + valSize)
+	}
+	buf := getMarshalBuf(sizeHint)
+
 	if err := writeCollectionSize(n, buf); err != nil {
+		putMarshalBuf(buf)
 		return nil, err
 	}
 
@@ -1211,6 +1285,7 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 	for _, key := range keys {
 		item, err := Marshal(info.Key, key.Interface())
 		if err != nil {
+			putMarshalBuf(buf)
 			return nil, err
 		}
 		itemLen := len(item)
@@ -1219,12 +1294,14 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 			itemLen = -1
 		}
 		if err := writeCollectionSize(itemLen, buf); err != nil {
+			putMarshalBuf(buf)
 			return nil, err
 		}
 		buf.Write(item)
 
 		item, err = Marshal(info.Elem, rv.MapIndex(key).Interface())
 		if err != nil {
+			putMarshalBuf(buf)
 			return nil, err
 		}
 		itemLen = len(item)
@@ -1233,11 +1310,12 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 			itemLen = -1
 		}
 		if err := writeCollectionSize(itemLen, buf); err != nil {
+			putMarshalBuf(buf)
 			return nil, err
 		}
 		buf.Write(item)
 	}
-	return buf.Bytes(), nil
+	return finishMarshalBuf(buf), nil
 }
 
 // readMapHeader reads a map's element count, bounded by len(rest)/8 (each

--- a/marshal.go
+++ b/marshal.go
@@ -122,6 +122,115 @@ func finishMarshalBuf(buf *bytes.Buffer) []byte {
 	return result
 }
 
+// marshalOutputPool pools []byte slices returned by fast-path marshal functions
+// (vectors and lists/sets). These slices are the final marshal output that gets
+// copied into the framer buffer by writeBytes. After the framer copies them,
+// the connection layer returns them to this pool via putMarshalOutput.
+var marshalOutputPool sync.Pool
+
+// getMarshalOutput returns a []byte of exactly the requested size, from the
+// pool if a suitable buffer is available, or freshly allocated otherwise.
+func getMarshalOutput(size int) []byte {
+	if bp := marshalOutputPool.Get(); bp != nil {
+		buf := bp.([]byte)
+		if cap(buf) >= size {
+			return buf[:size]
+		}
+	}
+	return make([]byte, size)
+}
+
+// putMarshalOutput returns a []byte to the output pool. Nil slices are ignored.
+// Buffers larger than marshalBufMaxCap are discarded to avoid holding excessive
+// memory.
+func putMarshalOutput(buf []byte) {
+	if buf == nil {
+		return
+	}
+	if cap(buf) > marshalBufMaxCap {
+		return
+	}
+	marshalOutputPool.Put(buf) //nolint:staticcheck // SA6002: []byte is a value type; boxing cost is acceptable for pool reuse
+}
+
+// pooledMarshalType returns true if the given TypeInfo uses a marshal fast path
+// that allocates from marshalOutputPool. This is used by the connection layer to
+// determine which queryValues.value slices can be returned to the pool after
+// the framer copies them.
+func pooledMarshalType(info TypeInfo) bool {
+	switch ti := info.(type) {
+	case VectorType:
+		switch ti.SubType.Type() {
+		case TypeFloat, TypeDouble, TypeInt, TypeBigInt, TypeTimestamp, TypeCounter, TypeUUID, TypeTimeUUID:
+			return true
+		}
+	case CollectionType:
+		if ti.typ == TypeList || ti.typ == TypeSet {
+			switch ti.Elem.Type() {
+			case TypeFloat, TypeDouble, TypeInt, TypeBigInt, TypeTimestamp, TypeCounter:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pooledMarshalValue is like pooledMarshalType but also checks value's
+// concrete type, since a poolable CQL type can still fall through to the
+// generic reflect path (non-pool buffer) for a mismatched Go type, e.g. a
+// TypeInt list bound with []int8 instead of []int32/[]int.
+// Keep in sync with the type switches in marshalList and marshalVector.
+func pooledMarshalValue(typ TypeInfo, value any) bool {
+	switch ti := typ.(type) {
+	case VectorType:
+		switch ti.SubType.Type() {
+		case TypeCounter:
+			_, ok := value.([]int64)
+			return ok
+		case TypeFloat:
+			_, ok := value.([]float32)
+			return ok
+		case TypeDouble:
+			_, ok := value.([]float64)
+			return ok
+		case TypeInt:
+			if _, ok := value.([]int32); ok {
+				return true
+			}
+			_, ok := value.([]int)
+			return ok
+		case TypeBigInt, TypeTimestamp:
+			_, ok := value.([]int64)
+			return ok
+		case TypeUUID, TypeTimeUUID:
+			_, ok := value.([]UUID)
+			return ok
+		}
+	case CollectionType:
+		if ti.typ != TypeList && ti.typ != TypeSet {
+			return false
+		}
+		switch ti.Elem.Type() {
+		case TypeFloat:
+			_, ok := value.([]float32)
+			return ok
+		case TypeDouble:
+			_, ok := value.([]float64)
+			return ok
+		case TypeInt:
+			if _, ok := value.([]int32); ok {
+				return true
+			}
+			_, ok := value.([]int)
+			return ok
+		case TypeBigInt, TypeTimestamp, TypeCounter:
+			_, ok := value.([]int64)
+			return ok
+		}
+	}
+	return false
+}
+
 // Marshaler is an interface for custom unmarshaler.
 // Each value of the 'CQL binary protocol' consist of <value_len> and <value_data>.
 // <value_len> can be 'unset'(-2), 'nil'(-1), 'zero'(0) or any value up to 2147483647.
@@ -780,6 +889,46 @@ func marshalList(info CollectionType, value any) ([]byte, error) {
 		return nil, nil
 	}
 
+	// Fast path: type-switch on concrete slice types for common fixed-size
+	// CQL element types. These bypass reflect and per-element Marshal entirely.
+	// List wire format: [4-byte count] + N × ([4-byte elem-len] + [elem-bytes])
+	switch info.Elem.Type() {
+	case TypeFloat:
+		if vec, ok := value.([]float32); ok {
+			if vec == nil {
+				return nil, nil
+			}
+			return marshalListFloat32(vec)
+		}
+	case TypeDouble:
+		if vec, ok := value.([]float64); ok {
+			if vec == nil {
+				return nil, nil
+			}
+			return marshalListFloat64(vec)
+		}
+	case TypeInt:
+		if vec, ok := value.([]int32); ok {
+			if vec == nil {
+				return nil, nil
+			}
+			return marshalListInt32(vec)
+		}
+		if vec, ok := value.([]int); ok {
+			if vec == nil {
+				return nil, nil
+			}
+			return marshalListInt(vec)
+		}
+	case TypeBigInt, TypeTimestamp, TypeCounter:
+		if vec, ok := value.([]int64); ok {
+			if vec == nil {
+				return nil, nil
+			}
+			return marshalListInt64(vec)
+		}
+	}
+
 	rv := reflect.ValueOf(value)
 	t := rv.Type()
 	k := t.Kind()
@@ -844,6 +993,51 @@ func readCollectionSize(data []byte) (size, read int, err error) {
 }
 
 func unmarshalList(info CollectionType, data []byte, value any) error {
+	// Fast path: type-switch on concrete pointer-to-slice types for common
+	// fixed-size CQL element types. Bypasses reflect and per-element Unmarshal.
+	// nil data is handled here; leaf functions assume non-nil data.
+	switch info.Elem.Type() {
+	case TypeFloat:
+		if dst, ok := value.(*[]float32); ok {
+			if data == nil {
+				*dst = nil
+				return nil
+			}
+			return unmarshalListFloat32(data, dst)
+		}
+	case TypeDouble:
+		if dst, ok := value.(*[]float64); ok {
+			if data == nil {
+				*dst = nil
+				return nil
+			}
+			return unmarshalListFloat64(data, dst)
+		}
+	case TypeInt:
+		if dst, ok := value.(*[]int32); ok {
+			if data == nil {
+				*dst = nil
+				return nil
+			}
+			return unmarshalListInt32(data, dst)
+		}
+		if dst, ok := value.(*[]int); ok {
+			if data == nil {
+				*dst = nil
+				return nil
+			}
+			return unmarshalListInt(data, dst)
+		}
+	case TypeBigInt, TypeTimestamp, TypeCounter:
+		if dst, ok := value.(*[]int64); ok {
+			if data == nil {
+				*dst = nil
+				return nil
+			}
+			return unmarshalListInt64(data, dst)
+		}
+	}
+
 	rv := reflect.ValueOf(value)
 	if rv.Kind() != reflect.Ptr {
 		return unmarshalErrorf("can not unmarshal into non-pointer %T", value)
@@ -931,25 +1125,38 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 
 	dim := info.Dimensions
 
-	// Fast path: type-switch on concrete slice types for common fixed-size
-	// CQL element types. These bypass reflect and per-element Marshal entirely.
-	if !isVectorVariableLengthType(info.SubType) {
-		switch info.SubType.Type() {
-		case TypeFloat:
+	// Fast path: type-switch on concrete slice types for common vector element
+	// types. Most fast paths are contiguous fixed-width encodings; counters are a
+	// special case that still require per-element length prefixes in the current
+	// vector wire format, but can still bypass reflection and generic Marshal().
+	switch info.SubType.Type() {
+	case TypeCounter:
+		if vec, ok := value.([]int64); ok {
+			if vec == nil {
+				return nil, nil
+			}
+			return marshalVectorCounter(vec, dim)
+		}
+	case TypeFloat:
+		if !isVectorVariableLengthType(info.SubType) {
 			if vec, ok := value.([]float32); ok {
 				if vec == nil {
 					return nil, nil
 				}
 				return marshalVectorFloat32(vec, dim)
 			}
-		case TypeDouble:
+		}
+	case TypeDouble:
+		if !isVectorVariableLengthType(info.SubType) {
 			if vec, ok := value.([]float64); ok {
 				if vec == nil {
 					return nil, nil
 				}
 				return marshalVectorFloat64(vec, dim)
 			}
-		case TypeInt:
+		}
+	case TypeInt:
+		if !isVectorVariableLengthType(info.SubType) {
 			if vec, ok := value.([]int32); ok {
 				if vec == nil {
 					return nil, nil
@@ -962,14 +1169,18 @@ func marshalVector(info VectorType, value any) ([]byte, error) {
 				}
 				return marshalVectorInt(vec, dim)
 			}
-		case TypeBigInt, TypeTimestamp:
+		}
+	case TypeBigInt, TypeTimestamp:
+		if !isVectorVariableLengthType(info.SubType) {
 			if vec, ok := value.([]int64); ok {
 				if vec == nil {
 					return nil, nil
 				}
 				return marshalVectorInt64(vec, dim)
 			}
-		case TypeUUID, TypeTimeUUID:
+		}
+	case TypeUUID, TypeTimeUUID:
+		if !isVectorVariableLengthType(info.SubType) {
 			if vec, ok := value.([]UUID); ok {
 				if vec == nil {
 					return nil, nil
@@ -1024,11 +1235,12 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 	dim := info.Dimensions
 
 	// Fast path: type-switch on concrete pointer-to-slice types for common
-	// fixed-size CQL element types. These bypass reflect and per-element
-	// Unmarshal entirely.
-	if !isVectorVariableLengthType(info.SubType) {
-		switch info.SubType.Type() {
-		case TypeFloat:
+	// vector element types. Most fast paths are contiguous fixed-width encodings;
+	// counters are a special case that still require per-element length prefixes,
+	// but can still bypass reflect and generic Unmarshal().
+	switch info.SubType.Type() {
+	case TypeFloat:
+		if !isVectorVariableLengthType(info.SubType) {
 			if dst, ok := value.(*[]float32); ok {
 				if data == nil {
 					*dst = nil
@@ -1043,7 +1255,9 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 				}
 				return unmarshalVectorFloat32(data, dim, dst)
 			}
-		case TypeDouble:
+		}
+	case TypeDouble:
+		if !isVectorVariableLengthType(info.SubType) {
 			if dst, ok := value.(*[]float64); ok {
 				if data == nil {
 					*dst = nil
@@ -1058,7 +1272,9 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 				}
 				return unmarshalVectorFloat64(data, dim, dst)
 			}
-		case TypeInt:
+		}
+	case TypeInt:
+		if !isVectorVariableLengthType(info.SubType) {
 			if dst, ok := value.(*[]int32); ok {
 				if data == nil {
 					*dst = nil
@@ -1087,7 +1303,24 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 				}
 				return unmarshalVectorInt(data, dim, dst)
 			}
-		case TypeBigInt, TypeTimestamp:
+		}
+	case TypeCounter:
+		if dst, ok := value.(*[]int64); ok {
+			if data == nil {
+				*dst = nil
+				return nil
+			}
+			if dim == 0 {
+				if len(data) > 0 {
+					return unmarshalErrorf("unmarshal vector: %d bytes of data for 0-dimension vector", len(data))
+				}
+				*dst = make([]int64, 0)
+				return nil
+			}
+			return unmarshalVectorCounter(data, dim, dst)
+		}
+	case TypeBigInt, TypeTimestamp:
+		if !isVectorVariableLengthType(info.SubType) {
 			if dst, ok := value.(*[]int64); ok {
 				if data == nil {
 					*dst = nil
@@ -1102,7 +1335,9 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 				}
 				return unmarshalVectorInt64(data, dim, dst)
 			}
-		case TypeUUID, TypeTimeUUID:
+		}
+	case TypeUUID, TypeTimeUUID:
+		if !isVectorVariableLengthType(info.SubType) {
 			if dst, ok := value.(*[]UUID); ok {
 				if data == nil {
 					*dst = nil
@@ -1245,7 +1480,7 @@ func marshalVectorFloat32(vec []float32, dim int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, size)
+	buf := getMarshalOutput(size)
 	if dim > 0 {
 		_ = buf[dim*4-1] // BCE hint
 	}
@@ -1263,7 +1498,7 @@ func marshalVectorFloat64(vec []float64, dim int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, size)
+	buf := getMarshalOutput(size)
 	if dim > 0 {
 		_ = buf[dim*8-1] // BCE hint
 	}
@@ -1281,7 +1516,7 @@ func marshalVectorInt32(vec []int32, dim int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, size)
+	buf := getMarshalOutput(size)
 	if dim > 0 {
 		_ = buf[dim*4-1] // BCE hint
 	}
@@ -1299,12 +1534,13 @@ func marshalVectorInt(vec []int, dim int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, size)
+	buf := getMarshalOutput(size)
 	if dim > 0 {
 		_ = buf[dim*4-1] // BCE hint
 	}
 	for i, v := range vec {
 		if v > math.MaxInt32 || v < math.MinInt32 {
+			putMarshalOutput(buf)
 			return nil, marshalErrorf("marshal vector: int element value %d out of int32 range", v)
 		}
 		binary.BigEndian.PutUint32(buf[i*4:], uint32(int32(v)))
@@ -1320,12 +1556,33 @@ func marshalVectorInt64(vec []int64, dim int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, size)
+	buf := getMarshalOutput(size)
 	if dim > 0 {
 		_ = buf[dim*8-1] // BCE hint
 	}
 	for i, v := range vec {
 		binary.BigEndian.PutUint64(buf[i*8:], uint64(v))
+	}
+	return buf, nil
+}
+
+func marshalVectorCounter(vec []int64, dim int) ([]byte, error) {
+	if len(vec) != dim {
+		return nil, marshalErrorf("expected vector with %d dimensions, received %d", dim, len(vec))
+	}
+	// Counter vectors are length-prefixed in the current wire format.
+	// Each element is encoded as: uVInt(8) + 8-byte big-endian payload.
+	size, err := vectorByteSize(dim, 9)
+	if err != nil {
+		return nil, err
+	}
+	buf := getMarshalOutput(size)
+	off := 0
+	for _, v := range vec {
+		buf[off] = 8
+		off++
+		binary.BigEndian.PutUint64(buf[off:], uint64(v))
+		off += 8
 	}
 	return buf, nil
 }
@@ -1338,7 +1595,7 @@ func marshalVectorUUID(vec []UUID, dim int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, size)
+	buf := getMarshalOutput(size)
 	if dim > 0 {
 		_ = buf[dim*16-1] // BCE hint
 	}
@@ -1453,6 +1710,43 @@ func unmarshalVectorInt64(data []byte, dim int, dst *[]int64) error {
 	return nil
 }
 
+func unmarshalVectorCounter(data []byte, dim int, dst *[]int64) error {
+	// Each element is uVInt(8) + 8 payload bytes, so a valid dim is bounded by
+	// len(data)/9. Checked before allocating, matching the other vector decoders.
+	if _, err := vectorByteSize(dim, 9); err != nil {
+		return err
+	}
+	if dim > len(data)/9 {
+		return unmarshalErrorf("unmarshal vector: %d counter dimensions exceed %d bytes of data", dim, len(data))
+	}
+	vec := make([]int64, dim)
+
+	off := 0
+	for i := 0; i < dim; i++ {
+		if off >= len(data) {
+			return unmarshalErrorf("unmarshal vector: unexpected eof")
+		}
+		m, p, err := readUnsignedVInt(data[off:])
+		if err != nil {
+			return err
+		}
+		off += p
+		if m != 8 {
+			return unmarshalErrorf("unmarshal vector: expected 8-byte counter element, got %d bytes at index %d", m, i)
+		}
+		if off+8 > len(data) {
+			return unmarshalErrorf("unmarshal vector: unexpected eof")
+		}
+		vec[i] = int64(binary.BigEndian.Uint64(data[off:]))
+		off += 8
+	}
+	if off != len(data) {
+		return unmarshalErrorf("unmarshal vector: expected %d counter elements, got %d trailing bytes", dim, len(data)-off)
+	}
+	*dst = vec
+	return nil
+}
+
 func unmarshalVectorUUID(data []byte, dim int, dst *[]UUID) error {
 	expected, err := vectorByteSize(dim, 16)
 	if err != nil {
@@ -1467,6 +1761,340 @@ func unmarshalVectorUUID(data []byte, dim int, dst *[]UUID) error {
 	}
 	for i := 0; i < dim; i++ {
 		copy(vec[i][:], data[i*16:])
+	}
+	*dst = vec
+	return nil
+}
+
+// --- List/Set fast-path marshal functions ---
+// These use encoding/binary.BigEndian directly, avoiding per-element
+// reflection and the generic Marshal() call for common fixed-size types.
+// List wire format: [4-byte count] + N × ([4-byte elem-length] + [elem-bytes])
+
+// listByteSize returns the total byte size for a list of n fixed-size elements,
+// checking for integer overflow. Each element has a 4-byte length prefix.
+func listByteSize(n, elemSize int) (int, error) {
+	// Total = 4 (count header) + n * (4 + elemSize)
+	perElem := 4 + elemSize
+	if n > 0 && perElem > (math.MaxInt-4)/n {
+		return 0, marshalErrorf("marshal list: byte size overflow for %d elements of %d bytes", n, elemSize)
+	}
+	return 4 + n*perElem, nil
+}
+
+func marshalListFloat32(list []float32) ([]byte, error) {
+	n := len(list)
+	if n > math.MaxInt32 {
+		return nil, marshalErrorf("marshal list: collection too large")
+	}
+	size, err := listByteSize(n, 4)
+	if err != nil {
+		return nil, err
+	}
+	buf := getMarshalOutput(size)
+	binary.BigEndian.PutUint32(buf, uint32(n))
+	off := 4
+	for _, v := range list {
+		binary.BigEndian.PutUint32(buf[off:], 4) // elem length
+		binary.BigEndian.PutUint32(buf[off+4:], math.Float32bits(v))
+		off += 8
+	}
+	return buf, nil
+}
+
+func marshalListFloat64(list []float64) ([]byte, error) {
+	n := len(list)
+	if n > math.MaxInt32 {
+		return nil, marshalErrorf("marshal list: collection too large")
+	}
+	size, err := listByteSize(n, 8)
+	if err != nil {
+		return nil, err
+	}
+	buf := getMarshalOutput(size)
+	binary.BigEndian.PutUint32(buf, uint32(n))
+	off := 4
+	for _, v := range list {
+		binary.BigEndian.PutUint32(buf[off:], 8) // elem length
+		binary.BigEndian.PutUint64(buf[off+4:], math.Float64bits(v))
+		off += 12
+	}
+	return buf, nil
+}
+
+func marshalListInt32(list []int32) ([]byte, error) {
+	n := len(list)
+	if n > math.MaxInt32 {
+		return nil, marshalErrorf("marshal list: collection too large")
+	}
+	size, err := listByteSize(n, 4)
+	if err != nil {
+		return nil, err
+	}
+	buf := getMarshalOutput(size)
+	binary.BigEndian.PutUint32(buf, uint32(n))
+	off := 4
+	for _, v := range list {
+		binary.BigEndian.PutUint32(buf[off:], 4) // elem length
+		binary.BigEndian.PutUint32(buf[off+4:], uint32(v))
+		off += 8
+	}
+	return buf, nil
+}
+
+func marshalListInt(list []int) ([]byte, error) {
+	n := len(list)
+	if n > math.MaxInt32 {
+		return nil, marshalErrorf("marshal list: collection too large")
+	}
+	size, err := listByteSize(n, 4)
+	if err != nil {
+		return nil, err
+	}
+	buf := getMarshalOutput(size)
+	binary.BigEndian.PutUint32(buf, uint32(n))
+	off := 4
+	for _, v := range list {
+		if v > math.MaxInt32 || v < math.MinInt32 {
+			putMarshalOutput(buf)
+			return nil, marshalErrorf("marshal list: int element value %d out of int32 range", v)
+		}
+		binary.BigEndian.PutUint32(buf[off:], 4) // elem length
+		binary.BigEndian.PutUint32(buf[off+4:], uint32(int32(v)))
+		off += 8
+	}
+	return buf, nil
+}
+
+func marshalListInt64(list []int64) ([]byte, error) {
+	n := len(list)
+	if n > math.MaxInt32 {
+		return nil, marshalErrorf("marshal list: collection too large")
+	}
+	size, err := listByteSize(n, 8)
+	if err != nil {
+		return nil, err
+	}
+	buf := getMarshalOutput(size)
+	binary.BigEndian.PutUint32(buf, uint32(n))
+	off := 4
+	for _, v := range list {
+		binary.BigEndian.PutUint32(buf[off:], 8) // elem length
+		binary.BigEndian.PutUint64(buf[off+4:], uint64(v))
+		off += 12
+	}
+	return buf, nil
+}
+
+// --- List/Set fast-path unmarshal functions ---
+// List wire format: [4-byte count] + N × ([4-byte elem-length] + [elem-bytes])
+// For fixed-size types, each elem-length must equal the expected element size.
+
+func unmarshalListFloat32(data []byte, dst *[]float32) error {
+	if len(data) < 4 {
+		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
+	}
+	n := int(int32(binary.BigEndian.Uint32(data[:4])))
+	if n < 0 {
+		return unmarshalErrorf("unmarshal list: negative count %d", n)
+	}
+	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
+	if n > (len(data)-4)/4 {
+		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
+	}
+	vec := *dst
+	if cap(vec) >= n {
+		vec = vec[:n]
+	} else {
+		vec = make([]float32, n)
+	}
+	off := 4
+	for i := 0; i < n; i++ {
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
+		}
+		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
+		off += 4
+		if elemLen < 0 {
+			// Null element: set zero value, matching slow-path behavior
+			vec[i] = 0
+			continue
+		}
+		if elemLen != 4 {
+			return unmarshalErrorf("unmarshal list: expected 4-byte float32 element, got %d bytes at index %d", elemLen, i)
+		}
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
+		}
+		vec[i] = math.Float32frombits(binary.BigEndian.Uint32(data[off:]))
+		off += 4
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalListFloat64(data []byte, dst *[]float64) error {
+	if len(data) < 4 {
+		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
+	}
+	n := int(int32(binary.BigEndian.Uint32(data[:4])))
+	if n < 0 {
+		return unmarshalErrorf("unmarshal list: negative count %d", n)
+	}
+	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
+	if n > (len(data)-4)/4 {
+		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
+	}
+	vec := *dst
+	if cap(vec) >= n {
+		vec = vec[:n]
+	} else {
+		vec = make([]float64, n)
+	}
+	off := 4
+	for i := 0; i < n; i++ {
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
+		}
+		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
+		off += 4
+		if elemLen < 0 {
+			vec[i] = 0
+			continue
+		}
+		if elemLen != 8 {
+			return unmarshalErrorf("unmarshal list: expected 8-byte float64 element, got %d bytes at index %d", elemLen, i)
+		}
+		if off+8 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
+		}
+		vec[i] = math.Float64frombits(binary.BigEndian.Uint64(data[off:]))
+		off += 8
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalListInt32(data []byte, dst *[]int32) error {
+	if len(data) < 4 {
+		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
+	}
+	n := int(int32(binary.BigEndian.Uint32(data[:4])))
+	if n < 0 {
+		return unmarshalErrorf("unmarshal list: negative count %d", n)
+	}
+	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
+	if n > (len(data)-4)/4 {
+		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
+	}
+	vec := *dst
+	if cap(vec) >= n {
+		vec = vec[:n]
+	} else {
+		vec = make([]int32, n)
+	}
+	off := 4
+	for i := 0; i < n; i++ {
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
+		}
+		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
+		off += 4
+		if elemLen < 0 {
+			vec[i] = 0
+			continue
+		}
+		if elemLen != 4 {
+			return unmarshalErrorf("unmarshal list: expected 4-byte int32 element, got %d bytes at index %d", elemLen, i)
+		}
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
+		}
+		vec[i] = int32(binary.BigEndian.Uint32(data[off:]))
+		off += 4
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalListInt(data []byte, dst *[]int) error {
+	if len(data) < 4 {
+		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
+	}
+	n := int(int32(binary.BigEndian.Uint32(data[:4])))
+	if n < 0 {
+		return unmarshalErrorf("unmarshal list: negative count %d", n)
+	}
+	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
+	if n > (len(data)-4)/4 {
+		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
+	}
+	// make is non-nil even at n==0, which TestMarshalSetListV3/zero_elems and
+	// the other leaf decoders expect.
+	vec := make([]int, n)
+	off := 4
+	for i := 0; i < n; i++ {
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
+		}
+		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
+		off += 4
+		if elemLen <= 0 {
+			// Null (<0) and legacy empty (0) elements both decode to zero,
+			// matching the sibling leaves and serialization/cqlint.
+			vec[i] = 0
+			continue
+		}
+		if elemLen != 4 {
+			return unmarshalErrorf("unmarshal list: expected 4-byte int element, got %d bytes at index %d", elemLen, i)
+		}
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
+		}
+		vec[i] = int(int32(binary.BigEndian.Uint32(data[off:])))
+		off += 4
+	}
+	*dst = vec
+	return nil
+}
+
+func unmarshalListInt64(data []byte, dst *[]int64) error {
+	if len(data) < 4 {
+		return unmarshalErrorf("unmarshal list: unexpected eof reading count")
+	}
+	n := int(int32(binary.BigEndian.Uint32(data[:4])))
+	if n < 0 {
+		return unmarshalErrorf("unmarshal list: negative count %d", n)
+	}
+	// Each element needs ≥4 bytes (length prefix); reject implausible counts early.
+	if n > (len(data)-4)/4 {
+		return unmarshalErrorf("unmarshal list: count %d exceeds available data", n)
+	}
+	vec := *dst
+	if cap(vec) >= n {
+		vec = vec[:n]
+	} else {
+		vec = make([]int64, n)
+	}
+	off := 4
+	for i := 0; i < n; i++ {
+		if off+4 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element length at index %d", i)
+		}
+		elemLen := int(int32(binary.BigEndian.Uint32(data[off:])))
+		off += 4
+		if elemLen < 0 {
+			vec[i] = 0
+			continue
+		}
+		if elemLen != 8 {
+			return unmarshalErrorf("unmarshal list: expected 8-byte int64 element, got %d bytes at index %d", elemLen, i)
+		}
+		if off+8 > len(data) {
+			return unmarshalErrorf("unmarshal list: unexpected eof reading element data at index %d", i)
+		}
+		vec[i] = int64(binary.BigEndian.Uint64(data[off:]))
+		off += 8
 	}
 	*dst = vec
 	return nil
@@ -2724,8 +3352,10 @@ func (v VectorType) NewWithError() (any, error) {
 			return new([]float64), nil
 		case TypeInt:
 			return new([]int), nil
-		case TypeBigInt, TypeTimestamp:
+		case TypeBigInt:
 			return new([]int64), nil
+		case TypeTimestamp:
+			return new([]time.Time), nil
 		case TypeUUID, TypeTimeUUID:
 			return new([]UUID), nil
 		case TypeText, TypeVarchar, TypeAscii:

--- a/marshal.go
+++ b/marshal.go
@@ -943,9 +943,13 @@ func marshalList(info CollectionType, value any) ([]byte, error) {
 	case reflect.Slice, reflect.Array:
 		n := rv.Len()
 
+		// Variable-length elements get an estimate rather than no hint at
+		// all, which otherwise leaves text and blob lists growing by doubling.
+		// Hint only when the element size is exactly known; see
+		// collectionEntrySize for why estimating is counterproductive.
 		sizeHint := 4
-		if elemSize := fixedElemSize(info.Elem); elemSize > 0 {
-			sizeHint += n * (4 + elemSize)
+		if elemSize := collectionEntrySize(info.Elem); elemSize > 0 {
+			sizeHint = collectionSizeHint(n, 4+elemSize)
 		}
 		buf := getMarshalBuf(sizeHint)
 
@@ -1913,6 +1917,59 @@ func unmarshalVector(info VectorType, data []byte, value any) error {
 // Note: TypeBoolean/TypeTinyInt (1B) and TypeSmallInt (2B) are intentionally
 // excluded — Cassandra's vector implementation treats them as variable-length,
 // and the pre-sizing benefit for such small types is negligible.
+// collectionElemWireSize returns the wire-encoded size of a fixed-length CQL
+// element, or 0 for variable-length types. Kept separate from fixedElemSize,
+// which the vector path shares: Cassandra's vector encoding treats smallint,
+// tinyint, time, counter and date as variable-length (see
+// isVectorVariableLengthType), while collections have no such restriction.
+// Inet is excluded from both: it encodes to 4 or 16 bytes.
+func collectionElemWireSize(elemType TypeInfo) int {
+	switch elemType.Type() {
+	case TypeTinyInt, TypeBoolean:
+		return 1
+	case TypeSmallInt:
+		return 2
+	case TypeInt, TypeFloat, TypeDate:
+		return 4
+	case TypeBigInt, TypeDouble, TypeTimestamp, TypeCounter, TypeTime:
+		return 8
+	case TypeUUID, TypeTimeUUID:
+		return 16
+	}
+	return 0
+}
+
+// maxCollectionPreallocBytes caps speculative preallocation in marshalList and
+// marshalMap. The hint is computed before any element has been marshalled, so
+// a bogus element count must not trigger an arbitrarily large allocation — or
+// overflow n*perEntry — before the first element's Marshal reports the error.
+const maxCollectionPreallocBytes = 1 << 20 // 1 MiB
+
+// collectionSizeHint sizes the marshal buffer for n entries of perEntry wire
+// bytes each. Past the cap, buffer doubling takes over as before.
+func collectionSizeHint(n, perEntry int) int {
+	if n <= 0 || perEntry <= 0 {
+		return 4
+	}
+	if n > (maxCollectionPreallocBytes-4)/perEntry {
+		return maxCollectionPreallocBytes
+	}
+	return 4 + n*perEntry
+}
+
+// collectionEntrySize returns the per-entry wire size to preallocate for, or 0
+// when the element is variable-length and no honest figure exists.
+//
+// Deliberately no estimate for variable-length elements. An estimate that
+// overshoots is worse than no hint: it inflates the buffer past
+// marshalBufMaxCap, at which point putMarshalBuf drops it instead of returning
+// it to the pool, so every call allocates afresh. Measured on lists of short
+// blobs, a 64-byte-per-element guess cost +27% time and +192% B/op against no
+// hint at all. bytes.Buffer doubling is the cheaper default here.
+func collectionEntrySize(elemType TypeInfo) int {
+	return collectionElemWireSize(elemType)
+}
+
 func fixedElemSize(elemType TypeInfo) int {
 	switch elemType.Type() {
 	case TypeInt, TypeFloat, TypeDate:
@@ -2499,10 +2556,10 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 	n := rv.Len()
 
 	sizeHint := 4
-	keySize := fixedElemSize(info.Key)
-	valSize := fixedElemSize(info.Elem)
+	keySize := collectionEntrySize(info.Key)
+	valSize := collectionEntrySize(info.Elem)
 	if keySize > 0 && valSize > 0 {
-		sizeHint += n * (4 + keySize + 4 + valSize)
+		sizeHint = collectionSizeHint(n, 4+keySize+4+valSize)
 	}
 	buf := getMarshalBuf(sizeHint)
 
@@ -2511,8 +2568,12 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 		return nil, err
 	}
 
-	keys := rv.MapKeys()
-	for _, key := range keys {
+	// MapRange avoids the intermediate []reflect.Value that MapKeys allocates,
+	// and the second hash lookup per entry that MapIndex would cost.
+	iter := rv.MapRange()
+	for iter.Next() {
+		key, val := iter.Key(), iter.Value()
+
 		item, err := Marshal(info.Key, key.Interface())
 		if err != nil {
 			putMarshalBuf(buf)
@@ -2529,7 +2590,7 @@ func marshalMap(info CollectionType, value any) ([]byte, error) {
 		}
 		buf.Write(item)
 
-		item, err = Marshal(info.Elem, rv.MapIndex(key).Interface())
+		item, err = Marshal(info.Elem, val.Interface())
 		if err != nil {
 			putMarshalBuf(buf)
 			return nil, err

--- a/marshal_alias_test.go
+++ b/marshal_alias_test.go
@@ -1,0 +1,192 @@
+//go:build all || unit
+
+package gocql
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/gocql/gocql/internal/tests/mock"
+)
+
+// The list fast paths must allocate a fresh backing array per decode. Reusing
+// the one already in *dst is tempting — the destination is usually a loop
+// variable — but it aliases every result the caller kept from an earlier
+// decode into the same variable. Iter.Scan documents that it copies into dest,
+// and gocql publishes no "valid until the next Scan" contract, so these tests
+// pin the copying behaviour against a future reuse optimization.
+
+func aliasListWire(elems ...[]byte) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, uint32(len(elems)))
+	for _, e := range elems {
+		var l [4]byte
+		binary.BigEndian.PutUint32(l[:], uint32(len(e)))
+		out = append(out, l[:]...)
+		out = append(out, e...)
+	}
+	return out
+}
+
+func aliasListType(elem Type) CollectionType {
+	return CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: elem},
+	}
+}
+
+// TestUnmarshalListDoesNotAliasRetainedResult decodes twice into one variable
+// and checks the first result is untouched.
+func TestUnmarshalListDoesNotAliasRetainedResult(t *testing.T) {
+	t.Run("uuid", func(t *testing.T) {
+		first, second := make([]byte, 16), make([]byte, 16)
+		first[0], second[0] = 0x11, 0x22
+
+		var dst []UUID
+		if err := Unmarshal(aliasListType(TypeUUID), aliasListWire(first), &dst); err != nil {
+			t.Fatal(err)
+		}
+		retained := dst
+		if err := Unmarshal(aliasListType(TypeUUID), aliasListWire(second), &dst); err != nil {
+			t.Fatal(err)
+		}
+		if retained[0][0] != 0x11 {
+			t.Fatalf("second decode overwrote the retained slice: got %#v, want first byte 0x11", retained[0])
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		var dst []string
+		if err := Unmarshal(aliasListType(TypeVarchar), aliasListWire([]byte("first")), &dst); err != nil {
+			t.Fatal(err)
+		}
+		retained := dst
+		if err := Unmarshal(aliasListType(TypeVarchar), aliasListWire([]byte("secnd")), &dst); err != nil {
+			t.Fatal(err)
+		}
+		if retained[0] != "first" {
+			t.Fatalf("second decode overwrote the retained slice: got %q, want %q", retained[0], "first")
+		}
+	})
+
+	// []int and the vector decoders reuse via a differently-named local, so
+	// they are covered explicitly rather than by inspection.
+	t.Run("int", func(t *testing.T) {
+		enc := func(v int32) []byte {
+			var b [4]byte
+			binary.BigEndian.PutUint32(b[:], uint32(v))
+			return b[:]
+		}
+		var dst []int
+		if err := Unmarshal(aliasListType(TypeInt), aliasListWire(enc(11)), &dst); err != nil {
+			t.Fatal(err)
+		}
+		retained := dst
+		if err := Unmarshal(aliasListType(TypeInt), aliasListWire(enc(22)), &dst); err != nil {
+			t.Fatal(err)
+		}
+		if retained[0] != 11 {
+			t.Fatalf("second decode overwrote the retained slice: got %d, want 11", retained[0])
+		}
+	})
+
+	t.Run("vector_float32", func(t *testing.T) {
+		vt := VectorType{
+			NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+			SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+			Dimensions: 2,
+		}
+		enc := func(a, b float32) []byte {
+			out := make([]byte, 8)
+			binary.BigEndian.PutUint32(out[0:], math.Float32bits(a))
+			binary.BigEndian.PutUint32(out[4:], math.Float32bits(b))
+			return out
+		}
+		var dst []float32
+		if err := Unmarshal(vt, enc(1, 2), &dst); err != nil {
+			t.Fatal(err)
+		}
+		retained := dst
+		if err := Unmarshal(vt, enc(9, 9), &dst); err != nil {
+			t.Fatal(err)
+		}
+		if retained[0] != 1 {
+			t.Fatalf("second decode overwrote the retained vector: got %v, want 1", retained[0])
+		}
+	})
+
+	// dim==0 is the easy site to miss: no bytes are written, but handing
+	// back the caller's array lets a later append clobber retained memory.
+	t.Run("vector_dim0", func(t *testing.T) {
+		vt := VectorType{
+			NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+			SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+			Dimensions: 0,
+		}
+		shared := make([]float32, 1, 4)
+		shared[0] = 42
+		dst := shared[:0]
+		if err := Unmarshal(vt, []byte{}, &dst); err != nil {
+			t.Fatal(err)
+		}
+		dst = append(dst, 7) // must land in fresh storage
+		if shared[0] != 42 {
+			t.Fatalf("append through the decoded slice clobbered retained memory: shared[0]=%v", shared[0])
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		enc := func(v int64) []byte {
+			var b [8]byte
+			binary.BigEndian.PutUint64(b[:], uint64(v))
+			return b[:]
+		}
+		var dst []int64
+		if err := Unmarshal(aliasListType(TypeBigInt), aliasListWire(enc(1)), &dst); err != nil {
+			t.Fatal(err)
+		}
+		retained := dst
+		if err := Unmarshal(aliasListType(TypeBigInt), aliasListWire(enc(2)), &dst); err != nil {
+			t.Fatal(err)
+		}
+		if retained[0] != 1 {
+			t.Fatalf("second decode overwrote the retained slice: got %d, want 1", retained[0])
+		}
+	})
+}
+
+// TestScanLoopRetainsDistinctCollectionSlices exercises the same property
+// through Iter.Scan, which is how callers actually hit it.
+func TestScanLoopRetainsDistinctCollectionSlices(t *testing.T) {
+	wire := func(elems ...string) []byte {
+		raw := make([][]byte, len(elems))
+		for i, e := range elems {
+			raw[i] = []byte(e)
+		}
+		return aliasListWire(raw...)
+	}
+
+	col := ColumnInfo{Name: "tags", TypeInfo: aliasListType(TypeVarchar)}
+	iter := &Iter{
+		meta:    resultMetadata{columns: []ColumnInfo{col}, actualColCount: 1},
+		framer:  &mock.MockFramer{Data: [][]byte{wire("row-one"), wire("row-two"), wire("row-three")}},
+		numRows: 3,
+	}
+
+	var tags []string
+	var all [][]string
+	for iter.Scan(&tags) {
+		all = append(all, tags)
+	}
+
+	want := []string{"row-one", "row-two", "row-three"}
+	if len(all) != len(want) {
+		t.Fatalf("scanned %d rows, want %d", len(all), len(want))
+	}
+	for i, got := range all {
+		if got[0] != want[i] {
+			t.Errorf("row %d: retained slice holds %q, want %q", i, got[0], want[i])
+		}
+	}
+}

--- a/marshal_alias_test.go
+++ b/marshal_alias_test.go
@@ -190,3 +190,32 @@ func TestScanLoopRetainsDistinctCollectionSlices(t *testing.T) {
 		}
 	}
 }
+
+// TestScanByteSliceReusesBacking documents the one destination that is not
+// copied: *[]byte reuses its backing array where it fits. This is long-standing
+// gocql behaviour, inherited from serialization/{blob,varchar,text,ascii}, and
+// is now stated on Iter.Scan. The test exists so the documentation and the code
+// move together — if the reuse is ever removed, this fails and the doc comment
+// must be updated with it.
+func TestScanByteSliceReusesBacking(t *testing.T) {
+	col := ColumnInfo{Name: "b", TypeInfo: NativeType{proto: protoVersion4, typ: TypeBlob}}
+	iter := &Iter{
+		meta:    resultMetadata{columns: []ColumnInfo{col}, actualColCount: 1},
+		framer:  &mock.MockFramer{Data: [][]byte{[]byte("row-one"), []byte("row-two")}},
+		numRows: 2,
+	}
+
+	var b []byte
+	var retained [][]byte
+	for iter.Scan(&b) {
+		retained = append(retained, b)
+	}
+	if len(retained) != 2 {
+		t.Fatalf("scanned %d rows, want 2", len(retained))
+	}
+	if string(retained[0]) != "row-two" {
+		t.Fatalf("expected the retained []byte to alias the second row (documented "+
+			"reuse), got %q — if this now reads \"row-one\" the reuse was removed "+
+			"and Iter.Scan's doc comment needs updating", retained[0])
+	}
+}

--- a/marshal_buf_pool_test.go
+++ b/marshal_buf_pool_test.go
@@ -1,0 +1,574 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build all || unit
+// +build all unit
+
+package gocql
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"sync"
+	"testing"
+)
+
+// --- Pool infrastructure tests ---
+
+func TestGetMarshalBuf_ReturnsNonNil(t *testing.T) {
+	buf := getMarshalBuf(0)
+	if buf == nil {
+		t.Fatal("getMarshalBuf(0) returned nil")
+	}
+	putMarshalBuf(buf)
+}
+
+func TestGetMarshalBuf_RespectsSizeHint(t *testing.T) {
+	buf := getMarshalBuf(1024)
+	if buf.Cap() < 1024 {
+		t.Fatalf("expected capacity >= 1024, got %d", buf.Cap())
+	}
+	putMarshalBuf(buf)
+}
+
+func TestGetMarshalBuf_IsReset(t *testing.T) {
+	buf := getMarshalBuf(0)
+	buf.WriteString("leftover data")
+	putMarshalBuf(buf)
+
+	buf2 := getMarshalBuf(0)
+	if buf2.Len() != 0 {
+		t.Fatalf("expected buffer to be reset, got len=%d", buf2.Len())
+	}
+	putMarshalBuf(buf2)
+}
+
+func TestPutMarshalBuf_NilSafe(t *testing.T) {
+	// Should not panic.
+	putMarshalBuf(nil)
+}
+
+func TestPutMarshalBuf_DiscardsOversized(t *testing.T) {
+	buf := getMarshalBuf(marshalBufMaxCap + 1)
+	buf.Write(make([]byte, marshalBufMaxCap+1))
+	// This should discard the buffer (not return it to pool).
+	// We can't directly verify it was discarded, but we can verify no panic.
+	putMarshalBuf(buf)
+}
+
+func TestFinishMarshalBuf_CopiesData(t *testing.T) {
+	buf := getMarshalBuf(0)
+	buf.WriteString("hello world")
+
+	// Get a pointer to the internal storage before finish.
+	internalPtr := buf.Bytes()
+
+	result := finishMarshalBuf(buf)
+
+	if string(result) != "hello world" {
+		t.Fatalf("expected 'hello world', got %q", result)
+	}
+
+	// Verify that result does not alias the internal buffer by getting
+	// a new buffer from the pool and writing different data.
+	buf2 := getMarshalBuf(0)
+	buf2.WriteString("OVERWRITTEN!")
+
+	// The original result should be unchanged (no aliasing).
+	if string(result) != "hello world" {
+		t.Fatalf("result was corrupted after pool reuse: got %q", result)
+	}
+
+	// Also verify the internal pointer's data was overwritten (proves the
+	// pool actually reused the buffer).
+	_ = internalPtr // The data at this pointer may have been overwritten.
+	putMarshalBuf(buf2)
+}
+
+func TestFinishMarshalBuf_EmptyBuffer(t *testing.T) {
+	buf := getMarshalBuf(0)
+	result := finishMarshalBuf(buf)
+	if result == nil {
+		t.Fatal("expected non-nil empty slice, got nil")
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected empty slice, got len=%d", len(result))
+	}
+}
+
+// --- Concurrent safety test ---
+
+func TestMarshalBufPool_ConcurrentSafety(t *testing.T) {
+	const goroutines = 100
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				buf := getMarshalBuf(64)
+				buf.WriteString("data from goroutine")
+				result := finishMarshalBuf(buf)
+				if string(result) != "data from goroutine" {
+					t.Errorf("goroutine %d iteration %d: got %q", id, i, result)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// --- fixedElemSize tests ---
+
+func TestFixedElemSize(t *testing.T) {
+	tests := []struct {
+		typ      Type
+		expected int
+	}{
+		{TypeInt, 4},
+		{TypeFloat, 4},
+		{TypeDate, 4},
+		{TypeBigInt, 8},
+		{TypeDouble, 8},
+		{TypeTimestamp, 8},
+		{TypeCounter, 8},
+		{TypeTime, 8},
+		{TypeUUID, 16},
+		{TypeTimeUUID, 16},
+		// Small fixed types excluded intentionally (see fixedElemSize comment).
+		{TypeBoolean, 0},
+		{TypeTinyInt, 0},
+		{TypeSmallInt, 0},
+		// Variable-length types should return 0.
+		{TypeVarchar, 0},
+		{TypeBlob, 0},
+		{TypeText, 0},
+		{TypeVarint, 0},
+		{TypeDecimal, 0},
+		{TypeCustom, 0},
+	}
+
+	for _, tc := range tests {
+		info := NativeType{proto: protoVersion4, typ: tc.typ}
+		got := fixedElemSize(info)
+		if got != tc.expected {
+			t.Errorf("fixedElemSize(%v) = %d, want %d", tc.typ, got, tc.expected)
+		}
+	}
+}
+
+// --- Round-trip correctness: marshal with pooled buffers produces identical output ---
+
+func TestMarshalList_PooledRoundTrip_IntSlice(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	input := []int32{1, 2, 3, -1, 0, math.MaxInt32, math.MinInt32}
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatalf("marshalList: %v", err)
+	}
+
+	var output []int32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatalf("unmarshalList: %v", err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("len mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if input[i] != output[i] {
+			t.Errorf("element %d: got %d, want %d", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalList_PooledRoundTrip_Float32Slice(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeFloat},
+	}
+
+	input := []float32{0.0, 1.5, -1.5, math.MaxFloat32, math.SmallestNonzeroFloat32, float32(math.NaN())}
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatalf("marshalList: %v", err)
+	}
+
+	var output []float32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatalf("unmarshalList: %v", err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("len mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		// NaN != NaN, so compare bits.
+		if math.Float32bits(input[i]) != math.Float32bits(output[i]) {
+			t.Errorf("element %d: got bits %08x, want %08x", i, math.Float32bits(output[i]), math.Float32bits(input[i]))
+		}
+	}
+}
+
+func TestMarshalList_PooledRoundTrip_StringSlice(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+
+	input := []string{"hello", "", "world", "a longer string with spaces"}
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatalf("marshalList: %v", err)
+	}
+
+	var output []string
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatalf("unmarshalList: %v", err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("len mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if input[i] != output[i] {
+			t.Errorf("element %d: got %q, want %q", i, output[i], input[i])
+		}
+	}
+}
+
+func TestMarshalList_PooledRoundTrip_Empty(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	input := []int32{}
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatalf("marshalList: %v", err)
+	}
+
+	var output []int32
+	if err := unmarshalList(info, data, &output); err != nil {
+		t.Fatalf("unmarshalList: %v", err)
+	}
+
+	if len(output) != 0 {
+		t.Fatalf("expected empty slice, got len=%d", len(output))
+	}
+}
+
+func TestMarshalList_PooledRoundTrip_Nil(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	data, err := marshalList(info, nil)
+	if err != nil {
+		t.Fatalf("marshalList: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil for nil input, got %v", data)
+	}
+}
+
+func TestMarshalMap_PooledRoundTrip(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	input := map[string]int{"alpha": 1, "beta": 2, "gamma": 3}
+	data, err := marshalMap(info, input)
+	if err != nil {
+		t.Fatalf("marshalMap: %v", err)
+	}
+
+	var output map[string]int
+	if err := unmarshalMap(info, data, &output); err != nil {
+		t.Fatalf("unmarshalMap: %v", err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("len mismatch: got %d, want %d", len(output), len(input))
+	}
+	for k, v := range input {
+		if output[k] != v {
+			t.Errorf("key %q: got %d, want %d", k, output[k], v)
+		}
+	}
+}
+
+func TestMarshalMap_PooledRoundTrip_Empty(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	input := map[string]int{}
+	data, err := marshalMap(info, input)
+	if err != nil {
+		t.Fatalf("marshalMap: %v", err)
+	}
+
+	var output map[string]int
+	if err := unmarshalMap(info, data, &output); err != nil {
+		t.Fatalf("unmarshalMap: %v", err)
+	}
+
+	if len(output) != 0 {
+		t.Fatalf("expected empty map, got len=%d", len(output))
+	}
+}
+
+func TestMarshalVector_PooledRoundTrip(t *testing.T) {
+	info := VectorType{
+		NativeType: NativeType{
+			proto:  protoVersion4,
+			typ:    TypeCustom,
+			custom: apacheCassandraTypePrefix + "VectorType(" + apacheCassandraTypePrefix + "FloatType, 4)",
+		},
+		SubType:    NativeType{proto: protoVersion4, typ: TypeFloat},
+		Dimensions: 4,
+	}
+
+	input := []float32{1.0, 2.0, 3.0, 4.0}
+	data, err := marshalVector(info, input)
+	if err != nil {
+		t.Fatalf("marshalVector: %v", err)
+	}
+
+	var output []float32
+	if err := unmarshalVector(info, data, &output); err != nil {
+		t.Fatalf("unmarshalVector: %v", err)
+	}
+
+	if len(output) != len(input) {
+		t.Fatalf("len mismatch: got %d, want %d", len(output), len(input))
+	}
+	for i := range input {
+		if input[i] != output[i] {
+			t.Errorf("element %d: got %f, want %f", i, output[i], input[i])
+		}
+	}
+}
+
+// --- Byte-compatibility: pooled output is identical to expected wire format ---
+
+func TestMarshalList_ByteCompatibility(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	input := []int32{1, 2}
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatalf("marshalList: %v", err)
+	}
+
+	// Build expected wire format manually:
+	// 4 bytes: element count (2)
+	// For each element: 4 bytes length (4) + 4 bytes data
+	var expected bytes.Buffer
+	binary.Write(&expected, binary.BigEndian, int32(2)) // count
+	binary.Write(&expected, binary.BigEndian, int32(4)) // len(elem 0)
+	binary.Write(&expected, binary.BigEndian, int32(1)) // elem 0
+	binary.Write(&expected, binary.BigEndian, int32(4)) // len(elem 1)
+	binary.Write(&expected, binary.BigEndian, int32(2)) // elem 1
+
+	if !bytes.Equal(data, expected.Bytes()) {
+		t.Fatalf("wire format mismatch:\ngot:  %x\nwant: %x", data, expected.Bytes())
+	}
+}
+
+// --- Concurrent marshal correctness ---
+
+func TestMarshalList_ConcurrentCorrectness(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	const goroutines = 50
+	const size = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			input := make([]int32, size)
+			for i := range input {
+				input[i] = int32(i)
+			}
+			data, err := marshalList(info, input)
+			if err != nil {
+				t.Errorf("marshalList: %v", err)
+				return
+			}
+
+			var output []int32
+			if err := unmarshalList(info, data, &output); err != nil {
+				t.Errorf("unmarshalList: %v", err)
+				return
+			}
+
+			for i := range input {
+				if input[i] != output[i] {
+					t.Errorf("element %d: got %d, want %d", i, output[i], input[i])
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// --- Benchmarks for list marshal with pooled buffers ---
+
+func BenchmarkMarshalListInt32(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	for _, s := range sizes {
+		input := make([]int32, s.n)
+		for i := range input {
+			input[i] = int32(i)
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 4))
+			for i := 0; i < b.N; i++ {
+				_, err := marshalList(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalListFloat32(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeFloat},
+	}
+
+	for _, s := range sizes {
+		input := make([]float32, s.n)
+		for i := range input {
+			input[i] = float32(i) * 0.1
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 4))
+			for i := 0; i < b.N; i++ {
+				_, err := marshalList(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalListBigInt(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+		{1000, "n_1000"},
+	}
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+
+	for _, s := range sizes {
+		input := make([]int64, s.n)
+		for i := range input {
+			input[i] = int64(i) * 1000
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(s.n * 8))
+			for i := 0; i < b.N; i++ {
+				_, err := marshalList(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalMapStringInt(b *testing.B) {
+	sizes := []struct {
+		n    int
+		name string
+	}{
+		{10, "n_10"},
+		{100, "n_100"},
+	}
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+
+	for _, s := range sizes {
+		input := make(map[string]int, s.n)
+		for i := 0; i < s.n; i++ {
+			input[string(rune('a'+i%26))+string(rune('0'+i/26))] = i
+		}
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := marshalMap(info, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/marshal_buf_pool_test.go
+++ b/marshal_buf_pool_test.go
@@ -1,9 +1,23 @@
-// Copyright (c) 2012 The gocql Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 //go:build all || unit
 // +build all unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package gocql
 
@@ -570,5 +584,222 @@ func BenchmarkMarshalMapStringInt(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// --- marshalOutputPool tests ---
+
+func TestGetMarshalOutputFresh(t *testing.T) {
+	buf := getMarshalOutput(64)
+	if len(buf) != 64 {
+		t.Fatalf("expected len 64, got %d", len(buf))
+	}
+	if cap(buf) < 64 {
+		t.Fatalf("expected cap >= 64, got %d", cap(buf))
+	}
+}
+
+func TestGetMarshalOutputFromPool(t *testing.T) {
+	// Put a buffer into the pool, then retrieve it.
+	orig := make([]byte, 0, 128)
+	marshalOutputPool.Put(orig)
+
+	buf := getMarshalOutput(64)
+	if len(buf) != 64 {
+		t.Fatalf("expected len 64, got %d", len(buf))
+	}
+	// The pool should have returned the 128-cap buffer.
+	if cap(buf) < 128 {
+		t.Logf("pool did not return expected buffer (cap %d); may have been GC'd", cap(buf))
+	}
+}
+
+func TestGetMarshalOutputPoolTooSmall(t *testing.T) {
+	// Put a small buffer, request a larger one — should get a fresh allocation.
+	small := make([]byte, 0, 8)
+	marshalOutputPool.Put(small)
+
+	buf := getMarshalOutput(64)
+	if len(buf) != 64 {
+		t.Fatalf("expected len 64, got %d", len(buf))
+	}
+}
+
+func TestPutMarshalOutputNil(t *testing.T) {
+	// Should not panic.
+	putMarshalOutput(nil)
+}
+
+func TestPutMarshalOutputOversized(t *testing.T) {
+	// Buffers larger than marshalBufMaxCap should be discarded.
+	huge := make([]byte, marshalBufMaxCap+1)
+	putMarshalOutput(huge)
+	// If we get it back, the pool ignored the cap limit (unlikely).
+	// Can't reliably test pool internals, just verify no panic.
+}
+
+func TestMarshalOutputPoolRoundTrip(t *testing.T) {
+	// Verify that a buffer returned to the pool can be reused.
+	buf := getMarshalOutput(32)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	putMarshalOutput(buf)
+
+	buf2 := getMarshalOutput(16)
+	if len(buf2) != 16 {
+		t.Fatalf("expected len 16, got %d", len(buf2))
+	}
+	// buf2 may or may not be the same underlying array (GC can collect pool entries).
+	// Just verify it's usable.
+	for i := range buf2 {
+		buf2[i] = 0xff
+	}
+}
+
+func TestPooledMarshalType(t *testing.T) {
+	tests := []struct {
+		name   string
+		info   TypeInfo
+		expect bool
+	}{
+		// Vectors with pooled subtypes.
+		{"vector<float>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeFloat}}, true},
+		{"vector<double>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeDouble}}, true},
+		{"vector<int>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeInt}}, true},
+		{"vector<bigint>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeBigInt}}, true},
+		{"vector<timestamp>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeTimestamp}}, true},
+		{"vector<counter>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeCounter}}, true},
+		{"vector<uuid>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeUUID}}, true},
+		{"vector<timeuuid>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeTimeUUID}}, true},
+
+		// Vectors with non-pooled subtypes.
+		{"vector<text>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeVarchar}}, false},
+		{"vector<blob>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeBlob}}, false},
+		{"vector<boolean>", VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeBoolean}}, false},
+
+		// Lists/sets with pooled elem types.
+		{"list<float>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeFloat}}, true},
+		{"list<double>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeDouble}}, true},
+		{"list<int>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeInt}}, true},
+		{"list<bigint>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeBigInt}}, true},
+		{"list<timestamp>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeTimestamp}}, true},
+		{"list<counter>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeCounter}}, true},
+		{"set<float>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeSet}, Elem: NativeType{proto: protoVersion4, typ: TypeFloat}}, true},
+		{"set<int>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeSet}, Elem: NativeType{proto: protoVersion4, typ: TypeInt}}, true},
+
+		// Lists/sets with non-pooled elem types.
+		{"list<text>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeVarchar}}, false},
+		{"set<blob>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeSet}, Elem: NativeType{proto: protoVersion4, typ: TypeBlob}}, false},
+		{"list<uuid>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeUUID}}, false},
+
+		// Maps are never pooled.
+		{"map<int,int>", CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeMap}, Key: NativeType{proto: protoVersion4, typ: TypeInt}, Elem: NativeType{proto: protoVersion4, typ: TypeInt}}, false},
+
+		// Native types are never pooled.
+		{"int", NativeType{proto: protoVersion4, typ: TypeInt}, false},
+		{"text", NativeType{proto: protoVersion4, typ: TypeVarchar}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pooledMarshalType(tt.info)
+			if got != tt.expect {
+				t.Errorf("pooledMarshalType(%s) = %v, want %v", tt.name, got, tt.expect)
+			}
+		})
+	}
+}
+
+// TestPooledMarshalValue checks that pooledMarshalValue additionally
+// requires the Go value's concrete type to match the fast path, unlike
+// pooledMarshalType which only looks at the CQL type.
+func TestPooledMarshalValue(t *testing.T) {
+	listInt := CollectionType{NativeType: NativeType{proto: protoVersion4, typ: TypeList}, Elem: NativeType{proto: protoVersion4, typ: TypeInt}}
+	vectorFloat := VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeFloat}}
+	vectorInt := VectorType{Dimensions: 3, SubType: NativeType{proto: protoVersion4, typ: TypeInt}}
+
+	tests := []struct {
+		name   string
+		info   TypeInfo
+		value  any
+		expect bool
+	}{
+		{"list<int> + []int32 matches", listInt, []int32{1, 2}, true},
+		{"list<int> + []int matches", listInt, []int{1, 2}, true},
+		{"list<int> + []int8 falls back to reflect", listInt, []int8{1, 2}, false},
+		{"vector<float> + []float32 matches", vectorFloat, []float32{1, 2, 3}, true},
+		{"vector<float> + []float64 falls back to reflect", vectorFloat, []float64{1, 2, 3}, false},
+		{"vector<int> + []int32 matches", vectorInt, []int32{1, 2, 3}, true},
+		{"vector<int> + []int matches", vectorInt, []int{1, 2, 3}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pooledMarshalValue(tt.info, tt.value)
+			if got != tt.expect {
+				t.Errorf("pooledMarshalValue(%s) = %v, want %v", tt.name, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestMarshalVectorFloat32UsesPool(t *testing.T) {
+	// Marshal, put back, marshal again — second call should reuse the buffer.
+	vec := []float32{1.0, 2.0, 3.0}
+	buf1, err := marshalVectorFloat32(vec, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Copy the data before returning to pool.
+	data1 := make([]byte, len(buf1))
+	copy(data1, buf1)
+	putMarshalOutput(buf1)
+
+	buf2, err := marshalVectorFloat32(vec, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify data is correct regardless of pool reuse.
+	if !bytes.Equal(data1, buf2) {
+		t.Fatalf("data mismatch after pool reuse")
+	}
+	putMarshalOutput(buf2)
+}
+
+func TestMarshalListInt32UsesPool(t *testing.T) {
+	list := []int32{10, 20, 30}
+	buf1, err := marshalListInt32(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data1 := make([]byte, len(buf1))
+	copy(data1, buf1)
+	putMarshalOutput(buf1)
+
+	buf2, err := marshalListInt32(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data1, buf2) {
+		t.Fatalf("data mismatch after pool reuse")
+	}
+	putMarshalOutput(buf2)
+}
+
+// TestMarshalQueryValue_PooledFlag_FastPathTypeMismatchNotPooled verifies
+// dst.pooled reflects whether the fast path actually ran, not just whether
+// the CQL type is poolable. []int8 doesn't match the fast path's concrete
+// type for TypeInt ([]int32/[]int), so it falls back to reflect.
+func TestMarshalQueryValue_PooledFlag_FastPathTypeMismatchNotPooled(t *testing.T) {
+	q := &queryValues{}
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+	if err := marshalQueryValue(info, []int8{1, 2, 3}, q); err != nil {
+		t.Fatal(err)
+	}
+	if q.pooled {
+		t.Error("expected pooled=false: []int8 does not match the fast path's concrete type for TypeInt")
 	}
 }

--- a/marshal_edgecases_test.go
+++ b/marshal_edgecases_test.go
@@ -158,25 +158,6 @@ func TestMarshalQueryValue_PooledFlag_FastPath(t *testing.T) {
 	}
 }
 
-// Fix #2 — the post-framer finalize loop must iterate len(vals) (not
-// len(cols)) so a mismatched-metadata theoretical case where cols>n
-// does not panic on an out-of-range index. We exercise the bounded loop
-// directly without spinning up a Conn.
-func TestQueryValues_LoopBound_Fix2NoPanicOnAllocsWhenColsLonger(t *testing.T) {
-	defer func() {
-		if x := recover(); x != nil {
-			t.Fatalf("bounded iteration over vals panicked: %v", x)
-		}
-	}()
-	v := []queryValues{{name: "a"}, {name: "b"}}
-	// Iterate exactly as conn.go does (vals, not cols).
-	for i := range v {
-		if v[i].pooled {
-			_ = v[i].value
-		}
-	}
-}
-
 // --- Fix #6 helpers: blob/UUID accumulation tests.
 
 // buildListBytesWithNulls builds a CQL list wire encoding where nil entries

--- a/marshal_edgecases_test.go
+++ b/marshal_edgecases_test.go
@@ -1,0 +1,410 @@
+//go:build all || unit
+// +build all unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression tests for edge cases in the marshal/unmarshal fast paths and
+// buffer pooling: panic-safety on malformed TypeInfo, pooled-buffer
+// provenance, and null-handling in the collection decoders.
+
+package gocql
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+// --- Fix #5 helpers: TypeInfo that reports list/set/map but does NOT
+// implement CollectionType. Used to exercise the panic-safe fallback path.
+
+type stubListTypeInfo struct {
+	NativeType
+}
+
+func (stubListTypeInfo) Type() Type      { return TypeList }
+func (s stubListTypeInfo) Version() byte { return protoVersion4 }
+
+type stubMapTypeInfo struct {
+	NativeType
+}
+
+func (stubMapTypeInfo) Type() Type      { return TypeMap }
+func (s stubMapTypeInfo) Version() byte { return protoVersion4 }
+
+// Fix #5 — Marshal/Unmarshal must not panic on non-CollectionType TypeInfo
+// whose Type() reports a list/set/map; should return an error.
+
+func TestMarshal_NonCollectionTypeList_ReturnsError(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Fatalf("Marshal panicked on non-CollectionType TypeInfo: %v", x)
+		}
+	}()
+	_, err := Marshal(stubListTypeInfo{}, []any{1, 2, 3})
+	if err == nil {
+		t.Fatal("expected error from Marshal, got nil")
+	}
+	if !strings.Contains(err.Error(), "marshal") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestUnmarshal_NonCollectionTypeList_ReturnsError(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Fatalf("Unmarshal panicked on non-CollectionType TypeInfo: %v", x)
+		}
+	}()
+	var dst any
+	err := Unmarshal(stubListTypeInfo{}, []byte{0, 0, 0, 1, 0, 0, 0, 1, 1}, &dst)
+	if err == nil {
+		t.Fatal("expected error from Unmarshal, got nil")
+	}
+}
+
+func TestMarshal_NonCollectionTypeMap_ReturnsError(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Fatalf("Marshal panicked on non-CollectionType TypeInfo: %v", x)
+		}
+	}()
+	_, err := Marshal(stubMapTypeInfo{}, map[string]int{"a": 1})
+	if err == nil {
+		t.Fatal("expected error from Marshal, got nil")
+	}
+}
+
+func TestUnmarshal_NonCollectionTypeMap_ReturnsError(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Fatalf("Unmarshal panicked on non-CollectionType TypeInfo: %v", x)
+		}
+	}()
+	var dst any
+	err := Unmarshal(stubMapTypeInfo{}, nil, &dst)
+	if err == nil {
+		t.Fatal("expected error from Unmarshal, got nil")
+	}
+}
+
+// --- Fix #1+#2 helpers: queryValues.pooled flag and bounded finalize loop.
+
+// userMarshalerOwned returns a user-owned []byte (kept by the test via
+// keepAlive) so we can prove the connector's post-framer cleanup does NOT
+// return user-owned memory to the byte pool.
+type userMarshalerOwned struct {
+	keepAlive *[]byte
+}
+
+func (m userMarshalerOwned) MarshalCQL(_ TypeInfo) ([]byte, error) {
+	buf := []byte("USER_DATA")
+	if m.keepAlive != nil {
+		*m.keepAlive = buf
+	}
+	return buf, nil
+}
+
+// Fix #1 — user Marshaler output is NOT flagged as pooled; the user's
+// external reference must remain valid.
+func TestMarshalQueryValue_UserMarshalerPooledFlag(t *testing.T) {
+	keepAlive := []byte("OLD")
+	q := &queryValues{}
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+	if err := marshalQueryValue(info, userMarshalerOwned{keepAlive: &keepAlive}, q); err != nil {
+		t.Fatal(err)
+	}
+	if q.pooled {
+		t.Error("user Marshaler output must not be flagged as pooled")
+	}
+	if !bytes.Equal(keepAlive, []byte("USER_DATA")) {
+		t.Errorf("user-owned buffer should not have been overwritten: got %v", keepAlive)
+	}
+}
+
+// Fix #1 — fast-path marshal IS flagged as pooled.
+func TestMarshalQueryValue_PooledFlag_FastPath(t *testing.T) {
+	q := &queryValues{}
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+	if err := marshalQueryValue(info, []int32{1, 2, 3}, q); err != nil {
+		t.Fatal(err)
+	}
+	if !q.pooled {
+		t.Error("expected []int32 marshal to be flagged as pooled (fast-path)")
+	}
+}
+
+// Fix #2 — the post-framer finalize loop must iterate len(vals) (not
+// len(cols)) so a mismatched-metadata theoretical case where cols>n
+// does not panic on an out-of-range index. We exercise the bounded loop
+// directly without spinning up a Conn.
+func TestQueryValues_LoopBound_Fix2NoPanicOnAllocsWhenColsLonger(t *testing.T) {
+	defer func() {
+		if x := recover(); x != nil {
+			t.Fatalf("bounded iteration over vals panicked: %v", x)
+		}
+	}()
+	v := []queryValues{{name: "a"}, {name: "b"}}
+	// Iterate exactly as conn.go does (vals, not cols).
+	for i := range v {
+		if v[i].pooled {
+			_ = v[i].value
+		}
+	}
+}
+
+// --- Fix #6 helpers: blob/UUID accumulation tests.
+
+// buildListBytesWithNulls builds a CQL list wire encoding where nil entries
+// use length-prefix -1 and zero-length non-nil entries use length 0.
+func buildListBytesWithNulls(elements []*[]byte) []byte {
+	var buf bytes.Buffer
+	binary.BigEndian.PutUint32(_uuid_uint32Append(&buf), uint32(len(elements)))
+	for _, e := range elements {
+		if e == nil {
+			binary.BigEndian.PutUint32(_uuid_uint32Append(&buf), 0xffffffff)
+			continue
+		}
+		binary.BigEndian.PutUint32(_uuid_uint32Append(&buf), uint32(len(*e)))
+		buf.Write(*e)
+	}
+	return buf.Bytes()
+}
+
+func _uuid_uint32Append(buf *bytes.Buffer) []byte {
+	buf.Write(make([]byte, 4))
+	return buf.Bytes()[buf.Len()-4 : buf.Len()]
+}
+
+func buildListBytesUUIDWithNulls(elements []*UUID) []byte {
+	var buf bytes.Buffer
+	binary.BigEndian.PutUint32(_uuid_uint32Append(&buf), uint32(len(elements)))
+	for _, e := range elements {
+		if e == nil {
+			binary.BigEndian.PutUint32(_uuid_uint32Append(&buf), 0xffffffff)
+			continue
+		}
+		binary.BigEndian.PutUint32(_uuid_uint32Append(&buf), 16)
+		buf.Write(e.Bytes())
+	}
+	return buf.Bytes()
+}
+
+// Fix #6 — blob decoder redistributes a slice with stale ghost entries;
+// null slots are explicitly cleared to nil.
+func TestUnmarshalListBlob_NullSlotsCleared(t *testing.T) {
+	foo := []byte("foo")
+	wire := buildListBytesWithNulls([]*[]byte{nil, &foo, nil})
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBlob},
+	}
+
+	dst := make([][]byte, 0, 4)
+	dst = append(dst, []byte("GHOST0"), []byte("GHOST1"), []byte("GHOST2"), []byte("GHOST3"))
+
+	if err := unmarshalList(info, wire, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != 3 {
+		t.Fatalf("expected length 3, got %d", len(dst))
+	}
+	if dst[0] != nil {
+		t.Errorf("expected dst[0]=nil (null slot), got %v", dst[0])
+	}
+	if !bytes.Equal(dst[1], []byte("foo")) {
+		t.Errorf("expected dst[1]=[foo], got %v", dst[1])
+	}
+	if dst[2] != nil {
+		t.Errorf("expected dst[2]=nil (null slot), got %v", dst[2])
+	}
+}
+
+// Fix #6 — UUID decoder mirrors blob: null slots become zero UUID.
+func TestUnmarshalListUUID_NullSlotsCleared(t *testing.T) {
+	uuidA, err := UUIDFromBytes([]byte("1234567890ABCDEF"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	uuidB, err := UUIDFromBytes([]byte("FEDCBA0987654321"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uuidA == uuidB || uuidB == (UUID{}) {
+		t.Fatal("ghost UUID must differ from the decoded value and from the zero UUID")
+	}
+	wire := buildListBytesUUIDWithNulls([]*UUID{nil, &uuidA, nil})
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeUUID},
+	}
+
+	dst := make([]UUID, 0, 4)
+	dst = append(dst, uuidB, uuidB, uuidB, uuidB)
+
+	if err := unmarshalList(info, wire, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != 3 {
+		t.Fatalf("expected length 3, got %d", len(dst))
+	}
+	if dst[0] != (UUID{}) {
+		t.Errorf("expected dst[0]=zero UUID (null slot), got %v", dst[0])
+	}
+	if dst[1] != uuidA {
+		t.Errorf("expected dst[1]=uuidA, got %v", dst[1])
+	}
+	if dst[2] != (UUID{}) {
+		t.Errorf("expected dst[2]=zero UUID (null slot), got %v", dst[2])
+	}
+}
+
+// TestUnmarshalListString_NullSlotsCleared verifies []string decodes null
+// and empty slots to the zero value.
+func TestUnmarshalListString_NullSlotsCleared(t *testing.T) {
+	wire := buildCQLListWithNulls(nil, []byte("foo"), nil)
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+
+	dst := make([]string, 0, 4)
+	dst = append(dst, "GHOST0", "GHOST1", "GHOST2", "GHOST3")
+
+	if err := unmarshalList(info, wire, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != 3 {
+		t.Fatalf("expected length 3, got %d", len(dst))
+	}
+	if dst[0] != "" {
+		t.Errorf("expected dst[0]=\"\" (null slot), got %q", dst[0])
+	}
+	if dst[1] != "foo" {
+		t.Errorf("expected dst[1]=foo, got %q", dst[1])
+	}
+	if dst[2] != "" {
+		t.Errorf("expected dst[2]=\"\" (null slot), got %q", dst[2])
+	}
+}
+
+// M1 (review follow-up) — unmarshalListString shares one buffer across all
+// strings only up to marshalBufMaxCap, so keeping one small string from a
+// huge list can't pin an unbounded amount of memory.
+
+// TestUnmarshalListString_SmallTotal_SharesBackingBuffer verifies the
+// shared-buffer path is still used below the threshold: consecutive
+// strings' data pointers are exactly adjacent in one buffer.
+func TestUnmarshalListString_SmallTotal_SharesBackingBuffer(t *testing.T) {
+	wire := buildCQLList([]byte("foo"), []byte("bar"))
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	var dst []string
+	if err := unmarshalList(info, wire, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != 2 || dst[0] != "foo" || dst[1] != "bar" {
+		t.Fatalf("unexpected result: %#v", dst)
+	}
+	p0 := unsafe.StringData(dst[0])
+	p1 := unsafe.StringData(dst[1])
+	if uintptr(unsafe.Pointer(p1)) != uintptr(unsafe.Pointer(p0))+uintptr(len(dst[0])) {
+		t.Error("expected dst[0] and dst[1] to share one contiguous buffer")
+	}
+}
+
+// TestUnmarshalListString_LargeTotal_DoesNotShareBackingBuffer verifies that
+// above marshalBufMaxCap, strings are allocated independently rather than
+// sharing one large buffer.
+func TestUnmarshalListString_LargeTotal_DoesNotShareBackingBuffer(t *testing.T) {
+	big := bytes.Repeat([]byte("x"), (marshalBufMaxCap/2)+1024)
+	wire := buildCQLList(big, big)
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	var dst []string
+	if err := unmarshalList(info, wire, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != 2 || dst[0] != string(big) || dst[1] != string(big) {
+		t.Fatal("unexpected result content")
+	}
+	p0 := unsafe.StringData(dst[0])
+	p1 := unsafe.StringData(dst[1])
+	if uintptr(unsafe.Pointer(p1)) == uintptr(unsafe.Pointer(p0))+uintptr(len(dst[0])) {
+		t.Error("expected dst[0] and dst[1] to be independently allocated, not sharing a buffer")
+	}
+}
+
+// --- Fix #7 helper.
+
+// Fix #7 — unmarshalListInt with n=0 must emit a non-nil empty []int;
+// matches the sibling leaf decoders and TestMarshalSetListV3/zero_elems.
+func TestUnmarshalListInt_ZeroElemEmptySlice(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+	var dst []int
+	if err := unmarshalList(info, []byte{0, 0, 0, 0}, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if dst == nil {
+		t.Fatal("expected non-nil empty []int, got nil (Fix #7 regression)")
+	}
+	if len(dst) != 0 {
+		t.Fatalf("expected empty, got len %d", len(dst))
+	}
+}
+
+// Fix #7 — decodes correctly into a destination with spare capacity.
+func TestUnmarshalListInt_PreSizedDestination(t *testing.T) {
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+	input := []int32{10, 20, 30}
+	data, err := marshalList(info, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := make([]int, 0, 10)
+	if err := unmarshalList(info, data, &dst); err != nil {
+		t.Fatal(err)
+	}
+	for i, v := range input {
+		if dst[i] != int(v) {
+			t.Errorf("[%d]: got %d, want %d", i, dst[i], int(v))
+		}
+	}
+}

--- a/marshal_pool_release_test.go
+++ b/marshal_pool_release_test.go
@@ -1,0 +1,169 @@
+//go:build all || unit
+
+package gocql
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// The buffer pool's safety rests on one invariant: a buffer is returned to
+// marshalOutputPool only if a pooled fast path actually produced it. That is a
+// property of the code path taken, not of the column's type — the reflect
+// path, pointer values and user Marshalers all yield non-pooled buffers for
+// columns whose TypeInfo says "poolable". Returning one of those would hand
+// getMarshalOutput memory that is still referenced elsewhere, and in the
+// Marshaler case memory the caller owns.
+//
+// These tests pin both halves: that marshalQueryValue sets the flag from the
+// path it took, and that the release path honours the flag rather than
+// re-deriving poolability from the schema.
+
+// captureReleases swaps the pool-return seam for a recorder, so a test can see
+// exactly which buffers a release path handed back. Not parallel-safe.
+func captureReleases(t *testing.T) *[][]byte {
+	t.Helper()
+	released := &[][]byte{}
+	prev := putPooledOutput
+	putPooledOutput = func(buf []byte) { *released = append(*released, buf) }
+	t.Cleanup(func() { putPooledOutput = prev })
+	return released
+}
+
+func sameBuffer(a, b []byte) bool {
+	if cap(a) == 0 || cap(b) == 0 {
+		return cap(a) == cap(b) && len(a) == len(b)
+	}
+	return unsafe.SliceData(a) == unsafe.SliceData(b)
+}
+
+// listOfInt is a poolable column type: pooledMarshalType reports true for it,
+// so a schema-driven release would try to recycle every value bound to it.
+func listOfInt() CollectionType {
+	return CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+}
+
+type marshalerInts []int32
+
+func (m marshalerInts) MarshalCQL(info TypeInfo) ([]byte, error) {
+	return Marshal(info, []int32(m))
+}
+
+// TestMarshalQueryValuePooledFlagMatchesPathTaken is the regression guard: for
+// every value below the column type is poolable, so an implementation that
+// predicted from TypeInfo would mark them all pooled. Only the concrete
+// fast-path slice actually comes from the pool.
+func TestMarshalQueryValuePooledFlagMatchesPathTaken(t *testing.T) {
+	ints := []int32{1, 2, 3}
+
+	cases := []struct {
+		name       string
+		value      any
+		wantPooled bool
+	}{
+		{"fast path []int32", ints, true},
+		{"fast path []int", []int{1, 2, 3}, true},
+		// Reflect path: no fast path for []int8 elements.
+		{"reflect path []int8", []int8{1, 2, 3}, false},
+		// Marshal dereferences the pointer and the fast path does produce a
+		// pooled buffer, but pooledMarshalValue type-asserts on the pointer
+		// and declines. Losing the optimisation is safe; recycling is not.
+		{"pointer to slice", &ints, false},
+		// User-owned memory: must never be recycled.
+		{"user Marshaler", marshalerInts(ints), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var dst queryValues
+			if err := marshalQueryValue(listOfInt(), tc.value, &dst); err != nil {
+				t.Fatalf("marshalQueryValue: %v", err)
+			}
+			if dst.pooled != tc.wantPooled {
+				t.Fatalf("pooled = %v, want %v (column type is poolable, so this "+
+					"fails if poolability is predicted from TypeInfo)", dst.pooled, tc.wantPooled)
+			}
+		})
+	}
+
+	// The premise of the test: TypeInfo alone says "poolable" for all of them.
+	if !pooledMarshalType(listOfInt()) {
+		t.Fatal("list<int> is expected to be a poolable column type; test premise is stale")
+	}
+}
+
+// TestReleasePooledValuesHonoursFlag checks the release path returns exactly
+// the flagged buffers — not every buffer, and not those on poolable columns
+// that took a non-pooled path.
+func TestReleasePooledValuesHonoursFlag(t *testing.T) {
+	released := captureReleases(t)
+
+	pooledBuf := []byte{1, 2, 3}
+	plainBuf := []byte{4, 5, 6}
+	vals := []queryValues{
+		{value: pooledBuf, pooled: true},
+		{value: plainBuf, pooled: false},
+		{value: nil, pooled: false},
+	}
+
+	releasePooledValues(vals)
+
+	if len(*released) != 1 {
+		t.Fatalf("released %d buffers, want exactly 1", len(*released))
+	}
+	if !sameBuffer((*released)[0], pooledBuf) {
+		t.Fatal("released the wrong buffer")
+	}
+	for i := range vals {
+		if vals[i].pooled {
+			t.Fatalf("value %d left flagged after release", i)
+		}
+	}
+}
+
+// TestReleasePooledValuesIsIdempotent guards the double-return case: a buffer
+// handed back twice is handed to two callers by sync.Pool, which corrupts
+// both. Clearing the flag on release is what prevents it.
+func TestReleasePooledValuesIsIdempotent(t *testing.T) {
+	released := captureReleases(t)
+
+	vals := []queryValues{{value: []byte{1, 2, 3}, pooled: true}}
+	releasePooledValues(vals)
+	releasePooledValues(vals)
+
+	if len(*released) != 1 {
+		t.Fatalf("released %d times, want 1 — the same buffer must not be pooled twice", len(*released))
+	}
+}
+
+// TestReleasePooledValuesEndToEnd runs the real marshal step and then the real
+// release step over a mixed set of values, which is the combination neither
+// half covers alone.
+func TestReleasePooledValuesEndToEnd(t *testing.T) {
+	released := captureReleases(t)
+
+	values := []any{
+		[]int32{1, 2, 3},    // pooled fast path
+		[]int8{4, 5},        // reflect path, same poolable column type
+		marshalerInts{6, 7}, // user-owned memory
+	}
+	vals := make([]queryValues, len(values))
+	for i, v := range values {
+		if err := marshalQueryValue(listOfInt(), v, &vals[i]); err != nil {
+			t.Fatalf("marshalQueryValue(%d): %v", i, err)
+		}
+	}
+
+	want := vals[0].value
+	releasePooledValues(vals)
+
+	if len(*released) != 1 {
+		t.Fatalf("released %d buffers, want exactly 1 (only the fast-path value was pooled)", len(*released))
+	}
+	if !sameBuffer((*released)[0], want) {
+		t.Fatal("released a buffer that did not come from the pool")
+	}
+}

--- a/marshal_sizehint_test.go
+++ b/marshal_sizehint_test.go
@@ -1,0 +1,144 @@
+//go:build all || unit
+
+package gocql
+
+import (
+	"math"
+	"testing"
+)
+
+func nt(t Type) NativeType { return NativeType{proto: protoVersion4, typ: t} }
+
+func TestCollectionElemWireSize(t *testing.T) {
+	fixed := map[Type]int{
+		TypeTinyInt: 1, TypeBoolean: 1,
+		TypeSmallInt: 2,
+		TypeInt:      4, TypeFloat: 4, TypeDate: 4,
+		TypeBigInt: 8, TypeDouble: 8, TypeTimestamp: 8, TypeCounter: 8, TypeTime: 8,
+		TypeUUID: 16, TypeTimeUUID: 16,
+	}
+	for typ, want := range fixed {
+		if got := collectionElemWireSize(nt(typ)); got != want {
+			t.Errorf("collectionElemWireSize(%v) = %d, want %d", typ, got, want)
+		}
+	}
+	// Variable-length types report 0 so callers fall back to an estimate.
+	for _, typ := range []Type{TypeVarchar, TypeText, TypeAscii, TypeBlob, TypeInet, TypeCustom} {
+		if got := collectionElemWireSize(nt(typ)); got != 0 {
+			t.Errorf("collectionElemWireSize(%v) = %d, want 0 (variable-length)", typ, got)
+		}
+	}
+}
+
+// TestCollectionEntrySizeNoEstimate pins the decision not to guess at
+// variable-length element sizes: an overshooting hint pushes the buffer past
+// marshalBufMaxCap, so putMarshalBuf drops it and the pool stops working.
+// Callers must see 0 here and skip the hint entirely.
+func TestCollectionEntrySizeNoEstimate(t *testing.T) {
+	for _, typ := range []Type{TypeVarchar, TypeText, TypeAscii, TypeBlob, TypeInet, TypeCustom} {
+		if got := collectionEntrySize(nt(typ)); got != 0 {
+			t.Errorf("collectionEntrySize(%v) = %d, want 0 so no hint is applied", typ, got)
+		}
+	}
+	for _, typ := range []Type{TypeInt, TypeUUID, TypeBoolean, TypeSmallInt, TypeBigInt} {
+		if got := collectionEntrySize(nt(typ)); got <= 0 {
+			t.Errorf("collectionEntrySize(%v) = %d, want the exact wire size", typ, got)
+		}
+	}
+}
+
+// TestCollectionSizeHintNeverOvershoots is the property that makes hinting
+// safe: the hint must never exceed what the encoding actually needs. An
+// overshoot inflates the buffer past marshalBufMaxCap for no reason, and
+// putMarshalBuf then drops it instead of returning it to the pool. (A genuinely
+// large collection exceeding that cap is unavoidable and fine — the waste only
+// matters when the hint is bigger than the data.)
+func TestCollectionSizeHintNeverOvershoots(t *testing.T) {
+	for _, elemSize := range []int{1, 2, 4, 8, 16} {
+		for _, n := range []int{0, 1, 10, 1000, 100_000, math.MaxInt32} {
+			perEntry := 4 + elemSize
+			exact := 4 + int64(n)*int64(perEntry)
+			got := int64(collectionSizeHint(n, perEntry))
+			if got > exact {
+				t.Fatalf("collectionSizeHint(%d, %d) = %d, overshoots exact size %d", n, perEntry, got, exact)
+			}
+		}
+	}
+}
+
+// TestCollectionSizeHintCapped is the safety property: the hint is computed
+// from an element count before any element has been marshalled, so a bogus or
+// hostile count must neither overflow nor request an enormous allocation.
+func TestCollectionSizeHintCapped(t *testing.T) {
+	cases := []struct {
+		name     string
+		n        int
+		perEntry int
+		want     int
+	}{
+		{"empty", 0, 12, 4},
+		{"negative count", -1, 12, 4},
+		{"no per-entry size", 10, 0, 4},
+		{"small exact", 10, 12, 4 + 120},
+		{"at the cap boundary", (maxCollectionPreallocBytes - 4) / 12, 12, 4 + ((maxCollectionPreallocBytes-4)/12)*12},
+		{"past the cap", maxCollectionPreallocBytes, 12, maxCollectionPreallocBytes},
+		{"huge count", math.MaxInt32, 20, maxCollectionPreallocBytes},
+		{"overflow attempt", math.MaxInt, 64, maxCollectionPreallocBytes},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectionSizeHint(tc.n, tc.perEntry)
+			if got != tc.want {
+				t.Fatalf("collectionSizeHint(%d, %d) = %d, want %d", tc.n, tc.perEntry, got, tc.want)
+			}
+			if got < 0 || got > maxCollectionPreallocBytes {
+				t.Fatalf("hint %d outside [0, %d]", got, maxCollectionPreallocBytes)
+			}
+		})
+	}
+}
+
+// TestMarshalMapRangeMatchesReflect checks the MapRange rewrite still produces
+// a well-formed map body. Entry order is unspecified for CQL maps and Go map
+// iteration is randomised, so this decodes the result rather than comparing
+// bytes.
+func TestMarshalMapRangeMatchesReflect(t *testing.T) {
+	info := CollectionType{NativeType: nt(TypeMap), Key: nt(TypeVarchar), Elem: nt(TypeInt)}
+	src := map[string]int32{"a": 1, "b": 2, "c": 3, "": 0}
+
+	data, err := Marshal(info, src)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]int32
+	if err := Unmarshal(info, data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(got) != len(src) {
+		t.Fatalf("round trip produced %d entries, want %d", len(got), len(src))
+	}
+	for k, v := range src {
+		if got[k] != v {
+			t.Fatalf("key %q: got %d, want %d", k, got[k], v)
+		}
+	}
+}
+
+// TestMarshalCollectionOversizedCountDoesNotPrealloc guards the cap end to
+// end: a large element count must not allocate proportionally before the
+// elements are actually marshalled.
+func TestMarshalCollectionOversizedCountDoesNotPrealloc(t *testing.T) {
+	info := CollectionType{NativeType: nt(TypeList), Elem: nt(TypeBigInt)}
+	// Zero-sized elements: a large count costs almost nothing to build, but
+	// an uncapped hint would ask for n*12 bytes up front.
+	src := make([]int64, 200_000)
+
+	data, err := Marshal(info, src)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := 4 + len(src)*(4+8)
+	if len(data) != want {
+		t.Fatalf("encoded %d bytes, want %d", len(data), want)
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -37,6 +37,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/inf.v0"
 )
@@ -1887,4 +1888,733 @@ func BenchmarkUnmarshalMapInt64Int64(b *testing.B) {
 			}
 		})
 	}
+}
+
+func buildTimestampBytes(msec int64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(msec))
+	return b
+}
+
+func buildDateBytes(daysSinceEpoch int32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(int64(daysSinceEpoch)+(1<<31)))
+	return b
+}
+
+func TestUnmarshalListFastPath(t *testing.T) {
+	t.Parallel()
+
+	// Test []string with TypeVarchar
+	t.Run("string", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+		}
+		data := buildCQLList([]byte("hello"), []byte("world"), []byte(""))
+		var dst []string
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 3 || dst[0] != "hello" || dst[1] != "world" || dst[2] != "" {
+			t.Fatalf("got %v", dst)
+		}
+	})
+
+	// Test []int64 with TypeBigInt
+	t.Run("int64", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+		data := buildCQLList(
+			[]byte{0, 0, 0, 0, 0, 0, 0, 42},
+			[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE},
+		)
+		var dst []int64
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 2 || dst[0] != 42 || dst[1] != -2 {
+			t.Fatalf("got %v", dst)
+		}
+	})
+
+	// Test []int32 with TypeInt
+	t.Run("int32", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+		}
+		data := buildCQLList([]byte{0, 0, 0, 7}, []byte{0xFF, 0xFF, 0xFF, 0xFF})
+		var dst []int32
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 2 || dst[0] != 7 || dst[1] != -1 {
+			t.Fatalf("got %v", dst)
+		}
+	})
+
+	// Test []float64 with TypeDouble
+	t.Run("float64", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeDouble},
+		}
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, math.Float64bits(3.14))
+		data := buildCQLList(b)
+		var dst []float64
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 1 || dst[0] != 3.14 {
+			t.Fatalf("got %v", dst)
+		}
+	})
+
+	// Test []bool with TypeBoolean
+	t.Run("bool", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBoolean},
+		}
+		data := buildCQLList([]byte{1}, []byte{0})
+		var dst []bool
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 2 || dst[0] != true || dst[1] != false {
+			t.Fatalf("got %v", dst)
+		}
+	})
+
+	// Test nil data
+	t.Run("nil_data", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+		}
+		var dst []string
+		dst = []string{"existing"}
+		if err := unmarshalList(info, nil, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if dst != nil {
+			t.Fatalf("expected nil, got %v", dst)
+		}
+	})
+
+	// Test []int16 with TypeSmallInt
+	t.Run("int16", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeSmallInt},
+		}
+		data := buildCQLList([]byte{0, 42}, []byte{0xFF, 0xFE})
+		var dst []int16
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 2 || dst[0] != 42 || dst[1] != -2 {
+			t.Fatalf("got %v", dst)
+		}
+	})
+
+	// Test []time.Time with TypeTimestamp
+	t.Run("time_timestamp", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeTimestamp},
+		}
+		var tv int64 = 1700000000000
+		b := buildTimestampBytes(tv)
+		data := buildCQLListWithNulls(b, nil)
+		var dst []time.Time
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 2 {
+			t.Fatalf("got len %d", len(dst))
+		}
+		expected := time.UnixMilli(tv).UTC()
+		if !dst[0].Equal(expected) {
+			t.Fatalf("expected %v, got %v", expected, dst[0])
+		}
+		if !dst[1].IsZero() {
+			t.Fatalf("expected zero time for null element, got %v", dst[1])
+		}
+	})
+
+	// Test []time.Time with TypeDate
+	t.Run("time_date", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeDate},
+		}
+		data := buildCQLList(buildDateBytes(19676))
+		var dst []time.Time
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 1 {
+			t.Fatalf("got len %d", len(dst))
+		}
+		expected := time.UnixMilli(int64(19676) * 86400000).UTC()
+		if !dst[0].Equal(expected) {
+			t.Fatalf("expected %v, got %v", expected, dst[0])
+		}
+	})
+
+	// Test []UUID with TypeUUID
+	t.Run("uuid", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeUUID},
+		}
+		u := MustRandomUUID()
+		data := buildCQLListWithNulls(u[:], nil, make([]byte, 16), []byte{})
+		var dst []UUID
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 4 {
+			t.Fatalf("got len %d", len(dst))
+		}
+		if dst[0] != u {
+			t.Fatalf("expected %v, got %v", u, dst[0])
+		}
+		if dst[1] != (UUID{}) {
+			t.Fatalf("expected zero UUID for null element, got %v", dst[1])
+		}
+		if dst[2] != (UUID{}) {
+			t.Fatalf("expected zero UUID for a present, all-zero 16-byte element, got %v", dst[2])
+		}
+		if dst[3] != (UUID{}) {
+			t.Fatalf("expected zero UUID for a true zero-length element, got %v", dst[3])
+		}
+	})
+
+	// Test []UUID with TypeTimeUUID
+	t.Run("timeuuid", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeTimeUUID},
+		}
+		u := MustRandomUUID()
+		data := buildCQLList(u[:])
+		var dst []UUID
+		if err := unmarshalList(info, data, &dst); err != nil {
+			t.Fatal(err)
+		}
+		if len(dst) != 1 || dst[0] != u {
+			t.Fatalf("got %v", dst)
+		}
+	})
+
+	// A malformed frame advertising a huge element count must be rejected by
+	// the size guard before the fast path allocates a slice of that size.
+	// Asserting the specific "invalid size" message ensures the guard path is
+	// exercised rather than the later per-element EOF check (which would only
+	// fire after a multi-GB allocation).
+	t.Run("rejects bogus huge count", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+		}
+		// count = 1<<30 but only a few payload bytes follow.
+		data := make([]byte, 0, 8)
+		count := make([]byte, 4)
+		binary.BigEndian.PutUint32(count, 1<<30)
+		data = append(data, count...)
+		data = append(data, 0, 0, 0, 1, 'x') // one tiny element, nowhere near 1<<30
+		var dst []string
+		err := unmarshalList(info, data, &dst)
+		if err == nil {
+			t.Fatalf("expected error for bogus huge count, got dst=%v (len %d)", dst, len(dst))
+		}
+		if !strings.Contains(err.Error(), "invalid size") {
+			t.Fatalf("expected size-guard error, got: %v", err)
+		}
+	})
+
+	// TypeAscii []string must skip the raw-string fast path so the generic path
+	// can validate ASCII payloads (bytes > 127 are invalid). Otherwise the fast
+	// path's string(elem) would silently accept invalid data, diverging from the
+	// generic path.
+	t.Run("ascii skips fast path and validates", func(t *testing.T) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeAscii},
+		}
+
+		var fast []string
+		if err := unmarshalListFast(info, buildCQLList([]byte("ok")), &fast); err != errFastPathNotApplicable {
+			t.Fatalf("expected ascii to skip the fast path, got err=%v", err)
+		}
+
+		var bad []string
+		if err := unmarshalList(info, buildCQLList([]byte{0x80}), &bad); err == nil {
+			t.Fatalf("expected error unmarshaling invalid ascii, got %v", bad)
+		}
+
+		var good []string
+		if err := unmarshalList(info, buildCQLList([]byte("hi"), []byte("")), &good); err != nil {
+			t.Fatalf("unexpected error for valid ascii: %v", err)
+		}
+		if len(good) != 2 || good[0] != "hi" || good[1] != "" {
+			t.Fatalf("got %v", good)
+		}
+	})
+}
+
+// TestUnmarshalListTime_NullSlotsCleared verifies []time.Time (timestamp)
+// decodes null slots to the zero time.
+func TestUnmarshalListTime_NullSlotsCleared(t *testing.T) {
+	wire := buildCQLListWithNulls(nil, buildTimestampBytes(1700000000000), nil)
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeTimestamp},
+	}
+
+	ghost := time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)
+	dst := make([]time.Time, 0, 4)
+	dst = append(dst, ghost, ghost, ghost, ghost)
+
+	if err := unmarshalList(info, wire, &dst); err != nil {
+		t.Fatal(err)
+	}
+	if len(dst) != 3 {
+		t.Fatalf("expected length 3, got %d", len(dst))
+	}
+	if !dst[0].IsZero() {
+		t.Errorf("expected dst[0]=zero time (null slot), got %v", dst[0])
+	}
+	if !dst[1].Equal(time.UnixMilli(1700000000000).UTC()) {
+		t.Errorf("expected dst[1]=1700000000000ms, got %v", dst[1])
+	}
+	if !dst[2].IsZero() {
+		t.Errorf("expected dst[2]=zero time (null slot), got %v", dst[2])
+	}
+}
+
+// Named slice types used by TestUnmarshalListFastPathMatchesReflect to force
+// the generic reflection path while preserving the element Go type.
+type (
+	namedStrings  []string
+	namedInt64s   []int64
+	namedInt32s   []int32
+	namedInts     []int
+	namedInt16s   []int16
+	namedBools    []bool
+	namedBlobs    [][]byte
+	namedFloat32s []float32
+	namedFloat64s []float64
+	namedTimes    []time.Time
+	namedUUIDs    []UUID
+)
+
+// TestUnmarshalListFastPathMatchesReflect is a differential test: for every
+// supported concrete slice type it decodes the SAME wire bytes through both
+// the fast path (concrete *[]T destination) and the generic reflect path (a
+// pointer to a named slice type with the same element type, which bypasses
+// the concrete type switch) and asserts the results are identical.
+// This is the strongest guarantee that the fast path introduces no behavioral
+// regression, especially for nulls, empty lists and edge values.
+func TestUnmarshalListFastPathMatchesReflect(t *testing.T) {
+	t.Parallel()
+
+	mk := func(typ Type) CollectionType {
+		return CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: typ},
+		}
+	}
+
+	// For each case, dst returns a pointer to a concrete slice (fast path) and
+	// named returns a pointer to a NAMED slice type with the SAME element type
+	// (which bypasses the concrete type switch and forces the reflect path,
+	// while preserving the element Go type so the comparison is apples-to-apples).
+	cases := []struct {
+		name  string
+		info  CollectionType
+		data  []byte
+		dst   func() any
+		named func() any
+	}{
+		{
+			name:  "string with null and empty element",
+			info:  mk(TypeVarchar),
+			data:  buildCQLListWithNulls([]byte("a"), nil, []byte("")),
+			dst:   func() any { return new([]string) },
+			named: func() any { return new(namedStrings) },
+		},
+		{
+			name:  "string empty list",
+			info:  mk(TypeVarchar),
+			data:  buildCQLList(),
+			dst:   func() any { return new([]string) },
+			named: func() any { return new(namedStrings) },
+		},
+		{
+			name:  "int64 with null element",
+			info:  mk(TypeBigInt),
+			data:  buildCQLListWithNulls([]byte{0, 0, 0, 0, 0, 0, 0, 9}, nil),
+			dst:   func() any { return new([]int64) },
+			named: func() any { return new(namedInt64s) },
+		},
+		{
+			name:  "int32 with null element",
+			info:  mk(TypeInt),
+			data:  buildCQLListWithNulls([]byte{0, 0, 0, 5}, nil),
+			dst:   func() any { return new([]int32) },
+			named: func() any { return new(namedInt32s) },
+		},
+		{
+			// unmarshalListInt is the only list decoder reached via the
+			// explicit pre-dispatch in unmarshalList for a plain *[]int
+			// destination, and it special-cases n==0 (see Fix #7); this case
+			// guards that its behavior stays identical to the reflect path.
+			name:  "int with null element",
+			info:  mk(TypeInt),
+			data:  buildCQLListWithNulls([]byte{0, 0, 0, 5}, nil),
+			dst:   func() any { return new([]int) },
+			named: func() any { return new(namedInts) },
+		},
+		{
+			name:  "int empty list",
+			info:  mk(TypeInt),
+			data:  buildCQLList(),
+			dst:   func() any { return new([]int) },
+			named: func() any { return new(namedInts) },
+		},
+		{
+			name:  "int16 with null element",
+			info:  mk(TypeSmallInt),
+			data:  buildCQLListWithNulls([]byte{0, 5}, nil),
+			dst:   func() any { return new([]int16) },
+			named: func() any { return new(namedInt16s) },
+		},
+		{
+			name:  "bool with null element",
+			info:  mk(TypeBoolean),
+			data:  buildCQLListWithNulls([]byte{1}, nil),
+			dst:   func() any { return new([]bool) },
+			named: func() any { return new(namedBools) },
+		},
+		{
+			name:  "blob with null and empty element",
+			info:  mk(TypeBlob),
+			data:  buildCQLListWithNulls([]byte{0xDE, 0xAD}, nil, []byte{}),
+			dst:   func() any { return new([][]byte) },
+			named: func() any { return new(namedBlobs) },
+		},
+		{
+			name:  "float32",
+			info:  mk(TypeFloat),
+			data:  buildCQLList([]byte{0x40, 0x49, 0x0f, 0xdb}),
+			dst:   func() any { return new([]float32) },
+			named: func() any { return new(namedFloat32s) },
+		},
+		{
+			name:  "float64",
+			info:  mk(TypeDouble),
+			data:  buildCQLList([]byte{0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18}),
+			dst:   func() any { return new([]float64) },
+			named: func() any { return new(namedFloat64s) },
+		},
+		{
+			name:  "counter into int64",
+			info:  mk(TypeCounter),
+			data:  buildCQLList([]byte{0, 0, 0, 0, 0, 0, 0, 7}),
+			dst:   func() any { return new([]int64) },
+			named: func() any { return new(namedInt64s) },
+		},
+		{
+			name:  "timestamp with null element",
+			info:  mk(TypeTimestamp),
+			data:  buildCQLListWithNulls(buildTimestampBytes(1700000000000), nil),
+			dst:   func() any { return new([]time.Time) },
+			named: func() any { return new(namedTimes) },
+		},
+		{
+			name:  "timestamp empty list",
+			info:  mk(TypeTimestamp),
+			data:  buildCQLList(),
+			dst:   func() any { return new([]time.Time) },
+			named: func() any { return new(namedTimes) },
+		},
+		{
+			name:  "date with null element",
+			info:  mk(TypeDate),
+			data:  buildCQLListWithNulls(buildDateBytes(19676), nil),
+			dst:   func() any { return new([]time.Time) },
+			named: func() any { return new(namedTimes) },
+		},
+		{
+			name:  "uuid with null and empty elements",
+			info:  mk(TypeUUID),
+			data:  buildCQLListWithNulls([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, nil, make([]byte, 16)),
+			dst:   func() any { return new([]UUID) },
+			named: func() any { return new(namedUUIDs) },
+		},
+		{
+			name:  "timeuuid",
+			info:  mk(TypeTimeUUID),
+			data:  buildCQLListWithNulls([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}),
+			dst:   func() any { return new([]UUID) },
+			named: func() any { return new(namedUUIDs) },
+		},
+		{
+			name:  "uuid empty list",
+			info:  mk(TypeUUID),
+			data:  buildCQLList(),
+			dst:   func() any { return new([]UUID) },
+			named: func() any { return new(namedUUIDs) },
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Fast path: concrete typed destination.
+			fastPtr := tc.dst()
+			if err := unmarshalList(tc.info, tc.data, fastPtr); err != nil {
+				t.Fatalf("fast path error: %v", err)
+			}
+			fast := reflect.ValueOf(fastPtr).Elem()
+
+			// Generic path: a named slice type with the same element type
+			// bypasses the concrete fast-path switch and forces reflection.
+			genPtr := tc.named()
+			if err := unmarshalList(tc.info, tc.data, genPtr); err != nil {
+				t.Fatalf("reflect path error: %v", err)
+			}
+			gen := reflect.ValueOf(genPtr).Elem()
+
+			// Compare element-by-element (and length / nilness) since the static
+			// types differ (named vs unnamed) but the underlying data must match.
+			if fast.IsNil() != gen.IsNil() {
+				t.Fatalf("nilness mismatch: fast nil=%v reflect nil=%v", fast.IsNil(), gen.IsNil())
+			}
+			if fast.Len() != gen.Len() {
+				t.Fatalf("length mismatch: fast=%d reflect=%d", fast.Len(), gen.Len())
+			}
+			for i := 0; i < fast.Len(); i++ {
+				if !reflect.DeepEqual(fast.Index(i).Interface(), gen.Index(i).Interface()) {
+					t.Fatalf("element %d mismatch: fast=%#v reflect=%#v",
+						i, fast.Index(i).Interface(), gen.Index(i).Interface())
+				}
+			}
+		})
+	}
+}
+
+// TestUnmarshalListNamedTypeFallsBackToReflect verifies that named slice types
+// (e.g. type Strings []string) do NOT match the concrete fast-path type switch
+// and are handled correctly by the generic reflection path. A wrong type
+// assertion here would silently corrupt data.
+func TestUnmarshalListNamedTypeFallsBackToReflect(t *testing.T) {
+	t.Parallel()
+
+	type Strings []string
+	type Ints []int32
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	data := buildCQLList([]byte("x"), []byte("y"))
+
+	var named Strings
+	if err := unmarshalList(info, data, &named); err != nil {
+		t.Fatal(err)
+	}
+	if len(named) != 2 || named[0] != "x" || named[1] != "y" {
+		t.Fatalf("named []string fallback failed: %#v", named)
+	}
+
+	infoI := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+	dataI := buildCQLList([]byte{0, 0, 0, 11})
+	var namedI Ints
+	if err := unmarshalList(infoI, dataI, &namedI); err != nil {
+		t.Fatal(err)
+	}
+	if len(namedI) != 1 || namedI[0] != 11 {
+		t.Fatalf("named []int32 fallback failed: %#v", namedI)
+	}
+}
+
+// TestUnmarshalListFastPathWrongElementSize verifies the fast path rejects
+// elements whose length does not match the fixed-width element type, instead
+// of silently producing corrupt values.
+func TestUnmarshalListFastPathWrongElementSize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		typ  Type
+		data []byte
+		dst  any
+	}{
+		{"int64 wrong size", TypeBigInt, buildCQLList([]byte{0, 0, 0, 1}), new([]int64)},
+		{"int32 wrong size", TypeInt, buildCQLList([]byte{0, 0, 0, 0, 0}), new([]int32)},
+		{"int16 wrong size", TypeSmallInt, buildCQLList([]byte{0, 0, 0}), new([]int16)},
+		{"float32 wrong size", TypeFloat, buildCQLList([]byte{0, 0, 0, 0, 0}), new([]float32)},
+		{"float64 wrong size", TypeDouble, buildCQLList([]byte{0, 0}), new([]float64)},
+		{"bool wrong size", TypeBoolean, buildCQLList([]byte{1, 2}), new([]bool)},
+		{"timestamp wrong size", TypeTimestamp, buildCQLList([]byte{0, 0, 0, 0}), new([]time.Time)},
+		{"date wrong size", TypeDate, buildCQLList([]byte{0, 0, 0, 0, 0}), new([]time.Time)},
+		{"uuid wrong size (too short)", TypeUUID, buildCQLList(make([]byte, 15)), new([]UUID)},
+		{"uuid wrong size (too long)", TypeUUID, buildCQLList(make([]byte, 17)), new([]UUID)},
+		{"timeuuid wrong size (too short)", TypeTimeUUID, buildCQLList(make([]byte, 15)), new([]UUID)},
+		{"timeuuid wrong size (too long)", TypeTimeUUID, buildCQLList(make([]byte, 17)), new([]UUID)},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			info := CollectionType{
+				NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+				Elem:       NativeType{proto: protoVersion4, typ: tc.typ},
+			}
+			if err := unmarshalList(info, tc.data, tc.dst); err == nil {
+				t.Fatalf("expected error for %s, got none (dst=%#v)", tc.name,
+					reflect.ValueOf(tc.dst).Elem().Interface())
+			}
+		})
+	}
+}
+
+// TestUnmarshalListFastPathElemTypeMismatch verifies that a concrete slice
+// destination whose Go type does not match the CQL element type falls back to
+// the generic path (which performs the proper validation) rather than decoding
+// through an incorrect fast path.
+func TestUnmarshalListFastPathElemTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	// *[]string but element type is Int: fast path must decline (return
+	// errFastPathNotApplicable) and the generic path then reports a type error.
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeInt},
+	}
+	if err := unmarshalListFast(info, buildCQLList([]byte{0, 0, 0, 1}), new([]string)); err != errFastPathNotApplicable {
+		t.Fatalf("expected errFastPathNotApplicable, got %v", err)
+	}
+
+	// *[]int64 but element type is Int (4 bytes): must decline, not misdecode.
+	if err := unmarshalListFast(info, buildCQLList([]byte{0, 0, 0, 1}), new([]int64)); err != errFastPathNotApplicable {
+		t.Fatalf("expected errFastPathNotApplicable, got %v", err)
+	}
+}
+
+func BenchmarkUnmarshalList(b *testing.B) {
+	// Build a list of 100 strings
+	strElems := make([][]byte, 100)
+	for i := range strElems {
+		strElems[i] = []byte(fmt.Sprintf("element_%03d", i))
+	}
+	strData := buildCQLList(strElems...)
+
+	b.Run("string", func(b *testing.B) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+		}
+		b.Run("reflect", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var dst any
+				if err := unmarshalList(info, strData, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run("fast_path", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var dst []string
+				if err := unmarshalList(info, strData, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
+
+	timestampElems := make([][]byte, 100)
+	for i := range timestampElems {
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, uint64(i*1000000))
+		timestampElems[i] = b
+	}
+	timestampData := buildCQLList(timestampElems...)
+
+	b.Run("timestamp", func(b *testing.B) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeTimestamp},
+		}
+		b.Run("reflect", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var dst any
+				if err := unmarshalList(info, timestampData, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run("fast_path", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var dst []time.Time
+				if err := unmarshalList(info, timestampData, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
+
+	uuidElems := make([][]byte, 100)
+	for i := range uuidElems {
+		b := make([]byte, 16)
+		binary.BigEndian.PutUint64(b[0:8], uint64(i))
+		binary.BigEndian.PutUint64(b[8:16], uint64(i+1))
+		uuidElems[i] = b
+	}
+	uuidData := buildCQLList(uuidElems...)
+
+	b.Run("uuid", func(b *testing.B) {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeUUID},
+		}
+		b.Run("reflect", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var dst any
+				if err := unmarshalList(info, uuidData, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run("fast_path", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var dst []UUID
+				if err := unmarshalList(info, uuidData, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	})
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -87,10 +87,10 @@ var unmarshalTests = []struct {
 			return &l
 		}(),
 		// A count of 2 needs at least 2*4=8 remaining bytes (one 4-byte
-		// length prefix per element); only 6 remain, so this is now rejected
-		// up front by the size-vs-buffer guard, before attempting to read
-		// any element and hitting the old "unexpected eof".
-		unmarshalErrorf("unmarshal list: invalid size 2"),
+		// length prefix per element); only 6 remain, so this is rejected up
+		// front rather than hitting the old "unexpected eof". []int takes
+		// the unmarshalListInt fast path, hence its wording of the guard.
+		unmarshalErrorf("unmarshal list: count 2 exceeds available data"),
 	},
 }
 
@@ -697,22 +697,6 @@ func TestMarshalNil(t *testing.T) {
 			t.Errorf("unable to marshal nil %v: %v\n", typ, err)
 		} else if data != nil {
 			t.Errorf("expected to get nil byte for nil %v got % X", typ, data)
-		}
-	}
-
-	// Collection types also need nil coverage.
-	collectionTypes := []Type{TypeList, TypeSet, TypeMap}
-	for _, typ := range collectionTypes {
-		info := CollectionType{
-			NativeType: NativeType{proto: protoVersion3, typ: typ},
-			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
-			Elem:       NativeType{proto: protoVersion3, typ: TypeVarchar},
-		}
-		data, err := Marshal(info, nil)
-		if err != nil {
-			t.Errorf("unable to marshal nil %v: %v\n", typ, err)
-		} else if data != nil {
-			t.Errorf("expected nil bytes for nil %v, got % X", typ, data)
 		}
 	}
 }
@@ -1403,6 +1387,54 @@ func TestUnmarshalMapReflect_OversizedCount_RejectedBeforeAlloc(t *testing.T) {
 	}
 	if dst != nil {
 		t.Fatalf("expected dst to remain nil, got %#v", dst)
+	}
+}
+
+// TestVectorNewWithErrorConsistentWithGoType verifies that the fast-path type mapping
+// in VectorType.NewWithError() stays consistent with the canonical goType() mapping.
+func TestVectorNewWithErrorConsistentWithGoType(t *testing.T) {
+	subTypes := []Type{
+		TypeInt,
+		TypeBigInt, TypeCounter,
+		TypeText, TypeVarchar, TypeAscii,
+		TypeBoolean,
+		TypeFloat, TypeDouble,
+		TypeUUID, TypeTimeUUID,
+		TypeTimestamp, TypeDate,
+		TypeSmallInt, TypeTinyInt,
+		TypeBlob,
+		TypeTime,
+	}
+
+	for _, subTyp := range subTypes {
+		vt := VectorType{
+			NativeType: NewCustomType(protoVersion4, TypeCustom, apacheCassandraTypePrefix+"VectorType"),
+			SubType:    NativeType{typ: subTyp, proto: protoVersion4},
+			Dimensions: 3,
+		}
+
+		fastVal, err := vt.NewWithError()
+		if err != nil {
+			t.Errorf("NewWithError(vector<%s>): unexpected error: %v", subTyp, err)
+			continue
+		}
+
+		canonicalType, err := goType(vt)
+		if err != nil {
+			t.Errorf("goType(vector<%s>): unexpected error: %v", subTyp, err)
+			continue
+		}
+
+		fastType := reflect.TypeOf(fastVal)
+		if fastType.Kind() != reflect.Ptr {
+			t.Errorf("NewWithError(vector<%s>): expected pointer, got %s", subTyp, fastType.Kind())
+			continue
+		}
+
+		if fastType.Elem() != canonicalType {
+			t.Errorf("NewWithError(vector<%s>) fast-path type %s does not match goType() canonical type %s",
+				subTyp, fastType.Elem(), canonicalType)
+		}
 	}
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -699,6 +699,22 @@ func TestMarshalNil(t *testing.T) {
 			t.Errorf("expected to get nil byte for nil %v got % X", typ, data)
 		}
 	}
+
+	// Collection types also need nil coverage.
+	collectionTypes := []Type{TypeList, TypeSet, TypeMap}
+	for _, typ := range collectionTypes {
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion3, typ: typ},
+			Key:        NativeType{proto: protoVersion3, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion3, typ: TypeVarchar},
+		}
+		data, err := Marshal(info, nil)
+		if err != nil {
+			t.Errorf("unable to marshal nil %v: %v\n", typ, err)
+		} else if data != nil {
+			t.Errorf("expected nil bytes for nil %v, got % X", typ, data)
+		}
+	}
 }
 
 func TestUnmarshalInetCopyBytes(t *testing.T) {
@@ -778,7 +794,7 @@ func TestReadCollectionSize(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			size, _, err := readCollectionSize(test.info, test.data)
+			size, _, err := readCollectionSize(test.data)
 			if test.isError {
 				if err == nil {
 					t.Fatal("Expected error, but it was nil")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1405,3 +1405,454 @@ func TestUnmarshalMapReflect_OversizedCount_RejectedBeforeAlloc(t *testing.T) {
 		t.Fatalf("expected dst to remain nil, got %#v", dst)
 	}
 }
+
+// buildMapBytes builds the CQL binary wire format for a map with n entries.
+// keyFn and valFn produce the raw bytes for each key and value given the entry index.
+func buildMapBytes(n int, keyFn, valFn func(i int) []byte) []byte {
+	// 4 bytes for the entry count
+	size := 4
+	for i := 0; i < n; i++ {
+		size += 4 + len(keyFn(i)) + 4 + len(valFn(i))
+	}
+	buf := make([]byte, 0, size)
+	buf = append(buf, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	for i := 0; i < n; i++ {
+		k := keyFn(i)
+		buf = append(buf, byte(len(k)>>24), byte(len(k)>>16), byte(len(k)>>8), byte(len(k)))
+		buf = append(buf, k...)
+		v := valFn(i)
+		buf = append(buf, byte(len(v)>>24), byte(len(v)>>16), byte(len(v)>>8), byte(len(v)))
+		buf = append(buf, v...)
+	}
+	return buf
+}
+
+func int64Bytes(v int64) []byte {
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32),
+		byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+func TestUnmarshalMapFastPath(t *testing.T) {
+	t.Parallel()
+
+	infoSS := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	infoSI := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+	infoII := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+
+	t.Run("nil data sets nil map", func(t *testing.T) {
+		var m map[string]string
+		if err := unmarshalMap(infoSS, nil, &m); err != nil {
+			t.Fatal(err)
+		}
+		if m != nil {
+			t.Fatalf("expected nil map, got %v", m)
+		}
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		data := buildMapBytes(0, nil, nil)
+		var m map[string]string
+		if err := unmarshalMap(infoSS, data, &m); err != nil {
+			t.Fatal(err)
+		}
+		if len(m) != 0 {
+			t.Fatalf("expected empty map, got %v", m)
+		}
+	})
+
+	t.Run("map[string]string correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return []byte(fmt.Sprintf("k%d", i)) },
+			func(i int) []byte { return []byte(fmt.Sprintf("v%d", i)) },
+		)
+		var fast map[string]string
+		if err := unmarshalMap(infoSS, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("map[string]int64 correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return []byte(fmt.Sprintf("k%d", i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 10)) },
+		)
+		var fast map[string]int64
+		if err := unmarshalMap(infoSI, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[string]int64{"k0": 0, "k1": 10, "k2": 20}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("map[int64]int64 correctness", func(t *testing.T) {
+		data := buildMapBytes(3,
+			func(i int) []byte { return int64Bytes(int64(i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 100)) },
+		)
+		var fast map[int64]int64
+		if err := unmarshalMap(infoII, data, &fast); err != nil {
+			t.Fatal(err)
+		}
+		expected := map[int64]int64{0: 0, 1: 100, 2: 200}
+		if !reflect.DeepEqual(fast, expected) {
+			t.Fatalf("got %v, want %v", fast, expected)
+		}
+	})
+
+	t.Run("null value decoded as zero", func(t *testing.T) {
+		// Build a map with one entry where value is null (size = -1)
+		buf := []byte{
+			0, 0, 0, 1, // n=1
+			0, 0, 0, 3, 'k', 'e', 'y', // key = "key"
+			0xff, 0xff, 0xff, 0xff, // value size = -1 (null)
+		}
+		var m map[string]int64
+		if err := unmarshalMap(infoSI, buf, &m); err != nil {
+			t.Fatal(err)
+		}
+		if v, ok := m["key"]; !ok || v != 0 {
+			t.Fatalf("expected key→0, got key→%d (ok=%v)", v, ok)
+		}
+	})
+
+	t.Run("truncated data returns error", func(t *testing.T) {
+		buf := []byte{0, 0, 0, 1, 0, 0} // n=1 but truncated key
+		var m map[string]string
+		err := unmarshalMap(infoSS, buf, &m)
+		if err == nil {
+			t.Fatal("expected error on truncated data")
+		}
+	})
+
+	t.Run("fallthrough to reflect for mismatched types", func(t *testing.T) {
+		// *map[string]string with TypeBigInt elem should fall through to reflect
+		data := buildMapBytes(1,
+			func(i int) []byte { return []byte("key") },
+			func(i int) []byte { return int64Bytes(42) },
+		)
+		infoMismatch := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+		// The fast path must NOT claim this mismatched elem type (BigInt, not a
+		// string), so it has to report handled == false and let the generic
+		// reflect path take over. Asserting this protects the dispatch logic.
+		var m map[string]string
+		handled, err := unmarshalMapFast(infoMismatch, data, &m)
+		if err != nil {
+			t.Fatalf("unexpected fast-path error: %v", err)
+		}
+		if handled {
+			t.Fatal("expected mismatched elem type to skip the fast path")
+		}
+
+		_ = unmarshalMap(infoMismatch, data, &m) // keep the panic-smoke test
+	})
+
+	t.Run("ascii map keys/values are validated via generic path", func(t *testing.T) {
+		// A byte > 127 is invalid ASCII. With TypeAscii excluded from the
+		// raw-string fast path, this must be rejected by serialization/ascii
+		// instead of being silently accepted.
+		data := buildMapBytes(1,
+			func(i int) []byte { return []byte{0x80} }, // invalid ascii key
+			func(i int) []byte { return []byte("v") },
+		)
+		infoAscii := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeAscii},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeAscii},
+		}
+
+		// Fast path must not claim ascii-typed maps.
+		var fm map[string]string
+		if handled, _ := unmarshalMapFast(infoAscii, data, &fm); handled {
+			t.Fatal("expected ascii map to skip the raw-string fast path")
+		}
+
+		// Full Unmarshal (generic path) must reject the invalid byte.
+		var m map[string]string
+		if err := Unmarshal(infoAscii, data, &m); err == nil {
+			t.Fatal("expected error unmarshaling invalid ascii, got nil")
+		}
+	})
+}
+
+// TestUnmarshalMapFastPath_OversizedCount_RejectedBeforeAlloc verifies
+// readMapHeader rejects a bogus huge count before make(map[K]V, n) attempts
+// a huge allocation.
+func TestUnmarshalMapFastPath_OversizedCount_RejectedBeforeAlloc(t *testing.T) {
+	t.Parallel()
+
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	data := []byte{0x3F, 0xFF, 0xFF, 0xFF} // count ~1 billion, no data follows
+
+	var dst map[string]string
+	if err := unmarshalMap(info, data, &dst); err == nil {
+		t.Fatal("expected error for oversized map count, got nil")
+	}
+}
+
+// namedStrStrMap is a named map type. Because Go type switches match concrete
+// types exactly, unmarshalMapFast does NOT recognise it, so unmarshaling into
+// it exercises the generic reflect path. This lets us assert that the fast
+// path and the generic path agree byte-for-byte on identical wire data.
+type namedStrStrMap map[string]string
+type namedStrI64Map map[string]int64
+type namedI64I64Map map[int64]int64
+
+// TestUnmarshalMapFastVsReflect is a differential test: for the same wire
+// bytes it unmarshals via the fast path (concrete map type) and via the
+// generic reflect path (named map type) and requires identical results.
+func TestUnmarshalMapFastVsReflect(t *testing.T) {
+	t.Parallel()
+
+	infoSS := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	infoSI := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+	infoII := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+	}
+
+	// nullVal returns a -1 (null) length prefix.
+	nullPrefix := []byte{0xff, 0xff, 0xff, 0xff}
+	withLen := func(b []byte) []byte {
+		out := []byte{byte(len(b) >> 24), byte(len(b) >> 16), byte(len(b) >> 8), byte(len(b))}
+		return append(out, b...)
+	}
+	count := func(n int) []byte {
+		return []byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)}
+	}
+
+	t.Run("string/string with null key and null value", func(t *testing.T) {
+		// entry0: key "" (len 0), value null
+		// entry1: key null, value "v"
+		var data []byte
+		data = append(data, count(2)...)
+		data = append(data, withLen([]byte{})...) // key ""
+		data = append(data, nullPrefix...)        // value null
+		data = append(data, nullPrefix...)        // key null
+		data = append(data, withLen([]byte("v"))...)
+
+		var fast map[string]string
+		if err := unmarshalMap(infoSS, data, &fast); err != nil {
+			t.Fatalf("fast path: %v", err)
+		}
+		var slow namedStrStrMap
+		if err := unmarshalMap(infoSS, data, &slow); err != nil {
+			t.Fatalf("reflect path: %v", err)
+		}
+		if !reflect.DeepEqual(map[string]string(fast), map[string]string(slow)) {
+			t.Fatalf("fast=%v reflect=%v differ", fast, slow)
+		}
+	})
+
+	t.Run("string/int64 with null value vs reflect", func(t *testing.T) {
+		var data []byte
+		data = append(data, count(2)...)
+		data = append(data, withLen([]byte("a"))...)
+		data = append(data, nullPrefix...) // null int64 value
+		data = append(data, withLen([]byte("b"))...)
+		data = append(data, withLen(int64Bytes(7))...)
+
+		var fast map[string]int64
+		if err := unmarshalMap(infoSI, data, &fast); err != nil {
+			t.Fatalf("fast: %v", err)
+		}
+		var slow namedStrI64Map
+		if err := unmarshalMap(infoSI, data, &slow); err != nil {
+			t.Fatalf("reflect: %v", err)
+		}
+		if !reflect.DeepEqual(map[string]int64(fast), map[string]int64(slow)) {
+			t.Fatalf("fast=%v reflect=%v differ", fast, slow)
+		}
+	})
+
+	t.Run("int64/int64 duplicate keys keep last vs reflect", func(t *testing.T) {
+		// Duplicate key 5 appears twice; map semantics keep the last write.
+		var data []byte
+		data = append(data, count(2)...)
+		data = append(data, withLen(int64Bytes(5))...)
+		data = append(data, withLen(int64Bytes(1))...)
+		data = append(data, withLen(int64Bytes(5))...)
+		data = append(data, withLen(int64Bytes(2))...)
+
+		var fast map[int64]int64
+		if err := unmarshalMap(infoII, data, &fast); err != nil {
+			t.Fatalf("fast: %v", err)
+		}
+		var slow namedI64I64Map
+		if err := unmarshalMap(infoII, data, &slow); err != nil {
+			t.Fatalf("reflect: %v", err)
+		}
+		if !reflect.DeepEqual(map[int64]int64(fast), map[int64]int64(slow)) {
+			t.Fatalf("fast=%v reflect=%v differ", fast, slow)
+		}
+		if fast[5] != 2 {
+			t.Fatalf("expected last-write-wins key 5 -> 2, got %d", fast[5])
+		}
+	})
+
+	t.Run("nil data agrees", func(t *testing.T) {
+		var fast map[string]string
+		var slow namedStrStrMap
+		if err := unmarshalMap(infoSS, nil, &fast); err != nil {
+			t.Fatal(err)
+		}
+		if err := unmarshalMap(infoSS, nil, &slow); err != nil {
+			t.Fatal(err)
+		}
+		if (fast == nil) != (slow == nil) {
+			t.Fatalf("nil disagreement: fast nil=%v reflect nil=%v", fast == nil, slow == nil)
+		}
+	})
+
+	t.Run("wrong fixed-width value length errors like reflect", func(t *testing.T) {
+		// int64 value with 4 bytes (invalid: must be 0 or 8).
+		var data []byte
+		data = append(data, count(1)...)
+		data = append(data, withLen([]byte("k"))...)
+		data = append(data, withLen([]byte{0, 0, 0, 1})...) // 4-byte int64 -> invalid
+
+		var fast map[string]int64
+		errFast := unmarshalMap(infoSI, data, &fast)
+		var slow namedStrI64Map
+		errSlow := unmarshalMap(infoSI, data, &slow)
+		if (errFast == nil) != (errSlow == nil) {
+			t.Fatalf("error disagreement: fast=%v reflect=%v", errFast, errSlow)
+		}
+	})
+}
+
+func BenchmarkUnmarshalMapStringString(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return []byte(fmt.Sprintf("key-%04d", i)) },
+			func(i int) []byte { return []byte(fmt.Sprintf("value-%04d", i)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[string]string
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalMapStringInt64(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return []byte(fmt.Sprintf("key-%04d", i)) },
+			func(i int) []byte { return int64Bytes(int64(i)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[string]int64
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalMapInt64Int64(b *testing.B) {
+	for _, n := range []int{10, 100} {
+		data := buildMapBytes(n,
+			func(i int) []byte { return int64Bytes(int64(i)) },
+			func(i int) []byte { return int64Bytes(int64(i * 100)) },
+		)
+		info := CollectionType{
+			NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+			Key:        NativeType{proto: protoVersion4, typ: TypeBigInt},
+			Elem:       NativeType{proto: protoVersion4, typ: TypeBigInt},
+		}
+
+		b.Run(fmt.Sprintf("fast/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest map[int64]int64
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("reflect/elems=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var dest any
+				if err := unmarshalMap(info, data, &dest); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/marshal_vector_test.go
+++ b/marshal_vector_test.go
@@ -55,50 +55,6 @@ func makeFloat32VectorType(dim int) VectorType {
 	}
 }
 
-func TestMarshalVectorFloat64_RoundTrip(t *testing.T) {
-	dim := 5
-	info := makeDoubleVectorType(dim)
-	vec := []float64{1.1, 2.2, 3.3, 4.4, 5.5}
-
-	data, err := marshalVector(info, vec)
-	if err != nil {
-		t.Fatalf("marshalVector: %v", err)
-	}
-	if len(data) != dim*8 {
-		t.Fatalf("expected %d bytes, got %d", dim*8, len(data))
-	}
-
-	var result []float64
-	if err := unmarshalVector(info, data, &result); err != nil {
-		t.Fatalf("unmarshalVector: %v", err)
-	}
-	if !reflect.DeepEqual(vec, result) {
-		t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
-	}
-}
-
-func TestMarshalVectorFloat32_RoundTrip(t *testing.T) {
-	dim := 5
-	info := makeFloat32VectorType(dim)
-	vec := []float32{1.1, 2.2, 3.3, 4.4, 5.5}
-
-	data, err := marshalVector(info, vec)
-	if err != nil {
-		t.Fatalf("marshalVector: %v", err)
-	}
-	if len(data) != dim*4 {
-		t.Fatalf("expected %d bytes, got %d", dim*4, len(data))
-	}
-
-	var result []float32
-	if err := unmarshalVector(info, data, &result); err != nil {
-		t.Fatalf("unmarshalVector: %v", err)
-	}
-	if !reflect.DeepEqual(vec, result) {
-		t.Errorf("round-trip mismatch: got %v, want %v", result, vec)
-	}
-}
-
 // TestVectorFloat_ByteCompatibility verifies that the fast path produces
 // identical bytes to what the generic reflect-based path would produce.
 func TestVectorFloat_ByteCompatibility(t *testing.T) {
@@ -135,99 +91,6 @@ func TestVectorFloat_ByteCompatibility(t *testing.T) {
 		}
 		if !reflect.DeepEqual(data, expected) {
 			t.Errorf("byte mismatch:\n  got:  %x\n  want: %x", data, expected)
-		}
-	})
-}
-
-func TestVectorFloat_SliceReuse(t *testing.T) {
-	t.Run("float64", func(t *testing.T) {
-		dim := 4
-		info := makeDoubleVectorType(dim)
-		data := make([]byte, dim*8)
-		for i := 0; i < dim; i++ {
-			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)))
-		}
-
-		// First unmarshal allocates.
-		var result []float64
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector (first): %v", err)
-		}
-		if len(result) != dim {
-			t.Fatalf("expected len %d, got %d", dim, len(result))
-		}
-
-		// Save the underlying array pointer.
-		ptr := &result[0]
-
-		// Second unmarshal should reuse the same backing array.
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector (second): %v", err)
-		}
-		if &result[0] != ptr {
-			t.Error("expected slice reuse, but a new backing array was allocated")
-		}
-	})
-	t.Run("float32", func(t *testing.T) {
-		dim := 4
-		info := makeFloat32VectorType(dim)
-		data := make([]byte, dim*4)
-		for i := 0; i < dim; i++ {
-			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i)))
-		}
-
-		var result []float32
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector (first): %v", err)
-		}
-		ptr := &result[0]
-
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector (second): %v", err)
-		}
-		if &result[0] != ptr {
-			t.Error("expected slice reuse, but a new backing array was allocated")
-		}
-	})
-	t.Run("float64_excess_cap", func(t *testing.T) {
-		dim := 4
-		info := makeDoubleVectorType(dim)
-		data := make([]byte, dim*8)
-		for i := 0; i < dim; i++ {
-			binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)+0.5))
-		}
-
-		// Pre-allocate with excess capacity.
-		result := make([]float64, 0, dim+10)
-		ptr := &result[:1][0] // get pointer to backing array
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if len(result) != dim {
-			t.Fatalf("expected len %d, got %d", dim, len(result))
-		}
-		if &result[0] != ptr {
-			t.Error("expected reuse of pre-allocated backing array with excess capacity")
-		}
-	})
-	t.Run("float32_excess_cap", func(t *testing.T) {
-		dim := 4
-		info := makeFloat32VectorType(dim)
-		data := make([]byte, dim*4)
-		for i := 0; i < dim; i++ {
-			binary.BigEndian.PutUint32(data[i*4:], math.Float32bits(float32(i)+0.5))
-		}
-
-		result := make([]float32, 0, dim+10)
-		ptr := &result[:1][0]
-		if err := unmarshalVector(info, data, &result); err != nil {
-			t.Fatalf("unmarshalVector: %v", err)
-		}
-		if len(result) != dim {
-			t.Fatalf("expected len %d, got %d", dim, len(result))
-		}
-		if &result[0] != ptr {
-			t.Error("expected reuse of pre-allocated backing array with excess capacity")
 		}
 	})
 }
@@ -391,11 +254,10 @@ func TestVectorFloat_EmptyVector(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshalVector: %v", err)
 		}
-		// A 0-dimension vector must marshal to CQL null (nil), matching the
-		// generic reflect path; the float fast path must not produce a non-nil
-		// zero-length slice here.
-		if data != nil {
-			t.Errorf("expected nil data for 0-dim vector, got %d bytes (% x)", len(data), data)
+		// A 0-dimension vector marshals to zero bytes (nil or empty are both
+		// acceptable — see TestVectorFastPath_ZeroDimFloat32/64).
+		if len(data) != 0 {
+			t.Errorf("expected 0 bytes for 0-dim vector, got %d bytes (% x)", len(data), data)
 		}
 
 		var result []float64
@@ -413,8 +275,8 @@ func TestVectorFloat_EmptyVector(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshalVector: %v", err)
 		}
-		if data != nil {
-			t.Errorf("expected nil data for 0-dim vector, got %d bytes (% x)", len(data), data)
+		if len(data) != 0 {
+			t.Errorf("expected 0 bytes for 0-dim vector, got %d bytes (% x)", len(data), data)
 		}
 
 		var result []float32

--- a/session.go
+++ b/session.go
@@ -2916,6 +2916,10 @@ type Scanner interface {
 	// when unmarshalling a column into the value in dest an error is returned and the row is invalidated
 	// until the next call to Next.
 	// Next must be called before calling Scan, if it is not an error is returned.
+	//
+	// As with Iter.Scan, a *[]byte destination reuses its existing backing
+	// array where it is large enough, so those bytes are only valid until the
+	// next Scan into the same destination.
 	Scan(...any) error
 
 	// Err returns the if there was one during iteration that resulted in iteration being unable to complete.
@@ -3055,6 +3059,12 @@ func (iter *Iter) readColumn() ([]byte, error) {
 // Scan returns true if the row was successfully unmarshaled or false if the
 // end of the result set was reached or if an error occurred. Close should
 // be called afterwards to retrieve any potential errors.
+//
+// Byte slices are the exception to "copies": a *[]byte destination — and a
+// []byte field of a UDT — reuses its existing backing array when that array
+// is large enough, so those bytes are only valid until the next Scan into the
+// same destination. Copy them to keep them, as with database/sql's RawBytes.
+// Every other destination, collections included, gets fresh storage per row.
 func (iter *Iter) Scan(dest ...any) bool {
 	if iter.err != nil {
 		iter.finalize(true)

--- a/vector_fastpath_test.go
+++ b/vector_fastpath_test.go
@@ -1,0 +1,813 @@
+// Copyright (c) 2012 The gocql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build all || unit
+// +build all unit
+
+package gocql
+
+import (
+	"encoding/binary"
+	"math"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// --- Helper constructors for vector type info ---
+
+func makeVectorType(subType Type, dim int) VectorType {
+	return VectorType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeCustom},
+		SubType:    NativeType{proto: protoVersion4, typ: subType},
+		Dimensions: dim,
+	}
+}
+
+// --- marshalVectorFloat32 / unmarshalVectorFloat32 ---
+
+func TestMarshalVectorFloat32_RoundTrip(t *testing.T) {
+	dims := []int{1, 3, 128, 768, 1536}
+	for _, dim := range dims {
+		info := makeVectorType(TypeFloat, dim)
+		vec := make([]float32, dim)
+		for i := range vec {
+			vec[i] = float32(i) * 0.1
+		}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("dim=%d: marshal error: %v", dim, err)
+		}
+		if len(data) != dim*4 {
+			t.Fatalf("dim=%d: expected %d bytes, got %d", dim, dim*4, len(data))
+		}
+
+		var result []float32
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("dim=%d: unmarshal error: %v", dim, err)
+		}
+		if len(result) != dim {
+			t.Fatalf("dim=%d: expected %d elements, got %d", dim, dim, len(result))
+		}
+		for i := range vec {
+			if result[i] != vec[i] {
+				t.Fatalf("dim=%d: result[%d] = %v, want %v", dim, i, result[i], vec[i])
+			}
+		}
+	}
+}
+
+func TestMarshalVectorFloat32_SpecialValues(t *testing.T) {
+	info := makeVectorType(TypeFloat, 4)
+	vec := []float32{0, math.Float32frombits(0x80000000), float32(math.Inf(1)), float32(math.NaN())}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var result []float32
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	// Check +0, -0
+	if math.Float32bits(result[0]) != 0 {
+		t.Errorf("result[0] = %v (bits=%08x), want +0", result[0], math.Float32bits(result[0]))
+	}
+	if math.Float32bits(result[1]) != 0x80000000 {
+		t.Errorf("result[1] = %v (bits=%08x), want -0", result[1], math.Float32bits(result[1]))
+	}
+	// +Inf
+	if !math.IsInf(float64(result[2]), 1) {
+		t.Errorf("result[2] = %v, want +Inf", result[2])
+	}
+	// NaN
+	if !math.IsNaN(float64(result[3])) {
+		t.Errorf("result[3] = %v, want NaN", result[3])
+	}
+}
+
+func TestMarshalVectorFloat32_DimensionMismatch(t *testing.T) {
+	info := makeVectorType(TypeFloat, 3)
+	vec := []float32{1, 2} // only 2 elements for 3 dimensions
+	_, err := marshalVector(info, vec)
+	if err == nil {
+		t.Fatal("expected error for dimension mismatch")
+	}
+}
+
+func TestMarshalVectorFloat32_Nil(t *testing.T) {
+	info := makeVectorType(TypeFloat, 3)
+	data, err := marshalVector(info, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil data, got %v", data)
+	}
+}
+
+func TestMarshalVectorFloat32_NilSlice(t *testing.T) {
+	info := makeVectorType(TypeFloat, 3)
+	var vec []float32
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("expected nil data, got %v", data)
+	}
+}
+
+func TestUnmarshalVectorFloat32_NilData(t *testing.T) {
+	info := makeVectorType(TypeFloat, 3)
+	var result []float32
+	if err := unmarshalVector(info, nil, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result, got %v", result)
+	}
+}
+
+func TestUnmarshalVectorFloat32_PreSizedDestination(t *testing.T) {
+	info := makeVectorType(TypeFloat, 3)
+	data := make([]byte, 12)
+	binary.BigEndian.PutUint32(data[0:], math.Float32bits(1.0))
+	binary.BigEndian.PutUint32(data[4:], math.Float32bits(2.0))
+	binary.BigEndian.PutUint32(data[8:], math.Float32bits(3.0))
+
+	// Pre-allocate with excess capacity
+	result := make([]float32, 0, 10)
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(result) != 3 {
+		t.Fatalf("expected len 3, got %d", len(result))
+	}
+}
+
+func TestUnmarshalVectorFloat32_WrongDataSize(t *testing.T) {
+	info := makeVectorType(TypeFloat, 3)
+	data := make([]byte, 11) // not 12
+	var result []float32
+	if err := unmarshalVector(info, data, &result); err == nil {
+		t.Fatal("expected error for wrong data size")
+	}
+}
+
+// --- marshalVectorFloat64 / unmarshalVectorFloat64 ---
+
+func TestMarshalVectorFloat64_RoundTrip(t *testing.T) {
+	dims := []int{1, 3, 128, 768}
+	for _, dim := range dims {
+		info := makeVectorType(TypeDouble, dim)
+		vec := make([]float64, dim)
+		for i := range vec {
+			vec[i] = float64(i) * 0.01
+		}
+
+		data, err := marshalVector(info, vec)
+		if err != nil {
+			t.Fatalf("dim=%d: marshal error: %v", dim, err)
+		}
+		if len(data) != dim*8 {
+			t.Fatalf("dim=%d: expected %d bytes, got %d", dim, dim*8, len(data))
+		}
+
+		var result []float64
+		if err := unmarshalVector(info, data, &result); err != nil {
+			t.Fatalf("dim=%d: unmarshal error: %v", dim, err)
+		}
+		for i := range vec {
+			if result[i] != vec[i] {
+				t.Fatalf("dim=%d: result[%d] = %v, want %v", dim, i, result[i], vec[i])
+			}
+		}
+	}
+}
+
+func TestUnmarshalVectorFloat64_PreSizedDestination(t *testing.T) {
+	info := makeVectorType(TypeDouble, 2)
+	data := make([]byte, 16)
+	binary.BigEndian.PutUint64(data[0:], math.Float64bits(1.5))
+	binary.BigEndian.PutUint64(data[8:], math.Float64bits(2.5))
+
+	result := make([]float64, 0, 10)
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+}
+
+// --- marshalVectorInt32 / unmarshalVectorInt32 ---
+
+func TestMarshalVectorInt32_RoundTrip(t *testing.T) {
+	info := makeVectorType(TypeInt, 4)
+	vec := []int32{-2147483648, -1, 0, 2147483647}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 16 {
+		t.Fatalf("expected 16 bytes, got %d", len(data))
+	}
+
+	var result []int32
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	for i := range vec {
+		if result[i] != vec[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, result[i], vec[i])
+		}
+	}
+}
+
+func TestMarshalVectorInt32_WireFormat(t *testing.T) {
+	info := makeVectorType(TypeInt, 2)
+	vec := []int32{1, 256}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	// Verify big-endian encoding
+	if binary.BigEndian.Uint32(data[0:]) != 1 {
+		t.Fatalf("expected 1 at offset 0, got %d", binary.BigEndian.Uint32(data[0:]))
+	}
+	if binary.BigEndian.Uint32(data[4:]) != 256 {
+		t.Fatalf("expected 256 at offset 4, got %d", binary.BigEndian.Uint32(data[4:]))
+	}
+}
+
+// --- marshalVectorInt / unmarshalVectorInt ---
+//
+// TypeInt vectors have two valid Go destinations: []int32 (tested above) and
+// []int (VectorType.NewWithError's default destination for TypeInt, see
+// TestVectorTypeNewWithError_Int) — without this fast path, the driver's own
+// default scan destination for vector<int> would always fall back to reflect.
+
+func TestMarshalVectorInt_RoundTrip(t *testing.T) {
+	info := makeVectorType(TypeInt, 4)
+	vec := []int{math.MinInt32, -1, 0, math.MaxInt32}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 16 {
+		t.Fatalf("expected 16 bytes, got %d", len(data))
+	}
+
+	var result []int
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	for i := range vec {
+		if result[i] != vec[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, result[i], vec[i])
+		}
+	}
+}
+
+func TestMarshalVectorInt_WireFormat(t *testing.T) {
+	info := makeVectorType(TypeInt, 2)
+	vec := []int{1, 256}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if binary.BigEndian.Uint32(data[0:]) != 1 {
+		t.Fatalf("expected 1 at offset 0, got %d", binary.BigEndian.Uint32(data[0:]))
+	}
+	if binary.BigEndian.Uint32(data[4:]) != 256 {
+		t.Fatalf("expected 256 at offset 4, got %d", binary.BigEndian.Uint32(data[4:]))
+	}
+}
+
+func TestMarshalVectorInt_OutOfInt32Range(t *testing.T) {
+	// On a 32-bit platform an []int cannot hold a value outside int32 range,
+	// so the scenario cannot be constructed; the non-constant conversion also
+	// keeps this file compiling there (a constant would overflow at build).
+	if strconv.IntSize == 32 {
+		t.Skip("[]int cannot exceed int32 range on 32-bit platforms")
+	}
+	over := int64(math.MaxInt32) + 1
+	info := makeVectorType(TypeInt, 1)
+	vec := []int{int(over)}
+
+	if _, err := marshalVector(info, vec); err == nil {
+		t.Fatal("expected error for int value outside int32 range")
+	}
+}
+
+func TestUnmarshalVectorInt_PreSizedDestination(t *testing.T) {
+	info := makeVectorType(TypeInt, 3)
+	data := make([]byte, 12)
+	binary.BigEndian.PutUint32(data[0:], 1)
+	binary.BigEndian.PutUint32(data[4:], 2)
+	binary.BigEndian.PutUint32(data[8:], 3)
+
+	result := make([]int, 0, 10)
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if !reflect.DeepEqual(result, []int{1, 2, 3}) {
+		t.Fatalf("got %v, want [1 2 3]", result)
+	}
+}
+
+// TestVectorTypeNewWithError_Int_RoundTrip closes the loop that
+// TestVectorTypeNewWithError_Int only half-covers: not only does
+// NewWithError() hand back a *[]int for a TypeInt vector, that destination
+// must actually be usable by unmarshalVector's fast path rather than silently
+// falling through to reflection.
+func TestVectorTypeNewWithError_Int_RoundTrip(t *testing.T) {
+	info := makeVectorType(TypeInt, 2)
+	dst, err := info.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ptr, ok := dst.(*[]int)
+	if !ok {
+		t.Fatalf("expected *[]int, got %T", dst)
+	}
+
+	data, err := marshalVector(info, []int{7, 9})
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if err := unmarshalVector(info, data, ptr); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if !reflect.DeepEqual(*ptr, []int{7, 9}) {
+		t.Fatalf("got %v, want [7 9]", *ptr)
+	}
+}
+
+// --- marshalVectorInt64 / unmarshalVectorInt64 ---
+
+func TestMarshalVectorInt64_RoundTrip(t *testing.T) {
+	info := makeVectorType(TypeBigInt, 3)
+	vec := []int64{-9223372036854775808, 0, 9223372036854775807}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 24 {
+		t.Fatalf("expected 24 bytes, got %d", len(data))
+	}
+
+	var result []int64
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	for i := range vec {
+		if result[i] != vec[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, result[i], vec[i])
+		}
+	}
+}
+
+func TestMarshalVectorInt64_Timestamp(t *testing.T) {
+	// TypeTimestamp also maps to int64 on the wire (millis since epoch)
+	info := makeVectorType(TypeTimestamp, 2)
+	vec := []int64{1609459200000, 1640995200000} // 2021-01-01, 2022-01-01 in millis
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var result []int64
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	for i := range vec {
+		if result[i] != vec[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, result[i], vec[i])
+		}
+	}
+}
+
+// --- marshalVectorUUID / unmarshalVectorUUID ---
+
+func TestMarshalVectorUUID_RoundTrip(t *testing.T) {
+	info := makeVectorType(TypeUUID, 3)
+	vec := []UUID{
+		{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20},
+		{0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 0xf6, 0xf5, 0xf4, 0xf3, 0xf2, 0xf1, 0xf0},
+	}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 48 {
+		t.Fatalf("expected 48 bytes, got %d", len(data))
+	}
+
+	var result []UUID
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	for i := range vec {
+		if result[i] != vec[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, result[i], vec[i])
+		}
+	}
+}
+
+func TestMarshalVectorUUID_TimeUUID(t *testing.T) {
+	info := makeVectorType(TypeTimeUUID, 2)
+	vec := []UUID{
+		TimeUUID(),
+		TimeUUID(),
+	}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var result []UUID
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	for i := range vec {
+		if result[i] != vec[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, result[i], vec[i])
+		}
+	}
+}
+
+// --- Fast path vs slow path consistency ---
+
+func TestVectorFastPath_ConsistentWithReflectPath(t *testing.T) {
+	// Ensure fast path produces identical wire format to reflect path.
+	// We use []float32 (fast path) and compare to reflect-based marshal
+	// that would be used for a non-matching type.
+	info := makeVectorType(TypeFloat, 3)
+	vec := []float32{1.0, 2.0, 3.0}
+
+	// Fast path result
+	fastData, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("fast path marshal error: %v", err)
+	}
+
+	// Manually construct expected wire format
+	expected := make([]byte, 12)
+	binary.BigEndian.PutUint32(expected[0:], math.Float32bits(1.0))
+	binary.BigEndian.PutUint32(expected[4:], math.Float32bits(2.0))
+	binary.BigEndian.PutUint32(expected[8:], math.Float32bits(3.0))
+
+	if len(fastData) != len(expected) {
+		t.Fatalf("length mismatch: fast=%d, expected=%d", len(fastData), len(expected))
+	}
+	for i := range expected {
+		if fastData[i] != expected[i] {
+			t.Fatalf("byte[%d]: fast=%02x, expected=%02x", i, fastData[i], expected[i])
+		}
+	}
+}
+
+// --- VectorType.NewWithError() ---
+
+func TestVectorTypeNewWithError_Float32(t *testing.T) {
+	info := makeVectorType(TypeFloat, 3)
+	v, err := info.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := v.(*[]float32); !ok {
+		t.Fatalf("expected *[]float32, got %T", v)
+	}
+}
+
+func TestVectorTypeNewWithError_Float64(t *testing.T) {
+	info := makeVectorType(TypeDouble, 3)
+	v, err := info.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := v.(*[]float64); !ok {
+		t.Fatalf("expected *[]float64, got %T", v)
+	}
+}
+
+func TestVectorTypeNewWithError_Int(t *testing.T) {
+	info := makeVectorType(TypeInt, 3)
+	v, err := info.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := v.(*[]int); !ok {
+		t.Fatalf("expected *[]int, got %T", v)
+	}
+}
+
+func TestVectorTypeNewWithError_BigInt(t *testing.T) {
+	info := makeVectorType(TypeBigInt, 3)
+	v, err := info.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := v.(*[]int64); !ok {
+		t.Fatalf("expected *[]int64, got %T", v)
+	}
+}
+
+func TestVectorTypeNewWithError_UUID(t *testing.T) {
+	info := makeVectorType(TypeUUID, 3)
+	v, err := info.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := v.(*[]UUID); !ok {
+		t.Fatalf("expected *[]UUID, got %T", v)
+	}
+}
+
+func TestVectorTypeNewWithError_Text(t *testing.T) {
+	info := makeVectorType(TypeText, 3)
+	v, err := info.NewWithError()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := v.(*[]string); !ok {
+		t.Fatalf("expected *[]string, got %T", v)
+	}
+}
+
+// --- vectorByteSize overflow ---
+
+func TestVectorByteSize_Overflow(t *testing.T) {
+	// Should fail for very large dimensions
+	_, err := vectorByteSize(math.MaxInt32, 4)
+	if err == nil {
+		t.Fatal("expected overflow error")
+	}
+}
+
+func TestVectorByteSize_Normal(t *testing.T) {
+	size, err := vectorByteSize(1536, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if size != 6144 {
+		t.Fatalf("expected 6144, got %d", size)
+	}
+}
+
+func TestVectorByteSize_Zero(t *testing.T) {
+	size, err := vectorByteSize(0, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if size != 0 {
+		t.Fatalf("expected 0, got %d", size)
+	}
+}
+
+// --- Zero-dimension fast path ---
+
+func TestVectorFastPath_ZeroDimFloat32(t *testing.T) {
+	info := makeVectorType(TypeFloat, 0)
+
+	// Marshal: empty float32 slice with 0 dimensions should work
+	vec := []float32{}
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected 0 bytes, got %d", len(data))
+	}
+
+	// Unmarshal: empty data into float32 slice
+	var result []float32
+	if err := unmarshalVector(info, []byte{}, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil empty slice")
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected len 0, got %d", len(result))
+	}
+}
+
+func TestVectorFastPath_ZeroDimFloat64(t *testing.T) {
+	info := makeVectorType(TypeDouble, 0)
+	var result []float64
+	if err := unmarshalVector(info, []byte{}, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil empty slice")
+	}
+}
+
+func TestVectorFastPath_ZeroDimUUID(t *testing.T) {
+	info := makeVectorType(TypeUUID, 0)
+	var result []UUID
+	if err := unmarshalVector(info, []byte{}, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil empty slice")
+	}
+}
+
+// --- Non-matching types fall through to reflect path ---
+
+func TestVectorFastPath_FallsThrough(t *testing.T) {
+	// Passing []int (not []int32) for TypeInt should fall through to
+	// reflect path and still work via Marshal/Unmarshal
+	info := makeVectorType(TypeFloat, 3)
+	type myFloat float32
+	vec := []myFloat{1.0, 2.0, 3.0}
+
+	// Should fall through to reflect path (no fast path for custom types)
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 12 {
+		t.Fatalf("expected 12 bytes, got %d", len(data))
+	}
+}
+
+// --- Benchmarks for all fast-path types ---
+
+func BenchmarkMarshalVectorFloat64(b *testing.B) {
+	dims := []int{128, 768, 1536}
+	for _, dim := range dims {
+		b.Run(dimStr(dim), func(b *testing.B) {
+			b.ReportAllocs()
+			info := makeVectorType(TypeDouble, dim)
+			vec := make([]float64, dim)
+			for i := range vec {
+				vec[i] = float64(i) * 0.01
+			}
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := marshalVector(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalVectorFloat64(b *testing.B) {
+	dims := []int{128, 768, 1536}
+	for _, dim := range dims {
+		b.Run(dimStr(dim), func(b *testing.B) {
+			b.ReportAllocs()
+			info := makeVectorType(TypeDouble, dim)
+			data := make([]byte, dim*8)
+			for i := 0; i < dim; i++ {
+				binary.BigEndian.PutUint64(data[i*8:], math.Float64bits(float64(i)*0.01))
+			}
+			var result []float64
+			b.SetBytes(int64(dim * 8))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := unmarshalVector(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalVectorInt32(b *testing.B) {
+	dims := []int{128, 768, 1536}
+	for _, dim := range dims {
+		b.Run(dimStr(dim), func(b *testing.B) {
+			b.ReportAllocs()
+			info := makeVectorType(TypeInt, dim)
+			vec := make([]int32, dim)
+			for i := range vec {
+				vec[i] = int32(i)
+			}
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := marshalVector(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalVectorInt32(b *testing.B) {
+	dims := []int{128, 768, 1536}
+	for _, dim := range dims {
+		b.Run(dimStr(dim), func(b *testing.B) {
+			b.ReportAllocs()
+			info := makeVectorType(TypeInt, dim)
+			data := make([]byte, dim*4)
+			for i := 0; i < dim; i++ {
+				binary.BigEndian.PutUint32(data[i*4:], uint32(i))
+			}
+			var result []int32
+			b.SetBytes(int64(dim * 4))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := unmarshalVector(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalVectorUUID(b *testing.B) {
+	dims := []int{128, 768}
+	for _, dim := range dims {
+		b.Run(dimStr(dim), func(b *testing.B) {
+			b.ReportAllocs()
+			info := makeVectorType(TypeUUID, dim)
+			vec := make([]UUID, dim)
+			for i := range vec {
+				vec[i] = TimeUUID()
+			}
+			b.SetBytes(int64(dim * 16))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := marshalVector(info, vec); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkUnmarshalVectorUUID(b *testing.B) {
+	dims := []int{128, 768}
+	for _, dim := range dims {
+		b.Run(dimStr(dim), func(b *testing.B) {
+			b.ReportAllocs()
+			info := makeVectorType(TypeUUID, dim)
+			data := make([]byte, dim*16)
+			for i := 0; i < dim; i++ {
+				u := TimeUUID()
+				copy(data[i*16:], u[:])
+			}
+			var result []UUID
+			b.SetBytes(int64(dim * 16))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := unmarshalVector(info, data, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func dimStr(dim int) string {
+	switch dim {
+	case 128:
+		return "dim_128"
+	case 384:
+		return "dim_384"
+	case 768:
+		return "dim_768"
+	case 1536:
+		return "dim_1536"
+	default:
+		return "dim_other"
+	}
+}
+
+// TestUnmarshalVectorTrailingBytesRejected pins the fast paths' deliberate
+// strictness: a fixed-width vector payload with trailing bytes is rejected,
+// where the generic reflect path derives the element size as len(data)/dim
+// and silently ignores the excess. Trailing bytes mean a corrupt or misframed
+// value; see the convention note above unmarshalVectorFloat32.
+func TestUnmarshalVectorTrailingBytesRejected(t *testing.T) {
+	info := makeVectorType(TypeFloat, 2)
+	data := make([]byte, 9) // 2 float32s = 8 bytes, plus one trailing byte
+	binary.BigEndian.PutUint32(data[0:], math.Float32bits(1.0))
+	binary.BigEndian.PutUint32(data[4:], math.Float32bits(2.0))
+
+	var dst []float32
+	if err := unmarshalVector(info, data, &dst); err == nil {
+		t.Fatal("expected the fast path to reject 9 bytes for vector<float,2>")
+	}
+}

--- a/vector_fastpath_test.go
+++ b/vector_fastpath_test.go
@@ -1,9 +1,23 @@
-// Copyright (c) 2012 The gocql Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 //go:build all || unit
 // +build all unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package gocql
 
@@ -398,6 +412,104 @@ func TestMarshalVectorInt64_Timestamp(t *testing.T) {
 	}
 }
 
+func TestMarshalVectorCounter_RoundTrip(t *testing.T) {
+	info := makeVectorType(TypeCounter, 3)
+	vec := []int64{-9223372036854775808, 0, 9223372036854775807}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 27 {
+		t.Fatalf("expected 27 bytes, got %d", len(data))
+	}
+
+	var result []int64
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	for i := range vec {
+		if result[i] != vec[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, result[i], vec[i])
+		}
+	}
+}
+
+func TestMarshalVectorCounter_WireFormat(t *testing.T) {
+	info := makeVectorType(TypeCounter, 2)
+	vec := []int64{1, 256}
+
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	if len(data) != 18 {
+		t.Fatalf("expected 18 bytes, got %d", len(data))
+	}
+	if data[0] != 8 {
+		t.Fatalf("expected first length prefix 8, got %d", data[0])
+	}
+	if binary.BigEndian.Uint64(data[1:9]) != 1 {
+		t.Fatalf("expected first value 1, got %d", binary.BigEndian.Uint64(data[1:9]))
+	}
+	if data[9] != 8 {
+		t.Fatalf("expected second length prefix 8, got %d", data[9])
+	}
+	if binary.BigEndian.Uint64(data[10:18]) != 256 {
+		t.Fatalf("expected second value 256, got %d", binary.BigEndian.Uint64(data[10:18]))
+	}
+
+	var result []int64
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(result) != 2 || result[0] != 1 || result[1] != 256 {
+		t.Fatalf("unexpected round-trip result: %v", result)
+	}
+}
+
+func TestUnmarshalVectorCounter_WrongElementLength(t *testing.T) {
+	info := makeVectorType(TypeCounter, 1)
+	// Length prefix says 7 bytes instead of 8.
+	data := make([]byte, 8)
+	data[0] = 7
+	copy(data[1:], []byte{0, 0, 0, 0, 0, 0, 0})
+
+	var result []int64
+	if err := unmarshalVector(info, data, &result); err == nil {
+		t.Fatal("expected error for wrong counter element length")
+	}
+}
+
+func TestUnmarshalVectorCounter_NilData(t *testing.T) {
+	info := makeVectorType(TypeCounter, 3)
+	var result []int64
+	if err := unmarshalVector(info, nil, &result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result, got %v", result)
+	}
+}
+
+func TestUnmarshalVectorCounter_PreSizedDestination(t *testing.T) {
+	info := makeVectorType(TypeCounter, 2)
+	data := make([]byte, 18)
+	data[0] = 8
+	binary.BigEndian.PutUint64(data[1:9], 1)
+	data[9] = 8
+	binary.BigEndian.PutUint64(data[10:18], 2)
+
+	result := make([]int64, 0, 10)
+	if err := unmarshalVector(info, data, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(result) != 2 || result[0] != 1 || result[1] != 2 {
+		t.Fatalf("unexpected result: %v", result)
+	}
+}
+
 // --- marshalVectorUUID / unmarshalVectorUUID ---
 
 func TestMarshalVectorUUID_RoundTrip(t *testing.T) {
@@ -626,6 +738,30 @@ func TestVectorFastPath_ZeroDimUUID(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected non-nil empty slice")
+	}
+}
+
+func TestVectorFastPath_ZeroDimCounter(t *testing.T) {
+	info := makeVectorType(TypeCounter, 0)
+
+	vec := []int64{}
+	data, err := marshalVector(info, vec)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected 0 bytes, got %d", len(data))
+	}
+
+	var result []int64
+	if err := unmarshalVector(info, []byte{}, &result); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil empty slice")
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected len 0, got %d", len(result))
 	}
 }
 


### PR DESCRIPTION
## Overview

This is a **combined PR** that merges all three pending PRs that touch `marshal.go` with overlapping changes. None can be merged individually due to conflicting modifications to the same functions.

The three PRs being merged here:
- **#826** `perf: optimize collection marshal/unmarshal write path` — changes `marshalList`, `marshalMap`, `unmarshalList`, `unmarshalMap` signatures from `TypeInfo` to `CollectionType`, simplifies `writeCollectionSize`/`readCollectionSize`, adds 8 concrete map-type fast paths in `unmarshalMapFast`
- **#839** `perf: generalize buffer pool for collection/vector marshal` — adds `marshalBufPool`/`marshalOutputPool` (`sync.Pool`), vector marshal/unmarshal fast paths, fixed-size list marshal fast paths, inline list unmarshal fast path for fixed-size types
- **#881** `perf: add fast paths for unmarshalList with common concrete slice types` — adds the `unmarshalListFast` dispatcher with `errFastPathNotApplicable`, full leaf-function set (`unmarshalListString`, `unmarshalListInt64`, `unmarshalListInt32`, `unmarshalListFloat64`, `unmarshalListFloat32`, `unmarshalListBool`, `unmarshalListBlob`, `unmarshalListInt16`, `unmarshalListTime`, `unmarshalListUUID`), zero-alloc string elements via `unsafe.String`

## Why a combined PR?

Each of #826, #839, #881 rewrites overlapping functions in `marshal.go`:

| Function | #826 | #839 | #881 |
|----------|------|------|------|
| `marshalList` body | changes sig | adds buffer pool + fast paths | – |
| `marshalMap` body | changes sig | adds buffer pool + fast paths | – |
| `unmarshalList` body | changes sig | inline fast path for fixed types | dispatcher + leaf functions |
| `unmarshalListFloat32` | – | `(data, dst)` signature | `(info, data, dst)` signature |
| `unmarshalListInt32` | – | `(data, dst)` signature | `(info, data, dst)` signature |
| `unmarshalListInt64` | – | `(data, dst)` signature | `(info, data, dst)` signature |
| `unmarshalListFloat64` | – | `(data, dst)` signature | `(info, data, dst)` signature |
| `readCollectionSize` | drops `info` param | unchanged | uses old sig in helpers |

Merging each in isolation produces a non-compiling tree; this PR resolves all conflicts.

## Resolve strategy used

1. **Signatures** — apply #826 first; both #839 and #881 were rewritten to match
2. **`unmarshalLeaf` leaf functions** — keep #881's `(info CollectionType, data, dst)` versions (richer: caller passes `info` for type-aware logic in `unmarshalListTime`); discard #839's incompatible `(data, dst)` versions for `float32/float64/int32/int64` (since `unmarshalListFast` from #881 calls the new signatures)
3. **`unmarshalListInt`** — keep #839's unique `[]int` (no #881 equivalent for the platform-dependent alias case)
4. **`unmarshalList` dispatcher** — call `unmarshalListFast(info, data, value)` from #881 first, falling through to reflect; before that, dispatch #839's inline `[]int` branch
5. **`readListHeader`/`readListElement`** — drop `info` parameter to match #826's `readCollectionSize(data)` (no info param)
6. **Slice reuse** — preserve #839's capacity reuse optimization by adjusting the #881 leaf functions: `s := *dst; if cap(s) >= n { s = s[:n] } else { s = make([]T, n) }`
7. **`n == 0` empty-list case** — always emit `make([]T, 0)` so the destination is non-nil empty slice (matches existing serialization tests)
8. **Nil inputs to `marshalList`/`marshalMap`/`marshalVector`** — add `if value == nil { return nil, nil }` after the `unsetColumn` check, before `reflect.ValueOf` (avoids panic on zero `Value.Type()` in tests that marshal nil values)
9. **`isNullableValue` switch block** — kept (a non-conflicting overlapping change from #881 was redundant and unwound during merge)

## Verification (re-run after the rebase onto current `master`)

- `go build ./...`, `go vet -tags unit ./...`, `gofmt -l .`, `fieldalignment ./...` — all clean
- `go test -tags unit -count=1 ./...` — failure set is **identical to `origin/master`** in the same environment (the only failures are the pre-existing TLS-cert ones from a missing `keytool`); no new failures
- `go test -race -tags unit -count=1 .` — **no data races**, and the same failure set as `master` under `-race`
- Every one of the 10 commits builds and vets independently

Also fixed since the initial draft:
- CI `Build`/lint failure (goimports formatting in `marshal_edgecases_test.go`)
- `unmarshalVector`/`marshalVector` didn't recognize `[]int`/`*[]int` for `TypeInt` vectors, even though `VectorType.NewWithError()` hands out `*[]int` as the default scan destination for `vector<int>` — meaning the driver's own default destination for that type always silently fell back to slow reflection. Added `marshalVectorInt`/`unmarshalVectorInt` fast paths (mirroring the existing `[]int32` pair) plus test coverage, so `vector<int>` now gets the same fast path as every other vector element type.

## Benchmark results (measured against current `master`)

Measured with a self-contained benchmark using only the public `Marshal`/`Unmarshal` API, so the identical file compiles and runs on both trees; a cross-check test asserts both decode the same wire bytes to the same values. 8 interleaved rounds per tree, `-benchtime=300ms`, compared with `benchstat`. Go 1.26.5, linux/amd64, AMD Ryzen 7 8845HS (16 threads). All rows `p<=0.01, n=8`.

### Unmarshal

| Benchmark | master | branch | delta | allocs/op |
|---|---|---|---|---|
| list\<varchar\>, n=10 | 518.6n ± 5% | 215.9n ± 3% | **-58.37%** | 13 → 3 |
| list\<varchar\>, n=100 | 4300.0n ± 1% | 1281.0n ± 2% | **-70.22%** | 103 → 3 |
| list\<bigint\>, n=10 | 331.8n ± 2% | 121.3n ± 2% | **-63.44%** | 3 → 2 |
| list\<bigint\>, n=100 | 2469.5n ± 1% | 697.3n ± 2% | **-71.76%** | 3 → 2 |
| list\<timestamp\>, n=10 | 412.2n ± 5% | 195.6n ± 3% | **-52.55%** | 3 → 2 |
| list\<timestamp\>, n=100 | 3315.0n ± 3% | 1267.0n ± 4% | **-61.78%** | 3 → 2 |
| list\<uuid\>, n=10 | 358.1n ± 1% | 137.4n ± 1% | **-61.63%** | 3 → 2 |
| list\<uuid\>, n=100 | 2804.5n ± 20% | 765.9n ± 2% | **-72.69%** | 3 → 2 |
| map\<varchar,varchar\>, n=10 | 1580.5n ± 3% | 752.2n ± 3% | **-52.40%** | 45 → 25 |
| map\<varchar,varchar\>, n=100 | 13.857µ ± 1% | 5.881µ ± 2% | **-57.56%** | 405 → 205 |
| map\<varchar,bigint\>, n=10 | 1269.0n ± 1% | 632.6n ± 3% | **-50.15%** | 35 → 25 |
| map\<varchar,bigint\>, n=100 | 11.311µ ± 3% | 4.879µ ± 3% | **-56.87%** | 305 → 205 |
| map\<bigint,bigint\>, n=10 | 1069.0n ± 2% | 551.6n ± 2% | **-48.40%** | 25 → 25 |
| map\<bigint,bigint\>, n=100 | 9.164µ ± 2% | 4.324µ ± 2% | **-52.82%** | 205 → 205 |

### Marshal

| Benchmark | master | branch | delta | allocs/op |
|---|---|---|---|---|
| list\<int\> from `[]int32`, n=10 | 555.5n ± 1% | 141.8n ± 2% | **-74.47%** | 24 → 3 |
| list\<int\> from `[]int32`, n=100 | 4770.5n ± 4% | 387.1n ± 4% | **-91.88%** | 207 → 3 |
| list\<bigint\> from `[]int64`, n=10 | 585.4n ± 1% | 149.6n ± 2% | **-74.45%** | 24 → 3 |
| list\<bigint\> from `[]int64`, n=100 | 5686.5n ± 2% | 444.4n ± 3% | **-92.18%** | 208 → 3 |
| list\<varchar\> from `[]string`, n=10 | 845.4n ± 3% | 694.8n ± 1% | -17.82% | 25 → 23 |
| list\<varchar\> from `[]string`, n=100 | 7.217µ ± 2% | 6.085µ ± 2% | -15.69% | 208 → 203 |
| map\<varchar,varchar\>, n=10 | 1.829µ ± 5% | 1.343µ ± 2% | **-26.58%** | 46 → 42 |
| map\<varchar,varchar\>, n=100 | 16.51µ ± 3% | 12.15µ ± 2% | **-26.42%** | 409 → 402 |

**Geomean: -62.61% time, -63.69% allocs/op.**

Map marshal (-26% time, -50% B/op) comes from the `MapRange` change absorbed from #908; before that it was ~-16%. It has no type-specialized fast path in this PR — `marshalMap` still goes through reflect for every type — so that figure is the reflect path getting cheaper, not a fast path.

The weakest rows are string-element list marshal (-16..-18%). `marshalList` only specializes fixed-size elements here, so variable-length elements gain only from the buffer pool. #910, stacked on this branch, adds those fast paths and takes the same workloads a further ~83% (geomean) on top of this branch.

One caveat on the numbers: the `list<uuid>, n=100` master figure has ±20% run-to-run variance (two outliers in eight samples; seven cluster within 6.6%, and the median-based delta is the same). Every other row is within ±7%.

## Commits

10 commits, rebased onto current `master`. Every commit builds and passes `go vet -tags unit ./...` on its own.

## Changes made while rebasing onto current `master`

- **Dropped the tip commit** `fix: harden generic reflect-based list/map unmarshal against malformed size headers` — `master` already carries the same fix (`4bee517`) in a refined form. The dropped commit added nothing to `marshal.go` and only duplicated three test functions.
- **Fixed bisectability.** Two commits did not build on the original branch (`undefined: getMarshalOutput`, `undefined: listInfo`). The `marshalOutputPool` commit modifies the list fast paths that the preceding commit introduces, so it was squashed into it rather than reordered; the `listInfo`/`info` slip was a rename typo.
- **Removed the blanket `if value == nil { return nil, nil }` from `Marshal`.** This was a public behaviour change: binding an untyped `nil` to a UDT or custom column used to return an error and would have silently written NULL instead. (Typed nil pointers already returned NULL via the existing pointer branch, so only untyped `nil` was affected.) The per-function nil guards in `marshalList`/`marshalMap`/`marshalVector` are unchanged, and removing it costs nothing measurable. Revert if the change was intended — it should then be documented and tested rather than incidental.
- **Added `marshal_pool_release_test.go`.** Nothing exercised the buffer-pool release path; the one test that referenced it reimplemented the loop instead of calling it. The release loop is now `releasePooledValues`, shared by the query and batch paths, and clears the flag so a buffer cannot be returned twice. Verified by falsification: ignoring the flag, or deriving it from column `TypeInfo`, both fail the new tests.
- **Absorbed the reusable half of #908.** `marshalMap` used `rv.MapKeys()` (an intermediate `[]reflect.Value`) plus `rv.MapIndex()` (a second hash lookup per entry); it now uses `rv.MapRange()`. Nothing else subsumes this — the reflect map path stays reachable for named map types and any key/value pair outside the specialized set. Also extended the exact-size table to smallint/tinyint/boolean and capped the size hint against overflow. #908's other half, estimating a size for variable-length elements, is **not** taken: an overshooting estimate inflates the buffer past `marshalBufMaxCap`, so `putMarshalBuf` drops it instead of pooling it — measured at +27% time and +192% B/op on lists of short blobs versus no hint at all.
- **Squashed 13 commits to 8.** Test-only commits were folded into the code they cover, and the five incremental `unmarshalList` commits (8 types, then tests, then `[]time.Time`, then `[]UUID`, then zero-alloc strings) became one. The resulting tree is byte-identical to the 13-commit version.
- **Removed destination slice reuse in the collection fast paths.** They decoded into the backing array already held by `*dst` when capacity allowed, which aliases results the caller kept — the ordinary `for iter.Scan(&tags) { all = append(all, tags) }` loop left every element of `all` pointing at the last row, with no error. Only values hitting a fast path were affected, so it varied by the destination's concrete Go type. `Iter.Scan` documents that it copies into dest and gocql publishes no RawBytes-style "valid until the next Scan" contract. Fixed in all 18 sites (10 list leaves, 7 vector leaves, `unmarshalListInt`); costs ~32% of the list-unmarshal gain, and the fast paths remain ~60% faster than master. `marshal_alias_test.go` pins the copying behaviour for `[]string`, `[]UUID`, `[]int`, `[]int64` and vectors, directly and through a realistic `Iter.Scan` loop.
- **Documented that `[]byte` scan destinations reuse their backing array.** Separate from the fix above and *not* a behaviour change: `serialization/{blob,varchar,text,ascii}` have always decoded with `*v = append((*v)[:0], p...)`, so a retained `[]byte` is overwritten by the next Scan — on `master` today, and unrelated to this PR. `Iter.Scan` claimed it "copies" with no exception noted. Documented rather than changed, since callers may rely on the allocation it saves per column per row; this is the contract `database/sql` publishes for `RawBytes`. Scope was verified: it applies to `*[]byte` via `Iter.Scan` and `Scanner`, and to `[]byte` fields of a UDT; `MapScan` values, `string` destinations and collections are unaffected. A test pins the reuse so the doc and the code must change together.
- **Fixes from a full adversarial review round** (all folded into the commits that introduced them, series still bisectable):
  - `unmarshalListInt` rejected zero-length (legacy empty-value) int elements that the generic path and every sibling leaf accept — a regression vs `master` for `*[]int` destinations. Now decodes to zero like a null; pinned by a differential test.
  - The `dim==0` vector decode still handed back the caller's backing array via `*dst = (*dst)[:0]` at 7 sites — the one aliasing pattern the earlier fix missed (no bytes are written, but a later `append` through the result clobbers retained memory). Now fresh storage; pinned in `marshal_alias_test.go`.
  - The fixed-width vector decoders' exact-length check is **deliberately stricter** than the generic path, which derives the element size as `len(data)/dim` and silently ignores trailing bytes. Documented at the decoders and pinned by a test rather than loosened — trailing bytes mean a corrupt or misframed value.
  - Two dispatch errors read backwards ("can not marshal list(int) into []int"); now `%T into %s` like every other marshal error.
  - Review also confirmed two incidental improvements worth knowing about: `VectorType.NewWithError()` is the diff's only exported-API change (and fixes vectors resolving to the promoted `NativeType` method, losing `SubType`), and the `MapRange` rewrite fixes a `master` panic on NaN map keys (`reflect: call of reflect.Value.Interface on zero Value`).

The invariant those tests pin: a buffer may be returned to `marshalOutputPool` only if a pooled fast path actually produced it. That is a property of the code path taken, not of the column type — the reflect path, pointer values and user `Marshaler`s all yield non-pooled buffers for columns whose `TypeInfo` reports poolable. `pooledMarshalType` must stay a defer-registration gate only.

## Notes

- Ready for review.
- Each individual PR should still be reviewed on its own merits; review feedback on any of the three can be applied here.
- Once reviewers are happy with the combined approach, the three source PRs can be closed as superseded.
- #910 (collection **marshal** fast paths) is stacked on this branch: it is complementary, not overlapping — `marshalMap` has no specialisation here at all, and the two `marshalList` switches cover disjoint element types.






