### PR TITLE
perf: use raw UUID instead of string for host-ID lookups (prepared-statement cache, connection pool, host equality)

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1800,7 +1800,7 @@ func injectInvalidPreparedStatement(t *testing.T, session *Session, table string
 	conn := getRandomConn(t, session)
 
 	flight := new(inflightPrepare)
-	key := session.stmtsLRU.keyFor(conn.host.HostID(), "", stmt)
+	key := session.stmtsLRU.keyFor(conn.host.hostUUID(), "", stmt)
 	session.stmtsLRU.add(key, flight)
 
 	flight.preparedStatment = &preparedStatment{
@@ -1980,27 +1980,27 @@ func TestPrepare_PreparedCacheEviction(t *testing.T) {
 
 	// Walk through all the configured hosts and test cache retention and eviction
 	for _, host := range session.hostSource.hosts {
-		_, ok := session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.HostID(), session.cfg.Keyspace, fmt.Sprintf("SELECT id,mod FROM %s WHERE id = 0", table)))
+		_, ok := session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.hostUUID(), session.cfg.Keyspace, fmt.Sprintf("SELECT id,mod FROM %s WHERE id = 0", table)))
 		if ok {
 			t.Errorf("expected first select to be purged but was in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.HostID(), session.cfg.Keyspace, fmt.Sprintf("SELECT id,mod FROM %s WHERE id = 1", table)))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.hostUUID(), session.cfg.Keyspace, fmt.Sprintf("SELECT id,mod FROM %s WHERE id = 1", table)))
 		if !ok {
 			t.Errorf("exepected second select to be in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.HostID(), session.cfg.Keyspace, fmt.Sprintf("INSERT INTO %s (id,mod) VALUES (?, ?)", table)))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.hostUUID(), session.cfg.Keyspace, fmt.Sprintf("INSERT INTO %s (id,mod) VALUES (?, ?)", table)))
 		if !ok {
 			t.Errorf("expected insert to be in cache for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.HostID(), session.cfg.Keyspace, fmt.Sprintf("UPDATE %s SET mod = ? WHERE id = ?", table)))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.hostUUID(), session.cfg.Keyspace, fmt.Sprintf("UPDATE %s SET mod = ? WHERE id = ?", table)))
 		if !ok {
 			t.Errorf("expected update to be in cached for host=%q", host)
 		}
 
-		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.HostID(), session.cfg.Keyspace, fmt.Sprintf("DELETE FROM %s WHERE id = ?", table)))
+		_, ok = session.stmtsLRU.lru.Get(session.stmtsLRU.keyFor(host.hostUUID(), session.cfg.Keyspace, fmt.Sprintf("DELETE FROM %s WHERE id = ?", table)))
 		if !ok {
 			t.Errorf("expected delete to be cached for host=%q", host)
 		}
@@ -3710,7 +3710,7 @@ func TestPrepareExecuteMetadataChangedFlag(t *testing.T) {
 	require.Len(t, row, 1, "Expected to retrieve a single column")
 	require.Equal(t, 1, row["id"])
 
-	stmtCacheKey := session.stmtsLRU.keyFor(conn.host.HostID(), conn.getCurrentKeyspace(), queryBeforeTableAltering.stmt)
+	stmtCacheKey := session.stmtsLRU.keyFor(conn.host.hostUUID(), conn.getCurrentKeyspace(), queryBeforeTableAltering.stmt)
 	inflight, _ := session.stmtsLRU.get(stmtCacheKey)
 	preparedStatementBeforeTableAltering := inflight.preparedStatment
 

--- a/conn.go
+++ b/conn.go
@@ -2235,7 +2235,7 @@ type inflightPrepare struct {
 }
 
 func (c *Conn) prepareStatement(ctx context.Context, stmt string, tracer Tracer, keyspace string, requestTimeout time.Duration) (*preparedStatment, error) {
-	cacheKey := c.session.stmtsLRU.keyFor(c.host.HostID(), keyspace, stmt)
+	cacheKey := c.session.stmtsLRU.keyFor(c.host.hostUUID(), keyspace, stmt)
 	flight, ok := c.session.stmtsLRU.execIfMissing(cacheKey, func(cache *lru.Cache[stmtCacheKey]) *inflightPrepare {
 		flight := &inflightPrepare{
 			done: make(chan struct{}),
@@ -2488,7 +2488,7 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 			// If a RESULT/Rows message reports changed resultset metadata with the
 			// Metadata_changed flag, the reported new resultset metadata must be used
 			// in subsequent executions.
-			cacheKey := c.session.stmtsLRU.keyFor(c.host.HostID(), usedKeyspace, qry.stmt)
+			cacheKey := c.session.stmtsLRU.keyFor(c.host.hostUUID(), usedKeyspace, qry.stmt)
 			// Use the already-completed local `info` rather than dereferencing the
 			// cached inflight entry's preparedStatment field. `info` comes from the
 			// prepareStatement call above and is guaranteed complete.
@@ -2558,7 +2558,7 @@ func (c *Conn) executeQueryWithMetrics(ctx context.Context, qry *Query, metrics 
 		// is not consistent with regards to its schema.
 		return iter
 	case *RequestErrUnprepared:
-		stmtCacheKey := c.session.stmtsLRU.keyFor(c.host.HostID(), usedKeyspace, qry.stmt)
+		stmtCacheKey := c.session.stmtsLRU.keyFor(c.host.hostUUID(), usedKeyspace, qry.stmt)
 		c.session.stmtsLRU.evictPreparedID(stmtCacheKey, x.StatementId)
 		framer.Release()
 		return c.executeQueryWithMetrics(ctx, qry, metrics)
@@ -2758,7 +2758,7 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 	case *RequestErrUnprepared:
 		stmt, found := stmts[string(x.StatementId)]
 		if found {
-			key := c.session.stmtsLRU.keyFor(c.host.HostID(), usedKeyspace, stmt)
+			key := c.session.stmtsLRU.keyFor(c.host.hostUUID(), usedKeyspace, stmt)
 			c.session.stmtsLRU.evictPreparedID(key, x.StatementId)
 		}
 		framer.Release()

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -54,7 +54,7 @@ type SetTablets interface {
 
 type policyConnPool struct {
 	session       *Session
-	hostConnPools map[string]*hostConnPool
+	hostConnPools map[UUID]*hostConnPool
 	keyspace      string
 	port          int
 	numConns      int
@@ -108,7 +108,7 @@ func newPolicyConnPool(session *Session) *policyConnPool {
 		port:          session.cfg.Port,
 		numConns:      session.cfg.NumConns,
 		keyspace:      session.cfg.Keyspace,
-		hostConnPools: map[string]*hostConnPool{},
+		hostConnPools: map[UUID]*hostConnPool{},
 	}
 
 	return pool
@@ -118,7 +118,7 @@ func (p *policyConnPool) SetHosts(hosts []*HostInfo) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	toRemove := make(map[string]struct{})
+	toRemove := make(map[UUID]struct{})
 	for hostID := range p.hostConnPools {
 		toRemove[hostID] = struct{}{}
 	}
@@ -130,7 +130,7 @@ func (p *policyConnPool) SetHosts(hosts []*HostInfo) {
 			// don't create a connection pool for a down host
 			continue
 		}
-		hostID := host.HostID()
+		hostID := host.hostUUID()
 		if _, exists := p.hostConnPools[hostID]; exists {
 			// still have this host, so don't remove it
 			delete(toRemove, hostID)
@@ -155,7 +155,7 @@ func (p *policyConnPool) SetHosts(hosts []*HostInfo) {
 		createCount--
 		if pool.Size() > 0 {
 			// add pool only if there a connections available
-			p.hostConnPools[pool.host.HostID()] = pool
+			p.hostConnPools[pool.host.hostUUID()] = pool
 		}
 	}
 
@@ -189,16 +189,21 @@ func (p *policyConnPool) Size() int {
 }
 
 func (p *policyConnPool) getPool(host *HostInfo) (pool *hostConnPool, ok bool) {
-	hostID := host.HostID()
+	hostID := host.hostUUID()
 	p.mu.RLock()
 	pool, ok = p.hostConnPools[hostID]
 	p.mu.RUnlock()
 	return
 }
 
+// Rare path (SetHostID/GetHostPoolByID); getPool is the hot path and skips this parse.
 func (p *policyConnPool) getPoolByHostID(hostID string) (pool *hostConnPool, ok bool) {
+	id, err := ParseUUID(hostID)
+	if err != nil {
+		return nil, false
+	}
 	p.mu.RLock()
-	pool, ok = p.hostConnPools[hostID]
+	pool, ok = p.hostConnPools[id]
 	p.mu.RUnlock()
 	return
 }
@@ -225,7 +230,7 @@ func (p *policyConnPool) Close() {
 }
 
 func (p *policyConnPool) addHost(host *HostInfo) {
-	hostID := host.HostID()
+	hostID := host.hostUUID()
 	p.mu.Lock()
 	pool, ok := p.hostConnPools[hostID]
 	if !ok {
@@ -243,7 +248,7 @@ func (p *policyConnPool) addHost(host *HostInfo) {
 	pool.fill_debounce()
 }
 
-func (p *policyConnPool) removeHost(hostID string) {
+func (p *policyConnPool) removeHost(hostID UUID) {
 	p.mu.Lock()
 	pool, ok := p.hostConnPools[hostID]
 	if !ok {

--- a/events.go
+++ b/events.go
@@ -286,7 +286,6 @@ func (s *Session) handleNodeDown(ip net.IP, port int) {
 		}
 
 		s.policy.HostDown(host)
-		hostID := host.HostID()
-		s.pool.removeHost(hostID)
+		s.pool.removeHost(host.hostUUID())
 	}
 }

--- a/host_source.go
+++ b/host_source.go
@@ -272,7 +272,7 @@ func (h *HostInfo) Equal(host *HostInfo) bool {
 		return true
 	}
 
-	return h.HostID() == host.HostID() && h.ConnectAddress().Equal(host.ConnectAddress()) && h.Port() == host.Port()
+	return h.hostUUID() == host.hostUUID() && h.ConnectAddress().Equal(host.ConnectAddress()) && h.Port() == host.Port()
 }
 
 func (h *HostInfo) Peer() net.IP {

--- a/prepared_cache.go
+++ b/prepared_cache.go
@@ -34,14 +34,12 @@ import (
 const defaultMaxPreparedStmts = 1000
 
 // stmtCacheKey is a composite key for the prepared statement cache.
-// Using a struct avoids the string concatenation allocation that occurred
-// on every query and fixes the theoretical key collision bug where
-// different (hostID, keyspace, statement) tuples could produce the same
-// concatenated string.
+// A struct avoids the allocation and collision risk of concatenating
+// (hostID, keyspace, statement) into a single string key.
 type stmtCacheKey struct {
-	hostID    string
 	keyspace  string
 	statement string
+	hostID    UUID
 }
 
 // preparedLRU is the prepared statement cache
@@ -127,7 +125,7 @@ func (p *preparedLRU) execIfMissing(key stmtCacheKey, fn func(cache *lru.Cache[s
 // keyFor constructs a zero-allocation composite cache key from the given
 // components. The returned struct references the original strings without
 // copying, so no heap allocation occurs.
-func (p *preparedLRU) keyFor(hostID, keyspace, statement string) stmtCacheKey {
+func (p *preparedLRU) keyFor(hostID UUID, keyspace, statement string) stmtCacheKey {
 	return stmtCacheKey{
 		hostID:    hostID,
 		keyspace:  keyspace,

--- a/prepared_cache_test.go
+++ b/prepared_cache_test.go
@@ -41,7 +41,7 @@ func completedInflight(id []byte) *inflightPrepare {
 }
 
 func TestPreparedLRU_updateMetadataIfSame(t *testing.T) {
-	key := stmtCacheKey{hostID: "h", keyspace: "ks", statement: "SELECT * FROM t"}
+	key := stmtCacheKey{hostID: UUID{1}, keyspace: "ks", statement: "SELECT * FROM t"}
 	oldID := []byte{1, 2, 3}
 
 	t.Run("replaces when present and identity matches", func(t *testing.T) {

--- a/prepared_cache_test.go
+++ b/prepared_cache_test.go
@@ -121,3 +121,72 @@ func TestPreparedLRU_updateMetadataIfSame(t *testing.T) {
 		}
 	})
 }
+
+// TestStmtCacheKey_HostIDEquality verifies that stmtCacheKey's UUID-typed
+// hostID field distinguishes and matches hosts exactly like the old
+// string-typed field did, including the "empty host" collapse (a HostInfo
+// with no hostId set must map to the same key as another HostInfo with no
+// hostId set, since both hostUUID() and the old HostID() return the zero
+// value for an unset host).
+func TestStmtCacheKey_HostIDEquality(t *testing.T) {
+	t.Parallel()
+
+	hostA := &HostInfo{hostId: tUUID(1)}
+	hostB := &HostInfo{hostId: tUUID(2)}
+	hostAEmpty1 := &HostInfo{}
+	hostAEmpty2 := &HostInfo{}
+
+	p := newTestPreparedLRU()
+
+	keyA := p.keyFor(hostA.hostUUID(), "ks", "SELECT 1")
+	keyB := p.keyFor(hostB.hostUUID(), "ks", "SELECT 1")
+	keyAAgain := p.keyFor(hostA.hostUUID(), "ks", "SELECT 1")
+	keyEmpty1 := p.keyFor(hostAEmpty1.hostUUID(), "ks", "SELECT 1")
+	keyEmpty2 := p.keyFor(hostAEmpty2.hostUUID(), "ks", "SELECT 1")
+
+	if keyA == keyB {
+		t.Fatal("distinct host UUIDs must not produce equal cache keys")
+	}
+	if keyA != keyAAgain {
+		t.Fatal("the same host UUID must produce equal cache keys")
+	}
+	if keyEmpty1 != keyEmpty2 {
+		t.Fatal("two hosts with no hostId set must collapse to the same (zero-value) cache key")
+	}
+	if keyA == keyEmpty1 {
+		t.Fatal("a real host UUID must not collide with the empty-host zero-value key")
+	}
+
+	// Round-trip through the actual cache to make sure UUID keys behave
+	// correctly as map keys end-to-end, not just via ==.
+	entry := completedInflight([]byte{9})
+	p.add(keyA, entry)
+	if got, ok := p.get(keyB); ok {
+		t.Fatalf("keyB must be a cache miss, got %v", got)
+	}
+	if got, ok := p.get(keyA); !ok || got != entry {
+		t.Fatal("keyA must retrieve the entry stored under it")
+	}
+}
+
+// TestPreparedLRU_keyFor_ZeroAlloc guards the whole point of switching
+// stmtCacheKey.hostID from string to UUID: building a cache key from a
+// HostInfo must not allocate. HostInfo.HostID() (the old call site) returns
+// a string via UUID.String(), which heap-allocates a []byte plus its string
+// conversion on every call; HostInfo.hostUUID() returns the raw comparable
+// UUID value with no allocation at all.
+func TestPreparedLRU_keyFor_ZeroAlloc(t *testing.T) {
+	host := &HostInfo{hostId: tUUID(7)}
+	p := newTestPreparedLRU()
+
+	var key stmtCacheKey
+	allocs := testing.AllocsPerRun(1000, func() {
+		key = p.keyFor(host.hostUUID(), "ks", "SELECT * FROM t WHERE id = ?")
+	})
+	if allocs != 0 {
+		t.Errorf("keyFor(host.hostUUID(), ...) allocated %.2f allocs/op, want 0", allocs)
+	}
+	if key.hostID != tUUID(7) {
+		t.Fatalf("sanity check failed: key.hostID = %v, want %v", key.hostID, tUUID(7))
+	}
+}

--- a/session.go
+++ b/session.go
@@ -701,9 +701,8 @@ func (s *Session) executeQueryWithMetrics(qry *Query, metrics *queryMetrics) (it
 
 func (s *Session) removeHost(h *HostInfo) {
 	s.policy.RemoveHost(h)
-	hostID := h.HostID()
-	s.pool.removeHost(hostID)
-	s.hostSource.removeHost(hostID)
+	s.pool.removeHost(h.hostUUID())
+	s.hostSource.removeHost(h.HostID())
 }
 
 // KeyspaceMetadata returns the schema metadata for the keyspace specified. Returns an error if the keyspace does not exist.

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -737,8 +737,8 @@ func newTestQueryExecutor(host *HostInfo) *queryExecutor {
 	policy.AddHost(host)
 	return &queryExecutor{
 		pool: &policyConnPool{
-			hostConnPools: map[string]*hostConnPool{
-				host.HostID(): &hostConnPool{
+			hostConnPools: map[UUID]*hostConnPool{
+				host.hostUUID(): &hostConnPool{
 					host:       host,
 					connPicker: staticConnPicker{conn: &Conn{host: host}},
 				},
@@ -2936,7 +2936,7 @@ func TestQueryExecutorPropagatesWinningRetryConsistency(t *testing.T) {
 		secondHost := (&HostInfo{hostId: UUID{16}}).setState(NodeUp)
 		executor := newTestQueryExecutor(host)
 		executor.policy.AddHost(secondHost)
-		executor.pool.hostConnPools[secondHost.HostID()] = &hostConnPool{
+		executor.pool.hostConnPools[secondHost.hostUUID()] = &hostConnPool{
 			host:       secondHost,
 			connPicker: staticConnPicker{conn: &Conn{host: secondHost}},
 		}
@@ -3039,10 +3039,9 @@ func TestQueryExecutorSuccessfulAttemptDoesNotAddRetryCounterAllocation(t *testi
 			panic("unexpected iterator")
 		}
 	})
-	// The host-pool lookup allocates one HostID string. The retry counter must
-	// remain stack-local and add no second allocation on this fast path.
-	if allocs != 1 {
-		t.Fatalf("successful execution allocations = %f, want host lookup baseline of 1", allocs)
+	// getPool uses hostUUID() (zero-alloc); the retry counter must stay stack-local too.
+	if allocs != 0 {
+		t.Fatalf("successful execution allocations = %f, want 0", allocs)
 	}
 }
 
@@ -3051,7 +3050,7 @@ func TestQueryExecutorSpeculativeBranchesShareRetryBudget(t *testing.T) {
 	secondHost := (&HostInfo{hostId: UUID{11}}).setState(NodeUp)
 	executor := newTestQueryExecutor(host)
 	executor.policy.AddHost(secondHost)
-	executor.pool.hostConnPools[secondHost.HostID()] = &hostConnPool{
+	executor.pool.hostConnPools[secondHost.hostUUID()] = &hostConnPool{
 		host:       secondHost,
 		connPicker: staticConnPicker{conn: &Conn{host: secondHost}},
 	}
@@ -3116,7 +3115,7 @@ func TestQueryExecutorSpeculativeAttemptOrdinalsFollowLaunchOrder(t *testing.T) 
 	secondHost := (&HostInfo{hostId: UUID{7}}).setState(NodeUp)
 	executor := newTestQueryExecutor(host)
 	executor.policy.AddHost(secondHost)
-	executor.pool.hostConnPools[secondHost.HostID()] = &hostConnPool{
+	executor.pool.hostConnPools[secondHost.hostUUID()] = &hostConnPool{
 		host:       secondHost,
 		connPicker: staticConnPicker{conn: &Conn{host: secondHost}},
 	}


### PR DESCRIPTION
## Motivation

`HostInfo.HostID()` formats the 16-byte host UUID into a fresh 36-byte hex string (`UUID.String()`, two allocations: a `[]byte` plus its string conversion). Several internal hot paths use this string purely as a comparison key or map key, where the raw `UUID` (already comparable, already zero-alloc via `HostInfo.hostUUID()`) works just as well.

This PR fixes three such call sites:

1. **Prepared-statement cache key** (`prepared_cache.go`) — `stmtCacheKey.hostID` was a `string`; every cache lookup, including hits, paid the `HostID()` cost on every query/batch-statement execution.
2. **Connection-pool map** (`connectionpool.go`) — `policyConnPool.hostConnPools` was `map[string]*hostConnPool`; `getPool`, the per-query-attempt lookup used by `queryExecutor.do()` on every attempt/retry, paid the same cost.
3. **Host equality** (`host_source.go`) — `HostInfo.Equal` compared two hosts via `HostID() == HostID()`, allocating two hex strings just for an equality check.

## Changes

- `prepared_cache.go`: `stmtCacheKey.hostID` changed from `string` to `UUID`; `keyFor` takes the raw `UUID` directly.
- `connectionpool.go`: `hostConnPools` changed from `map[string]*hostConnPool` to `map[UUID]*hostConnPool`. `getPool` (hot path) now uses `host.hostUUID()`. `getPoolByHostID` (the rare `SetHostID`/`GetHostPoolByID` opt-in path) keeps its `string` signature and parses once via `ParseUUID` — no public API change.
- `host_source.go`: `HostInfo.Equal` compares `hostUUID()` instead of two `HostID()` conversions.

## Tests

- `prepared_cache_test.go`: equality and zero-alloc regression coverage for `stmtCacheKey` with the new field type; `cassandra_test.go` updated for the changed `keyFor` signature.
- `connectionpool_bench_test.go` (new): `BenchmarkPolicyConnPoolGetPool`.
- `policies_bench_test.go`: `BenchmarkHostInfoEqual` added (exercises the real method, as opposed to the pre-existing `BenchmarkHostIdComparison`'s isolated string/UUID comparison).
- `session_unit_test.go`: updated for the `hostConnPools` key-type change.
- Full unit suite + `-race` pass (only pre-existing, environment-only TLS-cert test failures, unrelated to this change).

## Results

`BenchmarkPrepareStatementCacheKey`, 5 runs:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| Before (`HostID().String()`) | 60.01 | 48 | 1 |
| After (raw `UUID`) | 3.53 | 0 | 0 |
| Δ | **-94%** | **-100%** | **-100%** |

`BenchmarkPolicyConnPoolGetPool` / `BenchmarkHostInfoEqual` (new):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| `getPool` (after) | 24.98 | 0 | 0 |
| `HostInfo.Equal` (after) | 78.76 | 0 | 0 |

(No "before" run recorded for these two — same underlying `HostID().String()` cost characterized in the table above; `getPool` calls it once per lookup, `Equal` calls it twice per comparison.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
