### PR TITLE
Add code coverage measurement for unit and integration tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,10 @@ on:
       - .github/workflows/bench-tests.yml
       - .github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
   pull_request:
-    types: [opened, synchronize, reopened]
+    # labeled/unlabeled included so removing disable-coverage-tests
+    # re-triggers a run instead of leaving coverage skipped until the next
+    # push or reopen.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - "*.md"
       - "docs/**"
@@ -90,7 +93,7 @@ jobs:
 
       - name: Run CCM integration suite with coverage
         if: steps.scylla-version.outputs.value != 'NOT-FOUND'
-        run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla-coverage
+        run: make ccm-test-coverage
 
       - name: Generate coverage report
         if: always()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,105 @@
+name: Code coverage
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
+      - .github/workflows/docs-*
+      - .github/workflows/bench-tests.yml
+      - .github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
+      - .github/workflows/docs-*
+      - .github/workflows/bench-tests.yml
+      - .github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    name: Measure code coverage
+    if: "!contains(github.event.pull_request.labels.*.name, 'disable-coverage-tests')"
+    runs-on: ubuntu-latest
+    env:
+      SCYLLA_VERSION: LATEST
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.11'
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            /home/runner/.cache/pip
+            /home/runner/.local
+            /home/runner/.sdkman
+            testdata/pki
+            bin/
+          # CCM, pip and java versions are in Makefile
+          key: pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: |
+            lz4/go.sum
+            tests/bench/go.sum
+            go.sum
+
+      - name: Run unit tests with coverage
+        run: make test-unit-coverage
+
+      - name: Get scylla version
+        id: scylla-version
+        run: make resolve-scylla-version
+
+      - name: Pull CCM image from the cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
+        id: ccm-cache
+        with:
+          path: ~/.ccm/repository
+          key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
+
+      - name: Download ScyllaDB (${{ steps.scylla-version.outputs.value }}) image
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
+        run: make download-scylla
+
+      - name: Save CCM ScyllaDB image into the cache
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.ccm/repository
+          key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
+
+      - name: Run integration suite with coverage
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
+        run: make test-integration-scylla-coverage
+
+      - name: Run CCM integration suite with coverage
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
+        run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla-coverage
+
+      - name: Generate coverage report
+        if: always()
+        run: make coverage-report
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: |
+            coverage-root.html
+            coverage-root.out
+            coverage-lz4.html
+            coverage-lz4.out

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,9 @@ on:
       - .github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: Measure code coverage

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ testdata/pki/*.srl
 docs/_build/
 docs/source/.doctrees
 
+# Code coverage reports (see `make coverage-report` / .github/workflows/coverage.yml)
+.coverage/
+coverage-root.*
+coverage-lz4.*
+
 TODO*.md
 
 # Codex - AI assistant metadata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,9 @@ make scylla-start
 make test-integration-scylla-coverage
 ```
 
-Both targets accumulate into the same coverage data directory (`.coverage/data` by default, override with `COVERAGE_DIR`), so unit and integration runs combine into one picture. Once you've run whichever combination you want measured, generate the report:
+To also measure the `ccm`-tagged tests (`internal/ccm`, exercised by `make ccm-test`), run `make ccm-test-coverage` too -- it targets that package directly rather than going through `test-integration-scylla`, since `internal/ccm`'s tests don't accept the cluster-connection flags (`-distribution`, `-cluster`, ...) that target passes.
+
+All of these accumulate into the same coverage data directory (`.coverage/data` by default, override with `COVERAGE_DIR`), so unit and integration runs combine into one picture. Once you've run whichever combination you want measured, generate the report:
 
 ```sh
 make coverage-report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,25 @@ Unit tests are good, integration tests are even better. An example of a unit tes
 
 That said, the point of writing tests is to provide a safety net to catch regressions, so there is no need to go overboard with tests. Remember that the more tests you write, the more code we will have to maintain. So there's a balance to strike there.
 
+#### Measuring Code Coverage
+
+`make test-unit-coverage` runs the unit suite (root module and the `lz4` submodule) instrumented for coverage. To include the integration suite too, start a cluster and run its coverage target as well, e.g.:
+
+```sh
+make scylla-start
+make test-integration-scylla-coverage
+```
+
+Both targets accumulate into the same coverage data directory (`.coverage/data` by default, override with `COVERAGE_DIR`), so unit and integration runs combine into one picture. Once you've run whichever combination you want measured, generate the report:
+
+```sh
+make coverage-report
+```
+
+This prints a per-package percentage and writes `coverage-root.html`/`coverage-lz4.html` (open either in a browser for a line-by-line view) plus the underlying `.out` profiles. `lz4` is a separate Go module from the root one, so its report is generated and rendered separately -- `go tool cover` resolves source files against the module rooted at the current directory, and can't do that for two modules from one profile.
+
+`make clean-coverage` removes the coverage data directory and generated reports.
+
 ### Sign Off Procedure
 
 Generally speaking, a pull request can get merged by any one of the project's committers. If your change is minor, chances are that one team member will just go ahead and merge it there and then. As stated earlier, suitable test coverage will increase the likelihood that a single reviewer will assess and merge your change. If your change has no test coverage, or looks like it may have wider implications for the health and stability of the library, the reviewer may elect to refer the change to another team member to achieve consensus before proceeding. Therefore, the tighter and cleaner your patch is, the quicker it will go through the review process.

--- a/Makefile
+++ b/Makefile
@@ -367,20 +367,24 @@ test-integration-cassandra-coverage: .prepare-coverage-dir
 # run `go tool cover` from within each module's own directory instead.
 coverage-report:
 	@echo "Generate coverage report"
+	go tool covdata textfmt -i="${COVERAGE_DIR}" -pkg="github.com/gocql/gocql/..." -o="${MAKEFILE_PATH}/coverage-root.out"
+	go tool covdata textfmt -i="${COVERAGE_DIR}" -pkg="github.com/scylladb/gocql/lz4/..." -o="${MAKEFILE_PATH}/coverage-lz4.out"
 ifeq ($(shell if [[ -n "$${GITHUB_STEP_SUMMARY}" ]]; then echo "running-in-workflow"; else echo "running-in-shell"; fi), running-in-workflow)
 	echo "### Coverage Report" >>$${GITHUB_STEP_SUMMARY}
 	echo '```' >>$${GITHUB_STEP_SUMMARY}
 	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/gocql/gocql/..." | tee -a "$${GITHUB_STEP_SUMMARY}"
+	go tool cover -func="${MAKEFILE_PATH}/coverage-root.out" | tail -1 | sed 's/^total:/root module total:/' | tee -a "$${GITHUB_STEP_SUMMARY}"
 	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/scylladb/gocql/lz4/..." | tee -a "$${GITHUB_STEP_SUMMARY}"
+	(cd lz4 && go tool cover -func="${MAKEFILE_PATH}/coverage-lz4.out") | tail -1 | sed 's/^total:/lz4 module total:/' | tee -a "$${GITHUB_STEP_SUMMARY}"
 	echo '```' >>"$${GITHUB_STEP_SUMMARY}"
 else
 	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/gocql/gocql/..."
+	go tool cover -func="${MAKEFILE_PATH}/coverage-root.out" | tail -1 | sed 's/^total:/root module total:/'
 	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/scylladb/gocql/lz4/..."
+	(cd lz4 && go tool cover -func="${MAKEFILE_PATH}/coverage-lz4.out") | tail -1 | sed 's/^total:/lz4 module total:/'
 endif
-	go tool covdata textfmt -i="${COVERAGE_DIR}" -pkg="github.com/gocql/gocql/..." -o="${MAKEFILE_PATH}/coverage-root.out"
 	go tool cover -html="${MAKEFILE_PATH}/coverage-root.out" -o="${MAKEFILE_PATH}/coverage-root.html"
-	go tool covdata textfmt -i="${COVERAGE_DIR}" -pkg="github.com/scylladb/gocql/lz4/..." -o="${MAKEFILE_PATH}/coverage-lz4.out"
-	cd lz4 && go tool cover -html="${MAKEFILE_PATH}/coverage-lz4.out" -o="${MAKEFILE_PATH}/coverage-lz4.html"
+	(cd lz4 && go tool cover -html="${MAKEFILE_PATH}/coverage-lz4.out" -o="${MAKEFILE_PATH}/coverage-lz4.html")
 
 clean-coverage:
 	rm -rf "${COVERAGE_DIR}" "${MAKEFILE_PATH}"/coverage-root.* "${MAKEFILE_PATH}"/coverage-lz4.*

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,22 @@ TEST_INTEGRATION_TAGS ?= integration gocql_debug
 JVM_EXTRA_OPTS ?= -Dcassandra.test.fail_writes_ks=test -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler
 
 # COVER_ARGS is appended to every `go test ... ./...` invocation below. It is
-# empty by default, so plain `make test-unit`/`test-integration-*` behave
-# exactly as before; the *-coverage targets further down set it via a
-# recursive `make` call to instrument the same test run instead of
-# duplicating its recipe.
+# empty by default, so plain `make test-unit` behaves exactly as before; the
+# *-coverage targets further down set it via a recursive `make` call to
+# instrument the same test run instead of duplicating its recipe.
 COVER_ARGS ?=
+
+# test-integration-scylla/cassandra can't use the same COVER_ARGS trick: they
+# already pass custom, test-binary-defined flags (-distribution, -cluster,
+# ...) that `go test` itself doesn't recognize. Once `go test` hits the first
+# such flag, it stops parsing its own flags -- including the package pattern
+# (./...), which then silently defaults to "." instead of erroring -- so
+# anything placed after it (like COVER_ARGS previously was) is unreliable.
+# COVER_BUILD_ARGS (flags `go test` itself must recognize, e.g. -cover)
+# goes before the package pattern; COVER_RUNTIME_ARGS (everything meant for
+# the test binary, after -args) goes after it, alongside the custom flags.
+COVER_BUILD_ARGS ?=
+COVER_RUNTIME_ARGS ?=
 COVERAGE_DIR ?= $(MAKEFILE_PATH)/.coverage/data
 
 CCM_CASSANDRA_CLUSTER_NAME = gocql_cassandra_integration_test
@@ -286,6 +297,16 @@ scylla-stop: .prepare-scylla-ccm
 	@ccm stop --not-gently ${CCM_SCYLLA_CLUSTER_NAME} 2>/dev/null 1>&2 || true
 	@ccm remove ${CCM_SCYLLA_CLUSTER_NAME} 2>/dev/null 1>&2 || true
 
+# The package pattern below is "." (this package only), not "./...". All
+# integration-tagged test files live in this package; the handful of
+# unconditional (untagged) test files in other packages -- dialer,
+# hostpolicy, several serialization/* packages, etc. -- would also get
+# built and would fail to parse -distribution/-cluster/etc, which only this
+# package's test files register. Cross-package coverage attribution still
+# works without testing those packages directly: -coverpkg=./... controls
+# what gets *instrumented*, separately from what gets *run*, so code in
+# other packages exercised transitively through this package's tests is
+# still measured under test-integration-*-coverage.
 test-integration-cassandra: cassandra-start
 	@echo "Run integration tests for proto ${TEST_CQL_PROTOCOL} on cassandra ${CASSANDRA_VERSION}"
 	if [[ -z "$${CASSANDRA_VERSION_RESOLVED}" ]]; then
@@ -295,8 +316,8 @@ test-integration-cassandra: cassandra-start
 		echo "Cassandra version ${CASSANDRA_VERSION} was not resolved"
 		exit 1
 	fi
-	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" -distribution cassandra -timeout=10m -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${CASSANDRA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./... ${COVER_ARGS}"
-	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" -distribution cassandra -timeout=10m -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$$(ccm node1 versionfrombuild) -cluster=$$(ccm liveset) ./... ${COVER_ARGS}
+	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" ${COVER_BUILD_ARGS} -timeout=10m . -args -distribution cassandra -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${CASSANDRA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ${COVER_RUNTIME_ARGS}"
+	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" ${COVER_BUILD_ARGS} -timeout=10m . -args -distribution cassandra -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$$(ccm node1 versionfrombuild) -cluster=$$(ccm liveset) ${COVER_RUNTIME_ARGS}
 
 test-integration-scylla: scylla-start
 	@echo "Run integration tests for proto ${TEST_CQL_PROTOCOL} on scylla ${SCYLLA_VERSION}"
@@ -312,8 +333,8 @@ test-integration-scylla: scylla-start
 		echo "ScyllaDB version ${SCYLLA_VERSION} was not resolved"
 		exit 1
 	fi
-	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" -distribution scylla $${CLUSTER_SOCKET} -timeout=5m -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./... ${COVER_ARGS}"
-	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" -distribution scylla $${CLUSTER_SOCKET} -timeout=5m -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./... ${COVER_ARGS}
+	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" ${COVER_BUILD_ARGS} -timeout=5m . -args -distribution scylla $${CLUSTER_SOCKET} -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ${COVER_RUNTIME_ARGS}"
+	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" ${COVER_BUILD_ARGS} -timeout=5m . -args -distribution scylla $${CLUSTER_SOCKET} -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ${COVER_RUNTIME_ARGS}
 
 # The lz4 compressor lives in a nested module (lz4/go.mod), so the root "./..."
 # pattern does not reach it — it has to be invoked explicitly with `go test -C`,
@@ -344,20 +365,43 @@ endif
 	@mkdir -p "${COVERAGE_DIR}"
 
 # Coverage-instrumented variants of the targets above. Each recurses into the
-# original target with COVER_ARGS set, rather than duplicating its recipe, so
-# CCM setup, version resolution and GITHUB_STEP_SUMMARY handling stay in one
-# place. Every *-coverage target writes into the same COVERAGE_DIR, so unit
-# and integration runs (and multiple integration runs against different
-# clusters/tags) all accumulate into one combined report -- see
-# coverage-report.
+# original target with COVER_ARGS/COVER_BUILD_ARGS/COVER_RUNTIME_ARGS set,
+# rather than duplicating its recipe, so CCM setup, version resolution and
+# GITHUB_STEP_SUMMARY handling stay in one place. Every *-coverage target
+# writes into the same COVERAGE_DIR, so unit and integration runs (and
+# multiple integration runs against different clusters/tags) all accumulate
+# into one combined report -- see coverage-report.
+#
+# COVERAGE_DIR is quoted (with an escaped \" so the quote survives being
+# re-expanded, unquoted, inside the target recipe's own `go test` line) so a
+# path containing spaces isn't word-split by the shell into several
+# arguments.
+#
+# -covermode=atomic is explicit (rather than relying on -race, which forces
+# it) because `go tool covdata` refuses to merge data recorded under
+# different counter modes ("counter mode clash"): every *-coverage target
+# and ccm-test-coverage need to agree, not just test-unit-coverage, which is
+# the only one that would otherwise get atomic mode for free from -race.
 test-unit-coverage: .prepare-coverage-dir
-	@$(MAKE) test-unit COVER_ARGS="-cover -coverpkg=./... -args -test.gocoverdir=${COVERAGE_DIR}"
+	@$(MAKE) test-unit COVER_ARGS="-cover -covermode=atomic -coverpkg=./... -args -test.gocoverdir=\"${COVERAGE_DIR}\""
 
 test-integration-scylla-coverage: .prepare-coverage-dir
-	@$(MAKE) test-integration-scylla COVER_ARGS="-cover -coverpkg=./... -args -test.gocoverdir=${COVERAGE_DIR}"
+	@$(MAKE) test-integration-scylla COVER_BUILD_ARGS="-cover -covermode=atomic -coverpkg=./..." COVER_RUNTIME_ARGS="-test.gocoverdir=\"${COVERAGE_DIR}\""
 
 test-integration-cassandra-coverage: .prepare-coverage-dir
-	@$(MAKE) test-integration-cassandra COVER_ARGS="-cover -coverpkg=./... -args -test.gocoverdir=${COVERAGE_DIR}"
+	@$(MAKE) test-integration-cassandra COVER_BUILD_ARGS="-cover -covermode=atomic -coverpkg=./..." COVER_RUNTIME_ARGS="-test.gocoverdir=\"${COVERAGE_DIR}\""
+
+# internal/ccm's tests (the only tests the "ccm" build tag selects -- nothing
+# else in the module has a file gated by it) don't take any of the custom
+# flags test-integration-scylla passes (-distribution, -cluster, ...); its
+# test binary doesn't define them and would fail to parse them. It also needs
+# to be targeted directly rather than through ./...: `go test` stops
+# resolving its own flags (including the package pattern) at the first flag
+# it doesn't recognize, so a ./... alongside those custom flags silently
+# collapses to just ".", which is why reusing test-integration-scylla for
+# this never actually ran internal/ccm's tests.
+ccm-test-coverage: .prepare-coverage-dir
+	@go test -tags "ccm gocql_debug" -timeout=5m -v -cover -covermode=atomic -coverpkg=./... ./internal/ccm/... -args -test.gocoverdir="${COVERAGE_DIR}"
 
 # lz4 is a separate Go module (see its go.mod), so a single `go tool covdata`
 # invocation can't render both it and the root module together -- `go tool

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,14 @@ TEST_OPTS ?=
 TEST_INTEGRATION_TAGS ?= integration gocql_debug
 JVM_EXTRA_OPTS ?= -Dcassandra.test.fail_writes_ks=test -Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler
 
+# COVER_ARGS is appended to every `go test ... ./...` invocation below. It is
+# empty by default, so plain `make test-unit`/`test-integration-*` behave
+# exactly as before; the *-coverage targets further down set it via a
+# recursive `make` call to instrument the same test run instead of
+# duplicating its recipe.
+COVER_ARGS ?=
+COVERAGE_DIR ?= $(MAKEFILE_PATH)/.coverage/data
+
 CCM_CASSANDRA_CLUSTER_NAME = gocql_cassandra_integration_test
 CCM_CASSANDRA_IP_PREFIX = 127.0.1.
 CCM_CASSANDRA_REPO ?= github.com/apache/cassandra-ccm
@@ -287,8 +295,8 @@ test-integration-cassandra: cassandra-start
 		echo "Cassandra version ${CASSANDRA_VERSION} was not resolved"
 		exit 1
 	fi
-	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" -distribution cassandra -timeout=10m -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${CASSANDRA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./..."
-	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" -distribution cassandra -timeout=10m -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$$(ccm node1 versionfrombuild) -cluster=$$(ccm liveset) ./...
+	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" -distribution cassandra -timeout=10m -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${CASSANDRA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./... ${COVER_ARGS}"
+	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" -distribution cassandra -timeout=10m -runauth -gocql.timeout=60s -runssl -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$$(ccm node1 versionfrombuild) -cluster=$$(ccm liveset) ./... ${COVER_ARGS}
 
 test-integration-scylla: scylla-start
 	@echo "Run integration tests for proto ${TEST_CQL_PROTOCOL} on scylla ${SCYLLA_VERSION}"
@@ -304,8 +312,8 @@ test-integration-scylla: scylla-start
 		echo "ScyllaDB version ${SCYLLA_VERSION} was not resolved"
 		exit 1
 	fi
-	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" -distribution scylla $${CLUSTER_SOCKET} -timeout=5m -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./..."
-	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" -distribution scylla $${CLUSTER_SOCKET} -timeout=5m -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./...
+	echo "go test -v ${TEST_OPTS} -tags \"${TEST_INTEGRATION_TAGS}\" -distribution scylla $${CLUSTER_SOCKET} -timeout=5m -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./... ${COVER_ARGS}"
+	go test -v ${TEST_OPTS} -tags "${TEST_INTEGRATION_TAGS}" -distribution scylla $${CLUSTER_SOCKET} -timeout=5m -gocql.timeout=60s -proto=${TEST_CQL_PROTOCOL} -rf=3 -clusterSize=3 -autowait=2000ms -compressor=${TEST_COMPRESSOR} -gocql.cversion=$${SCYLLA_VERSION_RESOLVED} -cluster=$$(ccm liveset) ./... ${COVER_ARGS}
 
 # The lz4 compressor lives in a nested module (lz4/go.mod), so the root "./..."
 # pattern does not reach it — it has to be invoked explicitly with `go test -C`,
@@ -318,19 +326,64 @@ test-unit: .prepare-pki
 ifeq ($(shell if [[ -n "$${GITHUB_STEP_SUMMARY}" ]]; then echo "running-in-workflow"; else echo "running-in-shell"; fi), running-in-workflow)
 	echo "### Unit Test Results" >>$${GITHUB_STEP_SUMMARY}
 	echo '```' >>$${GITHUB_STEP_SUMMARY}
-	echo go test -tags unit -timeout=5m -race ./...
+	echo go test -tags unit -timeout=5m -race ./... ${COVER_ARGS}
 	TEST_STATUS=0
-	go test -tags unit -timeout=5m -race ./... | tee -a "$${GITHUB_STEP_SUMMARY}" || TEST_STATUS=$${PIPESTATUS[0]}
-	echo go test -C lz4 -tags unit -timeout=5m -race ./...
+	go test -tags unit -timeout=5m -race ./... ${COVER_ARGS} | tee -a "$${GITHUB_STEP_SUMMARY}" || TEST_STATUS=$${PIPESTATUS[0]}
+	echo go test -C lz4 -tags unit -timeout=5m -race ./... ${COVER_ARGS}
 	LZ4_TEST_STATUS=0
-	go test -C lz4 -tags unit -timeout=5m -race ./... | tee -a "$${GITHUB_STEP_SUMMARY}" || LZ4_TEST_STATUS=$${PIPESTATUS[0]}
+	go test -C lz4 -tags unit -timeout=5m -race ./... ${COVER_ARGS} | tee -a "$${GITHUB_STEP_SUMMARY}" || LZ4_TEST_STATUS=$${PIPESTATUS[0]}
 	echo '```' >>"$${GITHUB_STEP_SUMMARY}"
 	if (( TEST_STATUS != 0 )); then exit "$${TEST_STATUS}"; fi
 	exit "$${LZ4_TEST_STATUS}"
 else
-	go test -v -tags unit -timeout=5m -race ./...
-	go test -C lz4 -v -tags unit -timeout=5m -race ./...
+	go test -v -tags unit -timeout=5m -race ./... ${COVER_ARGS}
+	go test -C lz4 -v -tags unit -timeout=5m -race ./... ${COVER_ARGS}
 endif
+
+.prepare-coverage-dir:
+	@mkdir -p "${COVERAGE_DIR}"
+
+# Coverage-instrumented variants of the targets above. Each recurses into the
+# original target with COVER_ARGS set, rather than duplicating its recipe, so
+# CCM setup, version resolution and GITHUB_STEP_SUMMARY handling stay in one
+# place. Every *-coverage target writes into the same COVERAGE_DIR, so unit
+# and integration runs (and multiple integration runs against different
+# clusters/tags) all accumulate into one combined report -- see
+# coverage-report.
+test-unit-coverage: .prepare-coverage-dir
+	@$(MAKE) test-unit COVER_ARGS="-cover -coverpkg=./... -args -test.gocoverdir=${COVERAGE_DIR}"
+
+test-integration-scylla-coverage: .prepare-coverage-dir
+	@$(MAKE) test-integration-scylla COVER_ARGS="-cover -coverpkg=./... -args -test.gocoverdir=${COVERAGE_DIR}"
+
+test-integration-cassandra-coverage: .prepare-coverage-dir
+	@$(MAKE) test-integration-cassandra COVER_ARGS="-cover -coverpkg=./... -args -test.gocoverdir=${COVERAGE_DIR}"
+
+# lz4 is a separate Go module (see its go.mod), so a single `go tool covdata`
+# invocation can't render both it and the root module together -- `go tool
+# cover` resolves source files against the module rooted at the current
+# directory, and a merged profile spanning two modules fails with "no
+# required module provides package ...". Filter per module with `-pkg` and
+# run `go tool cover` from within each module's own directory instead.
+coverage-report:
+	@echo "Generate coverage report"
+ifeq ($(shell if [[ -n "$${GITHUB_STEP_SUMMARY}" ]]; then echo "running-in-workflow"; else echo "running-in-shell"; fi), running-in-workflow)
+	echo "### Coverage Report" >>$${GITHUB_STEP_SUMMARY}
+	echo '```' >>$${GITHUB_STEP_SUMMARY}
+	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/gocql/gocql/..." | tee -a "$${GITHUB_STEP_SUMMARY}"
+	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/scylladb/gocql/lz4/..." | tee -a "$${GITHUB_STEP_SUMMARY}"
+	echo '```' >>"$${GITHUB_STEP_SUMMARY}"
+else
+	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/gocql/gocql/..."
+	go tool covdata percent -i="${COVERAGE_DIR}" -pkg="github.com/scylladb/gocql/lz4/..."
+endif
+	go tool covdata textfmt -i="${COVERAGE_DIR}" -pkg="github.com/gocql/gocql/..." -o="${MAKEFILE_PATH}/coverage-root.out"
+	go tool cover -html="${MAKEFILE_PATH}/coverage-root.out" -o="${MAKEFILE_PATH}/coverage-root.html"
+	go tool covdata textfmt -i="${COVERAGE_DIR}" -pkg="github.com/scylladb/gocql/lz4/..." -o="${MAKEFILE_PATH}/coverage-lz4.out"
+	cd lz4 && go tool cover -html="${MAKEFILE_PATH}/coverage-lz4.out" -o="${MAKEFILE_PATH}/coverage-lz4.html"
+
+clean-coverage:
+	rm -rf "${COVERAGE_DIR}" "${MAKEFILE_PATH}"/coverage-root.* "${MAKEFILE_PATH}"/coverage-lz4.*
 
 # The benchmarks are behind the `bench` build tag (and, in the root module, some
 # behind `unit`), so the tags have to be passed or `go test -bench` compiles and

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,15 @@ COVER_ARGS ?=
 COVER_BUILD_ARGS ?=
 COVER_RUNTIME_ARGS ?=
 COVERAGE_DIR ?= $(MAKEFILE_PATH)/.coverage/data
+# Normalize to an absolute path even when overridden on the command line
+# (e.g. COVERAGE_DIR=.cov): go test's subpackages (and lz4, run via -C) each
+# execute with their own directory as the working directory, so a relative
+# -test.gocoverdir resolves differently -- and usually inaccessibly -- per
+# package instead of to one shared directory at the repo root. `override` is
+# required here: a variable set on the `make` command line takes precedence
+# over a plain assignment in the Makefile, so without it this would silently
+# do nothing whenever someone actually overrides COVERAGE_DIR.
+override COVERAGE_DIR := $(abspath $(COVERAGE_DIR))
 
 CCM_CASSANDRA_CLUSTER_NAME = gocql_cassandra_integration_test
 CCM_CASSANDRA_IP_PREFIX = 127.0.1.

--- a/policies_test.go
+++ b/policies_test.go
@@ -1578,6 +1578,10 @@ func TestTokenAwarePolicyReset(t *testing.T) {
 func TestTokenAwareHostPolicy_TabletReplicasPresizeAllocRegression(t *testing.T) {
 	t.Parallel()
 
+	if testing.CoverMode() != "" {
+		t.Skip("skipping alloc regression guard: coverage instrumentation adds allocations of its own")
+	}
+
 	const rf = 3
 	result := testing.Benchmark(func(b *testing.B) {
 		policy, s, queries := setupTabletAwareBench(b, 10, 100, rf)


### PR DESCRIPTION
## What

Adds code coverage measurement, runnable both locally (via new `make` targets) and in CI, across the unit suite (root module + the `lz4` submodule) and the integration suite.

- `Makefile`: threads a `COVER_ARGS` variable (empty by default) through the existing `test-unit`, `test-integration-cassandra`, and `test-integration-scylla` recipes, so plain `make test-unit` etc. behave exactly as before. New targets — `test-unit-coverage`, `test-integration-scylla-coverage`, `test-integration-cassandra-coverage` — set `COVER_ARGS` via a recursive `make` call into the *same* recipe, rather than duplicating CCM setup/version resolution/`GITHUB_STEP_SUMMARY` handling. `coverage-report` merges everything accumulated and renders it; `clean-coverage` removes the generated files.
- `.github/workflows/coverage.yml`: new CI job (`ubuntu-latest`) that runs unit coverage plus one integration configuration (Scylla `LATEST`, both the plain and `ccm` tag variants) against a live cluster, posts the merged percentages to the job summary, and uploads the HTML/text reports as a build artifact.
- `CONTRIBUTING.md` / `.gitignore`: docs and ignores for the new targets/artifacts.

## Why this approach

Uses Go's built-in coverage tooling — `go test -cover -coverpkg=./...` combined with `GOCOVERDIR` (introduced in Go 1.20, see the [Go blog post on integration test coverage](https://go.dev/blog/integration-test-coverage)) — rather than a third-party dependency or the older `-coverprofile`/`gocovmerge` combination. Multiple `go test` invocations (root module unit tests, `lz4`'s unit tests, and any number of integration runs against different clusters/tags) can all point at the same coverage data directory and accumulate into one combined report, which `-coverprofile` alone cannot do across separate process invocations.

One real gotcha found while validating this locally: `lz4` is a separate Go module (its own `go.mod`), so a single `go tool covdata` invocation can't render both it and the root module together — `go tool cover` resolves source files against the module rooted at the current directory, and a merged profile spanning two modules fails with `no required module provides package ...`. `coverage-report` works around this with `covdata`'s `-pkg` filter, generating and rendering each module's report separately from within its own directory — confirmed working end-to-end locally (root module and `lz4` module reports both render correctly, `-coverpkg=./...` correctly attributes coverage exercised transitively through other packages' tests, e.g. several `serialization/*` packages show far higher coverage in the merged report than any single package's own test run reports in isolation).

Coverage results are surfaced via a GitHub Actions job summary + artifact rather than Codecov/another third-party service, matching the same choice already made for the [Python driver's equivalent tooling](https://github.com/scylladb/python-driver/pull/967), to avoid needing an external account or token for this first pass. No `fail_under`-style gate yet — this establishes a baseline first.

## Testing

Verified end-to-end locally: ran `make test-unit-coverage` (root module + `lz4`) and `make coverage-report`, confirmed both per-module HTML/text reports render correctly with real, non-trivial coverage (root module ~74-75%, `lz4` ~93%), and confirmed the `COVER_ARGS`-threading leaves plain `make test-unit`/`test-integration-*` byte-for-byte unchanged when unset. Did not run the integration-coverage targets locally (no local Cassandra/Scylla via CCM in this environment); that leg is exercised by the new CI job on this PR.

Two root-module unit tests (`TestQueryMultinodeWithMetrics`, `TestSpeculativeExecution`) failed locally with `bind: can't assign requested address` for `127.0.0.2:9042` — a macOS-only loopback-alias limitation unrelated to this change (Linux, where CI runs, doesn't need the alias).