### PR TITLE
stage 2: populate the DRIVER_CONFIG report

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -637,7 +637,7 @@ func (s *startupCoordinator) options(ctx context.Context, startupCompleted *atom
 // The ordering is easy to lose, which is how it was lost: upstream has no
 // ApplicationInfo hook and writes these three as a map literal, so merging the
 // two put the callback last.
-func startupOptions(cqlVersion, driverName, driverVersion string, info ApplicationInfo, driverConfig *driverConfigReporter, sessionID string) map[string]string {
+func startupOptions(cqlVersion, driverName, driverVersion string, info ApplicationInfo, driverConfig *driverConfigReporter, sessionID string, isScyllaConn bool) map[string]string {
 	m := map[string]string{}
 
 	if info != nil {
@@ -645,7 +645,7 @@ func startupOptions(cqlVersion, driverName, driverVersion string, info Applicati
 	}
 
 	if driverConfig != nil {
-		driverConfig.updateStartupOptions(m)
+		driverConfig.updateStartupOptions(m, isScyllaConn)
 	}
 
 	m[sessionIDStartupKey] = sessionID
@@ -666,6 +666,7 @@ func (s *startupCoordinator) startup(ctx context.Context, startupCompleted *atom
 		s.conn.session.cfg.ApplicationInfo,
 		s.driverConfigReporter,
 		s.conn.session.id,
+		s.conn.isScyllaConn(),
 	)
 
 	if s.conn.compressor != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -3782,7 +3782,7 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 	)
 
 	t.Run("no ApplicationInfo", func(t *testing.T) {
-		m := startupOptions(cqlVersion, driverName, driverVersion, nil, nil, sessionID)
+		m := startupOptions(cqlVersion, driverName, driverVersion, nil, nil, sessionID, false)
 
 		require.Equal(t, map[string]string{
 			"CQL_VERSION":       cqlVersion,
@@ -3794,7 +3794,7 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 
 	t.Run("application options are kept", func(t *testing.T) {
 		m := startupOptions(cqlVersion, driverName, driverVersion,
-			NewStaticApplicationInfo("app", "9.9.9", "client-id"), nil, sessionID)
+			NewStaticApplicationInfo("app", "9.9.9", "client-id"), nil, sessionID, false)
 
 		require.Equal(t, "app", m["APPLICATION_NAME"])
 		require.Equal(t, "9.9.9", m["APPLICATION_VERSION"])
@@ -3813,7 +3813,7 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 				opts["DRIVER_VERSION"] = "0.0.0"
 				opts[sessionIDStartupKey] = "not-the-session-id"
 				opts["APPLICATION_NAME"] = "app"
-			}), nil, sessionID)
+			}), nil, sessionID, false)
 
 		require.Equal(t, cqlVersion, m["CQL_VERSION"], "a custom CQL version would fail every handshake")
 		require.Equal(t, driverName, m["DRIVER_NAME"])

--- a/docs/driver-config-schema.json
+++ b/docs/driver-config-schema.json
@@ -1,0 +1,1026 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://scylladb.com/schemas/driver-client-options/v1.json",
+  "title": "ScyllaDB driver DRIVER_CONFIG configuration",
+  "description": "Schema for the JSON value sent under the STARTUP option key DRIVER_CONFIG, describing the effective client configuration. The top-level object must include `version` and the required configuration groups listed by this schema. Unknown top-level keys are rejected. Built-in groups reject unknown keys and require the keys listed in each group; custom policy objects may include additional implementation-specific public attributes where explicitly allowed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "connection",
+    "control-plane",
+    "query"
+  ],
+  "properties": {
+    "version": {
+      "description": "Major schema version. Adding keys is backward-compatible and does not bump this; only changing/removing the meaning of an existing key does.",
+      "type": "integer",
+      "const": 1
+    },
+    "connection": {
+      "$ref": "#/$defs/connection"
+    },
+    "control-plane": {
+      "$ref": "#/$defs/control-plane"
+    },
+    "query": {
+      "$ref": "#/$defs/query"
+    }
+  },
+  "$defs": {
+    "positiveInteger": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "retryPolicyBackoff": {
+      "description": "Delay inserted between retry attempts of a retry policy. Discriminated union: when present, `type` selects the backoff algorithm and each algorithm carries only its own parameters. Absent when there is no delay between attempts.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Exponential backoff: the delay starts at base-ms and doubles after each attempt (capped at max-ms), with a small random jitter to de-synchronize concurrent retries. When max-ms is present, it MUST be greater than or equal to base-ms; this cross-property invariant must be checked by the producer or consumer because JSON Schema Draft 2020-12 cannot compare sibling numeric values.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "base-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "exponential",
+              "description": "Exponential backoff algorithm."
+            },
+            "base-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Initial delay between retries in milliseconds; the starting delay that doubles each attempt."
+            },
+            "max-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum delay between retries in milliseconds; the exponentially growing delay is capped here. MUST be greater than or equal to base-ms. Absent when no maximum delay is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Constant backoff: wait a fixed, strictly positive delay between every retry attempt.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "delay-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "constant",
+              "description": "Constant (fixed-delay) backoff algorithm."
+            },
+            "delay-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Fixed delay between retries in milliseconds. Must be greater than 0; omit backoff when no delay is configured."
+            }
+          }
+        }
+      ]
+    },
+    "requests": {
+      "type": "object",
+      "description": "Per-connection CQL request and protocol stream capacity. `orphaned.max` is expected to be lower than `in-flight.max`.",
+      "additionalProperties": false,
+      "required": [
+        "in-flight"
+      ],
+      "properties": {
+        "in-flight": {
+          "type": "object",
+          "description": "Requests currently awaiting a response on the connection.",
+          "additionalProperties": false,
+          "required": [
+            "max"
+          ],
+          "properties": {
+            "max": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of concurrent in-flight requests allowed on one connection."
+            }
+          }
+        },
+        "orphaned": {
+          "type": "object",
+          "description": "Requests that the client stopped waiting for but whose stream identifiers cannot yet be safely reused.",
+          "additionalProperties": false,
+          "required": [
+            "max"
+          ],
+          "properties": {
+            "max": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of orphaned requests allowed on one connection before the driver closes and replaces it. Absent only when this bound is unknown, for example when the client never replaces a connection over accumulated orphans and so has no limit to report."
+            }
+          }
+        }
+      }
+    },
+    "connection-pool": {
+      "description": "Connection pooling configuration.",
+      "type": "object",
+      "required": [
+        "shard-aware"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "shard-aware": {
+          "type": "object",
+          "required": [
+            "enabled"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether the client is configured to use ScyllaDB's dedicated shard-aware port (default 19042, TLS 19043) to reach a chosen shard in a single connect, versus the fallback of opening connections on the normal port and reading the server-assigned shard. Reports configuration intent; at runtime the port must also be advertised by the server and reachable, otherwise the client falls back transparently."
+            }
+          }
+        }
+      }
+    },
+    "connection": {
+      "description": "Connection-level settings: socket read/write/connect timeouts plus the CQL-level idle heartbeat. Durations are in milliseconds. Optional duration fields are absent when unset or not applicable.",
+      "type": "object",
+      "required": [
+        "connect",
+        "requests",
+        "pool",
+        "socket",
+        "reconnection"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "$ref": "#/$defs/requests"
+        },
+        "node-preference": {
+          "$ref": "#/$defs/node-location-preference",
+          "description": "Defines part of the cluster driver holds connections to."
+        },
+        "connect": {
+          "type": "object",
+          "description": "Settings for establishing a TCP/CQL connection to a node.",
+          "additionalProperties": false,
+          "properties": {
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Timeout for establishing a TCP/CQL connection to a node."
+            }
+          }
+        },
+        "read": {
+          "type": "object",
+          "description": "Settings for reading from a connection.",
+          "additionalProperties": false,
+          "properties": {
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Read operation timeout."
+            }
+          }
+        },
+        "write": {
+          "type": "object",
+          "description": "Settings for writing to a connection. Direction-specific options such as write coalescing are expected to be added here in a future schema version.",
+          "additionalProperties": false,
+          "properties": {
+            "coalescing": {
+              "type": "object",
+              "description": "Settings for write coalescing. It is a placeholder for v2",
+              "additionalProperties": false,
+              "properties": {}
+            },
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Write operation timeout."
+            }
+          }
+        },
+        "heartbeat": {
+          "type": "object",
+          "description": "Reserved for CQL-level idle heartbeat settings. Optional and intentionally empty in this schema version. It is a placeholder for v2",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "pool": {
+          "$ref": "#/$defs/connection-pool",
+          "description": "A connection pooling configuration."
+        },
+        "socket": {
+          "$ref": "#/$defs/socket"
+        },
+        "reconnection": {
+          "description": "Connection reconnection configuration.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/reconnection-policy"
+            }
+          }
+        },
+        "tls": {
+          "$ref": "#/$defs/tls"
+        }
+      }
+    },
+    "control-plane": {
+      "description": "Control-plane timeout settings for internal/system queries run over the control connection and for schema agreement. Each value is in milliseconds. Optional values are absent when unset or not applicable.",
+      "type": "object",
+      "required": [
+        "queries",
+        "schema"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "queries": {
+          "type": "object",
+          "description": "Control-plane query settings.",
+          "additionalProperties": false,
+          "required": [
+            "system"
+          ],
+          "properties": {
+            "system": {
+              "type": "object",
+              "description": "Settings for internal/system queries run over the control connection.",
+              "additionalProperties": false,
+              "required": [
+                "timeout"
+              ],
+              "properties": {
+                "timeout": {
+                  "type": "object",
+                  "description": "Timeouts applied to internal/system queries. Each value is in milliseconds. Optional values are absent when unset or not applicable.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "client-side-ms": {
+                      "$ref": "#/$defs/positiveInteger",
+                      "description": "A client-side timeout for internal queries."
+                    },
+                    "server-side-ms": {
+                      "$ref": "#/$defs/positiveInteger",
+                      "description": "A server-side timeout for internal queries."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "schema": {
+          "type": "object",
+          "description": "Control-plane schema settings.",
+          "additionalProperties": false,
+          "required": [
+            "agreement"
+          ],
+          "properties": {
+            "agreement": {
+              "type": "object",
+              "description": "Settings for schema agreement across nodes.",
+              "additionalProperties": false,
+              "required": [
+                "timeout-ms"
+              ],
+              "properties": {
+                "timeout-ms": {
+                  "$ref": "#/$defs/nonNegativeInteger",
+                  "description": "Maximum time to wait for schema agreement across nodes. Always a concrete value; 0 means do not wait for agreement."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "socket": {
+      "description": "Low-level TCP socket options applied to client connections. Boolean options (tcp-no-delay, keep-alive, reuse-address) report the effective on/off state: when no explicit value is configured, the OS/platform default is reported. Buffer sizes are in bytes and linger is in seconds; these fields are absent when unset (kernel auto-tuned buffer / linger disabled).",
+      "type": "object",
+      "required": [
+        "tcp-no-delay",
+        "keep-alive",
+        "reuse-address"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "tcp-no-delay": {
+          "type": "boolean",
+          "description": "TCP_NODELAY: disable Nagle's algorithm. Reports the effective value; when no explicit value is configured, the OS/platform default is reported."
+        },
+        "keep-alive": {
+          "type": "boolean",
+          "description": "SO_KEEPALIVE: OS-level TCP keep-alive probes on idle connections. Reports the effective on/off state; when no explicit value is configured, the OS/platform default is reported."
+        },
+        "reuse-address": {
+          "type": "boolean",
+          "description": "SO_REUSEADDR: allow reuse of a local address. Reports the effective on/off state; when no explicit value is configured, the OS/platform default is reported."
+        },
+        "linger": {
+          "type": "object",
+          "required": [
+            "interval-s"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "interval-s": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "SO_LINGER lingering-close interval in seconds."
+            }
+          }
+        },
+        "receive-buffer": {
+          "type": "object",
+          "required": [
+            "size-bytes"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "size-bytes": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "SO_RCVBUF socket receive buffer size hint in bytes."
+            }
+          }
+        },
+        "send-buffer": {
+          "type": "object",
+          "required": [
+            "size-bytes"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "size-bytes": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "SO_SNDBUF socket send buffer size hint in bytes."
+            }
+          }
+        }
+      }
+    },
+    "reconnection-policy": {
+      "description": "Defines how connection attempts to a node are retried after a connection failure.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Exponential backoff reconnection policy. max-ms MUST be greater than or equal to base-ms; this cross-property invariant must be checked by the producer or consumer because JSON Schema Draft 2020-12 cannot compare sibling numeric values.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "base-ms",
+            "max-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "exponential",
+              "description": "Reconnection policy type."
+            },
+            "base-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Initial delay before the first reconnection attempt in milliseconds. Always a concrete value when this policy is reported."
+            },
+            "max-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum delay between reconnection attempts in milliseconds. MUST be greater than or equal to base-ms. Always a concrete value when this policy is reported."
+            },
+            "max-attempts": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of reconnection attempts before giving up. Absent when attempts are unlimited."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Constant-delay reconnection policy. A delay of 0 means reconnect immediately.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "delay-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "constant",
+              "description": "Reconnection policy type."
+            },
+            "delay-ms": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Fixed delay between reconnection attempts in milliseconds; 0 means reconnect immediately. Always a concrete value when this policy is reported."
+            },
+            "max-attempts": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of reconnection attempts before giving up. Absent when attempts are unlimited."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied reconnection policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Reconnection policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            }
+          }
+        },
+        {
+          "type": "null",
+          "description": "No reconnection attempts will be made."
+        }
+      ]
+    },
+    "retry-policy": {
+      "description": "Controls whether and how a failed query is retried. Discriminated on `type`; each policy only permits its own parameters.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Standard error-aware retry policy.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "standard-error-aware",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Simple retry policy with a fixed number of retries.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "max-retries"
+          ],
+          "properties": {
+            "type": {
+              "const": "simple",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up. Always a concrete value when this policy is reported; 0 means no retries."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Fall-through retry policy: never retries anything and always rethrows the original error to the caller. Every error type — read timeout, write timeout, unavailable, and unexpected request errors (connection errors, Overloaded, ServerError, Bootstrapping) — is propagated unchanged. This is a true no-op and is stricter than the 'never' policy, which still retries the next host on connection/server errors.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "fallthrough",
+              "description": "Retry policy type."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Never-retry policy: does not retry read timeouts, write timeouts, or unavailable errors, but may try the next host for connection and server errors.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "never",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Downgrading-consistency retry policy: retries at a lower consistency level on failure.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "downgrading-consistency",
+              "description": "Retry policy type."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied retry policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Retry policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Textual description of what this policy does."
+            },
+            "max-retries": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Maximum number of retries before giving up; 0 means no retries. Absent when no explicit retry limit is configured."
+            }
+          }
+        }
+      ]
+    },
+    "speculative-execution-policy": {
+      "description": "Controls pre-emptive duplicate requests to other replicas. Discriminated on `type`; each policy only permits its own parameters.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Constant-delay speculative execution: launch extra executions after a fixed delay. A delay of 0 means launch them immediately.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "max-executions",
+            "delay-ms"
+          ],
+          "properties": {
+            "type": {
+              "const": "constant",
+              "description": "Speculative execution policy type."
+            },
+            "max-executions": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of speculative executions per request."
+            },
+            "delay-ms": {
+              "$ref": "#/$defs/nonNegativeInteger",
+              "description": "Delay before launching each additional execution in milliseconds; 0 means launch immediately."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Percentile-based speculative execution: launch extra executions once latency exceeds a percentile threshold.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "max-executions",
+            "percentile"
+          ],
+          "properties": {
+            "type": {
+              "const": "percentile",
+              "description": "Speculative execution policy type."
+            },
+            "max-executions": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Maximum number of speculative executions per request."
+            },
+            "percentile": {
+              "type": "number",
+              "exclusiveMinimum": 0,
+              "exclusiveMaximum": 100,
+              "description": "Latency percentile (0–100, exclusive; e.g. 99.0) that triggers an additional execution."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied speculative execution policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Speculative execution policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Textual description of what this policy does."
+            }
+          }
+        }
+      ]
+    },
+    "adaptive-ordering": {
+      "type": "object",
+      "description": "Dynamic reordering of otherwise eligible candidate nodes using runtime responsiveness, load, or health observations. Absent when adaptive ordering is disabled. This capability does not imply a particular algorithm.",
+      "additionalProperties": false,
+      "required": [
+        "signals"
+      ],
+      "properties": {
+        "signals": {
+          "type": "array",
+          "description": "Runtime observations used to influence ordering.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "latency",
+              "response-rate",
+              "in-flight-requests",
+              "recovery-state"
+            ]
+          }
+        }
+      }
+    },
+    "load-balancing-policy": {
+      "description": "Load balancing / host selection policy, discriminated by `type`. A built-in token-aware policy is reported with `type` set to `token-aware` and the normalized capability flags below. A user-supplied policy is reported with `type` set to `custom`, a `name`, and, optionally, serialized public attributes.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "A built-in load balancing policy, reported with normalized location/awareness flags.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "load-distribution",
+            "fallback-to-non-preferred-nodes"
+          ],
+          "properties": {
+            "type": {
+              "const": "token-aware",
+              "description": "Load balancing policy type: the built-in token-aware policy."
+            },
+            "load-distribution": {
+              "type": "string",
+              "enum": [
+                "shuffle",
+                "round-robin",
+                "replica-set"
+              ],
+              "description": "Strategy used to distribute requests across otherwise equally preferred nodes. `shuffle` randomizes node selection across query plans; `round-robin` rotates the first selected node across successive query plans; `replica-set` preserves the replica set's existing order without reordering it."
+            },
+            "fallback-to-non-preferred-nodes": {
+              "type": "boolean",
+              "description": "Whether requests may fail over to nodes outside of the preference configured by `query.load-balancing.node-preference`."
+            },
+            "adaptive-ordering": {
+              "$ref": "#/$defs/adaptive-ordering"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "A user-supplied load balancing policy that is not one of the built-ins. Identified by `name` only. Implementations that can introspect a policy instance MAY also serialize its public attributes as additional properties on this object.",
+          "additionalProperties": true,
+          "required": [
+            "type",
+            "name"
+          ],
+          "properties": {
+            "type": {
+              "const": "custom",
+              "description": "Load balancing policy type: a user-supplied policy."
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Name of the custom policy (e.g. the public type name of the user-provided policy)."
+            },
+            "description": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Textual description of what this policy does."
+            }
+          }
+        }
+      ]
+    },
+    "node-location-preference": {
+      "description": "Session-level datacenter/rack preference, set independently of the load balancing policy. Some implementations let users set a preferred DC/rack directly on the session configuration; the load balancing policy and other components read this preference unless a policy overrides it. May be sourced from different places; if DC/rack preferences are specified in the load balancing policy, they should be reported here.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Explicitly configured datacenter preference.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "local-dc"
+          ],
+          "properties": {
+            "type": {
+              "const": "dc",
+              "description": "Session-level location preference: explicit datacenter."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred datacenter."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Explicitly configured datacenter and rack preference.",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "local-dc",
+            "local-rack"
+          ],
+          "properties": {
+            "type": {
+              "const": "rack",
+              "description": "Session-level location preference: explicit datacenter and rack."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred datacenter."
+            },
+            "local-rack": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred rack."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Datacenter preference inferred from the first node the client connects to.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "dc-auto",
+              "description": "Session-level location preference: inferred datacenter."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Inferred preferred datacenter. Absent when not yet known at report time."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "description": "Datacenter and/or rack preference inferred from the connected node. Configured and inferred values are reported separately.",
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "rack-auto",
+              "description": "At least one part of the location preference is inferred."
+            },
+            "local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred datacenter."
+            },
+            "local-rack": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Explicitly configured preferred rack."
+            },
+            "inferred-local-dc": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Inferred preferred datacenter. Absent when not yet known."
+            },
+            "inferred-local-rack": {
+              "$ref": "#/$defs/nonEmptyString",
+              "description": "Inferred preferred rack. Absent when not yet known."
+            }
+          },
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "local-dc",
+                  "inferred-local-dc"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "local-rack",
+                  "inferred-local-rack"
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "local-dc",
+                  "local-rack"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "query": {
+      "description": "Query execution configuration.",
+      "type": "object",
+      "required": [
+        "defaults",
+        "retry",
+        "load-balancing"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "defaults": {
+          "$ref": "#/$defs/query-defaults"
+        },
+        "retry": {
+          "description": "Query retry configuration. Backoff is optional and is omitted when no retry delay is configured.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "policy": {
+                    "properties": {
+                      "type": {
+                        "const": "fallthrough"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ]
+                  }
+                },
+                "required": [
+                  "policy"
+                ]
+              },
+              "then": {
+                "not": {
+                  "required": [
+                    "backoff"
+                  ]
+                }
+              }
+            }
+          ],
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/retry-policy"
+            },
+            "backoff": {
+              "$ref": "#/$defs/retryPolicyBackoff",
+              "description": "Delay inserted between retries. Omitted when no retry backoff is configured. Every configured delay must be greater than 0."
+            }
+          }
+        },
+        "load-balancing": {
+          "description": "Load-balancing configuration applied to queries.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/load-balancing-policy"
+            },
+            "node-preference": {
+              "$ref": "#/$defs/node-location-preference",
+              "description": "Defines part of the cluster queries will be scheduled on"
+            }
+          }
+        },
+        "speculative-execution": {
+          "description": "Speculative-execution configuration applied to queries. Absent when speculative execution is disabled.",
+          "type": "object",
+          "required": [
+            "policy"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "policy": {
+              "$ref": "#/$defs/speculative-execution-policy"
+            }
+          }
+        }
+      }
+    },
+    "query-defaults": {
+      "description": "Default per-request settings applied to statements that do not override them.",
+      "type": "object",
+      "required": [
+        "consistency",
+        "idempotence"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "page": {
+          "type": "object",
+          "required": [
+            "size"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Default page (fetch) size for result sets. Absent when page is not limited."
+            }
+          }
+        },
+        "consistency": {
+          "description": "Default consistency level applied to requests that do not override it. Always present when this group is reported.",
+          "type": "string",
+          "enum": [
+            "ANY",
+            "ONE",
+            "TWO",
+            "THREE",
+            "QUORUM",
+            "ALL",
+            "LOCAL_QUORUM",
+            "EACH_QUORUM",
+            "LOCAL_ONE",
+            "SERIAL",
+            "LOCAL_SERIAL"
+          ]
+        },
+        "serial-consistency": {
+          "description": "Default serial consistency for LWT/conditional statements. Absent when unset; the server default applies.",
+          "type": "string",
+          "enum": [
+            "SERIAL",
+            "LOCAL_SERIAL"
+          ]
+        },
+        "idempotence": {
+          "description": "Default idempotence flag applied to statements that do not set their own.",
+          "type": "boolean"
+        },
+        "client-timestamps": {
+          "description": "True when the client assigns the write timestamp client-side (protocol-level/USING TIMESTAMP) instead of letting the coordinator assign it. Absent only when this behavior is unknown, for example when a custom timestamp generator may or may not enforce a timestamp.",
+          "type": "boolean"
+        },
+        "request": {
+          "type": "object",
+          "description": "Default request-level settings.",
+          "additionalProperties": false,
+          "properties": {
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Client-side timeout for a single request/query in milliseconds. Absent when the timeout is disabled or unset."
+            }
+          }
+        }
+      }
+    },
+    "tls": {
+      "description": "TLS/SSL transport settings. Absent when TLS is disabled. Reports only booleans; never credentials, keys, or host lists.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hostname-verification": {
+          "type": "boolean",
+          "description": "Whether the server hostname is verified against its certificate. Absent only when this behavior is unknown, for example when a custom certificate validator may or may not enforce hostname verification."
+        }
+      }
+    }
+  }
+}

