### PR TITLE
perf: avoid boxing the routing token on the common token-aware Pick path

### DIFF
--- a/connectionpool.go
+++ b/connectionpool.go
@@ -308,8 +308,46 @@ func (pool *hostConnPool) Pick(token Token, qry ExecutableQuery) *Conn {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 
-	if pool.closed {
+	if !pool.pickable() {
 		return nil
+	}
+
+	return pool.connPicker.Pick(token, qry)
+}
+
+// PickInt64 picks a connection for the given raw int64 routing token, avoiding
+// the Token interface boxing. Picks fall back to the boxed path when the
+// connPicker does not support raw-int64 picking.
+func (pool *hostConnPool) PickInt64(token int64, qry ExecutableQuery) *Conn {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	if !pool.pickable() {
+		return nil
+	}
+
+	if p, ok := pool.connPicker.(int64ConnPicker); ok {
+		return p.PickInt64(token, qry)
+	}
+	return pool.connPicker.Pick(int64Token(token), qry)
+}
+
+// PickConn routes a picked host to the raw-int64 fast path when it exposes one,
+// and to the boxed Token path otherwise.
+func (pool *hostConnPool) PickConn(host SelectedHost, qry ExecutableQuery) *Conn {
+	if th, ok := host.(int64TokenSelectedHost); ok {
+		if token, has := th.TokenInt64(); has {
+			return pool.PickInt64(int64(token), qry)
+		}
+	}
+	return pool.Pick(host.Token(), qry)
+}
+
+// pickable reports whether the pool is open and has (or is filling) connections.
+// Must be called with pool.mu held.
+func (pool *hostConnPool) pickable() bool {
+	if pool.closed {
+		return false
 	}
 
 	size, missing := pool.connPicker.Size()
@@ -318,11 +356,11 @@ func (pool *hostConnPool) Pick(token Token, qry ExecutableQuery) *Conn {
 		go pool.fill_debounce()
 
 		if size == 0 {
-			return nil
+			return false
 		}
 	}
 
-	return pool.connPicker.Pick(token, qry)
+	return true
 }
 
 // Size returns the number of connections currently active in the pool

--- a/connpicker.go
+++ b/connpicker.go
@@ -24,6 +24,13 @@ type ConnPicker interface {
 	GetShardCount() int
 }
 
+// int64ConnPicker is an optional fast path on ConnPicker: shard-aware conn
+// selection from a raw int64 routing token, avoiding the Token interface
+// boxing. hostConnPool uses it when the routing token is an int64Token.
+type int64ConnPicker interface {
+	PickInt64(int64, ExecutableQuery) *Conn
+}
+
 type defaultConnPicker struct {
 	conns []*Conn
 	pos   uint32
@@ -96,6 +103,16 @@ func (p *defaultConnPicker) Size() (int, int) {
 }
 
 func (p *defaultConnPicker) Pick(Token, ExecutableQuery) *Conn {
+	return p.pickLeastBusy()
+}
+
+// PickInt64 is the raw-int64 variant of Pick; the token is unused, the least
+// busy connection is picked either way.
+func (p *defaultConnPicker) PickInt64(int64, ExecutableQuery) *Conn {
+	return p.pickLeastBusy()
+}
+
+func (p *defaultConnPicker) pickLeastBusy() *Conn {
 	pos := int(atomic.AddUint32(&p.pos, 1) - 1)
 
 	p.mu.RLock()
@@ -151,6 +168,10 @@ func (p nopConnPicker) GetShardCount() int {
 }
 
 func (nopConnPicker) Pick(Token, ExecutableQuery) *Conn {
+	return nil
+}
+
+func (nopConnPicker) PickInt64(int64, ExecutableQuery) *Conn {
 	return nil
 }
 

--- a/policies.go
+++ b/policies.go
@@ -480,6 +480,13 @@ type SelectedHost interface {
 	Mark(error)
 }
 
+// int64TokenSelectedHost is an optional fast path: SelectedHost implementations
+// that resolve routing via an int64Token expose the raw value so the shard-aware
+// conn picker can consume it without boxing it into the Token interface.
+type int64TokenSelectedHost interface {
+	TokenInt64() (int64Token, bool)
+}
+
 type selectedHost struct {
 	info  *HostInfo
 	token Token
@@ -493,7 +500,33 @@ func (host selectedHost) Token() Token {
 	return host.token
 }
 
+func (host selectedHost) TokenInt64() (int64Token, bool) {
+	return 0, false
+}
+
 func (host selectedHost) Mark(err error) {}
+
+// int64SelectedHost is the fast-path variant of selectedHost: it carries the
+// routing token as a raw int64 instead of a boxed Token, so shard-aware conn
+// picking consumes it without an interface allocation.
+type int64SelectedHost struct {
+	info        *HostInfo
+	tokenCasted int64Token
+}
+
+func (host int64SelectedHost) Info() *HostInfo {
+	return host.info
+}
+
+func (host int64SelectedHost) Token() Token {
+	return host.tokenCasted
+}
+
+func (host int64SelectedHost) TokenInt64() (int64Token, bool) {
+	return host.tokenCasted, true
+}
+
+func (host int64SelectedHost) Mark(err error) {}
 
 func newSingleHost(info *HostInfo, maxRetries byte, retryDelay time.Duration) *singleHost {
 	return &singleHost{info: info, maxRetries: maxRetries, delay: retryDelay}
@@ -936,8 +969,18 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 		partitioner = meta.tokenRing.partitioner
 	}
 
-	token := partitioner.Hash(routingKey)
-	tokenCasted, isInt64Token := token.(int64Token)
+	// Fast path: use the raw int64 hash when available, avoiding a Token-boxing
+	// allocation. Falls back to Hash() otherwise (see int64Hasher in token.go).
+	var token Token
+	var tokenCasted int64Token
+	var isInt64Token bool
+	if h64, ok := partitioner.(int64Hasher); ok {
+		tokenCasted = int64Token(h64.hashInt64(routingKey))
+		isInt64Token = true
+	} else {
+		token = partitioner.Hash(routingKey)
+		tokenCasted, isInt64Token = token.(int64Token)
+	}
 
 	var replicas []*HostInfo
 
@@ -956,7 +999,12 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 	}
 
 	if len(replicas) == 0 {
-		ht := meta.replicas[qry.Keyspace()].replicasFor(token)
+		var ht *hostTokens
+		if isInt64Token {
+			ht = meta.replicas[qry.Keyspace()].replicasForInt64(tokenCasted)
+		} else {
+			ht = meta.replicas[qry.Keyspace()].replicasFor(token)
+		}
 		if ht != nil {
 			needsMutation := t.shuffleReplicas || t.avoidSlowReplicas
 			if needsMutation {
@@ -970,6 +1018,11 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 	}
 
 	if len(replicas) == 0 {
+		// Rare fallback (no tablet/replica-map match): GetHostForToken needs a
+		// boxed Token, so box only here instead of on every query.
+		if token == nil {
+			token = tokenCasted
+		}
 		host, _ := meta.tokenRing.GetHostForToken(token)
 		replicas = []*HostInfo{host}
 	}
@@ -1029,6 +1082,9 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 
 			if h.IsUp() {
 				used.add(h)
+				if token == nil {
+					return int64SelectedHost{info: h, tokenCasted: tokenCasted}
+				}
 				return selectedHost{info: h, token: token}
 			}
 		}
@@ -1045,6 +1101,9 @@ func (t *tokenAwareHostPolicy) Pick(qry ExecutableQuery) NextHost {
 
 				if h.IsUp() {
 					used.add(h)
+					if token == nil {
+						return int64SelectedHost{info: h, tokenCasted: tokenCasted}
+					}
 					return selectedHost{info: h, token: token}
 				}
 			}

--- a/policies_bench_test.go
+++ b/policies_bench_test.go
@@ -166,6 +166,73 @@ func BenchmarkTabletAwarePickAllReplicas(b *testing.B) {
 	}
 }
 
+// setupReplicaMapAwareBench sets up a tokenAwareHostPolicy on the default
+// Murmur3Partitioner replica-map path (no tablets, no custom partitioner).
+func setupReplicaMapAwareBench(b *testing.B, numHosts, rf int) (HostSelectionPolicy, []*Query) {
+	b.Helper()
+
+	const keyspace = "benchks"
+
+	policy := TokenAwareHostPolicy(RoundRobinHostPolicy())
+	policyInternal := policy.(*tokenAwareHostPolicy)
+	policyInternal.getKeyspaceName = func() string { return keyspace }
+	policyInternal.getKeyspaceMetadata = func(ks string) (*KeyspaceMetadata, error) {
+		return &KeyspaceMetadata{
+			Name:          keyspace,
+			StrategyClass: "SimpleStrategy",
+			StrategyOptions: map[string]any{
+				"class":              "SimpleStrategy",
+				"replication_factor": rf,
+			},
+		}, nil
+	}
+
+	for i := 0; i < numHosts; i++ {
+		host := &HostInfo{
+			hostId:         tUUID(i),
+			connectAddress: net.IPv4(10, 0, byte(i>>8), byte(i)),
+			tokens:         []string{fmt.Sprintf("%d", int64(math.MinInt64)+int64(i)*100)},
+		}
+		policy.AddHost(host)
+	}
+	policy.SetPartitioner("Murmur3Partitioner")
+	policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: keyspace})
+
+	const numQueries = 256
+	queries := make([]*Query, numQueries)
+	for i := range queries {
+		queries[i] = &Query{
+			routingInfo: &queryRoutingInfo{keyspace: keyspace},
+		}
+		queries[i].getKeyspace = func() string { return keyspace }
+		queries[i].routingKey = []byte(fmt.Sprintf("routing-key-%d", i))
+	}
+
+	return policy, queries
+}
+
+// BenchmarkTokenAwarePickReplicaMap benchmarks Pick() on the int64Hasher fast path.
+func BenchmarkTokenAwarePickReplicaMap(b *testing.B) {
+	for _, numHosts := range []int{10, 50, 100} {
+		b.Run(fmt.Sprintf("Hosts%d", numHosts), func(b *testing.B) {
+			policy, queries := setupReplicaMapAwareBench(b, numHosts, 3)
+
+			runtime.GC()
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				qry := queries[i%len(queries)]
+				iter := policy.Pick(qry)
+				h := iter()
+				if h == nil {
+					b.Fatal("Pick returned nil on first call")
+				}
+			}
+		})
+	}
+}
+
 // BenchmarkHostIdComparison is a micro-benchmark for isolated host-ID
 // comparisons: string==string (current) baseline.
 func BenchmarkHostIdComparison(b *testing.B) {

--- a/policies_test.go
+++ b/policies_test.go
@@ -1610,6 +1610,80 @@ func TestTokenAwareHostPolicy_TabletReplicasPresizeAllocRegression(t *testing.T)
 	}
 }
 
