### PR TITLE
frame: bound pkeyCount allocation in parsePreparedMetadata

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -947,6 +947,17 @@ func (f *framer) parsePreparedMetadata() preparedMetadata {
 
 	if f.proto >= protoVersion4 {
 		pkeyCount := f.readInt()
+		// Like the colCount guard above, reject a negative count: make would panic
+		// with a runtime error, which parseFrame's recover re-panics rather than
+		// converting to an error. Unlike colCount — whose huge-value case is handled
+		// by the make/append split further down — also reject a count larger than the
+		// remaining buffer could supply: each pkey index is a short (2 bytes), so a
+		// valid frame always has pkeyCount <= len(f.buf)/2. That bounds make() to the
+		// actual frame size instead of a peer-declared count, so a small malformed
+		// frame cannot force a large allocation.
+		if pkeyCount < 0 || pkeyCount > len(f.buf)/2 {
+			panic(fmt.Errorf("invalid partition key count %d (remaining %d bytes)", pkeyCount, len(f.buf)))
+		}
 		pkeys := make([]int, pkeyCount)
 		for i := 0; i < pkeyCount; i++ {
 			pkeys[i] = int(f.readShort())

--- a/frame_test.go
+++ b/frame_test.go
@@ -389,6 +389,119 @@ func TestParseResultMetadata_PerColumnSpec(t *testing.T) {
 	}
 }
 
+// TestParsePreparedMetadataRejectsInvalidPkeyCount verifies that a RESULT/Prepared
+// frame declaring a negative or absurdly large partition-key count is reported as
+// an error rather than crashing the serve goroutine (a negative count makes
+// make([]int, n) raise a runtime error that parseFrame's recover re-panics) or
+// forcing a huge speculative allocation from a small frame.
+func TestParsePreparedMetadataRejectsInvalidPkeyCount(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		pkeyCount int32
+	}{
+		{name: "negative", pkeyCount: -1},
+		{name: "huge", pkeyCount: 1 << 30},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fr := newFramer(nil, protoVersion4)
+			fr.header = &frm.FrameHeader{Version: protoVersion4 | protoDirectionMask, Op: frm.OpResult}
+
+			fr.writeInt(frm.ResultKindPrepared)
+			fr.writeShortBytes([]byte{0x01, 0x02, 0x03}) // preparedID
+			// prepared metadata: flags=0, colCount=0, then the bogus pkeyCount.
+			fr.writeInt(0)
+			fr.writeInt(0)
+			fr.writeInt(tc.pkeyCount)
+
+			frame, err := fr.parseFrame()
+			if err == nil {
+				t.Fatalf("expected an error for pkeyCount=%d, got frame %+v", tc.pkeyCount, frame)
+			}
+			if frame != nil {
+				t.Errorf("expected nil frame on error, got %+v", frame)
+			}
+			// Assert on the message, not just on err != nil. Without the guard the
+			// "huge" case still returns an error — make() succeeds and the first
+			// readShort() then panics on the empty buffer — so a bare err != nil
+			// check passes either way and the allocation bound goes untested.
+			require.ErrorContains(t, err, "invalid partition key count")
+		})
+	}
+}
+
+// TestParsePreparedMetadataAcceptsValidPkeyCount pins the upper half of the
+// pkeyCount guard: a count that the remaining buffer can actually supply must be
+// accepted. Without this, a bound tightened by mistake (down to `> 0`, say) would
+// reject every prepared statement that has a partition key and no unit test would
+// notice — pk_count is 0 in every other prepared frame the suite builds.
+func TestParsePreparedMetadataAcceptsValidPkeyCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exactly at the bound", func(t *testing.T) {
+		t.Parallel()
+
+		fr := newFramer(nil, protoVersion4)
+		fr.header = &frm.FrameHeader{Version: protoVersion4 | protoDirectionMask}
+
+		// NO_METADATA so parsing stops right after the pkeys, leaving the buffer
+		// holding exactly 2*pkeyCount bytes at the guard: pkeyCount == len(buf)/2.
+		fr.writeInt(int32(frm.FlagNoMetaData))
+		fr.writeInt(0) // colCount
+		fr.writeInt(2) // pkeyCount
+		fr.writeShort(0)
+		fr.writeShort(1)
+
+		// NotPanics, because parsePreparedMetadata is called directly here and so
+		// the guard's panic would otherwise take down the whole test binary rather
+		// than failing this subtest.
+		var meta preparedMetadata
+		require.NotPanics(t, func() { meta = fr.parsePreparedMetadata() })
+
+		require.Equal(t, []int{0, 1}, meta.pkeyColumns)
+		require.Empty(t, fr.buf, "whole metadata block should be consumed")
+	})
+
+	t.Run("full prepared frame", func(t *testing.T) {
+		t.Parallel()
+
+		fr := newFramer(nil, protoVersion4)
+		fr.header = &frm.FrameHeader{Version: protoVersion4 | protoDirectionMask, Op: frm.OpResult}
+
+		fr.writeInt(frm.ResultKindPrepared)
+		fr.writeShortBytes([]byte{0x01, 0x02, 0x03}) // preparedID
+		// prepared metadata
+		fr.writeInt(int32(frm.FlagGlobalTableSpec))
+		fr.writeInt(2) // colCount
+		fr.writeInt(2) // pkeyCount
+		fr.writeShort(0)
+		fr.writeShort(1)
+		fr.writeString("test_ks")
+		fr.writeString("test_tbl")
+		fr.writeString("pk_a")
+		fr.writeShort(uint16(TypeInt))
+		fr.writeString("pk_b")
+		fr.writeShort(uint16(TypeVarchar))
+		// result metadata
+		fr.writeInt(int32(frm.FlagNoMetaData))
+		fr.writeInt(0)
+
+		frame, err := fr.parseFrame()
+		require.NoError(t, err)
+
+		prepared, ok := frame.(*resultPreparedFrame)
+		require.True(t, ok, "got %T", frame)
+		require.Equal(t, []int{0, 1}, prepared.reqMeta.pkeyColumns)
+		require.Len(t, prepared.reqMeta.columns, 2)
+		require.Empty(t, fr.buf, "whole frame should be consumed")
+	})
+}
+
 func Test_framer_writeExecuteFrame(t *testing.T) {
 	framer := newFramer(nil, protoVersion5)
 	nowInSeconds := 123


### PR DESCRIPTION
# Issue [gocql#978](https://github.com/scylladb/gocql/issues/978)

Split out of #590, where this was carried as a second, unrelated commit.

`parsePreparedMetadata` read the partition-key count from the server frame and passed it straight to `make([]int, pkeyCount)` with no validation, unlike the `colCount` field immediately above it:

- A **negative** `pkeyCount` makes `make()` raise a runtime error. `parseFrame`'s recover converts only plain `error` panics into a returned error and re-panics runtime errors, so a single malformed `RESULT/Prepared` frame crashes the serve goroutine.
- A **large positive** `pkeyCount` forces a multi-gigabyte speculative allocation from a tiny frame.

## Fix

Reject a negative count, and a count larger than the remaining buffer could supply. Each pkey index is a `short`, so a valid frame always has `pkeyCount <= len(f.buf)/2`. Rejection is a plain `error` panic, which `parseFrame`'s recover turns into a returned protocol error — the same shape as every other length check in the parser. The bound never rejects valid input and caps the allocation to the actual frame size.

## Scope

This is a **pre-existing defect** on the proto >= v4 prepared-metadata path. It predates the native protocol v5 work, and the same defect exists upstream in `apache/cassandra-gocql-driver`, so this is an **upstream backport candidate**. It is unrelated to `SCYLLA_USE_METADATA_ID`, which is why it is no longer stacked on #590.

## Tests

### Rejected side

`TestParsePreparedMetadataRejectsInvalidPkeyCount` covers the negative and oversized cases.

Both assert on the error **message**, not merely on `err != nil`. That matters: without the guard the oversized case still returns an error — `make()` succeeds, and the following `readShort()` then panics on the empty buffer with `"not enough bytes in buffer to read short"` — so a bare `err != nil` check passes either way and leaves the allocation bound untested. Verified by replacing the guard with `if false`:

- before asserting the message: the `huge` subtest **passed** (after an 8 GiB allocation)
- after: it **fails** with `Error "not enough bytes in buffer to read short require 2 got: 0" does not contain "invalid partition key count"`

The `negative` subtest fails without the guard either way, since it re-panics out of the recover.

### Accepted side

`TestParsePreparedMetadataAcceptsValidPkeyCount` pins the other half of the guard: that the bound admits a count the buffer can actually supply.

The rejection test alone did not cover this. Both of its cases build a frame with **zero** bytes remaining after `pkeyCount`, so *any* count `>= 1` is rejected no matter what the bound says. And `pkeyCount` was never `> 0` anywhere in the unit suite — all three prepared-frame builders write `pk_count = 0` (`conn_test.go:1989`, `:2003`, `:2023`) — so the pkey-parsing loop had no positive coverage at all. Verified by mutation, tightening the bound to `pkeyCount > 0`, which would reject every prepared statement that has a partition key:

- before this test: the **entire `-tags unit` suite stayed green**
- after: **both** subtests fail

Two complementary shapes:

- `exactly at the bound` — `NO_METADATA` stops parsing right after the pkeys, so the buffer holds exactly `2*pkeyCount` bytes at the guard and `pkeyCount == len(f.buf)/2`. This is the only way to sit precisely on the bound; a frame routed through `parseFrame` always has result-metadata bytes left over. Wrapped in `require.NotPanics`, because calling `parsePreparedMetadata` directly bypasses `parseFrame`'s recover, so a guard panic would otherwise abort the whole test binary and silently take the sibling subtest down with it.
- `full prepared frame` — the realistic end-to-end path through `parseFrame`, asserting `reqMeta.pkeyColumns` and the column specs.

## Verification

- `make test-unit` — green: 21 packages, 494 pass / 2 skip / 0 fail, no data races (`-race`)
- `make check` — 0 lint issues, no go.mod drift
- `gofmt -l .`, `go vet -tags unit ./...`, `go vet -tags integration ./...` — clean
