### PR TITLE
perf: cache qry.IsLWT() in tokenAwareHostPolicy.Pick()

### DIFF
--- a/policies.go
+++ b/policies.go
@@ -969,11 +969,15 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		replicas = []*HostInfo{host}
 	}
 
-	if t.shuffleReplicas && !qry.IsLWT() && len(replicas) > 1 {
+	// Cache IsLWT() once: it is read on both the shuffle and avoid-slow-replicas
+	// paths below, and computing it can take a lock on the query routing info.
+	isLWT := qry.IsLWT()
+
+	if t.shuffleReplicas && !isLWT && len(replicas) > 1 {
 		shuffleHostsInPlace(replicas)
 	}
 
-	if s := qry.GetSession(); s != nil && !qry.IsLWT() && t.avoidSlowReplicas {
+	if s := qry.GetSession(); s != nil && !isLWT && t.avoidSlowReplicas {
 		partitionHealthy(replicas, s)
 	}
 


### PR DESCRIPTION
## Summary

`IsLWT()` was evaluated twice in the replica-ordering tail of `Pick()` — once for the `shuffleReplicas` gate and once for the `avoidSlowReplicas` gate. Each call can take a read lock on the query routing info. Cache it once into a local since the value is stable for the duration of `Pick()`.

Extracted from a larger, closed LWT-routing-plan-cache effort (the standalone caching portion only — no behavioral changes, no new code paths, just avoiding the redundant second call).

This was originally bundled into #869 by mistake; split out here as its own focused, minimal change on top of current master.

## Tests

Existing `TestTokenAware*`/`Pick`-related tests pass unchanged (no behavior change). Full suite + `-race` pass locally.