--- a/driver_config.go
+++ b/driver_config.go
@@ -2,6 +2,9 @@ package gocql
 
 import (
 	"encoding/json"
+	"math"
+	"reflect"
+	"time"
 )
 
 // driverConfigStartupKey is the STARTUP option carrying the JSON description
@@ -21,19 +24,299 @@ const driverConfigVersion = 1
 // writes a 16-bit length prefix with no bounds check: a value over 65535
 // bytes would silently truncate that prefix modulo 65536 while still
 // appending the full body, corrupting the frame and failing the handshake.
-// Stage 1's report is a few bytes, but custom policy objects allow
-// implementation-specific properties, so a future report built from
-// user-supplied policy data could grow arbitrarily large. Enforcing a limit
-// here keeps "reporting must never prevent a connection from being
-// established" a property of this code rather than of the user's
-// configuration. 32KiB is generous for a configuration report.
+// Custom policy objects allow implementation-specific properties, so a report
+// built from user-supplied policy data could in principle grow large.
+// Enforcing a limit here keeps "reporting must never prevent a connection
+// from being established" a property of this code rather than of the user's
+// configuration. 32KiB is generous for a configuration report and matches the
+// limit csharp-driver and java-driver use for the same report.
 const maxDriverConfigSize = 32 * 1024
 
-// driverConfigReport is the value sent under driverConfigStartupKey.
-// For now only the schema version is reported; configuration groups will be
-// added in a follow-up change.
+// driverConfigReport is the value sent under driverConfigStartupKey, conforming
+// to docs/driver-config-schema.json. It groups the effective configuration the
+// way the schema does: connection-level settings, control-plane (system query
+// and schema agreement) settings, and query-execution defaults.
+// Field order here (and in the other report structs) is chosen for field
+// alignment, not readability: it decides how much of the struct the GC has to
+// scan, which govet's fieldalignment check enforces. The JSON key order it
+// produces is not the schema's order, which is fine -- object key order is
+// not significant in JSON.
 type driverConfigReport struct {
-	Version int `json:"version"`
+	Connection   connectionReport   `json:"connection"`
+	ControlPlane controlPlaneReport `json:"control-plane"`
+	Query        queryReport        `json:"query"`
+	Version      int                `json:"version"`
+}
+
+// connectionReport is the top-level "connection" group in the schema.
+type connectionReport struct {
+	// NodePreference is which nodes the driver opens connections to at all, a
+	// different claim from query.load-balancing.node-preference (which of those
+	// a query may be routed to). Omitted when nothing narrows pool membership;
+	// see buildConnectionNodePreferenceReport.
+	NodePreference any `json:"node-preference,omitempty"`
+	// Read and Write are omitted entirely when their timeout is 0 (disabled),
+	// matching the schema's "absent when unset or not applicable" convention
+	// for optional groups. write.coalescing and the sibling connection.heartbeat
+	// group are never populated: the schema declares both as
+	// additionalProperties:false with no properties, an explicit placeholder
+	// for a future schema version, so there is nothing a v1 report could put
+	// there even though gocql does have both features (WriteCoalesceWaitTime,
+	// the control connection's heartBeat()).
+	Read  *readWriteTimeoutReport `json:"read,omitempty"`
+	Write *readWriteTimeoutReport `json:"write,omitempty"`
+	// TLS is omitted when TLS is not configured, or when a HostDialer is set:
+	// HostDialer takes over the entire connection setup and SslOpts is ignored
+	// (see ClusterConfig.SslOpts), so the effective TLS state is unknown.
+	TLS          *tlsReport              `json:"tls,omitempty"`
+	Reconnection reconnectionGroupReport `json:"reconnection"`
+	Connect      connectReport           `json:"connect"`
+	Requests     requestsReport          `json:"requests"`
+	Pool         connectionPoolReport    `json:"pool"`
+	Socket       socketReport            `json:"socket"`
+}
+
+// connectReport carries an optional timeout-ms: the schema does not list it
+// under connect.required, so an empty "connect": {} is how a disabled connect
+// timeout is reported. See positiveMillis.
+type connectReport struct {
+	TimeoutMs *int64 `json:"timeout-ms,omitempty"`
+}
+
+type readWriteTimeoutReport struct {
+	TimeoutMs int64 `json:"timeout-ms"`
+}
+
+// requestsReport is connection.requests.
+//
+// Its orphaned group is never populated. Orphaned requests do exist here: a
+// request whose caller stopped waiting keeps its stream reserved until the
+// response arrives, precisely so the id is not reused (see StreamObserver's
+// documentation, and the timeout branch of Conn.exec, which stops waiting
+// without releasing the stream). What does not exist is any bound on them --
+// no setting caps how many a connection may accumulate, and nothing closes and
+// replaces a connection because too many did. The group asks for that bound,
+// so there is nothing to report, and 0 would assert the opposite: close the
+// connection on the very first orphan.
+//
+// The schema makes orphaned optional for exactly this case, and gives its
+// absence that meaning, so omitting it produces a document a consumer
+// validating against the schema accepts.
+type requestsReport struct {
+	InFlight inFlightReport `json:"in-flight"`
+}
+
+type inFlightReport struct {
+	Max int `json:"max"`
+}
+
+type connectionPoolReport struct {
+	ShardAware shardAwareReport `json:"shard-aware"`
+}
+
+type shardAwareReport struct {
+	Enabled bool `json:"enabled"`
+}
+
+type socketReport struct {
+	TCPNoDelay   bool `json:"tcp-no-delay"`
+	KeepAlive    bool `json:"keep-alive"`
+	ReuseAddress bool `json:"reuse-address"`
+}
+
+type reconnectionGroupReport struct {
+	// Policy is one of reconnectionExponentialReport, reconnectionConstantReport,
+	// reconnectionCustomReport, or nil (marshals to JSON null, the schema's "no
+	// reconnection attempts will be made" branch).
+	Policy any `json:"policy"`
+}
+
+// MaxAttempts is always present and always positive on both reports below: a
+// policy that would attempt nothing is reported as no policy at all, so it
+// never reaches these. The schema's "absent when attempts are unlimited" has
+// no counterpart here -- GetMaxRetries returns a plain count, with no value
+// standing for unlimited.
+type reconnectionExponentialReport struct {
+	Type        string `json:"type"`
+	BaseMs      int64  `json:"base-ms"`
+	MaxMs       int64  `json:"max-ms"`
+	MaxAttempts int    `json:"max-attempts"`
+}
+
+type reconnectionConstantReport struct {
+	Type        string `json:"type"`
+	DelayMs     int64  `json:"delay-ms"`
+	MaxAttempts int    `json:"max-attempts"`
+}
+
+type reconnectionCustomReport struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+type tlsReport struct {
+	HostnameVerification bool `json:"hostname-verification"`
+}
+
+// controlPlaneReport is the top-level "control-plane" group in the schema.
+type controlPlaneReport struct {
+	Queries controlPlaneQueriesReport `json:"queries"`
+	Schema  controlPlaneSchemaReport  `json:"schema"`
+}
+
+type controlPlaneQueriesReport struct {
+	System systemQueriesReport `json:"system"`
+}
+
+type systemQueriesReport struct {
+	Timeout systemQueriesTimeoutReport `json:"timeout"`
+}
+
+type systemQueriesTimeoutReport struct {
+	ClientSideMs *int64 `json:"client-side-ms,omitempty"`
+}
+
+type controlPlaneSchemaReport struct {
+	Agreement schemaAgreementReport `json:"agreement"`
+}
+
+type schemaAgreementReport struct {
+	TimeoutMs int64 `json:"timeout-ms"`
+}
+
+// queryReport is the top-level "query" group in the schema.
+//
+// It has no speculative-execution group: gocql has no session/cluster-wide
+// default speculative execution policy, only a per-Query/per-Batch opt-in via
+// SetSpeculativeExecutionPolicy. Every session's default is
+// NonSpeculativeExecution (disabled), and the schema says to omit the group
+// entirely when speculative execution is disabled -- which is always true of
+// the session-wide default this report describes.
+type queryReport struct {
+	Retry         queryRetryReport         `json:"retry"`
+	LoadBalancing queryLoadBalancingReport `json:"load-balancing"`
+	Defaults      queryDefaultsReport      `json:"defaults"`
+}
+
+type queryDefaultsReport struct {
+	Page *pageReport `json:"page,omitempty"`
+	// Request is omitted entirely when Timeout is 0: the schema no longer
+	// requires this group (only its inner timeout-ms was ever optional), so
+	// there is no reason to send an empty {} object.
+	Request *requestDefaultReport `json:"request,omitempty"`
+	// Consistency carries one of the schema's nine non-serial levels, or is
+	// omitted. Consistency's zero value (Any) is itself a real level, not a
+	// sentinel for "unset", so absence here means only one thing: the
+	// configured level is outside what the schema can express. See
+	// consistencyName.
+	Consistency string `json:"consistency,omitempty"`
+	// SerialConsistency is omitted when 0, mirroring the ">0" check
+	// ClusterConfig.Validate itself uses to treat the field as unset.
+	SerialConsistency string `json:"serial-consistency,omitempty"`
+	Idempotence       bool   `json:"idempotence"`
+	// ClientTimestamps reports DefaultTimestamp as configured, not additionally
+	// gated on the negotiated protocol version: the client-timestamp flag is
+	// only suppressed below protocol v3 (frame.go), a corner case not worth
+	// threading the negotiated version through the report for.
+	ClientTimestamps bool `json:"client-timestamps"`
+}
+
+type pageReport struct {
+	Size int `json:"size"`
+}
+
+type requestDefaultReport struct {
+	TimeoutMs int64 `json:"timeout-ms"`
+}
+
+type queryRetryReport struct {
+	// Policy is one of retryPolicySimpleReport, retryPolicyDowngradingReport, or
+	// retryPolicyCustomReport.
+	Policy any `json:"policy"`
+	// Backoff is decoupled from Policy's discriminant on purpose: the schema
+	// places it as a sibling of policy, not nested under a policy variant, so
+	// a policy reported as "custom" (e.g. gocql's own
+	// ExponentialBackoffRetryPolicy, which isn't one of the schema's built-in
+	// retry types) can still usefully report the delay it's known to apply.
+	// nil (omitted) when the effective policy has no such delay.
+	Backoff any `json:"backoff,omitempty"`
+}
+
+type retryPolicySimpleReport struct {
+	Type       string `json:"type"`
+	MaxRetries int    `json:"max-retries"`
+}
+
+type retryPolicyDowngradingReport struct {
+	Type string `json:"type"`
+	// MaxRetries is DowngradingConsistencyRetryPolicy's own retry limit: its
+	// Attempt method stops retrying once it has stepped through every entry of
+	// ConsistencyLevelsToTry, so the slice's length is a concrete, always-known
+	// retry limit -- not something to guess at or leave unset.
+	MaxRetries int `json:"max-retries"`
+}
+
+type retryPolicyCustomReport struct {
+	// MaxRetries is populated only for a custom policy whose retry limit the
+	// driver can read. That is just the built-in
+	// ExponentialBackoffRetryPolicy: the RetryPolicy interface exposes no
+	// attempt limit, so a genuinely user-supplied policy has nothing to report
+	// here.
+	MaxRetries *int   `json:"max-retries,omitempty"`
+	Type       string `json:"type"`
+	Name       string `json:"name"`
+}
+
+type retryBackoffExponentialReport struct {
+	Type   string `json:"type"`
+	BaseMs int64  `json:"base-ms"`
+	MaxMs  int64  `json:"max-ms"`
+}
+
+type queryLoadBalancingReport struct {
+	// Policy is one of loadBalancingTokenAwareReport or loadBalancingCustomReport.
+	Policy any `json:"policy"`
+	// NodePreference is one of nodeLocationDCReport, nodeLocationRackReport, or
+	// nil (omitted): gocql has no DC-inference feature, so the schema's
+	// dc-auto/rack-auto branches are never produced.
+	NodePreference any `json:"node-preference,omitempty"`
+}
+
+type loadBalancingTokenAwareReport struct {
+	// AdaptiveOrdering is omitted when the policy orders candidates only by
+	// the static rules above, which the schema spells "absent when adaptive
+	// ordering is disabled".
+	AdaptiveOrdering *adaptiveOrderingReport `json:"adaptive-ordering,omitempty"`
+	Type             string                  `json:"type"`
+	LoadDistribution string                  `json:"load-distribution"`
+	// FallbackToNonPreferredNodes reports whether requests may fail over to
+	// nodes outside of query.load-balancing.node-preference (DC or rack).
+	FallbackToNonPreferredNodes bool `json:"fallback-to-non-preferred-nodes"`
+}
+
+// adaptiveOrderingReport names the runtime observations that reorder
+// otherwise eligible candidates. The schema deliberately stops there: it
+// records which signals feed the decision, not the algorithm or its
+// thresholds, so AvoidSlowReplicas' MAX_IN_FLIGHT_THRESHOLD has nowhere to go
+// and is not reported.
+type adaptiveOrderingReport struct {
+	Signals []string `json:"signals"`
+}
+
+type loadBalancingCustomReport struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+type nodeLocationDCReport struct {
+	Type    string `json:"type"`
+	LocalDC string `json:"local-dc"`
+}
+
+type nodeLocationRackReport struct {
+	Type      string `json:"type"`
+	LocalDC   string `json:"local-dc"`
+	LocalRack string `json:"local-rack"`
 }
 
 // driverConfigReporter builds the DRIVER_CONFIG STARTUP option describing a
