### PR TITLE
perf: routingKeyInfo cache key avoids string concat

### DIFF
--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -3939,10 +3939,10 @@ func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	getRoutingKeyInfo := func(key string) *routingKeyInfo {
+	getRoutingKeyInfo := func(keyspace, stmt string) *routingKeyInfo {
 		t.Helper()
 		session.routingKeyInfoCache.mu.Lock()
-		value, _ := session.routingKeyInfoCache.lru.Get(key)
+		value, _ := session.routingKeyInfoCache.lru.Get(routingKeyInfoCacheKey{keyspace: keyspace, stmt: stmt})
 		session.routingKeyInfoCache.mu.Unlock()
 
 		inflight := value.(*inflightCachedEntry)
@@ -3958,7 +3958,7 @@ func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensuring that the cache contains the query with default ks
-	routingKeyInfo1 := getRoutingKeyInfo("gocql_test" + "\x00" + b1.Entries[0].Stmt)
+	routingKeyInfo1 := getRoutingKeyInfo("gocql_test", b1.Entries[0].Stmt)
 	require.Equal(t, "gocql_test", routingKeyInfo1.keyspace)
 
 	// Running batch in gocql_test_routing_key_cache ks
@@ -3969,7 +3969,7 @@ func TestRoutingKeyCacheUsesOverriddenKeyspace(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensuring that the cache contains the query with gocql_test_routing_key_cache ks
-	routingKeyInfo2 := getRoutingKeyInfo("gocql_test_routing_key_cache" + "\x00" + b2.Entries[0].Stmt)
+	routingKeyInfo2 := getRoutingKeyInfo("gocql_test_routing_key_cache", b2.Entries[0].Stmt)
 	require.Equal(t, "gocql_test_routing_key_cache", routingKeyInfo2.keyspace)
 
 	const selectStmt = "SELECT * FROM routing_key_cache_uses_overridden_ks WHERE id=?"

--- a/session.go
+++ b/session.go
@@ -174,7 +174,7 @@ func newSessionCommon(cfg ClusterConfig) (*Session, error) {
 	s.nodeEvents = newEventDebouncer("NodeEvents", s.handleNodeEvent, s.logger)
 	s.schemaEvents = newEventDebouncer("SchemaEvents", s.handleSchemaEvent, s.logger)
 
-	s.routingKeyInfoCache.lru = lru.New[string](cfg.MaxRoutingKeyInfo)
+	s.routingKeyInfoCache.lru = lru.New[routingKeyInfoCacheKey](cfg.MaxRoutingKeyInfo)
 
 	s.hostSource = &ringDescriber{cfg: &s.cfg, logger: s.logger}
 	s.ringRefresher = debounce.NewRefreshDebouncer(debounce.RingRefreshDebounceTime, func() error {
@@ -859,13 +859,13 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string, keyspace stri
 		keyspace = s.cfg.Keyspace
 	}
 
-	routingKeyInfoCacheKey := keyspace + "\x00" + stmt
+	cacheKey := routingKeyInfoCacheKey{keyspace: keyspace, stmt: stmt}
 
 	s.routingKeyInfoCache.mu.Lock()
 
 	// Using here keyspace + stmt as a cache key because
 	// the query keyspace could be overridden via SetKeyspace
-	entry, cached := s.routingKeyInfoCache.lru.Get(routingKeyInfoCacheKey)
+	entry, cached := s.routingKeyInfoCache.lru.Get(cacheKey)
 	if cached {
 		// done accessing the cache
 		s.routingKeyInfoCache.mu.Unlock()
@@ -889,7 +889,7 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string, keyspace stri
 	inflight := new(inflightCachedEntry)
 	inflight.wg.Add(1)
 	defer inflight.wg.Done()
-	s.routingKeyInfoCache.lru.Add(routingKeyInfoCacheKey, inflight)
+	s.routingKeyInfoCache.lru.Add(cacheKey, inflight)
 	s.routingKeyInfoCache.mu.Unlock()
 
 	var (
@@ -908,7 +908,7 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string, keyspace stri
 	info, inflight.err = conn.prepareStatement(ctx, stmt, nil, keyspace, requestTimeout)
 	if inflight.err != nil {
 		// don't cache this error
-		s.routingKeyInfoCache.Remove(routingKeyInfoCacheKey)
+		s.routingKeyInfoCache.Remove(cacheKey)
 		return nil, inflight.err
 	}
 
@@ -921,15 +921,15 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string, keyspace stri
 	}
 
 	// Resolve the statement's real target from the prepared metadata. Note this
-	// reassigns keyspace: routingKeyInfoCacheKey was already built from the
-	// requested keyspace above and is unaffected.
+	// reassigns keyspace: cacheKey was already built from the requested
+	// keyspace above and is unaffected.
 	keyspace, table := resolveRoutingKeyspaceTable(&info.request, keyspace)
 
 	partitioner, err := scyllaGetTablePartitioner(s, keyspace, table)
 	if err != nil {
 		// don't cache this error, but make sure all waiters see the same failure.
 		inflight.err = err
-		s.routingKeyInfoCache.Remove(routingKeyInfoCacheKey)
+		s.routingKeyInfoCache.Remove(cacheKey)
 		return nil, inflight.err
 	}
 
@@ -958,7 +958,7 @@ func (s *Session) routingKeyInfo(ctx context.Context, stmt string, keyspace stri
 	tableMetadata, inflight.err = s.TableMetadata(keyspace, table)
 	if inflight.err != nil {
 		// don't cache this error
-		s.routingKeyInfoCache.Remove(routingKeyInfoCacheKey)
+		s.routingKeyInfoCache.Remove(cacheKey)
 		return nil, inflight.err
 	}
 
@@ -3749,8 +3749,16 @@ func (c ColumnInfo) String() string {
 }
 
 // routing key indexes LRU cache
+// routingKeyInfoCacheKey avoids concatenating keyspace+stmt into a string on
+// every cache lookup; lru.Cache already takes a comparable key type for
+// exactly this reason.
+type routingKeyInfoCacheKey struct {
+	keyspace string
+	stmt     string
+}
+
 type routingKeyInfoLRU struct {
-	lru *lru.Cache[string]
+	lru *lru.Cache[routingKeyInfoCacheKey]
 	mu  sync.Mutex
 }
 
@@ -3767,7 +3775,7 @@ func (r *routingKeyInfo) String() string {
 	return fmt.Sprintf("routing key index=%v types=%v", r.indexes, r.types)
 }
 
-func (r *routingKeyInfoLRU) Remove(key string) {
+func (r *routingKeyInfoLRU) Remove(key routingKeyInfoCacheKey) {
 	r.mu.Lock()
 	r.lru.Remove(key)
 	r.mu.Unlock()

--- a/session_unit_test.go
+++ b/session_unit_test.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gocql/gocql/internal/lru"
 	"github.com/gocql/gocql/tablets"
 )
 
@@ -2259,6 +2260,26 @@ func BenchmarkAttemptMetricsPersistentHistory(b *testing.B) {
 				b.Fatalf("attempt history count = %d, want %d", metrics.Attempts(), attemptsPerExecution)
 			}
 		})
+	}
+}
+
+// Exercises the cache-hit path of Session.routingKeyInfo, called on every
+// Pick() by TokenAwareHostPolicy for every query/batch.
+func BenchmarkSessionRoutingKeyInfoCacheHit(b *testing.B) {
+	const keyspace, stmt = "benchks", "insert into t (id) values (?)"
+
+	s := &Session{}
+	s.routingKeyInfoCache.lru = lru.New[routingKeyInfoCacheKey](100)
+	inflight := &inflightCachedEntry{value: &routingKeyInfo{keyspace: keyspace, table: "t"}}
+	s.routingKeyInfoCache.lru.Add(routingKeyInfoCacheKey{keyspace: keyspace, stmt: stmt}, inflight)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.routingKeyInfo(ctx, stmt, keyspace, 0); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

`Session.routingKeyInfo` builds its LRU cache key via `keyspace + "\x00" + stmt` on every call — a fresh heap allocation, even on a cache hit. `TokenAwareHostPolicy.Pick()` (the default/recommended host-selection policy) calls `Query.GetRoutingKey()` / `Batch.GetRoutingKey()` unconditionally on every query and batch attempt, both of which call straight into `Session.routingKeyInfo()`. So this string concatenation runs on the hottest path in the driver, for every single request.

`internal/lru.Cache[K comparable]`'s own doc comment explains it was generalized with a comparable type parameter specifically "to avoid the allocations caused by wrapping keys in `any`" — but `routingKeyInfoLRU` instantiates it as `lru.New[string]` and then manufactures the string via concatenation instead of using a comparable struct key, so the allocation this cache type was built to avoid happens anyway, just one level up.

Confirmed with escape analysis (`go build -gcflags="-m -m"`):
```
./session.go:861:46: keyspace + "\x00" + stmt escapes to heap in (*Session).routingKeyInfo
```

## Changes

- Add `routingKeyInfoCacheKey struct { keyspace, stmt string }`.
- `routingKeyInfoLRU.lru` changed from `*lru.Cache[string]` to `*lru.Cache[routingKeyInfoCacheKey]`; `Remove` takes the struct key.
- `Session.routingKeyInfo` builds the struct directly instead of concatenating.
- `cassandra_test.go`'s `getRoutingKeyInfo` test helper updated for the new key type (mechanical signature change, same behavior).

## Tests

- `BenchmarkSessionRoutingKeyInfoCacheHit` (new, `session_unit_test.go`): exercises the cache-hit path without a live connection.
- Full unit suite + `-race` pass (only pre-existing, environment-only TLS-cert test failures, unrelated to this change).

## Results

`BenchmarkSessionRoutingKeyInfoCacheHit`:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| After (struct key) | 23.89 | 0 | 0 |

(No isolated "before" benchmark existed for this call site — the escape-analysis output above is the direct evidence the prior string-concat form escaped to heap on every call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