+// TestTokenAwareHostPolicy_Pick_FallbackToGetHostForToken_DefaultPartitioner
+// is a regression guard for the lazy-boxing fallback to GetHostForToken.
+func TestTokenAwareHostPolicy_Pick_FallbackToGetHostForToken_DefaultPartitioner(t *testing.T) {
+	t.Parallel()
+
+	policy := TokenAwareHostPolicy(RoundRobinHostPolicy())
+	policyInternal := policy.(*tokenAwareHostPolicy)
+	// No keyspace name means meta.replicas is never populated, forcing the GetHostForToken fallback.
+	policyInternal.getKeyspaceName = func() string { return "" }
+
+	host0 := &HostInfo{hostId: tUUID(0), connectAddress: net.IPv4(10, 0, 0, 1), tokens: []string{"-9223372036854775808"}}
+	host1 := &HostInfo{hostId: tUUID(1), connectAddress: net.IPv4(10, 0, 0, 2), tokens: []string{"0"}}
+	host2 := &HostInfo{hostId: tUUID(2), connectAddress: net.IPv4(10, 0, 0, 3), tokens: []string{"6148914691236517206"}}
+	policy.AddHost(host0)
+	policy.AddHost(host1)
+	policy.AddHost(host2)
+	policy.SetPartitioner("Murmur3Partitioner")
+
+	query := &Query{routingInfo: &queryRoutingInfo{}}
+	query.getKeyspace = func() string { return "unregistered-keyspace" }
+	query.routingKey = []byte("some-routing-key")
+
+	iter := policy.Pick(query)
+	got := iter()
+	if got == nil || got.Info() == nil {
+		t.Fatal("expected a host from the GetHostForToken fallback, got nil")
+	}
+
+	meta := policyInternal.getMetadataReadOnly()
+	if meta == nil || meta.tokenRing == nil {
+		t.Fatal("test setup did not build a token ring")
+	}
+	if len(meta.replicas) != 0 {
+		t.Fatalf("test setup unexpectedly populated a replica map: %v", meta.replicas)
+	}
+
+	wantHost, _ := meta.tokenRing.GetHostForToken(murmur3Partitioner{}.Hash(query.routingKey))
+	if wantHost == nil {
+		t.Fatal("direct GetHostForToken returned nil; test setup is broken")
+	}
+	if got.Info() != wantHost {
+		t.Fatalf("Pick() fallback returned host %v, want %v (from direct GetHostForToken with the same routing key)",
+			got.Info().ConnectAddress(), wantHost.ConnectAddress())
+	}
+}
+
+// TestSelectedHostTokenInt64 verifies the unboxed routing token: TokenInt64()
+// returns the raw int64, and Token() lazily boxes to a non-nil value so the
+// shard-aware invariant (a nil token would disable shard-aware picking) holds
+// for any caller, not just the raw fast path.
+func TestSelectedHostTokenInt64(t *testing.T) {
+	t.Parallel()
+
+	sh := int64SelectedHost{info: &HostInfo{}, tokenCasted: int64Token(42)}
+	tok, ok := sh.TokenInt64()
+	if !ok || tok != int64Token(42) {
+		t.Fatalf("TokenInt64() = %d, %v; want 42, true", tok, ok)
+	}
+	if got := sh.Token(); got == nil || got != int64Token(42) {
+		t.Fatalf("Token() = %v; want boxed int64Token(42)", got)
+	}
+	if got := sh.Token(); got == nil || got != int64Token(42) {
+		t.Fatalf("Token() (again) = %v; want boxed int64Token(42)", got)
+	}
+
+	shBoxed := selectedHost{info: &HostInfo{}, token: int64Token(7)}
+	if tok, ok := shBoxed.TokenInt64(); ok || tok != 0 {
+		t.Fatalf("TokenInt64() = %d, %v; want 0, false for a boxed-only host", tok, ok)
+	}
+	if got := shBoxed.Token(); got != int64Token(7) {
+		t.Fatalf("Token() = %v; want boxed int64Token(7)", got)
+	}
+}
+
 func TestTokenAwareHostPolicyTabletPath(t *testing.T) {
 	t.Parallel()
 

--- a/query_executor.go
+++ b/query_executor.go
@@ -300,7 +300,7 @@ func (q *queryExecutor) do(ctx context.Context, qry ExecutableQuery, metrics *qu
 				},
 			}, RetryNextHost
 		}