@@ -43,15 +326,15 @@ type driverConfigReport struct {
 //
 // The report is rebuilt on every control connection (re-)establishment
 // rather than cached, since future configuration groups may describe state
-// only known after ring and topology setup (e.g. an inferred local DC).
+// only known after ring and topology setup.
 //
 // The reporter holds the *Session itself and builds the report lazily, at
 // first use, rather than at construction time: newDriverConfigReporter runs
 // inside newSessionCommon before fields such as s.policy are assigned, so a
 // report built eagerly would see a partially initialized Session. For the
-// same reason, a future report describing the host selection policy must
-// read it off s.policy, not s.cfg.PoolConfig.HostSelectionPolicy: the latter
-// is never assigned the default policy that newSessionCommon applies.
+// same reason, the host selection policy is read off s.policy, not
+// s.cfg.PoolConfig.HostSelectionPolicy: the latter is never assigned the
+// default policy that newSessionCommon applies.
 type driverConfigReporter struct {
 	session *Session
 }
@@ -83,12 +366,579 @@ func (r *driverConfigReporter) updateStartupOptions(opts map[string]string) {
 // buildReport returns the JSON configuration report of the session, marshalled
 // fresh on every call so that it reflects the session's current state rather
 // than a snapshot from whenever it was first requested.
-//
-// The error is unreachable while the report only carries the schema version, but
-// it is the fail-safe boundary for the configuration groups added later: those
-// describe user-supplied values, such as the names and fields of custom
-// policies, whose marshalling can genuinely fail.
 func (r *driverConfigReporter) buildReport() (string, error) {
-	report, err := json.Marshal(driverConfigReport{Version: driverConfigVersion})
-	return string(report), err
+	cfg := &r.session.cfg
+	report := driverConfigReport{
+		Version:      driverConfigVersion,
+		Connection:   buildConnectionReport(cfg),
+		ControlPlane: buildControlPlaneReport(cfg),
+		Query:        buildQueryReport(r.session),
+	}
+	data, err := json.Marshal(report)
+	return string(data), err
+}
+
+func buildConnectionReport(cfg *ClusterConfig) connectionReport {
+	report := connectionReport{
+		Connect:      connectReport{TimeoutMs: positiveMillis(cfg.ConnectTimeout)},
+		Requests:     buildRequestsReport(cfg),
+		Pool:         connectionPoolReport{ShardAware: shardAwareReport{Enabled: shardAwareEnabled(cfg)}},
+		Socket:       buildSocketReport(),
+		Reconnection: reconnectionGroupReport{Policy: buildReconnectionPolicyReport(cfg.ReconnectionPolicy)},
+	}
+	if ms := positiveMillis(cfg.ReadTimeout); ms != nil {
+		report.Read = &readWriteTimeoutReport{TimeoutMs: *ms}
+	}
+	if ms := positiveMillis(cfg.WriteTimeout); ms != nil {
+		report.Write = &readWriteTimeoutReport{TimeoutMs: *ms}
+	}
+	report.TLS = buildTLSReport(cfg)
+	report.NodePreference = buildConnectionNodePreferenceReport(cfg)
+	return report
+}
+
+// buildConnectionNodePreferenceReport describes the part of the cluster the
+// driver holds connections to.
+//
+// Only HostFilter narrows that: Session.init drops every host cfg.filterHost
+// rejects, so such a host never gets a pool at all. The host selection policy's
+// DC/rack preference is reported separately and does not belong here -- it
+// orders and restricts routing among hosts that all still have pools.
+//
+// Of the filters shipped here only DataCenterHostFilter states a location.
+// WhiteListHostFilter selects by address, which the schema has no branch for;
+// AcceptAllFilter and DenyAllFilter state no location; and a caller-supplied
+// HostFilterFunc is a closure this cannot see into. All of those report no
+// preference.
+func buildConnectionNodePreferenceReport(cfg *ClusterConfig) any {
+	filter, ok := cfg.HostFilter.(dataCenterHostFilter)
+	if !ok || filter.dataCenter == "" {
+		return nil
+	}
+	return nodeLocationDCReport{Type: "dc", LocalDC: filter.dataCenter}
+}
+
+// buildTLSReport describes the TLS transport, or returns nil when there is
+// nothing trustworthy to say: TLS is not configured, or a HostDialer has taken
+// over connection setup entirely and SslOpts is ignored (see
+// ClusterConfig.SslOpts).
+//
+// hostname-verification is the effective setting rather than
+// SslOpts.EnableHostVerification, which is only one of its two inputs.
+// setupTLSConfig only ever forces verification *on* -- it flips
+// InsecureSkipVerify off when the caller asked to skip verification and set
+// EnableHostVerification, and never the reverse. So a caller-supplied
+// tls.Config with InsecureSkipVerify left false verifies the hostname even
+// though EnableHostVerification is false, and reporting that flag alone
+// inverts the truth for the most ordinary way of configuring TLS.
+func buildTLSReport(cfg *ClusterConfig) *tlsReport {
+	if cfg.SslOpts == nil || cfg.HostDialer != nil {
+		return nil
+	}
+	// The config setupTLSConfig actually produced, once ValidateAndInitSSL has
+	// run -- which is every session, but not a Session assembled by hand in a
+	// test.
+	if actual := cfg.getActualTLSConfig(); actual != nil {
+		return &tlsReport{HostnameVerification: !actual.InsecureSkipVerify}
+	}
+	verify := cfg.SslOpts.EnableHostVerification
+	if cfg.SslOpts.Config != nil {
+		verify = !cfg.SslOpts.Config.InsecureSkipVerify || cfg.SslOpts.EnableHostVerification
+	}
+	return &tlsReport{HostnameVerification: verify}
+}
+
+// positiveMillis renders d for a schema field declared positiveInteger
+// (minimum 1).
+//
+// It returns nil, so the key is omitted, when nothing is configured. Otherwise
+// it floors at 1ms: durations under a millisecond truncate to 0, which the
+// schema rejects, and a sub-millisecond timeout is still a timeout -- reporting
+// the schema minimum is truer than either a 0 no consumer will accept or an
+// absent key that would read as "disabled".
+//
+// Fields where 0 is itself meaningful (schema.agreement.timeout-ms, the
+// constant reconnection policy's delay-ms) are nonNegativeInteger in the schema
+// and must not go through here: they report their zero verbatim.
+func positiveMillis(d time.Duration) *int64 {
+	if d <= 0 {
+		return nil
+	}
+	ms := max(d.Milliseconds(), 1)
+	return &ms
+}
+
+// isNilPolicy reports whether v is nil, or a non-nil interface holding a nil
+// pointer.
+//
+// A type switch routes only an untyped nil to `case nil`; a policy held as a
+// typed nil pointer matches its own branch instead and panics on the first
+// field it reads. Reporting runs on the goroutine that establishes a
+// connection and must never do that to it, so every switch over a
+// caller-supplied policy checks this first.
+func isNilPolicy(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Func, reflect.Map, reflect.Slice, reflect.Chan:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+// nonNegativeMillis renders d for a schema field declared nonNegativeInteger.
+// A negative duration is normalized to 0 rather than reported: time.Sleep
+// returns immediately on one, so an immediate retry is what it means, and the
+// schema has no encoding for a negative delay.
+func nonNegativeMillis(d time.Duration) int64 {
+	return max(d.Milliseconds(), 0)
+}
+
+func buildRequestsReport(cfg *ClusterConfig) requestsReport {
+	return requestsReport{InFlight: inFlightReport{Max: effectiveInFlightMax(cfg.MaxRequestsPerConn)}}
+}
+
+// defaultMaxStreams mirrors streams.New(), the generator Session.streamIDGenerator
+// uses when MaxRequestsPerConn is left unset.
+const defaultMaxStreams = 32768
+
+// maxReportableInFlight is the most requests a connection can ever have
+// outstanding: the CQL v3+ stream id is a signed 16-bit value, so ids 0..32767
+// are all there are. The schema constrains this field only to a positive
+// integer, so this bound is the protocol's, not the schema's.
+const maxReportableInFlight = 32767
+
+// effectiveInFlightMax reports how many requests can actually be in flight on
+// one connection, which is not the configured limit. streams.NewLimited rounds
+// the limit up to a multiple of 64 and then reserves stream 0, so a configured
+// 100 really permits 127, and the 32768-stream default really permits 32767.
+//
+// A configured value above the stream-id range is clamped: gocql does not
+// reject it, but the protocol cannot address those streams, so reporting it
+// verbatim would claim a concurrency the connection can never reach.
+func effectiveInFlightMax(configured int) int {
+	if configured <= 0 {
+		configured = defaultMaxStreams
+	}
+	if configured >= maxReportableInFlight {
+		// Short-circuit before the rounding below, which overflows to a
+		// negative within 63 of the integer limit. The result is capped here
+		// anyway, so nothing is lost. ClusterConfig.Validate rejects only a
+		// negative MaxRequestsPerConn, so a value that large does reach this.
+		return maxReportableInFlight
+	}
+	inFlight := (((configured + 63) / 64) * 64) - 1
+	return min(inFlight, maxReportableInFlight)
+}
+
+// shardAwareEnabled reports whether the client can reach ScyllaDB's
+// shard-aware port at all. Two independent things have to hold, and the
+// schema has one boolean for both.
+//
+// DisableShardAwarePort must be unset: it makes scyllaConnPicker.NextShard
+// return no shard, which sends every dial down the plain path.
+//
+// The dialer must also be able to target a shard. Session.dialWithoutObserver
+// type-asserts HostDialer to ShardDialer and silently falls back to DialHost
+// when the assertion fails, so a custom HostDialer that does not implement
+// DialShard can never reach the shard-aware port however the flag is set.
+// A nil HostDialer is capable: connConfig substitutes a *scyllaDialer, which
+// implements ShardDialer.
+func shardAwareEnabled(cfg *ClusterConfig) bool {
+	if cfg.DisableShardAwarePort {
+		return false
+	}
+	if cfg.HostDialer == nil {
+		return true
+	}
+	_, ok := cfg.HostDialer.(ShardDialer)
+	return ok
+}
+
+// buildSocketReport describes what gocql's own built-in dialer does with a
+// TCP socket. A user-supplied Dialer/HostDialer can set one up differently;
+// the driver has no way to observe that, so the report always describes the
+// built-in dialer's behavior, per the schema's own framing of these fields as
+// "the effective value ... the OS/platform default".
+func buildSocketReport() socketReport {
+	return socketReport{
+		// Go's net package unconditionally disables Nagle's algorithm for every
+		// TCP connection it creates (net.newTCPConn calls setNoDelay(fd, true));
+		// gocql never overrides that.
+		TCPNoDelay: true,
+		// cfg.SocketKeepalive can't be negative (see ClusterConfig.Validate), and
+		// net.Dialer.KeepAlive == 0 still means "enabled, OS default period" --
+		// there is currently no way to disable keep-alive through gocql's
+		// configuration.
+		KeepAlive: true,
+		// gocql never sets SO_REUSEADDR.
+		ReuseAddress: false,
+	}
+}
+
+// buildReconnectionPolicyReport describes the policy hostConnPool.connect will
+// drive, or nil for the schema's null branch, "no reconnection attempts will
+// be made".
+//
+// A policy whose retry limit is not positive takes that null branch whatever
+// its type: connect loops `for i := 0; i < GetMaxRetries(); i++`, so it makes
+// no attempt at all. Reporting it as a policy with max-attempts omitted would
+// state the opposite, since the schema reads an absent max-attempts as
+// unlimited attempts.
+func buildReconnectionPolicyReport(rp ReconnectionPolicy) any {
+	if isNilPolicy(rp) {
+		return nil
+	}
+	switch p := rp.(type) {
+	case *NoReconnectionPolicy:
+		return nil
+	case *ConstantReconnectionPolicy:
+		if p.MaxRetries <= 0 {
+			return nil
+		}
+		return reconnectionConstantReport{
+			Type:        "constant",
+			DelayMs:     nonNegativeMillis(p.Interval),
+			MaxAttempts: p.MaxRetries,
+		}
+	case *ExponentialReconnectionPolicy:
+		if p.MaxRetries <= 0 {
+			return nil
+		}
+		maxInterval := p.MaxInterval
+		if maxInterval < p.InitialInterval {
+			// Matches ExponentialReconnectionPolicy.GetInterval's own fallback.
+			maxInterval = math.MaxInt16 * time.Second
+		}
+		// GetInterval delegates to getExponentialTime, which substitutes its own
+		// defaults for a non-positive bound, so report the window retries
+		// actually use rather than a zero the schema rejects (both fields are
+		// positiveInteger).
+		base, maxDelay := exponentialDelayWindow(p.InitialInterval, maxInterval)
+		return reconnectionExponentialReport{
+			Type:        "exponential",
+			BaseMs:      base,
+			MaxMs:       maxDelay,
+			MaxAttempts: p.MaxRetries,
+		}
+	default:
+		return reconnectionCustomReport{Type: "custom", Name: customPolicyName(rp)}
+	}
+}
+
+func buildControlPlaneReport(cfg *ClusterConfig) controlPlaneReport {
+	var timeout systemQueriesTimeoutReport
+	if clientMs := positiveMillis(cfg.MetadataSchemaRequestTimeout); clientMs != nil {
+		timeout.ClientSideMs = clientMs
+	}
+	return controlPlaneReport{
+		Queries: controlPlaneQueriesReport{System: systemQueriesReport{Timeout: timeout}},
+		Schema: controlPlaneSchemaReport{
+			// Always emitted, including 0: the schema documents 0 as meaningful
+			// ("do not wait for agreement"), not as "unset".
+			Agreement: schemaAgreementReport{TimeoutMs: cfg.MaxWaitSchemaAgreement.Milliseconds()},
+		},
+	}
+}
+
+func buildQueryReport(s *Session) queryReport {
+	cfg := &s.cfg
+	return queryReport{
+		Defaults:      buildQueryDefaultsReport(cfg),
+		Retry:         buildQueryRetryReport(cfg),
+		LoadBalancing: buildLoadBalancingReport(s.policy),
+	}
+}
+
+func buildQueryDefaultsReport(cfg *ClusterConfig) queryDefaultsReport {
+	report := queryDefaultsReport{
+		Consistency:      consistencyName(cfg.Consistency),
+		Idempotence:      cfg.DefaultIdempotence,
+		ClientTimestamps: cfg.DefaultTimestamp,
+	}
+	if cfg.PageSize > 0 {
+		report.Page = &pageReport{Size: cfg.PageSize}
+	}
+	if cfg.SerialConsistency.IsSerial() {
+		report.SerialConsistency = cfg.SerialConsistency.String()
+	}
+	if ms := positiveMillis(cfg.Timeout); ms != nil {
+		report.Request = &requestDefaultReport{TimeoutMs: *ms}
+	}
+	return report
+}
+
+// consistencyName renders c for query.defaults.consistency, and returns "" for
+// a value the schema's enum cannot carry so the key is omitted.
+//
+// The enum covers every level Consistency defines, serial ones included, so
+// only an unrecognized numeric value is unreportable -- Consistency.String()
+// renders those as "UNKNOWN_CONS_0x..", which no consumer can interpret.
+// Nothing rejects such a value today; the fix belongs in ClusterConfig.Validate
+// and is left to a follow-up.
+func consistencyName(c Consistency) string {
+	switch c {
+	case Any, One, Two, Three, Quorum, All, LocalQuorum, EachQuorum, LocalOne, Serial, LocalSerial:
+		return c.String()
+	default:
+		return ""
+	}
+}
+
+func buildQueryRetryReport(cfg *ClusterConfig) queryRetryReport {
+	rp := cfg.RetryPolicy
+	if rp == nil {
+		// Mirrors query_executor.go's own fallback for an unset RetryPolicy.
+		rp = defaultRetryPolicy
+	}
+	return queryRetryReport{
+		Policy:  buildRetryPolicyReport(rp),
+		Backoff: buildRetryBackoffReport(rp),
+	}
+}
+
+// nonNegativeRetries clamps a policy's retry count for max-retries, which the
+// schema declares nonNegativeInteger.
+//
+// Nothing validates RetryPolicy -- ClusterConfig.Validate does not look at it
+// at all -- so a negative count reaches the report. Clamping loses nothing:
+// both built-in policies compare the attempt number against this field
+// (Attempts() <= NumRetries, Attempts() > NumRetries), and since the first
+// attempt is 1, every negative count refuses the first retry exactly as 0
+// does.
+func nonNegativeRetries(numRetries int) int {
+	return max(numRetries, 0)
+}
+
+func buildRetryPolicyReport(rp RetryPolicy) any {
+	if isNilPolicy(rp) {
+		// Nothing can be read off it, but its type still names something.
+		return retryPolicyCustomReport{Type: "custom", Name: customPolicyName(rp)}
+	}
+	switch p := rp.(type) {
+	case *SimpleRetryPolicy:
+		return retryPolicySimpleReport{Type: "simple", MaxRetries: nonNegativeRetries(p.NumRetries)}
+	case *DowngradingConsistencyRetryPolicy:
+		return retryPolicyDowngradingReport{Type: "downgrading-consistency", MaxRetries: len(p.ConsistencyLevelsToTry)}
+	case *ExponentialBackoffRetryPolicy:
+		// Not one of the schema's built-in retry-policy types, so it is reported
+		// as custom like any other RetryPolicy implementation -- but its retry
+		// limit and its backoff are both readable, and the schema's custom
+		// branch accepts max-retries. The backoff surfaces separately, as a
+		// sibling of the policy: see buildRetryBackoffReport.
+		maxRetries := nonNegativeRetries(p.NumRetries)
+		return retryPolicyCustomReport{
+			Type:       "custom",
+			Name:       customPolicyName(rp),
+			MaxRetries: &maxRetries,
+		}
+	default:
+		return retryPolicyCustomReport{Type: "custom", Name: customPolicyName(rp)}
+	}
+}
+
+func buildRetryBackoffReport(rp RetryPolicy) any {
+	backoff, ok := rp.(*ExponentialBackoffRetryPolicy)
+	if !ok || isNilPolicy(rp) {
+		return nil
+	}
+	base, maxDelay := exponentialDelayWindow(backoff.Min, backoff.Max)
+	return retryBackoffExponentialReport{Type: "exponential", BaseMs: base, MaxMs: maxDelay}
+}
+
+// exponentialDelayWindow reports the delay window getExponentialTime
+// (policies.go) actually produces for a configured min/max pair, in
+// milliseconds.
+//
+// Both the exponential retry backoff and the exponential reconnection policy
+// route their delays through getExponentialTime, and both describe the result
+// with schema fields declared positiveInteger where max-ms must be >= base-ms.
+// Neither invariant survives the configured values untouched:
+//
+//   - a non-positive bound is not used as-is; getExponentialTime substitutes
+//     100ms for the minimum and 10s for the maximum, so reporting the raw 0
+//     would name a delay the policy never waits and one the schema rejects.
+//   - a maximum below the minimum caps every delay at the maximum, so the
+//     minimum is never reached. Reporting it as base-ms would both misdescribe
+//     the policy and break max-ms >= base-ms.
+//   - a sub-millisecond bound truncates to 0, so both are floored the same way
+//     positiveMillis floors the report's other positiveInteger durations.
+func exponentialDelayWindow(configuredMin, configuredMax time.Duration) (baseMs, maxMs int64) {
+	base := effectiveExpBackoff(configuredMin, 100*time.Millisecond)
+	maxDelay := effectiveExpBackoff(configuredMax, 10*time.Second)
+	if maxDelay < base {
+		base = maxDelay
+	}
+	return max(base.Milliseconds(), 1), max(maxDelay.Milliseconds(), 1)
+}
+
+func effectiveExpBackoff(configured, fallback time.Duration) time.Duration {
+	if configured <= 0 {
+		return fallback
+	}
+	return configured
+}
+
+func buildLoadBalancingReport(policy HostSelectionPolicy) queryLoadBalancingReport {
+	policy = unwrapHostSelectionPolicy(policy)
+	return queryLoadBalancingReport{
+		Policy:         buildLoadBalancingPolicyReport(policy),
+		NodePreference: buildNodeLocationPreferenceReport(policy),
+	}
+}
+
+func buildLoadBalancingPolicyReport(policy HostSelectionPolicy) any {
+	tap, ok := policy.(*tokenAwareHostPolicy)
+	if !ok || isNilPolicy(policy) {
+		// The schema's built-in load-balancing type only ever admits
+		// "token-aware" (matching csharp-driver/java-driver's own narrowing);
+		// any other policy -- including gocql's plain RoundRobinHostPolicy or
+		// DCAwareRoundRobinPolicy used without token-awareness -- is reported as
+		// custom.
+		return loadBalancingCustomReport{Type: "custom", Name: customPolicyName(policy)}
+	}
+	distribution := "replica-set"
+	if tap.shuffleReplicas {
+		distribution = "shuffle"
+	}
+	report := loadBalancingTokenAwareReport{
+		Type:                        "token-aware",
+		LoadDistribution:            distribution,
+		FallbackToNonPreferredNodes: fallbackToNonPreferredNodesAllowed(tap),
+	}
+	if tap.avoidSlowReplicas {
+		// AvoidSlowReplicas makes Pick partition the replica set so hosts at or
+		// above MAX_IN_FLIGHT_THRESHOLD outstanding requests sort last: see
+		// partitionHealthy, which orders by HostInfo.IsBusy. That is adaptive
+		// ordering, and the count of outstanding requests is the one signal it
+		// reads.
+		report.AdaptiveOrdering = &adaptiveOrderingReport{Signals: []string{"in-flight-requests"}}
+	}
+	return report
+}
+
+// maxPolicyUnwrapDepth bounds the walk below. A wrapper cycle is not
+// reachable through the constructors, but the report must never hang a
+// connection over a policy someone assembled by hand.
+const maxPolicyUnwrapDepth = 16
+
+// unwrapHostSelectionPolicy peels driver-supplied wrappers off a host
+// selection policy so the report describes the policy the caller actually
+// configured rather than the wrapper around it.
+//
+// SingleHostReadyPolicy is the only such wrapper, and it is transparent to
+// routing: it forwards every selection decision to the policy it holds and
+// adds only a readiness signal. Left wrapped, both the load-balancing
+// discriminant and the DC/rack preference behind it would be lost, which is
+// everything the group exists to report.
+func unwrapHostSelectionPolicy(p HostSelectionPolicy) HostSelectionPolicy {
+	for range maxPolicyUnwrapDepth {
+		wrapper, ok := p.(*singleHostReadyPolicy)
+		if !ok || isNilPolicy(p) {
+			return p
+		}
+		p = wrapper.HostSelectionPolicy
+	}
+	return p
+}
+
+// fallbackToNonPreferredNodesAllowed reports whether a request can reach a
+// node outside the DC/rack preference this policy reports.
+//
+// Two separate things can let it. NonLocalReplicasFallback makes Pick serve
+// replicas from remote tiers itself, out of its own `remote` buckets and
+// before it ever delegates to the fallback policy, so requests escape the
+// preference however the fallback is configured. Failing that it comes down to
+// the fallback: only dcAwareRR and rackAwareRR confine requests at all, and
+// only when DC failover is disabled. Any other fallback has no DC/rack notion,
+// so nothing is confined.
+func fallbackToNonPreferredNodesAllowed(tap *tokenAwareHostPolicy) bool {
+	if tap.nonLocalReplicasFallback {
+		return true
+	}
+	if isNilPolicy(tap.fallback) {
+		return true
+	}
+	switch p := tap.fallback.(type) {
+	case *dcAwareRR:
+		// The preference is the whole local DC, and disabling failover confines
+		// requests to exactly that.
+		return !p.dcFailoverDisabled()
+	case *rackAwareRR:
+		// The preference reported for this fallback names a rack as well as a
+		// DC, but Pick always serves tier 1 -- the local DC's other racks --
+		// before giving up, whether or not DC failover is disabled. Requests
+		// therefore always reach nodes outside the reported preference;
+		// disabling failover only stops them leaving the DC, which the schema's
+		// single boolean cannot express.
+		return true
+	default:
+		// No DC/rack notion at all, so nothing is confined.
+		return true
+	}
+}
+
+// buildNodeLocationPreferenceReport looks for a DC/rack preference on policy
+// itself or, if policy is token-aware, on its fallback -- there is no separate
+// session-level DC/rack setting, only what a DCAwareRoundRobinPolicy or
+// RackAwareRoundRobinPolicy carries. Returns nil (omitted) for any other
+// policy: the driver infers no datacenter, so the schema's dc-auto/rack-auto
+// branches are never produced.
+//
+// An empty datacenter or rack is also reported as no preference. The schema
+// declares both local-dc and local-rack nonEmptyString and requires them on
+// the branch that names them, so an empty one cannot be reported -- and a
+// policy constructed with an empty name expresses no preference anyway.
+func buildNodeLocationPreferenceReport(policy HostSelectionPolicy) any {
+	if isNilPolicy(policy) {
+		return nil
+	}
+	target := policy
+	if tap, ok := policy.(*tokenAwareHostPolicy); ok {
+		target = tap.fallback
+	}
+	if isNilPolicy(target) {
+		return nil
+	}
+	switch p := target.(type) {
+	case *dcAwareRR:
+		if p.localDatacenter() == "" {
+			return nil
+		}
+		return nodeLocationDCReport{Type: "dc", LocalDC: p.localDatacenter()}
+	case *rackAwareRR:
+		if p.localDatacenter() == "" || p.localRackName() == "" {
+			return nil
+		}
+		return nodeLocationRackReport{Type: "rack", LocalDC: p.localDatacenter(), LocalRack: p.localRackName()}
+	default:
+		return nil
+	}
+}
+
+// customPolicyName returns a short, package-qualifier-free name for a
+// user-supplied policy value -- e.g. *mypkg.MyPolicy becomes "MyPolicy" --
+// mirroring how java-driver/csharp-driver report a policy's simple class name
+// rather than its fully qualified one.
+func customPolicyName(v any) string {
+	t := reflect.TypeOf(v)
+	if t == nil {
+		// A nil policy: reflect.TypeOf returns a nil Type, which would panic
+		// below. The schema declares name nonEmptyString, so there is no way to
+		// say "no name" -- and a report that omitted it would be as wrong as one
+		// that crashed the connection reporting it.
+		return "unknown"
+	}
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if name := t.Name(); name != "" {
+		return name
+	}
+	// An unnamed type, such as an anonymous struct embedding the policy
+	// interface. Name() is empty for those, which nonEmptyString rejects.
+	return t.String()
 }

--- a/driver_config.go
+++ b/driver_config.go
@@ -174,6 +174,7 @@ type systemQueriesReport struct {
 
 type systemQueriesTimeoutReport struct {
 	ClientSideMs *int64 `json:"client-side-ms,omitempty"`
+	ServerSideMs *int64 `json:"server-side-ms,omitempty"`
 }
 
 type controlPlaneSchemaReport struct {
@@ -325,8 +326,9 @@ type nodeLocationRackReport struct {
 // the STARTUP options of the control connection.
 //
 // The report is rebuilt on every control connection (re-)establishment
-// rather than cached, since future configuration groups may describe state
-// only known after ring and topology setup.
+// rather than cached, since some of what it describes (e.g. whether the
+// server-side-ms control-plane timeout applies) is only known once a
+// connection has completed its OPTIONS/SUPPORTED exchange.
 //
 // The reporter holds the *Session itself and builds the report lazily, at
 // first use, rather than at construction time: newDriverConfigReporter runs
@@ -348,10 +350,14 @@ func newDriverConfigReporter(s *Session) *driverConfigReporter {
 // Only the control connection's startup holds a reporter, so this is not the
 // place that decides which connections report: see Conn.init.
 //
+// isScyllaConn is known by the time this runs: startupCoordinator.options
+// parses the OPTIONS/SUPPORTED exchange, which sets Conn.scyllaSupported,
+// before calling startup, which is what builds these STARTUP options.
+//
 // Reporting is best effort: it must never prevent a connection from being
 // established, so a report that cannot be built is logged and left out.
-func (r *driverConfigReporter) updateStartupOptions(opts map[string]string) {
-	report, err := r.buildReport()
+func (r *driverConfigReporter) updateStartupOptions(opts map[string]string, isScyllaConn bool) {
+	report, err := r.buildReport(isScyllaConn)
 	if err != nil {
 		r.session.logger.Printf("gocql: unable to report driver configuration: %v", err)
 		return
@@ -366,12 +372,12 @@ func (r *driverConfigReporter) updateStartupOptions(opts map[string]string) {
 // buildReport returns the JSON configuration report of the session, marshalled
 // fresh on every call so that it reflects the session's current state rather
 // than a snapshot from whenever it was first requested.
-func (r *driverConfigReporter) buildReport() (string, error) {
+func (r *driverConfigReporter) buildReport(isScyllaConn bool) (string, error) {
 	cfg := &r.session.cfg
 	report := driverConfigReport{
 		Version:      driverConfigVersion,
 		Connection:   buildConnectionReport(cfg),
-		ControlPlane: buildControlPlaneReport(cfg),
+		ControlPlane: buildControlPlaneReport(cfg, isScyllaConn),
 		Query:        buildQueryReport(r.session),
 	}
 	data, err := json.Marshal(report)
@@ -629,10 +635,27 @@ func buildReconnectionPolicyReport(rp ReconnectionPolicy) any {
 	}
 }
 
-func buildControlPlaneReport(cfg *ClusterConfig) controlPlaneReport {
+func buildControlPlaneReport(cfg *ClusterConfig, isScyllaConn bool) controlPlaneReport {
 	var timeout systemQueriesTimeoutReport
 	if clientMs := positiveMillis(cfg.MetadataSchemaRequestTimeout); clientMs != nil {
 		timeout.ClientSideMs = clientMs
+		if isScyllaConn {
+			// The USING TIMEOUT clause is ScyllaDB-only, so this key only ever
+			// applies against Scylla -- and it carries whatever
+			// Conn.recalculateSystemRequestTimeout put in the clause, which
+			// truncates rather than floors: a sub-millisecond timeout is sent as
+			// "USING TIMEOUT 0ms". Derive it from the same conversion so the
+			// report cannot claim a clause the connection never sends, and omit
+			// the key when that conversion yields 0, which the schema's
+			// positiveInteger cannot carry.
+			//
+			// client-side-ms is deliberately not aligned with this: it bounds a
+			// Go-side deadline that a sub-millisecond duration expresses just
+			// fine, so it keeps positiveMillis' floor.
+			if serverMs := cfg.MetadataSchemaRequestTimeout.Milliseconds(); serverMs > 0 {
+				timeout.ServerSideMs = &serverMs
+			}
+		}
 	}
 	return controlPlaneReport{
 		Queries: controlPlaneQueriesReport{System: systemQueriesReport{Timeout: timeout}},

--- a/driver_config.go
+++ b/driver_config.go
@@ -101,7 +101,8 @@ type readWriteTimeoutReport struct {
 //
 // The schema makes orphaned optional for exactly this case, and gives its
 // absence that meaning, so omitting it produces a document a consumer
-// validating against the schema accepts.
+// validating against the schema accepts. See
+// TestSchemaPermitsAnAbsentOrphanBound, which fails if that ever changes.
 type requestsReport struct {
 	InFlight inFlightReport `json:"in-flight"`
 }

--- a/driver_config_lb_plan_test.go
+++ b/driver_config_lb_plan_test.go
@@ -1,0 +1,144 @@
+//go:build unit
+// +build unit
+
+package gocql
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+// TestFallbackToNonPreferredNodesMatchesQueryPlan pins the reported flag
+// against the plan the policy really produces, rather than against a reading
+// of the configuration.
+//
+// The flag answers "may a request reach a node outside the reported
+// node-preference?", and two independent things decide it: whether the
+// fallback confines requests at all, and whether NonLocalReplicasFallback
+// makes Pick serve remote replicas out of its own buckets before consulting
+// the fallback. Deriving the expectation from an actual query plan is the only
+// way to keep the report honest about their combination.
+func TestFallbackToNonPreferredNodesMatchesQueryPlan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fallback HostSelectionPolicy
+		opts     []func(*tokenAwareHostPolicy)
+	}{
+		{name: "dc-aware", fallback: DCAwareRoundRobinPolicy("local")},
+		{
+			name:     "dc-aware, failover disabled",
+			fallback: DCAwareRoundRobinPolicy("local", HostPolicyOptionDisableDCFailover),
+		},
+		{
+			name:     "dc-aware, failover disabled, non-local replicas allowed",
+			fallback: DCAwareRoundRobinPolicy("local", HostPolicyOptionDisableDCFailover),
+			opts:     []func(*tokenAwareHostPolicy){NonLocalReplicasFallback()},
+		},
+		{name: "rack-aware", fallback: RackAwareRoundRobinPolicy("local", "rack1")},
+		{
+			name:     "rack-aware, failover disabled",
+			fallback: RackAwareRoundRobinPolicy("local", "rack1", HostPolicyOptionDisableDCFailover),
+		},
+		{name: "round-robin", fallback: RoundRobinHostPolicy()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := TokenAwareHostPolicy(tt.fallback, append(tt.opts, DontShuffleReplicas())...)
+			tap := policy.(*tokenAwareHostPolicy)
+
+			plan := queryPlanLocations(t, policy, tap)
+			preference := buildNodeLocationPreferenceReport(tap)
+			got := buildLoadBalancingPolicyReport(tap).(loadBalancingTokenAwareReport).FallbackToNonPreferredNodes
+
+			if preference == nil {
+				// Nothing is preferred, so nothing can be escaped and the plan
+				// cannot answer the question. What must still hold is that a
+				// policy constraining nothing does not claim to confine.
+				if !got {
+					t.Errorf("reported fallback-to-non-preferred-nodes = false with no node-preference to confine requests to")
+				}
+				return
+			}
+
+			// Does the plan actually reach a node the reported preference
+			// excludes?
+			planEscapes := false
+			for _, loc := range plan {
+				if !preferenceCovers(preference, loc) {
+					planEscapes = true
+					break
+				}
+			}
+			if got != planEscapes {
+				t.Errorf("reported fallback-to-non-preferred-nodes = %v, but the query plan %v against preference %#v reaches outside it = %v",
+					got, plan, preference, planEscapes)
+			}
+		})
+	}
+}
+
+// hostLocation is a host's datacenter and rack as the plan saw them.
+type hostLocation struct{ dc, rack string }
+
+func (l hostLocation) String() string { return l.dc + "/" + l.rack }
+
+// preferenceCovers reports whether loc is inside the reported preference. A
+// report with no preference covers everything, since it constrains nothing.
+func preferenceCovers(preference any, loc hostLocation) bool {
+	switch p := preference.(type) {
+	case nodeLocationDCReport:
+		return loc.dc == p.LocalDC
+	case nodeLocationRackReport:
+		return loc.dc == p.LocalDC && loc.rack == p.LocalRack
+	default:
+		return true
+	}
+}
+
+// queryPlanLocations drives the policy over a small ring spanning two
+// datacenters and two racks, and returns every host the plan yields.
+func queryPlanLocations(t *testing.T, policy HostSelectionPolicy, tap *tokenAwareHostPolicy) []hostLocation {
+	t.Helper()
+
+	const keyspace = "ks"
+	tap.getKeyspaceName = func() string { return keyspace }
+	tap.getKeyspaceMetadata = func(string) (*KeyspaceMetadata, error) { return nil, errors.New("not initialized") }
+
+	hosts := []*HostInfo{
+		{hostId: tUUID(0), connectAddress: net.IPv4(10, 0, 0, 1), tokens: []string{"05"}, dataCenter: "local", rack: "rack1", state: NodeUp},
+		{hostId: tUUID(1), connectAddress: net.IPv4(10, 0, 0, 2), tokens: []string{"10"}, dataCenter: "local", rack: "rack2", state: NodeUp},
+		{hostId: tUUID(2), connectAddress: net.IPv4(10, 0, 0, 3), tokens: []string{"15"}, dataCenter: "remote", rack: "rack9", state: NodeUp},
+	}
+	for _, host := range hosts {
+		policy.AddHost(host)
+	}
+	policy.SetPartitioner("OrderedPartitioner")
+	tap.getKeyspaceMetadata = func(string) (*KeyspaceMetadata, error) {
+		return &KeyspaceMetadata{
+			Name:          keyspace,
+			StrategyClass: "NetworkTopologyStrategy",
+			StrategyOptions: map[string]any{
+				"class": "NetworkTopologyStrategy", "local": 2, "remote": 1,
+			},
+		}, nil
+	}
+	policy.KeyspaceChanged(KeyspaceUpdateEvent{Keyspace: keyspace})
+
+	query := &Query{routingInfo: &queryRoutingInfo{}}
+	query.getKeyspace = func() string { return keyspace }
+	query.RoutingKey([]byte("05"))
+
+	var plan []hostLocation
+	iter := policy.Pick(query)
+	for selected := iter(); selected != nil; selected = iter() {
+		plan = append(plan, hostLocation{dc: selected.Info().DataCenter(), rack: selected.Info().Rack()})
+	}
+	if len(plan) == 0 {
+		t.Fatal("expected the policy to yield a query plan")
+	}
+	return plan
+}

--- a/driver_config_schema_test.go
+++ b/driver_config_schema_test.go
@@ -1,0 +1,399 @@
+//go:build unit
+// +build unit
+
+package gocql
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+)
+
+// driverConfigSchemaPath is the normative schema the report is written
+// against. It is shared with the other drivers, so it is validated as shipped:
+// nothing here may edit it to accommodate this driver.
+const driverConfigSchemaPath = "docs/driver-config-schema.json"
+
+// loadDriverConfigSchema compiles the schema exactly as shipped. Nothing here
+// may relax it: the point of validating is to prove a consumer that checks the
+// payload accepts it, which a locally-adjusted schema would not establish.
+func loadDriverConfigSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+
+	f, err := os.Open(driverConfigSchemaPath)
+	if err != nil {
+		t.Fatalf("unable to open %s: %v", driverConfigSchemaPath, err)
+	}
+	defer f.Close()
+
+	doc, err := jsonschema.UnmarshalJSON(f)
+	if err != nil {
+		t.Fatalf("unable to parse %s: %v", driverConfigSchemaPath, err)
+	}
+
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(driverConfigSchemaPath, doc); err != nil {
+		t.Fatalf("unable to add %s: %v", driverConfigSchemaPath, err)
+	}
+	sch, err := c.Compile(driverConfigSchemaPath)
+	if err != nil {
+		t.Fatalf("unable to compile %s: %v", driverConfigSchemaPath, err)
+	}
+	return sch
+}
+
+// TestSchemaPermitsAnAbsentOrphanBound guards the schema property the report
+// depends on. Nothing in this driver bounds orphaned requests, so it has no
+// value for connection.requests.orphaned; if that key were required again,
+// every report this driver produces would fail validation, and the conformance
+// test below would be the only thing standing between that and a release.
+func TestSchemaPermitsAnAbsentOrphanBound(t *testing.T) {
+	f, err := os.Open(driverConfigSchemaPath)
+	if err != nil {
+		t.Fatalf("unable to open %s: %v", driverConfigSchemaPath, err)
+	}
+	defer f.Close()
+
+	doc, err := jsonschema.UnmarshalJSON(f)
+	if err != nil {
+		t.Fatalf("unable to parse %s: %v", driverConfigSchemaPath, err)
+	}
+	root, ok := doc.(map[string]any)
+	if !ok {
+		t.Fatalf("expected the schema root to be an object, got %T", doc)
+	}
+	defs, ok := root["$defs"].(map[string]any)
+	if !ok {
+		t.Fatal("expected the schema to have $defs")
+	}
+	requests, ok := defs["requests"].(map[string]any)
+	if !ok {
+		t.Fatal("expected the schema to have $defs.requests")
+	}
+	required, ok := requests["required"].([]any)
+	if !ok {
+		t.Fatal("expected $defs.requests.required to be an array")
+	}
+	for _, key := range required {
+		if key == "orphaned" {
+			t.Error("$defs.requests.required lists \"orphaned\", which this driver cannot report: " +
+				"nothing bounds orphaned requests, so every report would fail validation")
+		}
+	}
+}
+
+// driverConfigCases spans the report's decision points: every optional group
+// present and absent, every policy discriminant, and the boundary values that
+// the schema constrains but nothing in the driver rejects.
+func driverConfigCases() []struct {
+	name         string
+	cfg          func(*ClusterConfig)
+	policy       HostSelectionPolicy
+	isScyllaConn bool
+} {
+	return []struct {
+		name         string
+		cfg          func(*ClusterConfig)
+		policy       HostSelectionPolicy
+		isScyllaConn bool
+	}{
+		{name: "defaults"},
+		{name: "defaults against scylla", isScyllaConn: true},
+		{
+			name: "every optional duration disabled",
+			cfg: func(c *ClusterConfig) {
+				c.ConnectTimeout = 0
+				c.ReadTimeout = 0
+				c.WriteTimeout = 0
+				c.Timeout = 0
+				c.MetadataSchemaRequestTimeout = 0
+				c.MaxWaitSchemaAgreement = 0
+				c.PageSize = 0
+			},
+		},
+		{
+			name: "sub-millisecond durations",
+			cfg: func(c *ClusterConfig) {
+				c.ConnectTimeout = 500 * time.Microsecond
+				c.ReadTimeout = 500 * time.Microsecond
+				c.WriteTimeout = 500 * time.Microsecond
+				c.Timeout = 500 * time.Microsecond
+				c.MetadataSchemaRequestTimeout = 500 * time.Microsecond
+			},
+			isScyllaConn: true,
+		},
+		{
+			name: "in-flight limit above the stream-id range",
+			cfg:  func(c *ClusterConfig) { c.MaxRequestsPerConn = 40000 },
+		},
+		{
+			name: "in-flight limit not a multiple of 64",
+			cfg:  func(c *ClusterConfig) { c.MaxRequestsPerConn = 100 },
+		},
+		{
+			name: "serial default consistency",
+			cfg:  func(c *ClusterConfig) { c.Consistency = LocalSerial },
+		},
+		{
+			name: "serial consistency set",
+			cfg:  func(c *ClusterConfig) { c.SerialConsistency = LocalSerial },
+		},
+		{
+			name: "no reconnection policy",
+			cfg:  func(c *ClusterConfig) { c.ReconnectionPolicy = &NoReconnectionPolicy{} },
+		},
+		{
+			name: "constant reconnection with no attempts",
+			cfg: func(c *ClusterConfig) {
+				c.ReconnectionPolicy = &ConstantReconnectionPolicy{MaxRetries: 0, Interval: time.Second}
+			},
+		},
+		{
+			name: "constant reconnection with a negative attempt limit",
+			cfg: func(c *ClusterConfig) {
+				c.ReconnectionPolicy = &ConstantReconnectionPolicy{MaxRetries: -1, Interval: time.Second}
+			},
+		},
+		{
+			name: "nil reconnection policy",
+			cfg:  func(c *ClusterConfig) { c.ReconnectionPolicy = nil },
+		},
+		{
+			name: "typed-nil reconnection policy",
+			cfg:  func(c *ClusterConfig) { c.ReconnectionPolicy = (*ConstantReconnectionPolicy)(nil) },
+		},
+		{
+			name: "constant reconnection with a negative interval",
+			cfg: func(c *ClusterConfig) {
+				c.ReconnectionPolicy = &ConstantReconnectionPolicy{MaxRetries: 3, Interval: -5 * time.Second}
+			},
+		},
+		{
+			name: "typed-nil retry policy",
+			cfg:  func(c *ClusterConfig) { c.RetryPolicy = (*SimpleRetryPolicy)(nil) },
+		},
+		{
+			name:   "typed-nil load balancing fallback",
+			policy: TokenAwareHostPolicy((*dcAwareRR)(nil)),
+		},
+		{
+			name: "exponential reconnection with unset intervals",
+			cfg:  func(c *ClusterConfig) { c.ReconnectionPolicy = &ExponentialReconnectionPolicy{MaxRetries: 3} },
+		},
+		{
+			name: "exponential reconnection with max below base",
+			cfg: func(c *ClusterConfig) {
+				c.ReconnectionPolicy = &ExponentialReconnectionPolicy{MaxRetries: 3, InitialInterval: 5 * time.Second, MaxInterval: time.Second}
+			},
+		},
+		{
+			name: "custom reconnection policy",
+			cfg: func(c *ClusterConfig) {
+				c.ReconnectionPolicy = &fakeReconnectionPolicy{ReconnectionPolicy: &NoReconnectionPolicy{}}
+			},
+		},
+		{
+			name: "downgrading consistency retry policy",
+			cfg: func(c *ClusterConfig) {
+				c.RetryPolicy = &DowngradingConsistencyRetryPolicy{ConsistencyLevelsToTry: []Consistency{One, Any}}
+			},
+		},
+		{
+			name: "exponential backoff retry policy with max below min",
+			cfg: func(c *ClusterConfig) {
+				c.RetryPolicy = &ExponentialBackoffRetryPolicy{NumRetries: 3, Min: 5 * time.Second, Max: time.Second}
+			},
+		},
+		{
+			name: "exponential backoff retry policy with sub-millisecond bounds",
+			cfg: func(c *ClusterConfig) {
+				c.RetryPolicy = &ExponentialBackoffRetryPolicy{NumRetries: 3, Min: time.Microsecond, Max: 2 * time.Microsecond}
+			},
+		},
+		{
+			name: "custom retry policy",
+			cfg:  func(c *ClusterConfig) { c.RetryPolicy = &fakeRetryPolicy{RetryPolicy: &SimpleRetryPolicy{}} },
+		},
+		{
+			name: "simple retry policy with a negative retry limit",
+			cfg:  func(c *ClusterConfig) { c.RetryPolicy = &SimpleRetryPolicy{NumRetries: -1} },
+		},
+		{
+			name: "exponential backoff retry policy with a negative retry limit",
+			cfg:  func(c *ClusterConfig) { c.RetryPolicy = &ExponentialBackoffRetryPolicy{NumRetries: -2} },
+		},
+		{
+			name: "tls without hostname verification",
+			cfg:  func(c *ClusterConfig) { c.SslOpts = &SslOptions{} },
+		},
+		{
+			name: "tls with a caller-supplied config",
+			cfg:  func(c *ClusterConfig) { c.SslOpts = &SslOptions{Config: &tls.Config{InsecureSkipVerify: true}} },
+		},
+		{
+			name: "datacenter host filter",
+			cfg:  func(c *ClusterConfig) { c.HostFilter = DataCenterHostFilter("dc1") },
+		},
+		{
+			name: "whitelist host filter",
+			cfg:  func(c *ClusterConfig) { c.HostFilter = WhiteListHostFilter("127.0.0.1") },
+		},
+		{
+			name: "host dialer that cannot target a shard",
+			cfg:  func(c *ClusterConfig) { c.HostDialer = fakeHostDialer{} },
+		},
+		{
+			name: "host dialer that can target a shard",
+			cfg:  func(c *ClusterConfig) { c.HostDialer = fakeShardDialer{} },
+		},
+		{name: "dc-aware policy", policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1"))},
+		{
+			name:   "dc-aware policy without failover",
+			policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1", HostPolicyOptionDisableDCFailover)),
+		},
+		{name: "rack-aware policy", policy: TokenAwareHostPolicy(RackAwareRoundRobinPolicy("dc1", "rack1"))},
+		{
+			name:   "rack-aware policy without dc failover",
+			policy: TokenAwareHostPolicy(RackAwareRoundRobinPolicy("dc1", "rack1", HostPolicyOptionDisableDCFailover)),
+		},
+		{
+			name:   "non-local replicas fallback over a confined fallback",
+			policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1", HostPolicyOptionDisableDCFailover), NonLocalReplicasFallback()),
+		},
+		{name: "empty datacenter", policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy(""))},
+		{name: "replica-set ordering", policy: TokenAwareHostPolicy(RoundRobinHostPolicy(), DontShuffleReplicas())},
+		{
+			name:   "adaptive ordering by in-flight requests",
+			policy: TokenAwareHostPolicy(RoundRobinHostPolicy(), AvoidSlowReplicas(MAX_IN_FLIGHT_THRESHOLD)),
+		},
+		{name: "non-token-aware policy", policy: RoundRobinHostPolicy()},
+		{name: "wrapped policy", policy: SingleHostReadyPolicy(TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1")))},
+		{name: "custom policy", policy: &fakeHostSelectionPolicy{HostSelectionPolicy: RoundRobinHostPolicy()}},
+	}
+}
+
+// buildCaseReport produces the report a case describes, decoded for
+// validation.
+func buildCaseReport(t *testing.T, cfgFn func(*ClusterConfig), policy HostSelectionPolicy, isScyllaConn bool) any {
+	t.Helper()
+
+	cfg := *NewCluster("127.0.0.1")
+	if cfgFn != nil {
+		cfgFn(&cfg)
+	}
+	if policy == nil {
+		policy = TokenAwareHostPolicy(RoundRobinHostPolicy())
+	}
+	// Resolve SslOpts the way session creation does, so the TLS group is built
+	// from the config the driver would really dial with.
+	if err := cfg.ValidateAndInitSSL(); err != nil {
+		t.Fatalf("unable to initialize ssl config: %v", err)
+	}
+
+	raw, err := newDriverConfigReporter(newTestReportSession(cfg, policy)).buildReport(isScyllaConn)
+	if err != nil {
+		t.Fatalf("unable to build the report: %v", err)
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		t.Fatalf("report is not valid JSON: %v (%s)", err, raw)
+	}
+	return decoded
+}
+
+// TestDriverConfigReportConformsToSchema validates the report against the
+// shipped JSON Schema across every configuration that changes its shape.
+//
+// The value constraints are the point: the schema pins ranges, enums and
+// non-empty strings that are easy to satisfy by accident and easy to break by
+// accident, and several of them describe values nothing in the driver's own
+// validation rejects.
+func TestDriverConfigReportConformsToSchema(t *testing.T) {
+	schema := loadDriverConfigSchema(t)
+
+	for _, tt := range driverConfigCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			report := buildCaseReport(t, tt.cfg, tt.policy, tt.isScyllaConn)
+			if err := schema.Validate(report); err != nil {
+				encoded, _ := json.Marshal(report)
+				t.Errorf("report does not conform to %s:\n%v\n\nreport: %s", driverConfigSchemaPath, err, encoded)
+			}
+		})
+	}
+}
+
+// TestDriverConfigReportUnrepresentableConsistency documents the one
+// configuration for which no conforming report exists.
+//
+// query.defaults.consistency is required, and its enum covers every level
+// Consistency defines. An unrecognized numeric value is outside it, so such a
+// consistency can be reported either as a token the enum rejects or not at all
+// -- both are violations, and the report chooses to omit (see
+// consistencyName).
+//
+// Nothing rejects such a configuration today, which is what makes it
+// reachable. Adding that rejection to ClusterConfig.Validate is a behaviour
+// change beyond this report and is left to a follow-up; this test pins the
+// residual gap in the meantime, and should be deleted when the follow-up makes
+// it unreachable.
+func TestDriverConfigReportUnrepresentableConsistency(t *testing.T) {
+	schema := loadDriverConfigSchema(t)
+
+	for _, tt := range []struct {
+		name string
+		cons Consistency
+	}{
+		{"unrecognized default consistency", Consistency(0x42)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			report := buildCaseReport(t, func(c *ClusterConfig) { c.Consistency = tt.cons }, nil, false)
+
+			err := schema.Validate(report)
+			if err == nil {
+				t.Fatal("expected the report to be non-conforming; if consistency is now representable, delete this test")
+			}
+
+			var validationErr *jsonschema.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("expected a validation error, got %T: %v", err, err)
+			}
+			causes := leafCauses(validationErr)
+			if len(causes) != 1 {
+				t.Fatalf("expected the unreportable consistency to be the only deviation, got %d:\n%v", len(causes), err)
+			}
+			sole := causes[0]
+			if got, want := strings.Join(sole.InstanceLocation, "/"), "query/defaults"; got != want {
+				t.Errorf("expected the sole deviation at /%s, got /%s", want, got)
+			}
+			missing, ok := sole.ErrorKind.(*kind.Required)
+			if !ok {
+				t.Fatalf("expected a missing required key, got %T: %v", sole.ErrorKind, sole)
+			}
+			if diff := cmp.Diff([]string{"consistency"}, missing.Missing); diff != "" {
+				t.Errorf("expected consistency to be the only missing key:\n%s", diff)
+			}
+		})
+	}
+}
+
+// leafCauses flattens a validation error to the individual constraint failures
+// at its leaves; the intermediate nodes only describe which subschema the
+// failures were found under.
+func leafCauses(err *jsonschema.ValidationError) []*jsonschema.ValidationError {
+	if len(err.Causes) == 0 {
+		return []*jsonschema.ValidationError{err}
+	}
+	var out []*jsonschema.ValidationError
+	for _, cause := range err.Causes {
+		out = append(out, leafCauses(cause)...)
+	}
+	return out
+}

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -52,7 +52,7 @@ func TestDriverConfigReporterStartupOptions(t *testing.T) {
 	reporter := newDriverConfigReporter(s)
 
 	opts := map[string]string{}
-	reporter.updateStartupOptions(opts)
+	reporter.updateStartupOptions(opts, false)
 
 	raw, ok := opts[driverConfigStartupKey]
 	if !ok {
@@ -82,6 +82,35 @@ func TestDriverConfigReporterStartupOptions(t *testing.T) {
 	policyMap, ok := report.Query.Retry.Policy.(map[string]any)
 	if !ok || policyMap["type"] != "simple" {
 		t.Errorf("query.retry.policy = %#v, want type simple (SimpleRetryPolicy fallback)", report.Query.Retry.Policy)
+	}
+}
+
+// TestDriverConfigReporterStartupOptions_ScyllaConnGatesServerSideMs pins that
+// control-plane.queries.system.timeout.server-side-ms only appears when the
+// connection is talking to Scylla, mirroring the USING TIMEOUT clause in
+// Conn.recalculateSystemRequestTimeout.
+func TestDriverConfigReporterStartupOptions_ScyllaConnGatesServerSideMs(t *testing.T) {
+	cfg := *NewCluster("127.0.0.1")
+	s := newTestReportSession(cfg, TokenAwareHostPolicy(RoundRobinHostPolicy()))
+	reporter := newDriverConfigReporter(s)
+
+	for _, isScylla := range []bool{false, true} {
+		opts := map[string]string{}
+		reporter.updateStartupOptions(opts, isScylla)
+
+		var report driverConfigReport
+		if err := json.Unmarshal([]byte(opts[driverConfigStartupKey]), &report); err != nil {
+			t.Fatalf("isScyllaConn=%v: DRIVER_CONFIG did not decode: %v", isScylla, err)
+		}
+
+		timeout := report.ControlPlane.Queries.System.Timeout
+		if timeout.ClientSideMs == nil {
+			t.Errorf("isScyllaConn=%v: expected client-side-ms to be set", isScylla)
+		}
+		gotServerSide := timeout.ServerSideMs != nil
+		if gotServerSide != isScylla {
+			t.Errorf("isScyllaConn=%v: server-side-ms present = %v, want %v", isScylla, gotServerSide, isScylla)
+		}
 	}
 }
 
@@ -629,10 +658,11 @@ func TestBuildLoadBalancingReport_UnwrapsWrappers(t *testing.T) {
 
 func TestBuildControlPlaneReport(t *testing.T) {
 	tests := []struct {
-		name      string
-		timeout   time.Duration
-		agreement time.Duration
-		want      controlPlaneReport
+		name         string
+		timeout      time.Duration
+		agreement    time.Duration
+		isScyllaConn bool
+		want         controlPlaneReport
 	}{
 		{
 			name:      "system query timeout disabled entirely omits the timeout object's contents",
@@ -643,12 +673,42 @@ func TestBuildControlPlaneReport(t *testing.T) {
 			},
 		},
 		{
-			name:      "system query timeout reports client-side-ms",
-			timeout:   30 * time.Second,
-			agreement: 60 * time.Second,
+			name:         "non-Scylla connection only reports client-side-ms",
+			timeout:      30 * time.Second,
+			agreement:    60 * time.Second,
+			isScyllaConn: false,
 			want: controlPlaneReport{
 				Queries: controlPlaneQueriesReport{System: systemQueriesReport{Timeout: systemQueriesTimeoutReport{
 					ClientSideMs: ptr(int64(30000)),
+				}}},
+				Schema: controlPlaneSchemaReport{Agreement: schemaAgreementReport{TimeoutMs: 60000}},
+			},
+		},
+		{
+			name:         "Scylla connection also reports server-side-ms",
+			timeout:      30 * time.Second,
+			agreement:    60 * time.Second,
+			isScyllaConn: true,
+			want: controlPlaneReport{
+				Queries: controlPlaneQueriesReport{System: systemQueriesReport{Timeout: systemQueriesTimeoutReport{
+					ClientSideMs: ptr(int64(30000)),
+					ServerSideMs: ptr(int64(30000)),
+				}}},
+				Schema: controlPlaneSchemaReport{Agreement: schemaAgreementReport{TimeoutMs: 60000}},
+			},
+		},
+		{
+			// Conn.recalculateSystemRequestTimeout truncates when it builds the
+			// USING TIMEOUT clause, so this connection really is sent
+			// "USING TIMEOUT 0ms". The schema cannot carry that, so the key is
+			// omitted rather than rounded up to a clause never sent.
+			name:         "sub-millisecond timeout omits server-side-ms but keeps the client-side floor",
+			timeout:      500 * time.Microsecond,
+			agreement:    60 * time.Second,
+			isScyllaConn: true,
+			want: controlPlaneReport{
+				Queries: controlPlaneQueriesReport{System: systemQueriesReport{Timeout: systemQueriesTimeoutReport{
+					ClientSideMs: ptr(int64(1)),
 				}}},
 				Schema: controlPlaneSchemaReport{Agreement: schemaAgreementReport{TimeoutMs: 60000}},
 			},
@@ -667,7 +727,7 @@ func TestBuildControlPlaneReport(t *testing.T) {
 			cfg := *NewCluster("127.0.0.1")
 			cfg.MetadataSchemaRequestTimeout = tt.timeout
 			cfg.MaxWaitSchemaAgreement = tt.agreement
-			got := buildControlPlaneReport(&cfg)
+			got := buildControlPlaneReport(&cfg, tt.isScyllaConn)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("buildControlPlaneReport() mismatch:\n%s", diff)
 			}
@@ -714,7 +774,7 @@ func TestBuildReport_SubMillisecondTimeouts(t *testing.T) {
 	cfg.MetadataSchemaRequestTimeout = 500 * time.Microsecond
 
 	s := newTestReportSession(cfg, TokenAwareHostPolicy(RoundRobinHostPolicy()))
-	raw, err := newDriverConfigReporter(s).buildReport()
+	raw, err := newDriverConfigReporter(s).buildReport(true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -753,6 +813,15 @@ func TestBuildReport_SubMillisecondTimeouts(t *testing.T) {
 		if *v < 1 {
 			t.Errorf("%s = %d, want >= 1 (the schema's positiveInteger minimum)", field, *v)
 		}
+	}
+
+	// server-side-ms is the exception, and deliberately so: it reports the
+	// USING TIMEOUT clause, which Conn.recalculateSystemRequestTimeout builds by
+	// truncating. A sub-millisecond timeout is sent as "USING TIMEOUT 0ms", and
+	// the schema cannot carry a 0 here, so the key is omitted rather than
+	// claiming a 1ms clause the connection never sends.
+	if got := report.ControlPlane.Queries.System.Timeout.ServerSideMs; got != nil {
+		t.Errorf("control-plane...server-side-ms = %d, want it omitted: the connection sends USING TIMEOUT 0ms", *got)
 	}
 }
 

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -5,12 +5,18 @@ package gocql
 
 import (
 	"context"
-	"slices"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	frm "github.com/gocql/gocql/internal/frame"
+	"github.com/gocql/gocql/internal/streams"
 )
 
 // TestControlConnConfigIsMarked pins the wiring that makes the control connection,
@@ -33,14 +39,1021 @@ func TestControlConnConfigIsMarked(t *testing.T) {
 	}
 }
 
+// newTestReportSession builds a *Session suitable for exercising the report
+// builders directly, without dialing anything. Only the fields the builders
+// read (cfg, policy, logger) are populated.
+func newTestReportSession(cfg ClusterConfig, policy HostSelectionPolicy) *Session {
+	return &Session{cfg: cfg, policy: policy, logger: &defaultLogger{}}
+}
+
 func TestDriverConfigReporterStartupOptions(t *testing.T) {
-	reporter := newDriverConfigReporter(&Session{logger: &defaultLogger{}})
+	cfg := *NewCluster("127.0.0.1")
+	s := newTestReportSession(cfg, TokenAwareHostPolicy(RoundRobinHostPolicy()))
+	reporter := newDriverConfigReporter(s)
 
 	opts := map[string]string{}
 	reporter.updateStartupOptions(opts)
 
-	if got, want := opts[driverConfigStartupKey], `{"version":1}`; got != want {
-		t.Errorf("expected %s to be %q, got %q", driverConfigStartupKey, want, got)
+	raw, ok := opts[driverConfigStartupKey]
+	if !ok {
+		t.Fatal("expected DRIVER_CONFIG to be set")
+	}
+
+	var report driverConfigReport
+	if err := json.Unmarshal([]byte(raw), &report); err != nil {
+		t.Fatalf("DRIVER_CONFIG did not decode as JSON: %v", err)
+	}
+
+	if report.Version != driverConfigVersion {
+		t.Errorf("expected version %d, got %d", driverConfigVersion, report.Version)
+	}
+	if got := report.Connection.Connect.TimeoutMs; got == nil || *got != cfg.ConnectTimeout.Milliseconds() {
+		t.Errorf("connect.timeout-ms = %v, want %d", got, cfg.ConnectTimeout.Milliseconds())
+	}
+	if got, want := report.Query.Defaults.Consistency, "QUORUM"; got != want {
+		t.Errorf("query.defaults.consistency = %q, want %q", got, want)
+	}
+	if report.ControlPlane.Schema.Agreement.TimeoutMs != cfg.MaxWaitSchemaAgreement.Milliseconds() {
+		t.Errorf("control-plane.schema.agreement.timeout-ms = %d, want %d",
+			report.ControlPlane.Schema.Agreement.TimeoutMs, cfg.MaxWaitSchemaAgreement.Milliseconds())
+	}
+	// The default RetryPolicy is nil; the effective policy must be the package
+	// fallback, not an absent/zero policy.
+	policyMap, ok := report.Query.Retry.Policy.(map[string]any)
+	if !ok || policyMap["type"] != "simple" {
+		t.Errorf("query.retry.policy = %#v, want type simple (SimpleRetryPolicy fallback)", report.Query.Retry.Policy)
+	}
+}
+
+func rawKeys(t *testing.T, v any) map[string]json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal into map: %v", err)
+	}
+	return m
+}
+
+// TestBuildRequestsReport_OrphanedRequestsOmitted pins both halves of the
+// orphaned group's treatment: in-flight is always reported, and orphaned never
+// is, because nothing bounds orphaned requests (see the comment on
+// requestsReport). Without this, either "someone fabricates a number to fill
+// the key" or "someone drops in-flight too" would pass unnoticed.
+func TestBuildRequestsReport_OrphanedRequestsOmitted(t *testing.T) {
+	cfg := *NewCluster("127.0.0.1")
+	keys := rawKeys(t, buildRequestsReport(&cfg))
+
+	if _, ok := keys["in-flight"]; !ok {
+		t.Error(`expected "in-flight" to be present`)
+	}
+	if _, ok := keys["orphaned"]; ok {
+		t.Error(`expected "orphaned" to be absent (documented schema deviation)`)
+	}
+}
+
+func TestBuildRequestsReport_InFlightMax(t *testing.T) {
+	tests := []struct {
+		name               string
+		maxRequestsPerConn int
+		want               int
+	}{
+		// The reported number is what a connection can actually have
+		// outstanding, which is one below the stream count: streams.NewLimited
+		// rounds up to a multiple of 64 and reserves stream 0.
+		{"unset falls back to the streams default, less the reserved stream", 0, 32767},
+		{"an exact multiple of 64 loses only the reserved stream", 512, 511},
+		{"a value that is not a multiple of 64 is rounded up", 100, 127},
+		{"a value above the CQL stream-id range is clamped", 40000, 32767},
+		// Rounding up to a multiple of 64 overflows to a negative within 63 of
+		// the integer limit, and Validate rejects only a negative
+		// MaxRequestsPerConn, so such a value does reach the report.
+		{"a value near the integer limit does not overflow", math.MaxInt, 32767},
+		{"the largest value that would overflow the rounding", math.MaxInt - 1, 32767},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := *NewCluster("127.0.0.1")
+			cfg.MaxRequestsPerConn = tt.maxRequestsPerConn
+			got := buildRequestsReport(&cfg)
+			if got.InFlight.Max != tt.want {
+				t.Errorf("in-flight.max = %d, want %d", got.InFlight.Max, tt.want)
+			}
+			// The schema constrains this field to 1..32767; nothing the user can
+			// configure may push the report outside it.
+			if got.InFlight.Max < 1 || got.InFlight.Max > maxReportableInFlight {
+				t.Errorf("in-flight.max = %d, outside the schema's 1..%d range", got.InFlight.Max, maxReportableInFlight)
+			}
+		})
+	}
+}
+
+// TestEffectiveInFlightMaxMatchesStreamGenerator pins the report against the
+// generator it describes, so the two cannot drift: Available() on a freshly
+// built generator is exactly the number of requests that can be in flight.
+func TestEffectiveInFlightMaxMatchesStreamGenerator(t *testing.T) {
+	for _, configured := range []int{0, 1, 63, 64, 100, 512, 1000, 32766, 32767, 32768} {
+		gen := streams.New()
+		if configured > 0 {
+			gen = streams.NewLimited(configured)
+		}
+		want := min(gen.Available(), maxReportableInFlight)
+		if got := effectiveInFlightMax(configured); got != want {
+			t.Errorf("effectiveInFlightMax(%d) = %d, but the generator allows %d", configured, got, want)
+		}
+	}
+}
+
+// TestCustomPolicyNameIsAlwaysReportable pins that the name given to a custom
+// policy is always something the schema accepts. reflect.TypeOf returns a nil
+// Type for a nil interface, which used to panic here, and an unnamed type has
+// an empty Name(), which nonEmptyString rejects.
+func TestCustomPolicyNameIsAlwaysReportable(t *testing.T) {
+	type namedPolicy struct{ RetryPolicy }
+
+	for _, v := range []any{
+		nil,
+		(*SimpleRetryPolicy)(nil),
+		&SimpleRetryPolicy{},
+		&namedPolicy{},
+		struct{ RetryPolicy }{},
+	} {
+		if got := customPolicyName(v); got == "" {
+			t.Errorf("customPolicyName(%T) is empty, which the schema rejects", v)
+		}
+	}
+}
+
+// TestBuildLoadBalancingPolicyReport_NilPolicy pins that a nil policy is
+// reported rather than panicking. Reporting must never prevent a connection
+// from being established, and this runs on the goroutine that establishes it.
+func TestBuildLoadBalancingPolicyReport_NilPolicy(t *testing.T) {
+	got, ok := buildLoadBalancingPolicyReport(nil).(loadBalancingCustomReport)
+	if !ok {
+		t.Fatalf("expected a custom policy report, got %#v", buildLoadBalancingPolicyReport(nil))
+	}
+	if got.Name == "" {
+		t.Error("expected a non-empty name, which the schema requires")
+	}
+}
+
+// TestReportBuildersToleratePolicyNils pins that no builder panics on a policy
+// that is nil or a typed nil pointer. A type switch sends a typed nil to its
+// own branch rather than to `case nil`, so each branch would dereference it.
+// This runs on the goroutine establishing a connection, where a panic takes
+// down the process rather than the connection.
+func TestReportBuildersToleratePolicyNils(t *testing.T) {
+	reconnection := []ReconnectionPolicy{
+		nil,
+		(*NoReconnectionPolicy)(nil),
+		(*ConstantReconnectionPolicy)(nil),
+		(*ExponentialReconnectionPolicy)(nil),
+		(*fakeReconnectionPolicy)(nil),
+	}
+	for _, rp := range reconnection {
+		t.Run(fmt.Sprintf("reconnection/%T", rp), func(t *testing.T) {
+			buildReconnectionPolicyReport(rp)
+		})
+	}
+
+	retry := []RetryPolicy{
+		nil,
+		(*SimpleRetryPolicy)(nil),
+		(*DowngradingConsistencyRetryPolicy)(nil),
+		(*ExponentialBackoffRetryPolicy)(nil),
+	}
+	for _, rp := range retry {
+		t.Run(fmt.Sprintf("retry/%T", rp), func(t *testing.T) {
+			buildRetryPolicyReport(rp)
+			buildRetryBackoffReport(rp)
+		})
+	}
+
+	loadBalancing := []HostSelectionPolicy{
+		nil,
+		(*tokenAwareHostPolicy)(nil),
+		(*singleHostReadyPolicy)(nil),
+		TokenAwareHostPolicy((*dcAwareRR)(nil)),
+		TokenAwareHostPolicy((*rackAwareRR)(nil)),
+		SingleHostReadyPolicy((*tokenAwareHostPolicy)(nil)),
+	}
+	for _, p := range loadBalancing {
+		t.Run(fmt.Sprintf("load-balancing/%T", p), func(t *testing.T) {
+			buildLoadBalancingReport(p)
+		})
+	}
+}
+
+func TestBuildSocketReport(t *testing.T) {
+	// gocql has no configuration surface for any of these beyond what Go's net
+	// package and ClusterConfig.Validate already guarantee; this always
+	// reports the built-in dialer's fixed behavior.
+	want := socketReport{TCPNoDelay: true, KeepAlive: true, ReuseAddress: false}
+	if got := buildSocketReport(); got != want {
+		t.Errorf("buildSocketReport() = %+v, want %+v", got, want)
+	}
+}
+
+// fakeReconnectionPolicy wraps a ReconnectionPolicy so its dynamic type name
+// (used for the "custom" report branch) is distinct from any built-in policy.
+type fakeReconnectionPolicy struct {
+	ReconnectionPolicy
+}
+
+func TestBuildReconnectionPolicyReport(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy ReconnectionPolicy
+		want   any
+	}{
+		{
+			name:   "no reconnection reports as null",
+			policy: &NoReconnectionPolicy{},
+			want:   nil,
+		},
+		{
+			name:   "constant",
+			policy: &ConstantReconnectionPolicy{MaxRetries: 5, Interval: 2 * time.Second},
+			want:   reconnectionConstantReport{Type: "constant", DelayMs: 2000, MaxAttempts: 5},
+		},
+		{
+			name:   "exponential",
+			policy: &ExponentialReconnectionPolicy{MaxRetries: 10, InitialInterval: time.Second, MaxInterval: 30 * time.Second},
+			want:   reconnectionExponentialReport{Type: "exponential", BaseMs: 1000, MaxMs: 30000, MaxAttempts: 10},
+		},
+		{
+			name:   "exponential with max below base reports the effective fallback max",
+			policy: &ExponentialReconnectionPolicy{MaxRetries: 3, InitialInterval: 5 * time.Second, MaxInterval: time.Second},
+			want: reconnectionExponentialReport{
+				Type: "exponential", BaseMs: 5000,
+				MaxMs:       (math.MaxInt16 * time.Second).Milliseconds(),
+				MaxAttempts: 3,
+			},
+		},
+		{
+			// hostConnPool.connect loops `for i := 0; i < GetMaxRetries(); i++`,
+			// so a non-positive limit attempts nothing at all. Reporting a policy
+			// with max-attempts omitted would claim unlimited attempts.
+			name:   "constant with no attempts reports as no reconnection",
+			policy: &ConstantReconnectionPolicy{MaxRetries: 0, Interval: time.Second},
+			want:   nil,
+		},
+		{
+			name:   "constant with a negative attempt limit reports as no reconnection",
+			policy: &ConstantReconnectionPolicy{MaxRetries: -1, Interval: time.Second},
+			want:   nil,
+		},
+		{
+			name:   "exponential with no attempts reports as no reconnection",
+			policy: &ExponentialReconnectionPolicy{MaxRetries: 0, InitialInterval: time.Second, MaxInterval: 2 * time.Second},
+			want:   nil,
+		},
+		{
+			// time.Sleep returns immediately on a negative delay, so an immediate
+			// retry is what it means; delay-ms is nonNegativeInteger.
+			name:   "constant with a negative interval reports an immediate retry",
+			policy: &ConstantReconnectionPolicy{MaxRetries: 3, Interval: -5 * time.Second},
+			want:   reconnectionConstantReport{Type: "constant", DelayMs: 0, MaxAttempts: 3},
+		},
+		{
+			name:   "a typed-nil policy reports as no reconnection instead of panicking",
+			policy: (*ConstantReconnectionPolicy)(nil),
+			want:   nil,
+		},
+		{
+			// A nil policy cannot come from ClusterConfig.Validate, but reporting
+			// must not panic on one either.
+			name:   "a nil policy reports as no reconnection",
+			policy: nil,
+			want:   nil,
+		},
+		{
+			// base-ms and max-ms are both positiveInteger; getExponentialTime
+			// substitutes 100ms/10s for a non-positive bound, so those are the
+			// delays this policy really waits.
+			name:   "exponential with unset intervals reports getExponentialTime's own defaults",
+			policy: &ExponentialReconnectionPolicy{MaxRetries: 3},
+			want:   reconnectionExponentialReport{Type: "exponential", BaseMs: 100, MaxMs: 10000, MaxAttempts: 3},
+		},
+		{
+			name:   "custom",
+			policy: &fakeReconnectionPolicy{ReconnectionPolicy: &NoReconnectionPolicy{}},
+			want:   reconnectionCustomReport{Type: "custom", Name: "fakeReconnectionPolicy"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildReconnectionPolicyReport(tt.policy)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("buildReconnectionPolicyReport() mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+// fakeRetryPolicy wraps a RetryPolicy so its dynamic type name is distinct
+// from any built-in policy.
+type fakeRetryPolicy struct {
+	RetryPolicy
+}
+
+func TestBuildRetryPolicyReport(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy RetryPolicy
+		want   any
+	}{
+		{
+			name:   "simple",
+			policy: &SimpleRetryPolicy{NumRetries: 7},
+			want:   retryPolicySimpleReport{Type: "simple", MaxRetries: 7},
+		},
+		{
+			// max-retries is nonNegativeInteger, and nothing validates
+			// RetryPolicy, so a negative count reaches the report. It refuses the
+			// first retry exactly as 0 does, so 0 is what it means.
+			name:   "simple with a negative retry limit clamps to zero",
+			policy: &SimpleRetryPolicy{NumRetries: -1},
+			want:   retryPolicySimpleReport{Type: "simple", MaxRetries: 0},
+		},
+		{
+			name:   "exponential backoff with a negative retry limit clamps to zero",
+			policy: &ExponentialBackoffRetryPolicy{NumRetries: -2},
+			want:   retryPolicyCustomReport{Type: "custom", Name: "ExponentialBackoffRetryPolicy", MaxRetries: ptr(0)},
+		},
+		{
+			name:   "downgrading consistency with no consistency levels means no retries",
+			policy: &DowngradingConsistencyRetryPolicy{},
+			want:   retryPolicyDowngradingReport{Type: "downgrading-consistency", MaxRetries: 0},
+		},
+		{
+			name:   "downgrading consistency's max-retries is the length of ConsistencyLevelsToTry",
+			policy: &DowngradingConsistencyRetryPolicy{ConsistencyLevelsToTry: []Consistency{One, Any}},
+			want:   retryPolicyDowngradingReport{Type: "downgrading-consistency", MaxRetries: 2},
+		},
+		{
+			name:   "the built-in exponential backoff is not a schema built-in, reports as custom with its retry limit",
+			policy: &ExponentialBackoffRetryPolicy{NumRetries: 3},
+			want:   retryPolicyCustomReport{Type: "custom", Name: "ExponentialBackoffRetryPolicy", MaxRetries: ptr(3)},
+		},
+		{
+			name:   "custom",
+			policy: &fakeRetryPolicy{RetryPolicy: &SimpleRetryPolicy{}},
+			want:   retryPolicyCustomReport{Type: "custom", Name: "fakeRetryPolicy"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRetryPolicyReport(tt.policy)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("buildRetryPolicyReport() mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildRetryBackoffReport(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy RetryPolicy
+		want   any
+	}{
+		{
+			name:   "policy with no backoff concept reports nothing",
+			policy: &SimpleRetryPolicy{NumRetries: 3},
+			want:   nil,
+		},
+		{
+			name:   "exponential backoff with unset Min/Max reports getExponentialTime's own defaults",
+			policy: &ExponentialBackoffRetryPolicy{NumRetries: 3},
+			want:   retryBackoffExponentialReport{Type: "exponential", BaseMs: 100, MaxMs: 10000},
+		},
+		{
+			name:   "exponential backoff with explicit Min/Max",
+			policy: &ExponentialBackoffRetryPolicy{NumRetries: 3, Min: 50 * time.Millisecond, Max: 2 * time.Second},
+			want:   retryBackoffExponentialReport{Type: "exponential", BaseMs: 50, MaxMs: 2000},
+		},
+		{
+			// getExponentialTime caps every delay at Max, so a Max below Min means
+			// every retry waits exactly Max. Reporting Min as base-ms would name a
+			// delay the policy never waits, and would break max-ms >= base-ms.
+			name:   "exponential backoff with Max below Min reports the delay actually waited",
+			policy: &ExponentialBackoffRetryPolicy{NumRetries: 3, Min: 5 * time.Second, Max: time.Second},
+			want:   retryBackoffExponentialReport{Type: "exponential", BaseMs: 1000, MaxMs: 1000},
+		},
+		{
+			name:   "sub-millisecond bounds floor at the schema minimum instead of truncating to zero",
+			policy: &ExponentialBackoffRetryPolicy{NumRetries: 3, Min: 100 * time.Microsecond, Max: 500 * time.Microsecond},
+			want:   retryBackoffExponentialReport{Type: "exponential", BaseMs: 1, MaxMs: 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRetryBackoffReport(tt.policy)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("buildRetryBackoffReport() mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+// fakeHostSelectionPolicy wraps a HostSelectionPolicy so its dynamic type
+// name is distinct from any built-in policy, without reimplementing the
+// (large) HostSelectionPolicy interface by hand.
+type fakeHostSelectionPolicy struct {
+	HostSelectionPolicy
+}
+
+func TestBuildLoadBalancingPolicyReport(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy HostSelectionPolicy
+		want   any
+	}{
+		{
+			name:   "token-aware over plain round-robin: shuffle, fallback to non-preferred nodes allowed",
+			policy: TokenAwareHostPolicy(RoundRobinHostPolicy()),
+			want:   loadBalancingTokenAwareReport{Type: "token-aware", LoadDistribution: "shuffle", FallbackToNonPreferredNodes: true},
+		},
+		{
+			// AvoidSlowReplicas orders candidates by outstanding request count
+			// (partitionHealthy / HostInfo.IsBusy), which is what the schema's
+			// adaptive-ordering group describes. The threshold it also sets is
+			// deliberately not reported: the schema records signals, not
+			// algorithm parameters.
+			//
+			// The threshold is passed as its own default so this test does not
+			// mutate the MAX_IN_FLIGHT_THRESHOLD package global out from under
+			// anything else.
+			name:   "token-aware with AvoidSlowReplicas reports adaptive ordering",
+			policy: TokenAwareHostPolicy(RoundRobinHostPolicy(), AvoidSlowReplicas(MAX_IN_FLIGHT_THRESHOLD)),
+			want: loadBalancingTokenAwareReport{
+				Type: "token-aware", LoadDistribution: "shuffle", FallbackToNonPreferredNodes: true,
+				AdaptiveOrdering: &adaptiveOrderingReport{Signals: []string{"in-flight-requests"}},
+			},
+		},
+		{
+			name:   "token-aware without AvoidSlowReplicas omits adaptive ordering",
+			policy: TokenAwareHostPolicy(RoundRobinHostPolicy()),
+			want: loadBalancingTokenAwareReport{
+				Type: "token-aware", LoadDistribution: "shuffle", FallbackToNonPreferredNodes: true,
+			},
+		},
+		{
+			name:   "token-aware with DontShuffleReplicas reports replica-set",
+			policy: TokenAwareHostPolicy(RoundRobinHostPolicy(), DontShuffleReplicas()),
+			want:   loadBalancingTokenAwareReport{Type: "token-aware", LoadDistribution: "replica-set", FallbackToNonPreferredNodes: true},
+		},
+		{
+			name:   "token-aware over DC-aware fallback with fallback to non-preferred nodes disabled",
+			policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1", HostPolicyOptionDisableDCFailover)),
+			want:   loadBalancingTokenAwareReport{Type: "token-aware", LoadDistribution: "shuffle", FallbackToNonPreferredNodes: false},
+		},
+		{
+			name:   "token-aware over rack-aware fallback with fallback to non-preferred nodes allowed",
+			policy: TokenAwareHostPolicy(RackAwareRoundRobinPolicy("dc1", "rack1")),
+			want:   loadBalancingTokenAwareReport{Type: "token-aware", LoadDistribution: "shuffle", FallbackToNonPreferredNodes: true},
+		},
+		{
+			// rackAwareRR serves the local DC's other racks whether or not DC
+			// failover is disabled, and those are outside the {dc1, rack1}
+			// preference this same report names. See
+			// TestFallbackToNonPreferredNodesMatchesQueryPlan.
+			name:   "token-aware over rack-aware fallback still leaves the rack when DC failover is disabled",
+			policy: TokenAwareHostPolicy(RackAwareRoundRobinPolicy("dc1", "rack1", HostPolicyOptionDisableDCFailover)),
+			want:   loadBalancingTokenAwareReport{Type: "token-aware", LoadDistribution: "shuffle", FallbackToNonPreferredNodes: true},
+		},
+		{
+			// NonLocalReplicasFallback makes Pick serve remote replicas itself,
+			// before it consults the fallback at all.
+			name:   "NonLocalReplicasFallback escapes the preference despite a confined fallback",
+			policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1", HostPolicyOptionDisableDCFailover), NonLocalReplicasFallback()),
+			want:   loadBalancingTokenAwareReport{Type: "token-aware", LoadDistribution: "shuffle", FallbackToNonPreferredNodes: true},
+		},
+		{
+			name:   "non-token-aware built-in reports as custom",
+			policy: RoundRobinHostPolicy(),
+			want:   loadBalancingCustomReport{Type: "custom", Name: "roundRobinHostPolicy"},
+		},
+		{
+			name:   "custom",
+			policy: &fakeHostSelectionPolicy{HostSelectionPolicy: RoundRobinHostPolicy()},
+			want:   loadBalancingCustomReport{Type: "custom", Name: "fakeHostSelectionPolicy"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildLoadBalancingPolicyReport(tt.policy)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("buildLoadBalancingPolicyReport() mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildNodeLocationPreferenceReport(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy HostSelectionPolicy
+		want   any
+	}{
+		{
+			name:   "no DC/rack preference at all",
+			policy: TokenAwareHostPolicy(RoundRobinHostPolicy()),
+			want:   nil,
+		},
+		{
+			name:   "DC preference behind token-awareness",
+			policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1")),
+			want:   nodeLocationDCReport{Type: "dc", LocalDC: "dc1"},
+		},
+		{
+			name:   "rack preference behind token-awareness",
+			policy: TokenAwareHostPolicy(RackAwareRoundRobinPolicy("dc1", "rack1")),
+			want:   nodeLocationRackReport{Type: "rack", LocalDC: "dc1", LocalRack: "rack1"},
+		},
+		{
+			name:   "DC preference reported independently of the load-balancing discriminant, when not wrapped in token-awareness",
+			policy: DCAwareRoundRobinPolicy("dc1"),
+			want:   nodeLocationDCReport{Type: "dc", LocalDC: "dc1"},
+		},
+		{
+			// local-dc is nonEmptyString and required on the branch that names
+			// it, so an empty datacenter cannot be reported -- and expresses no
+			// preference anyway.
+			name:   "an empty datacenter is no preference",
+			policy: TokenAwareHostPolicy(DCAwareRoundRobinPolicy("")),
+			want:   nil,
+		},
+		{
+			name:   "an empty rack is no preference",
+			policy: TokenAwareHostPolicy(RackAwareRoundRobinPolicy("dc1", "")),
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildNodeLocationPreferenceReport(tt.policy)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("buildNodeLocationPreferenceReport() mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestBuildLoadBalancingReport_UnwrapsWrappers pins that a policy wrapped in
+// SingleHostReadyPolicy is still described by what it wraps. The wrapper is
+// transparent to routing, so reporting it as the policy would drop both the
+// token-aware discriminant and the DC preference behind it.
+func TestBuildLoadBalancingReport_UnwrapsWrappers(t *testing.T) {
+	inner := TokenAwareHostPolicy(DCAwareRoundRobinPolicy("dc1"))
+	want := buildLoadBalancingReport(inner)
+
+	for _, tt := range []struct {
+		name   string
+		policy HostSelectionPolicy
+	}{
+		{"wrapped once", SingleHostReadyPolicy(inner)},
+		{"wrapped twice", SingleHostReadyPolicy(SingleHostReadyPolicy(inner))},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(want, buildLoadBalancingReport(tt.policy)); diff != "" {
+				t.Errorf("expected the wrapped policy to report as the policy it wraps:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildControlPlaneReport(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeout   time.Duration
+		agreement time.Duration
+		want      controlPlaneReport
+	}{
+		{
+			name:      "system query timeout disabled entirely omits the timeout object's contents",
+			timeout:   0,
+			agreement: 60 * time.Second,
+			want: controlPlaneReport{
+				Schema: controlPlaneSchemaReport{Agreement: schemaAgreementReport{TimeoutMs: 60000}},
+			},
+		},
+		{
+			name:      "system query timeout reports client-side-ms",
+			timeout:   30 * time.Second,
+			agreement: 60 * time.Second,
+			want: controlPlaneReport{
+				Queries: controlPlaneQueriesReport{System: systemQueriesReport{Timeout: systemQueriesTimeoutReport{
+					ClientSideMs: ptr(int64(30000)),
+				}}},
+				Schema: controlPlaneSchemaReport{Agreement: schemaAgreementReport{TimeoutMs: 60000}},
+			},
+		},
+		{
+			name:      "schema agreement of 0 is reported verbatim, not treated as unset",
+			timeout:   0,
+			agreement: 0,
+			want: controlPlaneReport{
+				Schema: controlPlaneSchemaReport{Agreement: schemaAgreementReport{TimeoutMs: 0}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := *NewCluster("127.0.0.1")
+			cfg.MetadataSchemaRequestTimeout = tt.timeout
+			cfg.MaxWaitSchemaAgreement = tt.agreement
+			got := buildControlPlaneReport(&cfg)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("buildControlPlaneReport() mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// TestPositiveMillis pins the conversion every positiveInteger duration field
+// in the report goes through. A duration under a millisecond truncates to 0,
+// which the schema rejects (minimum 1), so it has to floor at 1 rather than be
+// reported verbatim or dropped as if the timeout were disabled.
+func TestPositiveMillis(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want *int64
+	}{
+		{"unset is omitted", 0, nil},
+		{"negative is omitted", -time.Second, nil},
+		{"sub-millisecond floors at the schema minimum", 500 * time.Microsecond, ptr(int64(1))},
+		{"exactly one millisecond", time.Millisecond, ptr(int64(1))},
+		{"whole milliseconds pass through", 11 * time.Second, ptr(int64(11000))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.want, positiveMillis(tt.d)); diff != "" {
+				t.Errorf("positiveMillis(%v) mismatch:\n%s", tt.d, diff)
+			}
+		})
+	}
+}
+
+// TestBuildReport_SubMillisecondTimeouts is the regression guard for the whole
+// class: every positiveInteger duration field in the report at once, driven by
+// a config where each one truncates to 0.
+func TestBuildReport_SubMillisecondTimeouts(t *testing.T) {
+	cfg := *NewCluster("127.0.0.1")
+	cfg.ConnectTimeout = 500 * time.Microsecond
+	cfg.ReadTimeout = 500 * time.Microsecond
+	cfg.WriteTimeout = 500 * time.Microsecond
+	cfg.Timeout = 500 * time.Microsecond
+	cfg.MetadataSchemaRequestTimeout = 500 * time.Microsecond
+
+	s := newTestReportSession(cfg, TokenAwareHostPolicy(RoundRobinHostPolicy()))
+	raw, err := newDriverConfigReporter(s).buildReport()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report driverConfigReport
+	if err := json.Unmarshal([]byte(raw), &report); err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]*int64{
+		"connection.connect.timeout-ms": report.Connection.Connect.TimeoutMs,
+		"query.defaults.request.timeout-ms": func() *int64 {
+			if report.Query.Defaults.Request == nil {
+				return nil
+			}
+			return &report.Query.Defaults.Request.TimeoutMs
+		}(),
+		"control-plane...client-side-ms": report.ControlPlane.Queries.System.Timeout.ClientSideMs,
+		"connection.read.timeout-ms": func() *int64 {
+			if report.Connection.Read == nil {
+				return nil
+			}
+			return &report.Connection.Read.TimeoutMs
+		}(),
+		"connection.write.timeout-ms": func() *int64 {
+			if report.Connection.Write == nil {
+				return nil
+			}
+			return &report.Connection.Write.TimeoutMs
+		}(),
+	}
+	for field, v := range got {
+		if v == nil {
+			t.Errorf("%s: expected a sub-millisecond timeout to still be reported, got omitted", field)
+			continue
+		}
+		if *v < 1 {
+			t.Errorf("%s = %d, want >= 1 (the schema's positiveInteger minimum)", field, *v)
+		}
+	}
+}
+
+func TestBuildConnectionReport_ReadWriteTLS(t *testing.T) {
+	cfg := *NewCluster("127.0.0.1")
+	cfg.ReadTimeout = 0
+	cfg.WriteTimeout = 0
+	report := buildConnectionReport(&cfg)
+	if report.Read != nil {
+		t.Errorf("expected read to be omitted when ReadTimeout is 0, got %+v", report.Read)
+	}
+	if report.Write != nil {
+		t.Errorf("expected write to be omitted when WriteTimeout is 0, got %+v", report.Write)
+	}
+	if report.TLS != nil {
+		t.Errorf("expected tls to be omitted when SslOpts is nil, got %+v", report.TLS)
+	}
+
+	cfg.ReadTimeout = 5 * time.Second
+	cfg.WriteTimeout = 7 * time.Second
+	cfg.SslOpts = &SslOptions{EnableHostVerification: true}
+	report = buildConnectionReport(&cfg)
+	if report.Read == nil || report.Read.TimeoutMs != 5000 {
+		t.Errorf("expected read.timeout-ms 5000, got %+v", report.Read)
+	}
+	if report.Write == nil || report.Write.TimeoutMs != 7000 {
+		t.Errorf("expected write.timeout-ms 7000, got %+v", report.Write)
+	}
+	if report.TLS == nil || !report.TLS.HostnameVerification {
+		t.Errorf("expected tls.hostname-verification true, got %+v", report.TLS)
+	}
+
+	// HostDialer takes over connection setup entirely, so SslOpts is ignored
+	// (see ClusterConfig.SslOpts) and the effective TLS state is unknown.
+	cfg.HostDialer = fakeHostDialer{}
+	report = buildConnectionReport(&cfg)
+	if report.TLS != nil {
+		t.Errorf("expected tls to be omitted when HostDialer is set, got %+v", report.TLS)
+	}
+}
+
+// TestBuildTLSReport_ReportsEffectiveHostnameVerification pins the report
+// against what setupTLSConfig actually produces, rather than against
+// SslOpts.EnableHostVerification, which is only one of the two inputs that
+// decide it. The case that matters is a caller-supplied tls.Config that does
+// not skip verification while EnableHostVerification is left false: hostnames
+// are verified, and reporting the flag alone would claim the opposite.
+func TestBuildTLSReport_ReportsEffectiveHostnameVerification(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *SslOptions
+	}{
+		{"no tls.Config, verification requested", &SslOptions{EnableHostVerification: true}},
+		{"no tls.Config, verification not requested", &SslOptions{EnableHostVerification: false}},
+		{"caller tls.Config verifies, flag not set", &SslOptions{Config: &tls.Config{InsecureSkipVerify: false}}},
+		{"caller tls.Config skips, flag not set", &SslOptions{Config: &tls.Config{InsecureSkipVerify: true}}},
+		{"caller tls.Config skips, flag overrides it back on", &SslOptions{Config: &tls.Config{InsecureSkipVerify: true}, EnableHostVerification: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := *NewCluster("127.0.0.1")
+			cfg.SslOpts = tt.opts
+			if err := cfg.ValidateAndInitSSL(); err != nil {
+				t.Fatal(err)
+			}
+			// The tls.Config the driver will actually hand to the dialer is the
+			// only authority on whether hostnames get verified.
+			actual := cfg.getActualTLSConfig()
+			if actual == nil {
+				t.Fatal("expected ValidateAndInitSSL to produce a tls.Config")
+			}
+			want := !actual.InsecureSkipVerify
+
+			got := buildTLSReport(&cfg)
+			if got == nil {
+				t.Fatal("expected a tls group when SslOpts is set")
+			}
+			if got.HostnameVerification != want {
+				t.Errorf("hostname-verification = %v, but the effective tls.Config verifies = %v",
+					got.HostnameVerification, want)
+			}
+
+			// The same config must be described identically before
+			// ValidateAndInitSSL has run, which is how a hand-built Session in a
+			// test reaches the reporter.
+			pristine := *NewCluster("127.0.0.1")
+			pristine.SslOpts = tt.opts
+			if fallback := buildTLSReport(&pristine); fallback == nil || fallback.HostnameVerification != want {
+				t.Errorf("without a resolved tls.Config: hostname-verification = %v, want %v", fallback, want)
+			}
+		})
+	}
+}
+
+// fakeShardDialer is a HostDialer that can target a shard, like the
+// *scyllaDialer the driver substitutes when no HostDialer is configured.
+type fakeShardDialer struct{ fakeHostDialer }
+
+func (fakeShardDialer) DialShard(ctx context.Context, host *HostInfo, shardID, nrShards int) (*DialedHost, error) {
+	return nil, nil
+}
+
+// TestBuildConnectionReport_ShardAware covers both gates on reaching the
+// shard-aware port. DisableShardAwarePort is the obvious one; the dialer's
+// capability is the one easy to miss, since Session.dialWithoutObserver falls
+// back to DialHost silently when HostDialer is not a ShardDialer.
+// TestBuildConnectionNodePreferenceReport pins connection.node-preference to
+// the only thing that narrows pool membership: HostFilter. Session.init drops
+// every host cfg.filterHost rejects, so such a host never gets a pool, which is
+// exactly what this group describes.
+func TestBuildConnectionNodePreferenceReport(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter HostFilter
+		want   any
+	}{
+		{name: "no filter narrows nothing", filter: nil, want: nil},
+		{
+			name:   "datacenter filter is the part of the cluster we hold connections to",
+			filter: DataCenterHostFilter("dc1"),
+			want:   nodeLocationDCReport{Type: "dc", LocalDC: "dc1"},
+		},
+		{
+			// The deprecated spelling delegates to the same constructor, so it
+			// must report identically rather than fall through as opaque.
+			name:   "the deprecated spelling reports the same",
+			filter: DataCentreHostFilter("dc1"),
+			want:   nodeLocationDCReport{Type: "dc", LocalDC: "dc1"},
+		},
+		{
+			// local-dc is nonEmptyString, and an empty datacenter expresses no
+			// preference anyway.
+			name:   "an empty datacenter is no preference",
+			filter: DataCenterHostFilter(""),
+			want:   nil,
+		},
+		{name: "accept-all states no location", filter: AcceptAllFilter(), want: nil},
+		{name: "deny-all states no location", filter: DenyAllFilter(), want: nil},
+		{
+			// Selects by address, which the schema has no branch for.
+			name: "whitelist filter is not a location", filter: WhiteListHostFilter("127.0.0.1"),
+			want: nil,
+		},
+		{
+			name:   "a caller-supplied filter is opaque",
+			filter: HostFilterFunc(func(*HostInfo) bool { return true }),
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := *NewCluster("127.0.0.1")
+			cfg.HostFilter = tt.filter
+			if diff := cmp.Diff(tt.want, buildConnectionReport(&cfg).NodePreference); diff != "" {
+				t.Errorf("connection.node-preference mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestDataCenterHostFilterStillFilters guards the behaviour the introspectable
+// type replaced: it is reported by reading the datacenter back off the filter,
+// which is only sound if the filter still accepts exactly that datacenter.
+func TestDataCenterHostFilterStillFilters(t *testing.T) {
+	filter := DataCenterHostFilter("dc1")
+	for _, tt := range []struct {
+		dc   string
+		want bool
+	}{{"dc1", true}, {"dc2", false}, {"", false}} {
+		if got := filter.Accept(&HostInfo{dataCenter: tt.dc}); got != tt.want {
+			t.Errorf("Accept(dataCenter=%q) = %v, want %v", tt.dc, got, tt.want)
+		}
+	}
+}
+
+func TestBuildConnectionReport_ShardAware(t *testing.T) {
+	tests := []struct {
+		name       string
+		disable    bool
+		hostDialer HostDialer
+		want       bool
+	}{
+		{name: "default: the substituted scyllaDialer is shard-aware", want: true},
+		{name: "explicitly disabled", disable: true, want: false},
+		{
+			name:       "a HostDialer that cannot target a shard can never reach the port",
+			hostDialer: fakeHostDialer{},
+			want:       false,
+		},
+		{
+			name:       "a HostDialer implementing ShardDialer can",
+			hostDialer: fakeShardDialer{},
+			want:       true,
+		},
+		{
+			name:       "a shard-aware HostDialer is still gated by the flag",
+			disable:    true,
+			hostDialer: fakeShardDialer{},
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := *NewCluster("127.0.0.1")
+			cfg.DisableShardAwarePort = tt.disable
+			cfg.HostDialer = tt.hostDialer
+			if got := buildConnectionReport(&cfg).Pool.ShardAware.Enabled; got != tt.want {
+				t.Errorf("shard-aware.enabled = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShardAwareEnabledMatchesDialPath pins the report against the branch it
+// describes: dialWithoutObserver only takes the shard-aware path when the
+// HostDialer satisfies ShardDialer, so the two must agree on every dialer.
+func TestShardAwareEnabledMatchesDialPath(t *testing.T) {
+	for _, hostDialer := range []HostDialer{fakeHostDialer{}, fakeShardDialer{}} {
+		cfg := *NewCluster("127.0.0.1")
+		cfg.HostDialer = hostDialer
+
+		_, canDialShard := hostDialer.(ShardDialer)
+		if got := shardAwareEnabled(&cfg); got != canDialShard {
+			t.Errorf("%T: reported %v, but dialWithoutObserver would take the shard-aware path = %v",
+				hostDialer, got, canDialShard)
+		}
+	}
+}
+
+type fakeHostDialer struct{}
+
+func (fakeHostDialer) DialHost(ctx context.Context, host *HostInfo) (*DialedHost, error) {
+	return nil, nil
+}
+
+// TestConsistencyName pins query.defaults.consistency to the schema's enum,
+// which covers every level Consistency defines. Only an unrecognized numeric
+// value has no representation, and nothing rejects one today, so it must be
+// omitted rather than emitted as a token no consumer can interpret.
+func TestConsistencyName(t *testing.T) {
+	for _, c := range []Consistency{
+		Any, One, Two, Three, Quorum, All, LocalQuorum, EachQuorum, LocalOne, Serial, LocalSerial,
+	} {
+		if got := consistencyName(c); got != c.String() {
+			t.Errorf("consistencyName(%v) = %q, want %q", c, got, c.String())
+		}
+	}
+	if got := consistencyName(Consistency(0x42)); got != "" {
+		t.Errorf("consistencyName(0x42) = %q, want it omitted: outside the schema enum", got)
+	}
+}
+
+// TestBuildQueryDefaultsReport_SerialConsistencyIsSerialOnly guards the sibling
+// key: serial-consistency's enum is SERIAL/LOCAL_SERIAL, so a non-serial level
+// left in the field must not be reported there either.
+func TestBuildQueryDefaultsReport_SerialConsistencyIsSerialOnly(t *testing.T) {
+	for _, tt := range []struct {
+		cons Consistency
+		want string
+	}{
+		{0, ""},
+		{Serial, "SERIAL"},
+		{LocalSerial, "LOCAL_SERIAL"},
+		{Quorum, ""},
+	} {
+		cfg := *NewCluster("127.0.0.1")
+		cfg.SerialConsistency = tt.cons
+		if got := buildQueryDefaultsReport(&cfg).SerialConsistency; got != tt.want {
+			t.Errorf("SerialConsistency=%v: serial-consistency = %q, want %q", tt.cons, got, tt.want)
+		}
+	}
+}
+
+func TestBuildQueryDefaultsReport(t *testing.T) {
+	cfg := *NewCluster("127.0.0.1")
+	cfg.PageSize = 0
+	cfg.SerialConsistency = 0
+	cfg.Timeout = 0
+	got := buildQueryDefaultsReport(&cfg)
+	if got.Page != nil {
+		t.Errorf("expected page to be omitted when PageSize is 0, got %+v", got.Page)
+	}
+	if got.SerialConsistency != "" {
+		t.Errorf("expected serial-consistency to be omitted when unset, got %q", got.SerialConsistency)
+	}
+	if got.Request != nil {
+		t.Errorf("expected request to be omitted entirely when Timeout is 0, got %+v", got.Request)
+	}
+
+	cfg.PageSize = 1000
+	cfg.SerialConsistency = LocalSerial
+	cfg.Timeout = 3 * time.Second
+	got = buildQueryDefaultsReport(&cfg)
+	if got.Page == nil || got.Page.Size != 1000 {
+		t.Errorf("expected page.size 1000, got %+v", got.Page)
+	}
+	if got.SerialConsistency != "LOCAL_SERIAL" {
+		t.Errorf("expected serial-consistency LOCAL_SERIAL, got %q", got.SerialConsistency)
+	}
+	if got.Request == nil || got.Request.TimeoutMs != 3000 {
+		t.Errorf("expected request.timeout-ms 3000, got %+v", got.Request)
 	}
 }
 
@@ -133,18 +1146,18 @@ func TestDriverConfigReportingDial(t *testing.T) {
 		// connConfig picks the ConnConfig to dial with: the one every path
 		// (re)establishing the control connection goes through, or the
 		// session-wide one every pool connection is dialed with.
-		connConfig  func(*Session) *ConnConfig
-		wantConfigs []string
+		connConfig    func(*Session) *ConnConfig
+		wantReporting bool
 	}{
 		{
-			name:        "control connection",
-			connConfig:  (*Session).controlConnConfig,
-			wantConfigs: []string{`{"version":1}`},
+			name:          "control connection",
+			connConfig:    (*Session).controlConnConfig,
+			wantReporting: true,
 		},
 		{
-			name:        "regular connection",
-			connConfig:  func(s *Session) *ConnConfig { return s.connCfg },
-			wantConfigs: nil,
+			name:          "regular connection",
+			connConfig:    func(s *Session) *ConnConfig { return s.connCfg },
+			wantReporting: false,
 		},
 	}
 
@@ -227,8 +1240,21 @@ func TestDriverConfigReportingDial(t *testing.T) {
 			if got := startups - startupsBeforeDial; got != 1 {
 				t.Fatalf("expected the connection dialed by hand to send exactly one STARTUP frame, got %d", got)
 			}
-			if !slices.Equal(configs, tt.wantConfigs) {
-				t.Errorf("expected %s %q on a %s, got %q", driverConfigStartupKey, tt.wantConfigs, tt.name, configs)
+			if len(configs) == 0 {
+				if tt.wantReporting {
+					t.Fatalf("expected %s on a %s, got none", driverConfigStartupKey, tt.name)
+				}
+				return
+			}
+			if !tt.wantReporting {
+				t.Fatalf("expected no %s on a %s, got %q", driverConfigStartupKey, tt.name, configs)
+			}
+			var report driverConfigReport
+			if err := json.Unmarshal([]byte(configs[0]), &report); err != nil {
+				t.Fatalf("%s did not decode as JSON: %v", driverConfigStartupKey, err)
+			}
+			if report.Version != driverConfigVersion {
+				t.Errorf("expected version %d, got %d", driverConfigVersion, report.Version)
 			}
 		})
 	}

--- a/filters.go
+++ b/filters.go
@@ -53,12 +53,25 @@ func DenyAllFilter() HostFilter {
 	})
 }
 
+// dataCenterHostFilter accepts hosts in one datacenter.
+//
+// It is a named type rather than a HostFilterFunc closure so that the
+// datacenter it selects can be read back: a closure captures it where nothing
+// can reach it, and every filter built from one is indistinguishable as a
+// HostFilterFunc. driver_config.go reports this filter as the part of the
+// cluster the driver holds connections to.
+type dataCenterHostFilter struct {
+	dataCenter string
+}
+
+func (f dataCenterHostFilter) Accept(host *HostInfo) bool {
+	return host.DataCenter() == f.dataCenter
+}
+
 // DataCenterHostFilter filters all hosts such that they are in the same data center
 // as the supplied data center.
 func DataCenterHostFilter(dataCenter string) HostFilter {
-	return HostFilterFunc(func(host *HostInfo) bool {
-		return host.DataCenter() == dataCenter
-	})
+	return dataCenterHostFilter{dataCenter: dataCenter}
 }
 
 // Deprecated: Use DataCenterHostFilter instead.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/klauspost/compress v1.19.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
 	gopkg.in/inf.v0 v0.9.1
@@ -31,6 +32,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -22,6 +24,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
@@ -32,6 +36,8 @@ golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/integration_test.go
+++ b/integration_test.go
@@ -388,7 +388,7 @@ func TestDriverConfigReporting(t *testing.T) {
 	// Assert on the decoded report rather than a byte-exact string: the payload
 	// is a full configuration description whose exact serialization is the unit
 	// tests' business, while what only a live server can confirm is that it
-	// round-trips intact.
+	// round-trips intact and that the ScyllaDB-gated key is decided correctly.
 	for _, config := range configs {
 		var report driverConfigReport
 		if err := json.Unmarshal([]byte(config), &report); err != nil {
@@ -400,6 +400,16 @@ func TestDriverConfigReporting(t *testing.T) {
 		}
 		if got, want := report.ControlPlane.Schema.Agreement.TimeoutMs, cluster.MaxWaitSchemaAgreement.Milliseconds(); got != want {
 			t.Errorf("expected schema agreement timeout-ms %d, got %d", want, got)
+		}
+		// server-side-ms describes the USING TIMEOUT clause, which only ScyllaDB
+		// understands. The fake server the unit tests run against cannot
+		// exercise either side of that gate.
+		wantServerSide := false
+		if ch := s.control.getConn(); ch != nil {
+			wantServerSide = ch.conn.isScyllaConn()
+		}
+		if got := report.ControlPlane.Queries.System.Timeout.ServerSideMs != nil; got != wantServerSide {
+			t.Errorf("expected server-side-ms present=%v against this server, got %v", wantServerSide, got)
 		}
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -30,6 +30,7 @@ package gocql
 // This file groups integration tests where Cassandra has to be set up with some special integration variables
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -384,9 +385,21 @@ func TestDriverConfigReporting(t *testing.T) {
 	if len(configs) != 1 {
 		t.Errorf("expected exactly one connection with SESSION_ID %q to report DRIVER_CONFIG, got %d", wantSessionID, len(configs))
 	}
+	// Assert on the decoded report rather than a byte-exact string: the payload
+	// is a full configuration description whose exact serialization is the unit
+	// tests' business, while what only a live server can confirm is that it
+	// round-trips intact.
 	for _, config := range configs {
-		if want := `{"version":1}`; config != want {
-			t.Errorf("expected DRIVER_CONFIG to be %q, got %q", want, config)
+		var report driverConfigReport
+		if err := json.Unmarshal([]byte(config), &report); err != nil {
+			t.Errorf("expected %s to be valid JSON, got %q: %v", driverConfigStartupKey, config, err)
+			continue
+		}
+		if report.Version != driverConfigVersion {
+			t.Errorf("expected %s version %d, got %d", driverConfigStartupKey, driverConfigVersion, report.Version)
+		}
+		if got, want := report.ControlPlane.Schema.Agreement.TimeoutMs, cluster.MaxWaitSchemaAgreement.Milliseconds(); got != want {
+			t.Errorf("expected schema agreement timeout-ms %d, got %d", want, got)
 		}
 	}
 }

--- a/policies.go
+++ b/policies.go
@@ -1099,6 +1099,20 @@ func DCAwareRoundRobinPolicy(localDC string, opts ...dcAwarePolicyOption) HostSe
 func (d *dcAwareRR) setDCFailoverDisabled() {
 	d.disableDCFailover = true
 }
+
+// dcFailoverDisabled reports whether this policy was constructed with
+// HostPolicyOptionDisableDCFailover. Used by driver_config.go to report
+// query.load-balancing.policy.fallback-to-non-preferred-nodes.
+func (d *dcAwareRR) dcFailoverDisabled() bool {
+	return d.disableDCFailover
+}
+
+// localDatacenter reports the datacenter this policy prioritizes. Used by
+// driver_config.go to report query.load-balancing.node-preference.
+func (d *dcAwareRR) localDatacenter() string {
+	return d.local
+}
+
 func (d *dcAwareRR) Init(*Session)                       {}
 func (d *dcAwareRR) Reset()                              {}
 func (d *dcAwareRR) KeyspaceChanged(KeyspaceUpdateEvent) {}
@@ -1245,6 +1259,24 @@ func (d *rackAwareRR) MaxHostTier() uint {
 
 func (d *rackAwareRR) setDCFailoverDisabled() {
 	d.disableDCFailover = true
+}
+
+// dcFailoverDisabled reports whether this policy was constructed with
+// HostPolicyOptionDisableDCFailover. Used by driver_config.go to report
+// query.load-balancing.policy.fallback-to-non-preferred-nodes.
+func (d *rackAwareRR) dcFailoverDisabled() bool {
+	return d.disableDCFailover
+}
+
+// localDatacenter and localRackName report the datacenter/rack this policy
+// prioritizes. Used by driver_config.go to report
+// query.load-balancing.node-preference.
+func (d *rackAwareRR) localDatacenter() string {
+	return d.localDC
+}
+
+func (d *rackAwareRR) localRackName() string {
+	return d.localRack
 }
 
 func (d *rackAwareRR) HostTier(host *HostInfo) uint {

--- a/tests/bench/go.sum
+++ b/tests/bench/go.sum
@@ -10,6 +10,8 @@ github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJn
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
@@ -18,6 +20,8 @@ golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Stage 1 landed the plumbing that sends a `DRIVER_CONFIG STARTUP` option on the control connection, with a placeholder payload of `{"version":1}`. This PR fills that payload in: the driver now sends a full JSON description of its effective configuration, which lands in `system.clients.client_options` and lets operators inspect a client's settings while investigating an incident.

Fixes: https://scylladb.atlassian.net/browse/DRIVER-380

