### PR TITLE
Report driver and session configuration via STARTUP options - stage 1

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -309,9 +309,12 @@ type ClusterConfig struct {
 	//
 	// The control connection sends a DRIVER_CONFIG startup option holding a JSON
 	// description of the effective configuration. It ends up in the
-	// system.clients.client_options column.
+	// system.clients.client_options column, alongside SESSION_ID, a per-session
+	// unique identifier that every connection of a session reports and that is
+	// always sent regardless of this setting, letting all of a session's
+	// connections be correlated with each other.
 	//
-	// When set to true, it is not sent.
+	// When set to true, DRIVER_CONFIG is not sent. SESSION_ID is unaffected.
 	//
 	// Default: false
 	DisableDriverConfigReporting bool

--- a/cluster.go
+++ b/cluster.go
@@ -302,6 +302,19 @@ type ClusterConfig struct {
 	// address in system.local or system.peers returns 127.0.0.1, the peer will be
 	// set to 10.0.0.1 which is what will be used to connect to.
 	IgnorePeerAddr bool
+	// DisableDriverConfigReporting turns off the driver's self-description to the
+	// cluster during connection setup. Reporting is enabled by default so that
+	// operators can inspect the settings of a client while investigating an
+	// incident.
+	//
+	// The control connection sends a DRIVER_CONFIG startup option holding a JSON
+	// description of the effective configuration. It ends up in the
+	// system.clients.client_options column.
+	//
+	// When set to true, it is not sent.
+	//
+	// Default: false
+	DisableDriverConfigReporting bool
 	// An event bus configuration
 	EventBusConfig eventbus.EventBusConfig
 }

--- a/conn.go
+++ b/conn.go
@@ -145,6 +145,9 @@ type ConnConfig struct {
 	ProtoVersion    int
 	Keepalive       time.Duration
 	disableCoalesce bool
+	// isControlConn marks the connection used by the control connection, which is
+	// the only one reporting the driver configuration on startup.
+	isControlConn bool
 }
 
 func (c *ConnConfig) logger() StdLogger {
@@ -455,6 +458,14 @@ func (c *Conn) init(ctx context.Context, dialedHost *DialedHost) error {
 		conn:        c,
 	}
 
+	// The driver configuration is identical for every connection of a session,
+	// so it is reported only on the control connection to keep the other STARTUP
+	// frames small. Leaving the reporter nil elsewhere reuses the same path that
+	// a session with reporting disabled takes.
+	if c.cfg.isControlConn {
+		startup.driverConfigReporter = c.session.driverConfigReporter
+	}
+
 	if err := startup.setupConn(ctx); err != nil {
 		return err
 	}
@@ -488,8 +499,9 @@ func (c *Conn) Read(p []byte) (n int, err error) {
 }
 
 type startupCoordinator struct {
-	conn        *Conn
-	frameTicker chan struct{}
+	conn                 *Conn
+	frameTicker          chan struct{}
+	driverConfigReporter *driverConfigReporter
 }
 
 func (s *startupCoordinator) setupConn(ctx context.Context) error {
@@ -614,11 +626,15 @@ func (s *startupCoordinator) options(ctx context.Context, startupCompleted *atom
 // The ordering is easy to lose, which is how it was lost: upstream has no
 // ApplicationInfo hook and writes these three as a map literal, so merging the
 // two put the callback last.
-func startupOptions(cqlVersion, driverName, driverVersion string, info ApplicationInfo) map[string]string {
+func startupOptions(cqlVersion, driverName, driverVersion string, info ApplicationInfo, driverConfig *driverConfigReporter) map[string]string {
 	m := map[string]string{}
 
 	if info != nil {
 		info.UpdateStartupOptions(m)
+	}
+
+	if driverConfig != nil {
+		driverConfig.updateStartupOptions(m)
 	}
 
 	m["CQL_VERSION"] = cqlVersion
@@ -636,6 +652,7 @@ func (s *startupCoordinator) startup(ctx context.Context, startupCompleted *atom
 		s.conn.session.cfg.DriverName,
 		s.conn.session.cfg.DriverVersion,
 		s.conn.session.cfg.ApplicationInfo,
+		s.driverConfigReporter,
 	)
 
 	if s.conn.compressor != nil {

--- a/conn.go
+++ b/conn.go
@@ -279,12 +279,6 @@ func (c *Conn) getScyllaSupported() ScyllaConnectionFeatures {
 	return c.scyllaSupported
 }
 
-// connect establishes a connection to a Cassandra node using session's connection config.
-// note: every connection needs to get `conn.finalizeConnection` called ont it when initialization process is done
-func (s *Session) connect(ctx context.Context, host *HostInfo, errorHandler ConnErrorHandler) (*Conn, error) {
-	return s.dial(ctx, host, s.connCfg, errorHandler)
-}
-
 // connectShard establishes a connection to a shard.
 // If nrShards is zero, shard-aware dialing is disabled.
 // note: every connection needs to get `conn.finalizeConnection` called ont it when initialization process is done

--- a/conn.go
+++ b/conn.go
@@ -617,16 +617,18 @@ func (s *startupCoordinator) options(ctx context.Context, startupCompleted *atom
 // startupOptions builds the STARTUP options the driver always sends.
 //
 // The application's options go in first so the driver-owned keys below can
-// overwrite them, never the other way round. They describe the driver and the
-// protocol it is speaking, and are not the application's to change: a callback
-// that set CQL_VERSION could make every connection in the cluster fail the
-// handshake, and one that set DRIVER_NAME or DRIVER_VERSION would misreport the
-// driver to the server for the life of the connection.
+// overwrite them, never the other way round. They describe the driver, the
+// protocol it is speaking and the session the connection belongs to, and are
+// not the application's to change: a callback that set CQL_VERSION could make
+// every connection in the cluster fail the handshake, one that set DRIVER_NAME
+// or DRIVER_VERSION would misreport the driver to the server for the life of
+// the connection, and one that set SESSION_ID would break correlating a
+// session's connections in system.clients.
 //
 // The ordering is easy to lose, which is how it was lost: upstream has no
 // ApplicationInfo hook and writes these three as a map literal, so merging the
 // two put the callback last.
-func startupOptions(cqlVersion, driverName, driverVersion string, info ApplicationInfo, driverConfig *driverConfigReporter) map[string]string {
+func startupOptions(cqlVersion, driverName, driverVersion string, info ApplicationInfo, driverConfig *driverConfigReporter, sessionID string) map[string]string {
 	m := map[string]string{}
 
 	if info != nil {
@@ -637,6 +639,7 @@ func startupOptions(cqlVersion, driverName, driverVersion string, info Applicati
 		driverConfig.updateStartupOptions(m)
 	}
 
+	m[sessionIDStartupKey] = sessionID
 	m["CQL_VERSION"] = cqlVersion
 	m["DRIVER_NAME"] = driverName
 	m["DRIVER_VERSION"] = driverVersion
@@ -653,6 +656,7 @@ func (s *startupCoordinator) startup(ctx context.Context, startupCompleted *atom
 		s.conn.session.cfg.DriverVersion,
 		s.conn.session.cfg.ApplicationInfo,
 		s.driverConfigReporter,
+		s.conn.session.id,
 	)
 
 	if s.conn.compressor != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -104,6 +104,28 @@ func testCluster(proto frm.ProtoVersion, addresses ...string) *ClusterConfig {
 	return cluster
 }
 
+// waitForPoolSize blocks until session's connection pool holds at least want
+// connections, or timeout elapses.
+//
+// CreateSession only guarantees the first connection to each host: the rest of
+// a pool is filled asynchronously, so a test making a claim about every
+// connection of a session has to wait for them rather than assert on whichever
+// ones it happened to observe.
+func waitForPoolSize(session *Session, want int, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	for {
+		if got := session.pool.Size(); got >= want {
+			return nil
+		}
+
+		select {
+		case <-deadline:
+			return fmt.Errorf("pool reached %d of %d connections in %s", session.pool.Size(), want, timeout)
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
 func TestSimple(t *testing.T) {
 	srv := NewTestServer(t, defaultProto, context.Background())
 	defer srv.Stop()
@@ -3659,7 +3681,7 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 	)
 
 	t.Run("no ApplicationInfo", func(t *testing.T) {
-		m := startupOptions(cqlVersion, driverName, driverVersion, nil)
+		m := startupOptions(cqlVersion, driverName, driverVersion, nil, nil)
 
 		require.Equal(t, map[string]string{
 			"CQL_VERSION":    cqlVersion,
@@ -3670,7 +3692,7 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 
 	t.Run("application options are kept", func(t *testing.T) {
 		m := startupOptions(cqlVersion, driverName, driverVersion,
-			NewStaticApplicationInfo("app", "9.9.9", "client-id"))
+			NewStaticApplicationInfo("app", "9.9.9", "client-id"), nil)
 
 		require.Equal(t, "app", m["APPLICATION_NAME"])
 		require.Equal(t, "9.9.9", m["APPLICATION_VERSION"])
@@ -3687,7 +3709,7 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 				opts["DRIVER_NAME"] = "not-gocql"
 				opts["DRIVER_VERSION"] = "0.0.0"
 				opts["APPLICATION_NAME"] = "app"
-			}))
+			}), nil)
 
 		require.Equal(t, cqlVersion, m["CQL_VERSION"], "a custom CQL version would fail every handshake")
 		require.Equal(t, driverName, m["DRIVER_NAME"])

--- a/conn_test.go
+++ b/conn_test.go
@@ -3671,6 +3671,8 @@ func TestRecvSegmentPayloadReadIsBounded(t *testing.T) {
 // protocol it speaks. A callback that set CQL_VERSION could make every connection
 // in the cluster fail its handshake; one that set DRIVER_NAME or DRIVER_VERSION
 // would misreport the driver to the server for the life of the connection.
+// SESSION_ID is driver-owned for the same reason: it is what correlates a
+// session's connections in system.clients.
 func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 	t.Parallel()
 
@@ -3678,21 +3680,23 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 		cqlVersion    = "3.4.5"
 		driverName    = "gocql"
 		driverVersion = "1.2.3"
+		sessionID     = "91b0b1a2-0000-4000-8000-000000000001"
 	)
 
 	t.Run("no ApplicationInfo", func(t *testing.T) {
-		m := startupOptions(cqlVersion, driverName, driverVersion, nil, nil)
+		m := startupOptions(cqlVersion, driverName, driverVersion, nil, nil, sessionID)
 
 		require.Equal(t, map[string]string{
-			"CQL_VERSION":    cqlVersion,
-			"DRIVER_NAME":    driverName,
-			"DRIVER_VERSION": driverVersion,
+			"CQL_VERSION":       cqlVersion,
+			"DRIVER_NAME":       driverName,
+			"DRIVER_VERSION":    driverVersion,
+			sessionIDStartupKey: sessionID,
 		}, m)
 	})
 
 	t.Run("application options are kept", func(t *testing.T) {
 		m := startupOptions(cqlVersion, driverName, driverVersion,
-			NewStaticApplicationInfo("app", "9.9.9", "client-id"), nil)
+			NewStaticApplicationInfo("app", "9.9.9", "client-id"), nil, sessionID)
 
 		require.Equal(t, "app", m["APPLICATION_NAME"])
 		require.Equal(t, "9.9.9", m["APPLICATION_VERSION"])
@@ -3700,6 +3704,7 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 		require.Equal(t, cqlVersion, m["CQL_VERSION"])
 		require.Equal(t, driverName, m["DRIVER_NAME"])
 		require.Equal(t, driverVersion, m["DRIVER_VERSION"])
+		require.Equal(t, sessionID, m[sessionIDStartupKey])
 	})
 
 	t.Run("driver-owned keys win", func(t *testing.T) {
@@ -3708,12 +3713,14 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 				opts["CQL_VERSION"] = "9.9.9"
 				opts["DRIVER_NAME"] = "not-gocql"
 				opts["DRIVER_VERSION"] = "0.0.0"
+				opts[sessionIDStartupKey] = "not-the-session-id"
 				opts["APPLICATION_NAME"] = "app"
-			}), nil)
+			}), nil, sessionID)
 
 		require.Equal(t, cqlVersion, m["CQL_VERSION"], "a custom CQL version would fail every handshake")
 		require.Equal(t, driverName, m["DRIVER_NAME"])
 		require.Equal(t, driverVersion, m["DRIVER_VERSION"])
+		require.Equal(t, sessionID, m[sessionIDStartupKey], "a custom session id would break correlating a session's connections")
 		require.Equal(t, "app", m["APPLICATION_NAME"], "keys the driver does not own must still come through")
 	})
 }

--- a/control.go
+++ b/control.go
@@ -270,9 +270,16 @@ func (c *controlConn) discoverProtocol(hosts []*HostInfo) (int, error) {
 //
 // It is declared here, rather than alongside the rest of Session, so it sits
 // next to the paths whose agreement it exists to guarantee.
+//
+// controlConn.discoverProtocol is a deliberate exception: it hand-copies
+// *s.connCfg instead of going through here, because its throwaway probe
+// connections are discarded immediately and must not be marked as the control
+// connection - doing so would race the real control connection and report
+// DRIVER_CONFIG more than once.
 func (s *Session) controlConnConfig() *ConnConfig {
 	cfg := *s.connCfg
 	cfg.disableCoalesce = true
+	cfg.isControlConn = true
 	return &cfg
 }
 

--- a/control.go
+++ b/control.go
@@ -264,6 +264,18 @@ func (c *controlConn) discoverProtocol(hosts []*HostInfo) (int, error) {
 	return 0, err
 }
 
+// controlConnConfig returns the connection config used for control connections.
+// It is the only place where control-connection specific settings are applied,
+// so that every path which (re)establishes the control connection agrees on them.
+//
+// It is declared here, rather than alongside the rest of Session, so it sits
+// next to the paths whose agreement it exists to guarantee.
+func (s *Session) controlConnConfig() *ConnConfig {
+	cfg := *s.connCfg
+	cfg.disableCoalesce = true
+	return &cfg
+}
+
 func (c *controlConn) connect(hosts []*HostInfo) error {
 	if len(hosts) == 0 {
 		return errors.New("control: no endpoints specified")
@@ -273,13 +285,12 @@ func (c *controlConn) connect(hosts []*HostInfo) error {
 	// node.
 	hosts = shuffleHosts(hosts)
 
-	cfg := *c.session.connCfg
-	cfg.disableCoalesce = true
+	cfg := c.session.controlConnConfig()
 
 	var conn *Conn
 	var err error
 	for _, host := range hosts {
-		conn, err = c.session.dial(c.session.ctx, host, &cfg, c)
+		conn, err = c.session.dial(c.session.ctx, host, cfg, c)
 		// conn.finalizeConnection() to be called outside of this function, since initialization process is not completed yet
 		if err != nil {
 			c.session.logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
@@ -459,8 +470,9 @@ func (c *controlConn) attemptReconnect() error {
 }
 
 func (c *controlConn) attemptReconnectToAnyOfHosts(hosts []*HostInfo) error {
+	cfg := c.session.controlConnConfig()
 	for _, host := range hosts {
-		conn, err := c.session.connect(c.session.ctx, host, c)
+		conn, err := c.session.dial(c.session.ctx, host, cfg, c)
 		if err != nil {
 			if c.session.cfg.ConvictionPolicy.AddFailure(err, host) {
 				c.session.handleNodeDown(host.ConnectAddress(), host.Port())

--- a/dialer/utils.go
+++ b/dialer/utils.go
@@ -194,7 +194,16 @@ func GetFrameHash(frame []byte) int64 {
 	}
 	switch frame[3+p] {
 	case byte(opStartup):
-		return murmur.Murmur3H1(frame[:8+p])
+		// Hash the header up to and including the opcode, deliberately stopping
+		// before the 4-byte body length: a connection sends exactly one STARTUP,
+		// so the opcode alone identifies it, and the options it carries are of
+		// no interest to a replay.
+		//
+		// Including the length would tie every checked-in recording to the exact
+		// set of STARTUP options the driver sent when it was recorded, so adding
+		// one (DRIVER_CONFIG, SESSION_ID, ...) would invalidate them all and
+		// panic the replay benchmarks until they were regenerated.
+		return murmur.Murmur3H1(frame[:4+p])
 	case byte(opPrepare):
 		return murmur.Murmur3H1(frame)
 	case byte(opAuthResponse):

--- a/dialer/utils_test.go
+++ b/dialer/utils_test.go
@@ -6,6 +6,45 @@ import (
 	"github.com/gocql/gocql/internal/murmur"
 )
 
+// startupFrameV4 builds a protocol v4 STARTUP request frame carrying body as
+// its options blob. The contents of body are irrelevant to the hash; only its
+// length is varied by the caller.
+func startupFrameV4(body []byte) []byte {
+	frame := []byte{
+		0x04,
+		0x00,       // no header flags
+		0x00, 0x7B, // stream id
+		byte(opStartup),
+		byte(len(body) >> 24), byte(len(body) >> 16), byte(len(body) >> 8), byte(len(body)),
+	}
+
+	return append(frame, body...)
+}
+
+// TestGetFrameHashStartupIgnoresBodyLength pins that the STARTUP hash does not
+// depend on the body, directly or through the length field in the header.
+//
+// The checked-in replay recordings in tests/bench store raw frames and are
+// rehashed at load time, so a body-dependent STARTUP hash silently couples them
+// to the exact set of STARTUP options the driver sent when they were recorded.
+// Adding one shifts the length field, no recorded frame matches any more, and
+// the replay benchmarks panic with "unable to find a response to replay" until
+// every recording is regenerated.
+func TestGetFrameHashStartupIgnoresBodyLength(t *testing.T) {
+	short := GetFrameHash(startupFrameV4([]byte{0x00, 0x01}))
+	long := GetFrameHash(startupFrameV4(make([]byte, 512)))
+
+	if short != long {
+		t.Errorf("STARTUP hash depends on the body length: %d != %d", short, long)
+	}
+
+	// Confirm the frame was parsed rather than diverted to the raw-bytes
+	// fallback, which would also make the two hashes differ if it regressed.
+	if raw := murmur.Murmur3H1(startupFrameV4([]byte{0x00, 0x01})); short == raw {
+		t.Error("GetFrameHash fell back to hashing the raw frame")
+	}
+}
+
 // TestGetFrameHashGuardsProtoV5Segments verifies that GetFrameHash does not
 // attempt to parse protocol v5+ input as a CQL frame. On v5 the recorded bytes
 // are a transport segment (see prepareModernLayout), so frame[0] is segment

--- a/driver_config.go
+++ b/driver_config.go
@@ -15,6 +15,20 @@ const driverConfigStartupKey = "DRIVER_CONFIG"
 // changing or removing the meaning of an existing key does.
 const driverConfigVersion = 1
 
+// maxDriverConfigSize bounds the size of the DRIVER_CONFIG STARTUP option.
+//
+// writeStartupFrame serializes STARTUP options through writeString, which
+// writes a 16-bit length prefix with no bounds check: a value over 65535
+// bytes would silently truncate that prefix modulo 65536 while still
+// appending the full body, corrupting the frame and failing the handshake.
+// Stage 1's report is a few bytes, but custom policy objects allow
+// implementation-specific properties, so a future report built from
+// user-supplied policy data could grow arbitrarily large. Enforcing a limit
+// here keeps "reporting must never prevent a connection from being
+// established" a property of this code rather than of the user's
+// configuration. 32KiB is generous for a configuration report.
+const maxDriverConfigSize = 32 * 1024
+
 // driverConfigReport is the value sent under driverConfigStartupKey.
 // For now only the schema version is reported; configuration groups will be
 // added in a follow-up change.
@@ -57,6 +71,10 @@ func (r *driverConfigReporter) updateStartupOptions(opts map[string]string) {
 	report, err := r.buildReport()
 	if err != nil {
 		r.session.logger.Printf("gocql: unable to report driver configuration: %v", err)
+		return
+	}
+	if len(report) > maxDriverConfigSize {
+		r.session.logger.Printf("gocql: driver configuration report is %d bytes, exceeding the %d byte limit; omitting it", len(report), maxDriverConfigSize)
 		return
 	}
 	opts[driverConfigStartupKey] = report

--- a/driver_config.go
+++ b/driver_config.go
@@ -1,0 +1,76 @@
+package gocql
+
+import (
+	"encoding/json"
+)
+
+// driverConfigStartupKey is the STARTUP option carrying the JSON description
+// of the effective driver configuration. The configuration is identical for
+// every connection of a session, so it is only sent on the control connection
+// to keep the other STARTUP frames small.
+const driverConfigStartupKey = "DRIVER_CONFIG"
+
+// driverConfigVersion is the major version of the reported configuration schema.
+// Adding keys to the report is backwards compatible and does not bump it, only
+// changing or removing the meaning of an existing key does.
+const driverConfigVersion = 1
+
+// driverConfigReport is the value sent under driverConfigStartupKey.
+// For now only the schema version is reported; configuration groups will be
+// added in a follow-up change.
+type driverConfigReport struct {
+	Version int `json:"version"`
+}
+
+// driverConfigReporter builds the DRIVER_CONFIG STARTUP option describing a
+// session's effective configuration to the cluster. It is created once per
+// session and shared by all of its connections, but only ever contributes to
+// the STARTUP options of the control connection.
+//
+// The report is rebuilt on every control connection (re-)establishment
+// rather than cached, since future configuration groups may describe state
+// only known after ring and topology setup (e.g. an inferred local DC).
+//
+// The reporter holds the *Session itself and builds the report lazily, at
+// first use, rather than at construction time: newDriverConfigReporter runs
+// inside newSessionCommon before fields such as s.policy are assigned, so a
+// report built eagerly would see a partially initialized Session. For the
+// same reason, a future report describing the host selection policy must
+// read it off s.policy, not s.cfg.PoolConfig.HostSelectionPolicy: the latter
+// is never assigned the default policy that newSessionCommon applies.
+type driverConfigReporter struct {
+	session *Session
+}
+
+func newDriverConfigReporter(s *Session) *driverConfigReporter {
+	return &driverConfigReporter{session: s}
+}
+
+// updateStartupOptions adds the DRIVER_CONFIG STARTUP option.
+//
+// Only the control connection's startup holds a reporter, so this is not the
+// place that decides which connections report: see Conn.init.
+//
+// Reporting is best effort: it must never prevent a connection from being
+// established, so a report that cannot be built is logged and left out.
+func (r *driverConfigReporter) updateStartupOptions(opts map[string]string) {
+	report, err := r.buildReport()
+	if err != nil {
+		r.session.logger.Printf("gocql: unable to report driver configuration: %v", err)
+		return
+	}
+	opts[driverConfigStartupKey] = report
+}
+
+// buildReport returns the JSON configuration report of the session, marshalled
+// fresh on every call so that it reflects the session's current state rather
+// than a snapshot from whenever it was first requested.
+//
+// The error is unreachable while the report only carries the schema version, but
+// it is the fail-safe boundary for the configuration groups added later: those
+// describe user-supplied values, such as the names and fields of custom
+// policies, whose marshalling can genuinely fail.
+func (r *driverConfigReporter) buildReport() (string, error) {
+	report, err := json.Marshal(driverConfigReport{Version: driverConfigVersion})
+	return string(report), err
+}

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -3,20 +3,216 @@
 
 package gocql
 
-import "testing"
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
 
-// TestControlConnConfigIsMarked pins the wiring that makes the control
-// connection agree on its connection-specific settings everywhere it is
-// (re)established. Every path which (re)establishes it must go through
-// Session.controlConnConfig.
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+// TestControlConnConfigIsMarked pins the wiring that makes the control connection,
+// and only the control connection, report the driver configuration. Every path
+// which (re)establishes the long-lived control connection must go through
+// Session.controlConnConfig. discoverProtocol's throwaway probe connections are a
+// deliberate exception, documented on controlConnConfig itself.
 func TestControlConnConfigIsMarked(t *testing.T) {
 	s := &Session{connCfg: &ConnConfig{}}
 
 	cfg := s.controlConnConfig()
+	if !cfg.isControlConn {
+		t.Error("expected the control connection config to be marked as such")
+	}
 	if !cfg.disableCoalesce {
 		t.Error("expected the control connection config to disable write coalescing")
 	}
-	if s.connCfg.disableCoalesce {
+	if s.connCfg.isControlConn || s.connCfg.disableCoalesce {
 		t.Error("expected the session-wide connection config to be left untouched")
 	}
+}
+
+func TestDriverConfigReporterStartupOptions(t *testing.T) {
+	reporter := newDriverConfigReporter(&Session{logger: &defaultLogger{}})
+
+	opts := map[string]string{}
+	reporter.updateStartupOptions(opts)
+
+	if got, want := opts[driverConfigStartupKey], `{"version":1}`; got != want {
+		t.Errorf("expected %s to be %q, got %q", driverConfigStartupKey, want, got)
+	}
+}
+
+// TestDriverConfigReportingStartupFrame checks what actually reaches the wire for
+// the connections of a session pool.
+func TestDriverConfigReportingStartupFrame(t *testing.T) {
+	// Enough connections that the absence asserted below is a claim about the
+	// pool rather than about a single sample: only the first connection is
+	// opened during session initialization, so a test that did not set
+	// NumConns and wait for the pool would routinely observe just that one.
+	const connsPerSession = 3
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		configs  []string
+		startups int
+	)
+
+	srv := newTestServerOpts{
+		addr:     "127.0.0.1:0",
+		protocol: defaultProto,
+		recvHook: func(f *framer) {
+			if f.header.Op != frm.OpStartup {
+				return
+			}
+			// Consuming the frame body here is only safe because the fake
+			// server does not read the body of a STARTUP request.
+			opts := readStartupOptions(t, f)
+
+			mu.Lock()
+			defer mu.Unlock()
+			startups++
+			if cfg, ok := opts[driverConfigStartupKey]; ok {
+				configs = append(configs, cfg)
+			}
+		},
+	}.newServer(t, ctx)
+	defer srv.Stop()
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.NumConns = connsPerSession
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	// A connection only joins the pool once its handshake has completed, which
+	// is strictly after the server has run recvHook on its STARTUP, so waiting
+	// here is what makes the whole pool visible to the snapshot below.
+	if err := waitForPoolSize(session, connsPerSession, 10*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Without this, the absence asserted below would hold just as well on a
+	// run that observed no STARTUP frame at all.
+	if startups < connsPerSession {
+		t.Fatalf("expected the whole pool to be observed: got %d STARTUP frames for %d connections", startups, connsPerSession)
+	}
+
+	// The control connection is disabled by testCluster, so no connection
+	// of this session may report the configuration.
+	if len(configs) != 0 {
+		t.Errorf("expected no %s outside of the control connection, got %v", driverConfigStartupKey, configs)
+	}
+}
+
+// TestDriverConfigReportingDisabled pins DisableDriverConfigReporting on the
+// wire: with the option set, not even a connection dialed with the config that
+// marks it as the control connection reports DRIVER_CONFIG.
+//
+// Nothing else in the tree sets the option, so without this test the guard in
+// newSessionCommon could be deleted, or inverted, and every test would still
+// pass.
+func TestDriverConfigReportingDisabled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		startups []map[string]string
+	)
+
+	srv := newTestServerOpts{
+		addr:     "127.0.0.1:0",
+		protocol: defaultProto,
+		recvHook: func(f *framer) {
+			if f.header.Op != frm.OpStartup {
+				return
+			}
+			// Consuming the frame body here is only safe because the fake
+			// server does not read the body of a STARTUP request.
+			opts := readStartupOptions(t, f)
+
+			mu.Lock()
+			defer mu.Unlock()
+			startups = append(startups, opts)
+		},
+	}.newServer(t, ctx)
+	defer srv.Stop()
+
+	cluster := testCluster(defaultProto, srv.Address)
+	cluster.NumConns = 1
+	cluster.DisableDriverConfigReporting = true
+	session, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	if session.driverConfigReporter != nil {
+		t.Error("expected a session with reporting disabled to hold no reporter")
+	}
+
+	if err := waitForPoolSize(session, 1, 10*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	hosts := session.GetHosts()
+	if len(hosts) == 0 {
+		t.Fatal("expected at least one host in the session")
+	}
+
+	// Dial with the config that reports when the option is left at its
+	// default, so that the option is the only reason DRIVER_CONFIG is absent
+	// below rather than the connection simply not being a control connection.
+	conn, err := session.dial(session.ctx, hosts[0], session.controlConnConfig(), connErrorHandlerFn(func(*Conn, error, bool) {}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This connection only exists to observe what reaches the wire, so it is
+	// discarded right away without calling conn.finalizeConnection, the same
+	// way controlConn.discoverProtocol does for its throwaway connections.
+	conn.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Without this the absence asserted below would hold just as well on a run
+	// that observed no STARTUP frame at all.
+	if len(startups) == 0 {
+		t.Fatal("expected at least one STARTUP frame to be observed")
+	}
+	for i, opts := range startups {
+		if config, ok := opts[driverConfigStartupKey]; ok {
+			t.Errorf("STARTUP %d: expected no %s when reporting is disabled, got %q", i, driverConfigStartupKey, config)
+		}
+	}
+}
+
+// readStartupOptions decodes the string map carried by a STARTUP frame body.
+// The framer read helpers panic on a truncated buffer and this runs on the fake
+// server's read goroutine, so a malformed frame is turned into a test failure
+// instead of taking the whole test binary down.
+func readStartupOptions(t *testing.T, f *framer) (opts map[string]string) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("malformed STARTUP frame: %v", r)
+			opts = nil
+		}
+	}()
+
+	opts = make(map[string]string)
+	for n := f.readShort(); n > 0; n-- {
+		key := f.readString()
+		opts[key] = f.readString()
+	}
+	return opts
 }

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -44,8 +44,8 @@ func TestDriverConfigReporterStartupOptions(t *testing.T) {
 	}
 }
 
-// TestDriverConfigReportingStartupFrame checks what actually reaches the wire for
-// the connections of a session pool.
+// TestDriverConfigReportingStartupFrame checks what actually reaches the wire
+// for the connections of a session pool.
 func TestDriverConfigReportingStartupFrame(t *testing.T) {
 	// Enough connections that the absence asserted below is a claim about the
 	// pool rather than about a single sample: only the first connection is
@@ -108,7 +108,7 @@ func TestDriverConfigReportingStartupFrame(t *testing.T) {
 	}
 
 	// The control connection is disabled by testCluster, so no connection
-	// of this session may report the configuration.
+	// of this session may report DRIVER_CONFIG.
 	if len(configs) != 0 {
 		t.Errorf("expected no %s outside of the control connection, got %v", driverConfigStartupKey, configs)
 	}
@@ -236,7 +236,9 @@ func TestDriverConfigReportingDial(t *testing.T) {
 
 // TestDriverConfigReportingDisabled pins DisableDriverConfigReporting on the
 // wire: with the option set, not even a connection dialed with the config that
-// marks it as the control connection reports DRIVER_CONFIG.
+// marks it as the control connection reports DRIVER_CONFIG, while SESSION_ID,
+// which the option is documented not to affect, is still reported by every
+// connection.
 //
 // Nothing else in the tree sets the option, so without this test the guard in
 // newSessionCommon could be deleted, or inverted, and every test would still
@@ -313,6 +315,10 @@ func TestDriverConfigReportingDisabled(t *testing.T) {
 	for i, opts := range startups {
 		if config, ok := opts[driverConfigStartupKey]; ok {
 			t.Errorf("STARTUP %d: expected no %s when reporting is disabled, got %q", i, driverConfigStartupKey, config)
+		}
+		if got := opts[sessionIDStartupKey]; got != session.ID() {
+			t.Errorf("STARTUP %d: expected %s %q to be reported whatever the option is set to, got %q",
+				i, sessionIDStartupKey, session.ID(), got)
 		}
 	}
 }

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -1,0 +1,22 @@
+//go:build unit
+// +build unit
+
+package gocql
+
+import "testing"
+
+// TestControlConnConfigIsMarked pins the wiring that makes the control
+// connection agree on its connection-specific settings everywhere it is
+// (re)established. Every path which (re)establishes it must go through
+// Session.controlConnConfig.
+func TestControlConnConfigIsMarked(t *testing.T) {
+	s := &Session{connCfg: &ConnConfig{}}
+
+	cfg := s.controlConnConfig()
+	if !cfg.disableCoalesce {
+		t.Error("expected the control connection config to disable write coalescing")
+	}
+	if s.connCfg.disableCoalesce {
+		t.Error("expected the session-wide connection config to be left untouched")
+	}
+}

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -5,6 +5,7 @@ package gocql
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -110,6 +111,126 @@ func TestDriverConfigReportingStartupFrame(t *testing.T) {
 	// of this session may report the configuration.
 	if len(configs) != 0 {
 		t.Errorf("expected no %s outside of the control connection, got %v", driverConfigStartupKey, configs)
+	}
+}
+
+// TestDriverConfigReportingDial exercises both sides of the gate in Conn.init
+// which decides that a connection reports DRIVER_CONFIG, by dialing the fake
+// server by hand with each of the two ConnConfigs a session builds.
+//
+// Neither side is covered elsewhere in the unit tests.
+// TestDriverConfigReporterStartupOptions calls updateStartupOptions directly,
+// bypassing ConnConfig entirely, so it says nothing about which connections
+// hold a reporter. TestDriverConfigReportingStartupFrame runs with
+// disableControlConn true, which leaves "a connection marked as the control
+// connection puts DRIVER_CONFIG on the wire" to the integration test, and that
+// skips on any server without client_options; and while it does assert the
+// absence over a pool of regular connections, it never exercises the gate
+// against a config it could have decided the other way on.
+func TestDriverConfigReportingDial(t *testing.T) {
+	tests := []struct {
+		name string
+		// connConfig picks the ConnConfig to dial with: the one every path
+		// (re)establishing the control connection goes through, or the
+		// session-wide one every pool connection is dialed with.
+		connConfig  func(*Session) *ConnConfig
+		wantConfigs []string
+	}{
+		{
+			name:        "control connection",
+			connConfig:  (*Session).controlConnConfig,
+			wantConfigs: []string{`{"version":1}`},
+		},
+		{
+			name:        "regular connection",
+			connConfig:  func(s *Session) *ConnConfig { return s.connCfg },
+			wantConfigs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var (
+				mu       sync.Mutex
+				configs  []string
+				startups int
+			)
+
+			srv := newTestServerOpts{
+				addr:     "127.0.0.1:0",
+				protocol: defaultProto,
+				recvHook: func(f *framer) {
+					if f.header.Op != frm.OpStartup {
+						return
+					}
+					// Consuming the frame body here is only safe because the
+					// fake server does not read the body of a STARTUP request.
+					opts := readStartupOptions(t, f)
+
+					mu.Lock()
+					defer mu.Unlock()
+					startups++
+					if cfg, ok := opts[driverConfigStartupKey]; ok {
+						configs = append(configs, cfg)
+					}
+				},
+			}.newServer(t, ctx)
+			defer srv.Stop()
+
+			// disableControlConn, set by testCluster, keeps the session's own
+			// control connection out of the way, so any DRIVER_CONFIG captured
+			// below can only have come from the connection dialed by hand. A
+			// single pool connection, waited for below, keeps the STARTUP count
+			// deterministic: the rest of a larger pool is filled
+			// asynchronously and could land a frame mid-test.
+			cluster := testCluster(defaultProto, srv.Address)
+			cluster.NumConns = 1
+			session, err := cluster.CreateSession()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer session.Close()
+
+			if err := waitForPoolSize(session, 1, 10*time.Second); err != nil {
+				t.Fatal(err)
+			}
+
+			hosts := session.GetHosts()
+			if len(hosts) == 0 {
+				t.Fatal("expected at least one host in the session")
+			}
+
+			mu.Lock()
+			startupsBeforeDial := startups
+			mu.Unlock()
+
+			conn, err := session.dial(session.ctx, hosts[0], tt.connConfig(session), connErrorHandlerFn(func(*Conn, error, bool) {}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// This connection only exists to observe what reaches the wire, so
+			// it is discarded right away without calling
+			// conn.finalizeConnection, the same way
+			// controlConn.discoverProtocol does for its throwaway connections.
+			conn.Close()
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			// The connection dialed above is the only one the assertion below
+			// is about, so pin its STARTUP frame down: without this the
+			// "regular connection" case would pass just as well on a frame
+			// that never reached the server.
+			if got := startups - startupsBeforeDial; got != 1 {
+				t.Fatalf("expected the connection dialed by hand to send exactly one STARTUP frame, got %d", got)
+			}
+			if !slices.Equal(configs, tt.wantConfigs) {
+				t.Errorf("expected %s %q on a %s, got %q", driverConfigStartupKey, tt.wantConfigs, tt.name, configs)
+			}
+		})
 	}
 }
 

--- a/exec.go
+++ b/exec.go
@@ -84,13 +84,12 @@ func NewSingleHostQueryExecutor(cfg *ClusterConfig) (e SingleHostQueryExecutor, 
 	// node.
 	hosts = shuffleHosts(hosts)
 
-	conncfg := *e.control.session.connCfg
-	conncfg.disableCoalesce = true
+	conncfg := e.session.controlConnConfig()
 
 	var conn *Conn
 
 	for _, host := range hosts {
-		conn, err = e.control.session.dial(e.control.session.ctx, host, &conncfg, e.control)
+		conn, err = e.control.session.dial(e.control.session.ctx, host, conncfg, e.control)
 		if err != nil {
 			e.control.session.logger.Printf("gocql: unable to dial control conn %v:%v: %v\n", host.ConnectAddress(), host.Port(), err)
 			continue

--- a/integration_test.go
+++ b/integration_test.go
@@ -270,8 +270,9 @@ func TestApplicationInformation(t *testing.T) {
 
 }
 
-// TestDriverConfigReporting verifies end to end that DRIVER_CONFIG is
-// reported by the control connection, mirroring the existing
+// TestDriverConfigReporting verifies end to end that a session reports one
+// SESSION_ID shared by all of its connections, and that DRIVER_CONFIG is
+// reported exactly once, by the control connection, mirroring the existing
 // TestApplicationInformation precedent.
 func TestDriverConfigReporting(t *testing.T) {
 	t.Parallel()
@@ -282,6 +283,14 @@ func TestDriverConfigReporting(t *testing.T) {
 		t.Fatalf("failed to connect to the cluster: %s", err)
 	}
 	defer s.Close()
+
+	// Read the id through the exported accessor rather than the field: an
+	// application correlating its own logs with system.clients has only the
+	// accessor, so that is the path worth exercising end to end.
+	wantSessionID := s.ID()
+	if wantSessionID == "" {
+		t.Fatal("expected the session to have a non-empty id")
+	}
 
 	var clientsTableName string
 	for _, tableName := range []string{"system_views.clients", "system.clients"} {
@@ -295,18 +304,60 @@ func TestDriverConfigReporting(t *testing.T) {
 		t.Skip("Skipping because server does not have `client_options` in clients table")
 	}
 
-	// The clients table is populated asynchronously as connections finish
-	// setting up, so the control connection's row may not be visible right
-	// after CreateSession returns. Poll until it shows up or we time out.
+	// Wait until the pools have finished filling so that the number of
+	// connections this session owns stops moving. Without this the poll below
+	// could reach its exit condition while connections are still being opened.
+	if err := waitUntilPoolsStopFilling(context.Background(), s, 10*time.Second); err != nil {
+		t.Fatalf("failed to wait for the connection pools to fill: %s", err)
+	}
+
+	// The clients table is node-local: every node lists only the connections
+	// made to it. Integration runs use a three node cluster, so a load-balanced
+	// query round-robins across the cluster and most polls would land on a node
+	// that the control connection was never made to, and therefore never see
+	// DRIVER_CONFIG at all. Run every poll on the control connection itself so
+	// the rows always come from the one node whose client list is being
+	// reasoned about.
+	//
+	// Stopping at the first row carrying DRIVER_CONFIG would also make the
+	// "exactly once" assertion below vacuous: the control connection is
+	// established before the pool ones, so its row is the first to appear, and a
+	// regression that also reported DRIVER_CONFIG on pool connections would go
+	// unnoticed because their rows are not in the table yet. Wait for every
+	// connection to that node to be accounted for instead.
 	var configs []string
 	deadline := time.After(10 * time.Second)
 	for {
+		// Re-read the control connection's host on every pass: it can move if
+		// the control connection reconnects, and the pool size it is compared
+		// against has to belong to the same node. Re-reading the pool size also
+		// means that should a pool start filling again, the bar rises with it
+		// instead of leaving the loop free to exit on a stale count.
+		ch := s.control.getConn()
+		if ch == nil {
+			t.Fatal("expected the session to have a control connection")
+		}
+		controlHost := ch.host
+
+		// Connections this session has to the control connection's node: its
+		// pool for that host, plus the control connection itself, which is
+		// dialed outside the pool.
+		wantConns := 1
+		if hostPool, ok := s.pool.getPool(controlHost); ok {
+			wantConns += hostPool.Size()
+		}
+
 		configs = nil
+		conns := 0
 
 		var row map[string]string
-		iter := s.Query("select client_options from " + clientsTableName).Iter()
+		iter := s.control.query("select client_options from " + clientsTableName)
 		for iter.Scan(&row) {
-			if config, ok := row["DRIVER_CONFIG"]; ok {
+			if row[sessionIDStartupKey] != wantSessionID {
+				continue
+			}
+			conns++
+			if config, ok := row[driverConfigStartupKey]; ok {
 				configs = append(configs, config)
 			}
 		}
@@ -314,17 +365,25 @@ func TestDriverConfigReporting(t *testing.T) {
 			t.Fatalf("failed to execute query: %s", err)
 		}
 
-		if len(configs) > 0 {
+		// More rows than connections is fine: a connection that has already been
+		// closed can linger in the clients table. Those rows cannot hide a
+		// regression, they can only reveal one, since a second DRIVER_CONFIG is
+		// a failure no matter which connection produced it.
+		if conns >= wantConns && len(configs) > 0 {
 			break
 		}
 
 		select {
 		case <-deadline:
-			t.Fatalf("expected at least one connection to report DRIVER_CONFIG within 10s")
+			t.Fatalf("expected all %d connections with SESSION_ID %q to node %s to be listed in %s with at least one reporting DRIVER_CONFIG within 10s, saw %d connections and %d DRIVER_CONFIG",
+				wantConns, wantSessionID, controlHost.ConnectAddress(), clientsTableName, conns, len(configs))
 		case <-time.After(250 * time.Millisecond):
 		}
 	}
 
+	if len(configs) != 1 {
+		t.Errorf("expected exactly one connection with SESSION_ID %q to report DRIVER_CONFIG, got %d", wantSessionID, len(configs))
+	}
 	for _, config := range configs {
 		if want := `{"version":1}`; config != want {
 			t.Errorf("expected DRIVER_CONFIG to be %q, got %q", want, config)

--- a/integration_test.go
+++ b/integration_test.go
@@ -270,6 +270,68 @@ func TestApplicationInformation(t *testing.T) {
 
 }
 
+// TestDriverConfigReporting verifies end to end that DRIVER_CONFIG is
+// reported by the control connection, mirroring the existing
+// TestApplicationInformation precedent.
+func TestDriverConfigReporting(t *testing.T) {
+	t.Parallel()
+
+	cluster := createCluster()
+	s, err := cluster.CreateSession()
+	if err != nil {
+		t.Fatalf("failed to connect to the cluster: %s", err)
+	}
+	defer s.Close()
+
+	var clientsTableName string
+	for _, tableName := range []string{"system_views.clients", "system.clients"} {
+		iter := s.Query("select client_options from " + tableName).Iter()
+		if _, err := iter.SliceMap(); err == nil {
+			clientsTableName = tableName
+			break
+		}
+	}
+	if clientsTableName == "" {
+		t.Skip("Skipping because server does not have `client_options` in clients table")
+	}
+
+	// The clients table is populated asynchronously as connections finish
+	// setting up, so the control connection's row may not be visible right
+	// after CreateSession returns. Poll until it shows up or we time out.
+	var configs []string
+	deadline := time.After(10 * time.Second)
+	for {
+		configs = nil
+
+		var row map[string]string
+		iter := s.Query("select client_options from " + clientsTableName).Iter()
+		for iter.Scan(&row) {
+			if config, ok := row["DRIVER_CONFIG"]; ok {
+				configs = append(configs, config)
+			}
+		}
+		if err := iter.Close(); err != nil {
+			t.Fatalf("failed to execute query: %s", err)
+		}
+
+		if len(configs) > 0 {
+			break
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("expected at least one connection to report DRIVER_CONFIG within 10s")
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+
+	for _, config := range configs {
+		if want := `{"version":1}`; config != want {
+			t.Errorf("expected DRIVER_CONFIG to be %q, got %q", want, config)
+		}
+	}
+}
+
 func TestWriteFailure(t *testing.T) {
 	t.Parallel()
 

--- a/session.go
+++ b/session.go
@@ -27,9 +27,11 @@ package gocql
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"maps"
+	mrand "math/rand/v2"
 	"net"
 	"slices"
 	"strings"
@@ -57,32 +59,36 @@ import (
 // and automatically sets a default consistency level on all operations
 // that do not have a consistency level set.
 type Session struct {
-	warningHandler            WarningHandler
-	queryObserver             QueryObserver
-	control                   controlConnection
-	ctx                       context.Context
-	logger                    StdLogger
-	trace                     Tracer
-	policy                    HostSelectionPolicy
-	batchObserver             BatchObserver
-	connectObserver           ConnectObserver
-	frameObserver             FrameHeaderObserver
-	streamObserver            StreamObserver
-	initErr                   error
-	nodeEvents                *eventDebouncer
-	stmtsLRU                  *preparedLRU
-	hostSource                *ringDescriber
-	pool                      *policyConnPool
-	ringRefresher             *debounce.RefreshDebouncer
-	readyCh                   chan struct{}
-	executor                  *queryExecutor
-	cancel                    context.CancelFunc
-	schemaEvents              *eventDebouncer
-	metadataDescriber         *metadataDescriber
-	eventBus                  *eventbus.EventBus[events.Event]
-	connCfg                   *ConnConfig
-	clientRoutesHandler       *ClientRoutesHandler
-	driverConfigReporter      *driverConfigReporter
+	warningHandler       WarningHandler
+	queryObserver        QueryObserver
+	control              controlConnection
+	ctx                  context.Context
+	logger               StdLogger
+	trace                Tracer
+	policy               HostSelectionPolicy
+	batchObserver        BatchObserver
+	connectObserver      ConnectObserver
+	frameObserver        FrameHeaderObserver
+	streamObserver       StreamObserver
+	initErr              error
+	nodeEvents           *eventDebouncer
+	stmtsLRU             *preparedLRU
+	hostSource           *ringDescriber
+	pool                 *policyConnPool
+	ringRefresher        *debounce.RefreshDebouncer
+	readyCh              chan struct{}
+	executor             *queryExecutor
+	cancel               context.CancelFunc
+	schemaEvents         *eventDebouncer
+	metadataDescriber    *metadataDescriber
+	eventBus             *eventbus.EventBus[events.Event]
+	connCfg              *ConnConfig
+	clientRoutesHandler  *ClientRoutesHandler
+	driverConfigReporter *driverConfigReporter
+	// id is a globally unique identifier for this session, reported to
+	// the cluster via the SESSION_ID STARTUP option so that all connections
+	// belonging to the same session can be correlated in system.clients.
+	id                        string
 	routingKeyInfoCache       routingKeyInfoLRU
 	addressTranslator         AddressTranslator
 	cfg                       ClusterConfig
@@ -160,6 +166,7 @@ func newSessionCommon(cfg ClusterConfig) (*Session, error) {
 	if !cfg.DisableDriverConfigReporting {
 		s.driverConfigReporter = newDriverConfigReporter(s)
 	}
+	s.id = newSessionID(s.logger)
 
 	// Close created resources on error otherwise they'll leak
 	var err error
@@ -216,6 +223,60 @@ func newSessionCommon(cfg ClusterConfig) (*Session, error) {
 		s.warningHandler = cfg.WarningsHandlerBuilder(s)
 	}
 	return s, nil
+}
+
+// sessionIDStartupKey is the STARTUP option correlating the connections that
+// belong to one session in system.clients. Unlike driverConfigStartupKey it is
+// sent on every connection, since correlating them is the whole point.
+const sessionIDStartupKey = "SESSION_ID"
+
+// newSessionID generates a globally unique identifier for a session.
+//
+// Every connection reports one, so this always returns an id rather than
+// propagating a failure to generate it.
+//
+// The fallback is defensive rather than reachable: RandomUUID reads from
+// crypto/rand, which since Go 1.24 terminates the process instead of
+// returning an error when the system entropy source fails
+// (golang/go#66821). Since RandomUUID's signature still admits an error,
+// handling it costs little and keeps the id unconditional whatever a future
+// implementation does.
+func newSessionID(logger StdLogger) string {
+	id, err := RandomUUID()
+	if err != nil {
+		logger.Printf("gocql: unable to generate a random session id, falling back to a pseudo-random one: %v", err)
+		id = pseudoRandomUUID()
+	}
+	return id.String()
+}
+
+// pseudoRandomUUID builds a version 4 UUID from the runtime's pseudo-random
+// source, for the case where crypto/rand reports a failure instead of
+// aborting the process. A session id merely correlates the connections of one
+// session in system.clients and is never a security token, so a weaker source
+// of randomness is preferable to no id at all.
+func pseudoRandomUUID() UUID {
+	var u UUID
+	binary.BigEndian.PutUint64(u[:8], mrand.Uint64())
+	binary.BigEndian.PutUint64(u[8:], mrand.Uint64())
+	u[6] = u[6]&0x0F | 0x40 // set version to 4 (random uuid)
+	u[8] = u[8]&0x3F | 0x80 // set to IETF variant
+	return u
+}
+
+// ID returns the globally unique identifier of this session.
+//
+// Every connection the session opens reports this value to the cluster as the
+// SESSION_ID startup option, where it appears in the
+// system.clients.client_options column. Logging it, recording it in a support
+// bundle or attaching it as a metric label is what allows client-side
+// observations to be matched against those rows, instead of correlating by
+// address and port.
+//
+// The id is assigned when the session is created and never changes, so it is
+// safe to call concurrently and safe to read after the session is closed.
+func (s *Session) ID() string {
+	return s.id
 }
 
 // NewSession wraps an existing Node.

--- a/session.go
+++ b/session.go
@@ -82,6 +82,7 @@ type Session struct {
 	eventBus                  *eventbus.EventBus[events.Event]
 	connCfg                   *ConnConfig
 	clientRoutesHandler       *ClientRoutesHandler
+	driverConfigReporter      *driverConfigReporter
 	routingKeyInfoCache       routingKeyInfoLRU
 	addressTranslator         AddressTranslator
 	cfg                       ClusterConfig
@@ -154,6 +155,10 @@ func newSessionCommon(cfg ClusterConfig) (*Session, error) {
 	if cfg.ClientRoutesConfig != nil {
 		s.clientRoutesHandler = NewClientRoutesAddressTranslator(*cfg.ClientRoutesConfig, s.cfg.DNSResolver, s.cfg.SslOpts != nil, s.logger)
 		s.addressTranslator = s.clientRoutesHandler
+	}
+
+	if !cfg.DisableDriverConfigReporting {
+		s.driverConfigReporter = newDriverConfigReporter(s)
 	}
 
 	// Close created resources on error otherwise they'll leak

--- a/session_id_test.go
+++ b/session_id_test.go
@@ -1,0 +1,163 @@
+//go:build unit
+// +build unit
+
+package gocql
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+func TestSessionIDIsUniquePerSession(t *testing.T) {
+	logger := &defaultLogger{}
+
+	id1 := newSessionID(logger)
+	id2 := newSessionID(logger)
+
+	if id1 == "" || id2 == "" {
+		t.Fatal("expected non-empty session ids")
+	}
+	if id1 == id2 {
+		t.Errorf("expected distinct session ids, got %q twice", id1)
+	}
+}
+
+// TestPseudoRandomUUID covers the fallback newSessionID uses if RandomUUID
+// ever reports an error. newSessionID cannot reach it on any supported Go
+// version, so the fallback is only exercised here: it must produce distinct,
+// well-formed random UUIDs.
+func TestPseudoRandomUUID(t *testing.T) {
+	first := pseudoRandomUUID()
+	second := pseudoRandomUUID()
+
+	if first == second {
+		t.Errorf("expected distinct uuids, got %q twice", first)
+	}
+	for _, u := range []UUID{first, second} {
+		if got := u.Version(); got != 4 {
+			t.Errorf("expected uuid %q to be version 4, got %d", u, got)
+		}
+		if got := u.Variant(); got != VariantIETF {
+			t.Errorf("expected uuid %q to use the IETF variant, got %d", u, got)
+		}
+	}
+}
+
+// TestSessionIDReportingStartupFrame checks what actually reaches the wire:
+// every connection of a session shares the same SESSION_ID, distinct
+// sessions get distinct ones, and every STARTUP frame carries one.
+func TestSessionIDReportingStartupFrame(t *testing.T) {
+	// Enough connections per session that "they all agree" is a claim about a
+	// set rather than about a single sample. The default NumConns of 2 would
+	// technically do, but only the first connection is opened during session
+	// initialization, so a test that did not wait would routinely observe just
+	// that one and assert nothing.
+	const connsPerSession = 3
+
+	tests := []struct {
+		name             string
+		sessionCount     int
+		expectedSessions int
+	}{
+		{name: "single session", sessionCount: 1, expectedSessions: 1},
+		{name: "multiple sessions", sessionCount: 2, expectedSessions: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var (
+				mu         sync.Mutex
+				sessionIDs = map[string]int{}
+				startups   int
+			)
+
+			srv := newTestServerOpts{
+				addr:     "127.0.0.1:0",
+				protocol: defaultProto,
+				recvHook: func(f *framer) {
+					if f.header.Op != frm.OpStartup {
+						return
+					}
+					// Consuming the frame body here is only safe because the fake
+					// server does not read the body of a STARTUP request.
+					opts := readStartupOptions(t, f)
+
+					mu.Lock()
+					defer mu.Unlock()
+					startups++
+					if id, ok := opts[sessionIDStartupKey]; ok {
+						sessionIDs[id]++
+					}
+				},
+			}.newServer(t, ctx)
+			defer srv.Stop()
+
+			sessions := make([]*Session, 0, tt.sessionCount)
+			for i := 0; i < tt.sessionCount; i++ {
+				cluster := testCluster(defaultProto, srv.Address)
+				cluster.NumConns = connsPerSession
+				session, err := cluster.CreateSession()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer session.Close()
+				sessions = append(sessions, session)
+			}
+
+			// CreateSession only guarantees one connection per host: the rest of
+			// the pool is filled asynchronously when NumConns > 1, so without
+			// this wait the snapshot below would capture an arbitrary prefix of
+			// the STARTUP frames. Waiting on the pool is what makes the counts
+			// deterministic, and a connection only joins the pool once its
+			// handshake has completed, which is strictly after the server has
+			// run recvHook on its STARTUP.
+			for i, session := range sessions {
+				if err := waitForPoolSize(session, connsPerSession, 10*time.Second); err != nil {
+					t.Fatalf("session %d: %s", i, err)
+				}
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if len(sessionIDs) != tt.expectedSessions {
+				t.Errorf("expected %d distinct SESSION_ID, got %d: %v", tt.expectedSessions, len(sessionIDs), sessionIDs)
+			}
+
+			// Every connection of a session, not merely the first, must report
+			// the id that session's own ID reports. Keying by ID rather than
+			// iterating the observed ids also pins the two ends of the
+			// correlation together: an accessor that returned anything other
+			// than the value on the wire would leave an application unable to
+			// match its logs to a system.clients row, which is the reason the
+			// id exists. Without the count check the test would pass on a
+			// driver that generated a fresh id per connection, as long as only
+			// one connection per session had been observed.
+			for i, session := range sessions {
+				if count := sessionIDs[session.ID()]; count < connsPerSession {
+					t.Errorf("session %d: expected SESSION_ID %q to be reported by all %d of its connections, got %d: %v",
+						i, session.ID(), connsPerSession, count, sessionIDs)
+				}
+			}
+
+			// Every STARTUP frame must carry a SESSION_ID: summing the
+			// per-id counts and comparing against the unconditional STARTUP
+			// count catches a frame that omits SESSION_ID entirely, which
+			// indexing sessionIDs by the (possibly absent) id would hide.
+			var reported int
+			for _, count := range sessionIDs {
+				reported += count
+			}
+			if reported != startups {
+				t.Errorf("expected every STARTUP frame to carry SESSION_ID: got %d STARTUP frames but only %d reported one", startups, reported)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

This PR adds driver configuration reporting so operators can inspect a client's
effective settings while investigating an incident, without needing access to
the client host.

- Every connection sends a `SESSION_ID` STARTUP option identifying the session
  it belongs to.
- The control connection additionally sends a `DRIVER_CONFIG` STARTUP option
  holding a JSON description of the effective configuration.
- Both options are echoed back by the server into
  `system.clients.client_options`, so `SELECT client_options FROM
  system.clients` shows a session's settings and lets all of a session's
  connections be correlated with each other.

This is **stage 1**: `DRIVER_CONFIG` currently only carries the schema version
(`{"version":1}`). The actual configuration groups (timeouts, policies,
connection pool, etc.) are to be added in a follow-up change.

Refs: https://scylladb.atlassian.net/browse/DRIVER-380