### PR TITLE
test: fix flaky TestNewConnectWithLowTimeout/Timeout/Regular_Query

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -475,8 +475,10 @@ func TestNewConnectWithLowTimeout(t *testing.T) {
 						cluster.Timeout = lowTimeout
 						return cluster
 					},
-					connect:                    Pass,
-					regularQuery:               Fail,
+					connect: Pass,
+					// At 100ns the query can complete before the deadline fires,
+					// the same race already tolerated below for WriteTimeout/ReadTimeout.
+					regularQuery:               canPassOnHighTimeout,
 					controlQuery:               Pass,
 					controlQueryAfterReconnect: Pass,
 				},


### PR DESCRIPTION
## Motivation

`TestNewConnectWithLowTimeout/100ns/Timeout/Regular_Query` intermittently fails on master — see #973.

## Root cause

Same class of bug as #822 (closed), recurring in a sub-case that fix didn't cover: at a 100ns `cluster.Timeout`, a regular query can legitimately complete before the deadline fires. `WriteTimeout`/`ReadTimeout` (and, after #822, `MetadataSchemaRequestTimeout`) already tolerate this via `canPassOnHighTimeout`/`CanPass` at the 100ns tier. The `"Timeout"` sub-case's `regularQuery` expectation was still hardcoded to `Fail`.

## Change

`regularQuery: Fail` → `regularQuery: canPassOnHighTimeout` in the `"Timeout"` sub-case of `TestNewConnectWithLowTimeout` (integration_test.go). `connect`, `controlQuery`, and `controlQueryAfterReconnect` are untouched — they don't use `cluster.Timeout` and aren't subject to this race.

Fixes #973