-		conn := pool.Pick(selectedHost.Token(), qry)
+		conn := pool.PickConn(selectedHost, qry)
 		if conn == nil {
 			return &Iter{
 				err: &QueryError{

--- a/scylla.go
+++ b/scylla.go
@@ -499,6 +499,26 @@ func (p *scyllaConnPicker) Pick(t Token, qry ExecutableQuery) *Conn {
 		return nil
 	}
 
+	return p.pickInt64Locked(mmt, qry)
+}
+
+// PickInt64 is the raw-int64 fast-path variant of Pick, avoiding the Token
+// interface boxing. It must only be called with int64-based routing tokens
+// (Murmur3/ScyllaCDC), which is guaranteed by int64TokenSelectedHost.
+func (p *scyllaConnPicker) PickInt64(token int64, qry ExecutableQuery) *Conn {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if len(p.conns) == 0 {
+		return nil
+	}
+
+	return p.pickInt64Locked(int64Token(token), qry)
+}
+
+// pickInt64Locked selects the shard-aware connection for the given raw token.
+// Must be called with p.mu held.
+func (p *scyllaConnPicker) pickInt64Locked(mmt int64Token, qry ExecutableQuery) *Conn {
 	idx := -1
 
 outer:

--- a/scylla_cdc.go
+++ b/scylla_cdc.go
@@ -35,13 +35,17 @@ func (p scyllaCDCPartitioner) Name() string {
 }
 
 func (p scyllaCDCPartitioner) Hash(partitionKey []byte) Token {
+	return int64Token(p.hashInt64(partitionKey))
+}
+
+func (p scyllaCDCPartitioner) hashInt64(partitionKey []byte) int64 {
 	if len(partitionKey) < 8 {
 		// The key is too short to extract any sensible token,
 		// so return the min token instead
 		if debug.Enabled {
 			p.logger.Printf("scylla: cdc partition key too short: %d < 8", len(partitionKey))
 		}
-		return scyllaCDCMinToken
+		return int64(scyllaCDCMinToken)
 	}
 
 	upperQword := binary.BigEndian.Uint64(partitionKey[0:])
@@ -69,8 +73,10 @@ func (p scyllaCDCPartitioner) Hash(partitionKey []byte) Token {
 		}
 	}
 
-	return int64Token(upperQword)
+	return int64(upperQword)
 }
+
+var _ int64Hasher = scyllaCDCPartitioner{}
 
 func (p scyllaCDCPartitioner) ParseString(str string) Token {
 	return parseInt64Token(str)

--- a/scylla_cdc_test.go
+++ b/scylla_cdc_test.go
@@ -1,0 +1,94 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gocql
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// TestScyllaCDCPartitioner_HashInt64MatchesHash verifies hashInt64 matches Hash().
+func TestScyllaCDCPartitioner_HashInt64MatchesHash(t *testing.T) {
+	t.Parallel()
+
+	p := scyllaCDCPartitioner{logger: &defaultLogger{}}
+	var _ int64Hasher = p
+
+	mk16 := func(upper uint64, version uint64) []byte {
+		buf := make([]byte, 16)
+		binary.BigEndian.PutUint64(buf[0:], upper)
+		binary.BigEndian.PutUint64(buf[8:], version)
+		return buf
+	}
+
+	keys := [][]byte{
+		nil,
+		{},
+		{1, 2, 3},             // < 8 bytes: min-token path
+		{1, 2, 3, 4, 5, 6, 7}, // 7 bytes: still < 8
+		mk16(0, 1)[:8],        // exactly 8 bytes: upper-qword path, no debug checks possible
+		mk16(1, scyllaCDCMinSupportedVersion),
+		mk16(math.MaxUint64, scyllaCDCMaxSupportedVersion),
+		mk16(12345, 0),                  // unsupported version (0 < min) -- still just logs in debug mode
+		mk16(12345, 99),                 // unsupported version (99 > max) -- still just logs in debug mode
+		append(mk16(42, 1), 0xFF, 0xFF), // >16 bytes: wrong-size path, still just logs
+	}
+
+	for _, k := range keys {
+		want := p.Hash(k)
+		wantInt64, ok := want.(int64Token)
+		if !ok {
+			t.Fatalf("Hash(%v) returned %T, want int64Token", k, want)
+		}
+		got := int64Token(p.hashInt64(k))
+		if got != wantInt64 {
+			t.Errorf("hashInt64(%v) = %d, want %d (from Hash)", k, got, wantInt64)
+		}
+	}
+}
+
+func TestScyllaCDCPartitioner_HashInt64_ShortKeyReturnsMinToken(t *testing.T) {
+	t.Parallel()
+
+	p := scyllaCDCPartitioner{logger: &defaultLogger{}}
+	got := p.hashInt64([]byte{1, 2, 3})
+	if got != int64(scyllaCDCMinToken) {
+		t.Fatalf("hashInt64(short key) = %d, want %d (scyllaCDCMinToken)", got, int64(scyllaCDCMinToken))
+	}
+}
+
+func TestScyllaCDCPartitioner_HashInt64_ZeroAlloc(t *testing.T) {
+	p := scyllaCDCPartitioner{logger: &defaultLogger{}}
+	pk := make([]byte, 16)
+	binary.BigEndian.PutUint64(pk[0:], 12345)
+	binary.BigEndian.PutUint64(pk[8:], 1)
+
+	var sink int64
+	allocs := testing.AllocsPerRun(1000, func() {
+		sink = p.hashInt64(pk)
+	})
+	if allocs != 0 {
+		t.Errorf("hashInt64 allocated %.2f allocs/op, want 0", allocs)
+	}
+	_ = sink
+}

--- a/scylla_test.go
+++ b/scylla_test.go
@@ -70,6 +70,69 @@ func TestScyllaConnPickerPickNilToken(t *testing.T) {
 	})
 }
 
+// TestScyllaConnPickerPickInt64MatchesPick verifies the raw-int64 fast path
+// PickInt64 selects exactly the same shard-aware connection as the boxed Pick.
+func TestScyllaConnPickerPickInt64MatchesPick(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		nrShards  int
+		msbIgnore uint64
+		tokens    []int64
+	}{
+		{"four-shards", 4, 12, []int64{math.MinInt64, -123456789, 0, 123456789, math.MaxInt64}},
+		{"eight-shards", 8, 0, []int64{-100000, 42, 999999999999}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scyllaConnPicker{nrShards: tc.nrShards, msbIgnore: tc.msbIgnore}
+			s.conns = make([]*Conn, tc.nrShards)
+			for i := range s.conns {
+				s.conns[i] = &Conn{streams: streams.New()}
+			}
+
+			for _, tok := range tc.tokens {
+				tt := int64Token(tok)
+				want := s.Pick(tt, nil)
+				got := s.PickInt64(tok, nil)
+				if got != want {
+					t.Fatalf("token %d: PickInt64=%p, want %p (Pick)", tok, got, want)
+				}
+				if shard := s.shardOf(tt); got != s.conns[shard] {
+					t.Fatalf("token %d: shard %d conn %p, got %p", tok, shard, s.conns[shard], got)
+				}
+			}
+		})
+	}
+}
+
+// TestHostConnPoolPickConnRoutesInt64TokenToShardAwarePicker is a regression
+// guard: a SelectedHost carrying an unboxed int64Token must still reach the
+// shard-aware picker. If the raw token were dropped, scyllaConnPicker would
+// fall back to leastBusyConn() and shard-aware routing would silently degrade.
+func TestHostConnPoolPickConnRoutesInt64TokenToShardAwarePicker(t *testing.T) {
+	t.Parallel()
+
+	picker := scyllaConnPicker{nrShards: 4, msbIgnore: 12, nrConns: 4}
+	picker.conns = make([]*Conn, 4)
+	for i := range picker.conns {
+		picker.conns[i] = &Conn{streams: streams.New()}
+	}
+
+	tok := int64Token(math.MinInt64)
+	shard := picker.shardOf(tok)
+	want := picker.conns[shard]
+
+	pool := &hostConnPool{connPicker: &picker}
+	host := int64SelectedHost{info: &HostInfo{}, tokenCasted: tok}
+
+	got := pool.PickConn(host, nil)
+	if got != want {
+		t.Fatalf("PickConn returned %p (least-busy fallback?); want shard-aware conn %p for shard %d",
+			got, want, shard)
+	}
+}
+
 func hammerConnPicker(t *testing.T, wg *sync.WaitGroup, s *scyllaConnPicker, loops int) {
 	t.Helper()
 	for i := 0; i < loops; i++ {

--- a/token.go
+++ b/token.go
@@ -53,6 +53,12 @@ type Token interface {
 	Less(Token) bool
 }
 
+// int64Hasher is an optional fast path avoiding Hash()'s Token-boxing
+// allocation; Pick uses the raw int64 when a Partitioner implements it.
+type int64Hasher interface {
+	hashInt64(partitionKey []byte) int64
+}
+
 // murmur3 partitioner
 type murmur3Partitioner struct{}
 
@@ -61,9 +67,14 @@ func (p murmur3Partitioner) Name() string {
 }
 
 func (p murmur3Partitioner) Hash(partitionKey []byte) Token {
-	h1 := murmur.Murmur3H1(partitionKey)
-	return int64Token(h1)
+	return int64Token(p.hashInt64(partitionKey))
 }
+
+func (p murmur3Partitioner) hashInt64(partitionKey []byte) int64 {
+	return murmur.Murmur3H1(partitionKey)
+}
+
+var _ int64Hasher = murmur3Partitioner{}
 
 // murmur3 little-endian, 128-bit hash, but returns only h1
 func (p murmur3Partitioner) ParseString(str string) Token {

--- a/token_test.go
+++ b/token_test.go
@@ -60,6 +60,67 @@ func TestMurmur3Partitioner(t *testing.T) {
 	}
 }
 
+// TestMurmur3Partitioner_HashInt64MatchesHash verifies hashInt64 matches Hash().
+func TestMurmur3Partitioner_HashInt64MatchesHash(t *testing.T) {
+	t.Parallel()
+
+	var p murmur3Partitioner
+	var _ int64Hasher = p // compile-time contract check, mirrors token.go's var _ assertion
+
+	keys := [][]byte{
+		nil,
+		{},
+		{0},
+		{1, 2, 3},
+		[]byte("routing-key"),
+		[]byte("a-somewhat-longer-partition-key-value-1234567890"),
+	}
+	for i := 0; i < 32; i++ {
+		buf := make([]byte, i)
+		for j := range buf {
+			buf[j] = byte(i*7 + j)
+		}
+		keys = append(keys, buf)
+	}
+
+	for _, k := range keys {
+		want := p.Hash(k)
+		wantInt64, ok := want.(int64Token)
+		if !ok {
+			t.Fatalf("Hash(%v) returned %T, want int64Token", k, want)
+		}
+		got := int64Token(p.hashInt64(k))
+		if got != wantInt64 {
+			t.Errorf("hashInt64(%v) = %d, want %d (from Hash)", k, got, wantInt64)
+		}
+	}
+}
+
+func TestMurmur3Partitioner_HashInt64_ZeroAlloc(t *testing.T) {
+	var p murmur3Partitioner
+	pk := []byte("routing-key")
+
+	var sink int64
+	allocs := testing.AllocsPerRun(1000, func() {
+		sink = p.hashInt64(pk)
+	})
+	if allocs != 0 {
+		t.Errorf("hashInt64 allocated %.2f allocs/op, want 0", allocs)
+	}
+	_ = sink
+
+	// Contrast: Hash() itself allocates once, boxing the int64 into a Token.
+	var tokSink Token
+	hashAllocs := testing.AllocsPerRun(1000, func() {
+		tokSink = p.Hash(pk)
+	})
+	_ = tokSink
+	if hashAllocs != 1 {
+		t.Logf("Hash() allocated %.2f allocs/op (expected ~1 from Token boxing); "+
+			"int64Hasher fast path may no longer be needed if this is 0", hashAllocs)
+	}
+}
+
 // Tests of the int64Token
 func TestInt64Token(t *testing.T) {
 	t.Parallel()

--- a/topology.go
+++ b/topology.go
@@ -65,6 +65,30 @@ func (h tokenRingReplicas) replicasFor(t Token) *hostTokens {
 	return &h[p]
 }
 
+// replicasForInt64 is replicasFor specialized for an already-unboxed int64Token,
+// avoiding a Token-interface comparison on every token-aware routing decision.
+func (h tokenRingReplicas) replicasForInt64(t int64Token) *hostTokens {
+	if len(h) == 0 {
+		return nil
+	}
+
+	p := sort.Search(len(h), func(i int) bool {
+		if ht, ok := h[i].token.(int64Token); ok {
+			return ht >= t
+		}
+		// Ring token type differs from int64Token (mismatched partitioner) —
+		// fall back to the boxed comparison, matching replicasFor's panic-or-not parity.
+		return !h[i].token.Less(t)
+	})
+
+	if p >= len(h) {
+		// rollover
+		p = 0
+	}
+
+	return &h[p]
+}
+
 type placementStrategy interface {
 	replicaMap(tokenRing *tokenRing) tokenRingReplicas
 	replicationFactor(dc string) int

--- a/topology_test.go
+++ b/topology_test.go
@@ -29,6 +29,7 @@ package gocql
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"testing"
 )
@@ -236,4 +237,74 @@ func TestPlacementStrategy_NetworkStrategy(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTokenRingReplicas_ReplicasForInt64MatchesReplicasFor checks replicasForInt64
+// matches replicasFor for every query token, including boundaries and wraparound.
+func TestTokenRingReplicas_ReplicasForInt64MatchesReplicasFor(t *testing.T) {
+	t.Parallel()
+
+	host0 := &HostInfo{hostId: tUUID(0)}
+	host1 := &HostInfo{hostId: tUUID(1)}
+	host2 := &HostInfo{hostId: tUUID(2)}
+
+	replicas := tokenRingReplicas{
+		{token: int64Token(-100), hosts: []*HostInfo{host0}},
+		{token: int64Token(0), hosts: []*HostInfo{host1}},
+		{token: int64Token(100), hosts: []*HostInfo{host2}},
+	}
+
+	queries := []int64Token{
+		math.MinInt64, -1000, -101, -100, -99, -50, -1,
+		0, 1, 50, 99, 100, 101, 1000, math.MaxInt64,
+	}
+	for _, q := range queries {
+		want := replicas.replicasFor(q)
+		got := replicas.replicasForInt64(q)
+		if want != got {
+			t.Errorf("token %d: replicasFor=%p (ring token %v) replicasForInt64=%p (ring token %v) diverge",
+				q, want, tokensOf(want), got, tokensOf(got))
+		}
+	}
+}
+
+// tokensOf is a small test helper to render a *hostTokens' token for
+// error messages without panicking on nil.
+func tokensOf(h *hostTokens) any {
+	if h == nil {
+		return nil
+	}
+	return h.token
+}
+
+func TestTokenRingReplicas_ReplicasForInt64_EmptyRing(t *testing.T) {
+	t.Parallel()
+
+	var replicas tokenRingReplicas
+	if got := replicas.replicasForInt64(42); got != nil {
+		t.Fatalf("expected nil for an empty ring, got %v", got)
+	}
+}
+
+// TestTokenRingReplicas_ReplicasForInt64_MismatchedTokenTypePanicsLikeReplicasFor
+// checks a mismatched ring token type panics the same way replicasFor does.
+func TestTokenRingReplicas_ReplicasForInt64_MismatchedTokenTypePanicsLikeReplicasFor(t *testing.T) {
+	t.Parallel()
+
+	host0 := &HostInfo{hostId: tUUID(0)}
+	replicas := tokenRingReplicas{
+		{token: intToken(0), hosts: []*HostInfo{host0}},
+	}
+
+	mustPanic := func(t *testing.T, name string, fn func()) {
+		defer func() {
+			if recover() == nil {
+				t.Errorf("%s: expected a panic from the mismatched Token type, got none", name)
+			}
+		}()
+		fn()
+	}
+
+	mustPanic(t, "replicasFor", func() { replicas.replicasFor(int64Token(50)) })
+	mustPanic(t, "replicasForInt64", func() { replicas.replicasForInt64(int64Token(50)) })
 }


### PR DESCRIPTION
### Problem

`murmur3Partitioner.Hash()` (and `scyllaCDCPartitioner.Hash()`) converts an arbitrary `int64` into the `Token` interface, which heap-allocates on every call because the value doesn't fit the runtime's small-int interface cache. This ran on **every** token-aware `Pick()` — the default host-selection policy path for every query.

The previous version of this PR added an `int64Hasher` fast path but then *re-boxed* the token into the returned `SelectedHost` (a nil token makes `scyllaConnPicker` fall back to least-busy picking, so the box was mandatory for correctness). The net effect was that the branch stayed **allocation-identical to origin/master** (8 allocs/op, 344 B/op) — the advertised win was not real.

### Change

Carry the token as a raw `int64` all the way to the conn picker, never boxing it on the hot path:

1. **`perf: avoid boxing the routing token on the common token-aware Pick path`** — unexported `int64Hasher` fast-path interface (murmur3 + scyllaCDC partitioners) returning the raw `int64`; `Pick` works with the unboxed value through `tokenRingReplicas.replicasForInt64` (comparing `int64Token` values directly instead of the boxed `Token.Less`). Boxing survives only in the rare `GetHostForToken` fallback. On its own this commit is allocation-neutral — the returned `SelectedHost` still needs a boxed token.
2. **`perf: propagate the raw int64 routing token to the conn picker`** — `int64SelectedHost` (fast-path variant of `selectedHost`) exposes the unboxed token via the optional `int64TokenSelectedHost` interface (`TokenInt64()`); `hostConnPool.PickConn` dispatches to a new `PickInt64(int64, qry)` over an optional `int64ConnPicker` implemented by `scyllaConnPicker` (shard-aware), `defaultConnPicker`, and `nopConnPicker`. Non-int64 hosts fall back to the boxed `Pick` path unchanged.

The exported API (`SelectedHost`, `ConnPicker`) is untouched. The non-nil-token shard-aware invariant is preserved end-to-end by propagating the raw token instead of re-boxing it (covered by `TestScyllaConnPickerPickInt64MatchesPick`, `TestHostConnPoolPickConnRoutesInt64TokenToShardAwarePicker`).

### Results vs origin/master

`BenchmarkTokenAwarePickReplicaMap` (default `Murmur3Partitioner`, no tablets), single core (`GOMAXPROCS=1`, `-cpu=1`):

| | allocs/op | B/op | ns/op |
|---|---|---|---|
| origin/master | 8 | 344 | ~238–251 |
| previous PR head | 8 | 344 | ~226–236 |
| **this PR** | **7** | **344** | **~210–213** |

One allocation removed per query, byte-neutral, and ~12–15% faster on a single core (multi-core delta is larger, since the ring search runs under the policy lock). Non-int64 partitioners and the rare fallback path are unaffected.

Note: the earlier "fix" commit that re-boxed the token was dropped and its content absorbed — history is now two clean commits.