### PR TITLE
fix: harden generic reflect-based list/map unmarshal against malformed size headers

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -818,12 +818,18 @@ func unmarshalList(info TypeInfo, data []byte, value any) error {
 		if err != nil {
 			return err
 		}
+		if n < 0 {
+			return unmarshalErrorf("unmarshal list: negative size %d", n)
+		}
 		data = data[p:]
 		if k == reflect.Array {
 			if rv.Len() != n {
 				return unmarshalErrorf("unmarshal list: array with wrong size")
 			}
 		} else {
+			if n > len(data)/4 {
+				return unmarshalErrorf("unmarshal list: invalid size %d", n)
+			}
 			rv.Set(reflect.MakeSlice(t, n, n))
 			// If rv was an interface, get the underlying slice
 			if rv.Kind() == reflect.Interface {
@@ -1182,6 +1188,9 @@ func unmarshalMap(info TypeInfo, data []byte, value any) error {
 	}
 	if n < 0 {
 		return unmarshalErrorf("negative map size %d", n)
+	}
+	if n > (len(data)-p)/8 {
+		return unmarshalErrorf("unmarshal map: invalid size %d", n)
 	}
 	rv.Set(reflect.MakeMapWithSize(t, n))
 	// If rv was an interface, get the underlying map

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -86,7 +86,11 @@ var unmarshalTests = []struct {
 			l := []int{1, 2}
 			return &l
 		}(),
-		unmarshalErrorf("unmarshal list: unexpected eof"),
+		// A count of 2 needs at least 2*4=8 remaining bytes (one 4-byte
+		// length prefix per element); only 6 remain, so this is now rejected
+		// up front by the size-vs-buffer guard, before attempting to read
+		// any element and hitting the old "unexpected eof".
+		unmarshalErrorf("unmarshal list: invalid size 2"),
 	},
 }
 
@@ -1298,5 +1302,90 @@ func TestCollectionNewWithErrorConsistentWithGoType(t *testing.T) {
 					keyTyp, valTyp, fastType.Elem(), canonicalType)
 			}
 		}
+	}
+}
+
+// TestUnmarshalListReflect_NegativeSize_ReturnsError guards against a
+// malformed frame with a negative list-count header reaching
+// reflect.MakeSlice, which panics on negative len. Uses a named slice type
+// to force the generic reflect path (the fast path's readListHeader already
+// rejects negative counts before this point).
+func TestUnmarshalListReflect_NegativeSize_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	type Strings []string
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	data := []byte{0xFF, 0xFF, 0xFF, 0xFF} // count = -1, no elements follow
+
+	var dst Strings
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unmarshalList panicked on negative size instead of returning an error: %v", r)
+		}
+	}()
+	if err := unmarshalList(info, data, &dst); err == nil {
+		t.Fatal("expected error for negative list size, got nil")
+	}
+}
+
+// TestUnmarshalListReflect_OversizedCount_RejectedBeforeAlloc verifies a list
+// header claiming far more elements than the buffer could contain is
+// rejected before reflect.MakeSlice attempts a huge allocation.
+func TestUnmarshalListReflect_OversizedCount_RejectedBeforeAlloc(t *testing.T) {
+	t.Parallel()
+
+	type Strings []string
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeList},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	// count = 1, but no element bytes follow: even a small count is rejected
+	// up front once it exceeds what the remaining buffer could hold, instead
+	// of risking a large allocation attempt if this test ever used a huge
+	// count and the guard regressed.
+	data := []byte{0x00, 0x00, 0x00, 0x01}
+
+	var dst Strings
+	err := unmarshalList(info, data, &dst)
+	if err == nil {
+		t.Fatal("expected error for oversized list count, got nil")
+	}
+	if err.Error() != "unmarshal list: invalid size 1" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dst != nil {
+		t.Fatalf("expected dst to remain nil, got %#v", dst)
+	}
+}
+
+// TestUnmarshalMapReflect_OversizedCount_RejectedBeforeAlloc verifies a map
+// header claiming far more entries than the buffer could contain is rejected
+// before reflect.MakeMapWithSize attempts a huge allocation. Uses a named map
+// type to force the generic reflect path.
+func TestUnmarshalMapReflect_OversizedCount_RejectedBeforeAlloc(t *testing.T) {
+	t.Parallel()
+
+	type StringMap map[string]string
+	info := CollectionType{
+		NativeType: NativeType{proto: protoVersion4, typ: TypeMap},
+		Key:        NativeType{proto: protoVersion4, typ: TypeVarchar},
+		Elem:       NativeType{proto: protoVersion4, typ: TypeVarchar},
+	}
+	// count = 1, but no entry bytes follow (same rationale as the list case).
+	data := []byte{0x00, 0x00, 0x00, 0x01}
+
+	var dst StringMap
+	err := unmarshalMap(info, data, &dst)
+	if err == nil {
+		t.Fatal("expected error for oversized map count, got nil")
+	}
+	if err.Error() != "unmarshal map: invalid size 1" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dst != nil {
+		t.Fatalf("expected dst to remain nil, got %#v", dst)
 	}
 }


### PR DESCRIPTION
## Summary

Hardens the generic reflection fallback path used by `unmarshalList`/`unmarshalMap` (reached for any list/map element type not covered by a fast-path type switch — custom types, structs, named collection types, etc.) against malformed or corrupted size headers on the wire.

Found while reviewing #957 (a different, larger optimization PR); these weaknesses are pre-existing and independent of that work, so submitting standalone here.

## Issues fixed

1. **Panic on negative list count.** `unmarshalList`'s reflection fallback calls `reflect.MakeSlice(t, n, n)` with no `n < 0` check. `reflect.MakeSlice` panics on negative `len`. This runs during `Scan()`, outside the `recover()` in `framer.parseFrame` (which only wraps frame-header parsing, and even then only handles panic values implementing `error`, not the plain string `reflect.MakeSlice` panics with). A malformed or corrupted response with a negative list-count header, for any non-fast-path element type, can crash the whole process.

2. **Unbounded allocation from a bogus huge count.** Neither `unmarshalList` nor `unmarshalMap`'s reflection fallback bounds `n` against the actual remaining buffer size before calling `reflect.MakeSlice`/`reflect.MakeMapWithSize`. A count header claiming ~1 billion elements with only a few actual bytes present forces a massive pre-allocation attempt. Confirmed empirically: an unguarded map path with a ~1 billion count header and a 4-byte buffer hangs 30+ seconds building bucket arrays before erroring; with the fix it's rejected in under a millisecond.

## Fix

Both paths are hardened the same way `readListHeader` (used by the list fast path) already guards against this: reject `n < 0`, and bound `n` against the remaining buffer length (minimum 4 bytes/element for lists, 8 bytes/entry for maps — each element/entry needs at least one/two 4-byte length prefixes) before allocating.

## Tests

Added:
- `TestUnmarshalListReflect_NegativeSize_ReturnsError` — asserts an error is returned (via `recover()`) instead of a panic, using a named slice type to force the reflect path.
- `TestUnmarshalListReflect_OversizedCount_RejectedBeforeAlloc`
- `TestUnmarshalMapReflect_OversizedCount_RejectedBeforeAlloc`

One pre-existing test (`TestMarshal_Decode`'s truncated-list case) needed its expected error string updated from `"unmarshal list: unexpected eof"` to `"unmarshal list: invalid size 2"`, since the malformed input it exercises is now caught earlier by the new bound check rather than deeper in the per-element read loop (same error class, just detected sooner).

Full suite + `-race` pass locally.