### PR TITLE
fix: make system-query timeout fields atomic

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -194,6 +194,17 @@ type ClusterConfig struct {
 	//    For that, see ConnectTimeout.
 	Timeout time.Duration
 	// The timeout for the requests to the schema tables. (default: 60s)
+	//
+	// Zero means the driver does not bound these queries itself: it arms no
+	// client-side deadline, and against ScyllaDB it sends them without the
+	// " USING TIMEOUT ...ms" override, so how long they may run is left to the
+	// server's own configuration - its request timeouts, or the service level in
+	// force. Nothing else on the driver side steps in: controlConn.runQuery, which
+	// every schema-table read goes through, passes a context with no deadline, and
+	// the connection's read deadline is disarmed while waiting for a response to
+	// begin. Schema agreement is the exception, bounding its own queries by
+	// MaxWaitSchemaAgreement. Set a positive value to keep these queries under a
+	// deadline of the client's choosing.
 	MetadataSchemaRequestTimeout time.Duration
 	// ConnectTimeout limits the time spent during connection setup.
 	// During initial connection setup, internal queries, AUTH requests will return an error if the client

--- a/conn.go
+++ b/conn.go
@@ -240,17 +240,25 @@ type Conn struct {
 	//
 	// Atomic because UseKeyspace is exported: a caller invoking it on a live
 	// connection would otherwise race the request goroutines reading it.
-	currentKeyspace      atomic.Pointer[string]
-	addr                 string
-	usingTimeoutClause   string
-	cqlProtoExts         []cqlProtocolExtension
-	scyllaSupported      ScyllaConnectionFeatures
-	systemRequestTimeout time.Duration
-	writeTimeout         atomic.Int64
-	mu                   sync.Mutex
-	tabletsRoutingV1     int32
-	headerBuf            [headSize]byte
-	isShardAware         bool
+	currentKeyspace atomic.Pointer[string]
+	addr            string
+	// systemRequest carries the timeouts driver-issued system queries are sent
+	// with. See systemRequestState for why the two travel together.
+	//
+	// Atomic because finalizeConnection switches the timeout from
+	// cfg.ConnectTimeout to cfg.MetadataSchemaRequestTimeout at the very end of
+	// Session.init, by which point the control connection is already registered
+	// for server push events: a SCHEMA_CHANGE arriving inside that window makes
+	// the event-debouncer goroutine run querySystem on this connection
+	// concurrently with the write.
+	systemRequest    atomic.Pointer[systemRequestState]
+	cqlProtoExts     []cqlProtocolExtension
+	scyllaSupported  ScyllaConnectionFeatures
+	writeTimeout     atomic.Int64
+	mu               sync.Mutex
+	tabletsRoutingV1 int32
+	headerBuf        [headSize]byte
+	isShardAware     bool
 	// true if connection close process for the connection started.
 	// closed is protected by mu.
 	closed     bool
@@ -266,15 +274,58 @@ func (c *Conn) setSchemaV2(s bool) {
 	c.isSchemaV2 = s
 }
 
-func (c *Conn) setSystemRequestTimeout(t time.Duration) {
-	c.systemRequestTimeout = t
-	c.recalculateSystemRequestTimeout()
+// systemRequestState is the immutable pair of timeouts a driver-issued system
+// query is sent with: the client-side deadline, and the ScyllaDB-only
+// " USING TIMEOUT ...ms" clause pre-rendered from it (empty when the clause does
+// not apply). The two are published as one snapshot so a reader can never pair
+// one with a stale version of the other - which would ask the server to abort a
+// system query on a deadline the client is not waiting on, or vice versa.
+//
+// Field order keeps the string first so the GC scans 8 pointer bytes, not 16
+// (govet's fieldalignment).
+type systemRequestState struct {
+	usingClause string
+	timeout     time.Duration
 }
 
-func (c *Conn) recalculateSystemRequestTimeout() {
-	if c.systemRequestTimeout > time.Duration(0) && c.isScyllaConn() {
-		c.usingTimeoutClause = " USING TIMEOUT " + strconv.FormatInt(c.systemRequestTimeout.Milliseconds(), 10) + "ms"
+// systemRequestStatement returns stmt with the USING TIMEOUT clause appended and
+// the client-side timeout to send it with, both taken from one snapshot so the
+// two can never disagree. It is the only way the query paths should reach them.
+func (c *Conn) systemRequestStatement(stmt string) (string, time.Duration) {
+	state := c.getSystemRequestState()
+	return stmt + state.usingClause, state.timeout
+}
+
+// getSystemRequestState returns the current snapshot.
+func (c *Conn) getSystemRequestState() systemRequestState {
+	if state := c.systemRequest.Load(); state != nil {
+		return *state
 	}
+	return systemRequestState{}
+}
+
+// setSystemRequestTimeout publishes t together with the clause derived from it.
+// The clause is ScyllaDB-only and needs a positive timeout, so it is empty
+// otherwise - a timeout the caller disabled must not leave an older clause in
+// force.
+func (c *Conn) setSystemRequestTimeout(t time.Duration) {
+	next := systemRequestState{timeout: t}
+	if t > time.Duration(0) && c.isScyllaConn() {
+		next.usingClause = " USING TIMEOUT " + strconv.FormatInt(t.Milliseconds(), 10) + "ms"
+	}
+	c.systemRequest.Store(&next)
+}
+
+// recalculateSystemRequestTimeout re-renders the clause for the timeout already
+// in effect. It is called once the connection knows whether it talks to
+// ScyllaDB, which the clause depends on.
+//
+// It re-reads the timeout rather than naming the value its only caller knows is
+// in force (cfg.ConnectTimeout, from dialWithoutObserver): republishing whatever
+// is current cannot overwrite a timeout some later change publishes earlier in
+// startup, which would put every system query back under an unrelated setting.
+func (c *Conn) recalculateSystemRequestTimeout() {
+	c.setSystemRequestTimeout(c.getSystemRequestState().timeout)
 }
 
 func (c *Conn) finalizeConnection() {
@@ -424,12 +475,12 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 			semaphore: make(chan struct{}, 1),
 			quit:      make(chan struct{}),
 		},
-		ctx:                  ctx,
-		cancel:               cancel,
-		logger:               cfg.logger(),
-		streamObserver:       s.streamObserver,
-		systemRequestTimeout: cfg.ConnectTimeout,
+		ctx:            ctx,
+		cancel:         cancel,
+		logger:         cfg.logger(),
+		streamObserver: s.streamObserver,
 	}
+	c.setSystemRequestTimeout(cfg.ConnectTimeout)
 
 	if err := c.init(ctx, dialedHost); err != nil {
 		cancel()
@@ -2927,12 +2978,13 @@ func (c *Conn) executeBatch(ctx context.Context, batch *Batch) (iter *Iter) {
 }
 
 func (c *Conn) querySystem(ctx context.Context, query string, values ...any) *Iter {
-	q := c.session.Query(query+c.usingTimeoutClause, values...).Consistency(One).Trace(nil)
+	stmt, timeout := c.systemRequestStatement(query)
+	q := c.session.Query(stmt, values...).Consistency(One).Trace(nil)
 	q.skipPrepare = true
 	q.disableSkipMetadata = true
 	// we want to keep the query on this connection
 	q.conn = c
-	q.SetRequestTimeout(c.systemRequestTimeout)
+	q.SetRequestTimeout(timeout)
 	return c.executeQuery(ctx, q)
 }
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -4251,3 +4251,159 @@ func TestStartupOptionsKeepDriverKeys(t *testing.T) {
 type applicationInfoFunc func(map[string]string)
 
 func (f applicationInfoFunc) UpdateStartupOptions(opts map[string]string) { f(opts) }
+
+// TestSystemRequestTimeoutRaceWithFinalizeConnection pins the state
+// driver-issued system queries read (Conn.systemRequest, holding the client-side
+// timeout and the pre-rendered USING TIMEOUT clause) as safe to read while
+// finalizeConnection switches it from ConnectTimeout to
+// MetadataSchemaRequestTimeout.
+//
+// The two are concurrent in practice: the control connection is registered for
+// server push events during controlConn.setupConn, but its
+// finalizeConnection() is deferred to the very end of Session.init. A keyspace
+// SCHEMA_CHANGE delivered inside that window (a freshly bootstrapped cluster
+// still creating its internal keyspaces is enough) makes the event-debouncer
+// goroutine run handleKeyspaceChange -> awaitSchemaAgreement -> querySystem on
+// the connection the main goroutine is mid-write on.
+//
+// Run under -race: were the two values plain fields again, this would report
+// "DATA RACE" on them — a torn string header for the clause and a stale timeout.
+func TestSystemRequestTimeoutRaceWithFinalizeConnection(t *testing.T) {
+	t.Parallel()
+
+	// finalizeConnection only stores into atomics - Conn.writeTimeout,
+	// Conn.systemRequest, and the timeout field of each of these two - so neither
+	// needs a net.Conn behind it.
+	c := &Conn{
+		r: &connReader{},
+		w: &deadlineContextWriter{},
+		cfg: &ConnConfig{
+			ConnectTimeout: 10 * time.Second,
+			WriteTimeout:   2 * time.Second,
+			ReadTimeout:    3 * time.Second,
+		},
+		session: &Session{
+			cfg: ClusterConfig{MetadataSchemaRequestTimeout: 42 * time.Millisecond},
+		},
+		// Only a ScyllaDB connection renders the USING TIMEOUT clause.
+		scyllaSupported: ScyllaConnectionFeatures{
+			ScyllaHostFeatures: ScyllaHostFeatures{isScylla: true},
+		},
+	}
+	c.setSystemRequestTimeout(c.cfg.ConnectTimeout)
+
+	// The only two snapshots a reader may observe: the one the connection is
+	// dialed with, and the one finalizeConnection replaces it with. Spelling both
+	// out keeps this test from re-deriving the rendering rule, which is
+	// TestSystemRequestStateClauseFollowsTimeout's job.
+	var (
+		beforeFinalize = systemRequestState{
+			timeout:     c.cfg.ConnectTimeout,
+			usingClause: " USING TIMEOUT 10000ms",
+		}
+		afterFinalize = systemRequestState{
+			timeout:     c.session.cfg.MetadataSchemaRequestTimeout,
+			usingClause: " USING TIMEOUT 42ms",
+		}
+	)
+
+	const readers = 4
+	done := make(chan struct{})
+	var wg, spinning sync.WaitGroup
+	wg.Add(readers)
+	spinning.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			first := true
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				// The single load querySystem performs.
+				state := c.getSystemRequestState()
+				if first {
+					// Only write once every reader is already spinning, so the
+					// two sides genuinely overlap.
+					spinning.Done()
+					first = false
+				}
+				// Both values must come from the same snapshot: the clause the
+				// server is asked to honour always matches the deadline the
+				// client is waiting on, never the other transition's value.
+				if state != beforeFinalize && state != afterFinalize {
+					t.Errorf("observed %+v, which is neither transition's snapshot; want %+v or %+v",
+						state, beforeFinalize, afterFinalize)
+					return
+				}
+			}
+		}()
+	}
+
+	spinning.Wait()
+	c.finalizeConnection()
+	close(done)
+	wg.Wait()
+
+	require.Equal(t, afterFinalize, c.getSystemRequestState(),
+		"finalizeConnection should publish the metadata timeout and its clause as one snapshot")
+}
+
+// TestSystemRequestStateClauseFollowsTimeout pins the USING TIMEOUT clause as
+// derived purely from the timeout in effect and whether the peer is ScyllaDB.
+//
+// The zero case is the one worth guarding: MetadataSchemaRequestTimeout is
+// documented as "positive or zero" (see ClusterConfig.Validate), and by the time
+// finalizeConnection applies it, startupCoordinator.options has already rendered a
+// clause from ConnectTimeout. Were that clause carried over, a caller who disabled
+// the metadata timeout would still have every system query bounded server-side by
+// an unrelated setting - while DRIVER_CONFIG reported no timeout at all, since
+// buildControlPlaneReport omits a non-positive one.
+func TestSystemRequestStateClauseFollowsTimeout(t *testing.T) {
+	t.Parallel()
+
+	newConn := func(isScylla bool) *Conn {
+		c := &Conn{scyllaSupported: ScyllaConnectionFeatures{
+			ScyllaHostFeatures: ScyllaHostFeatures{isScylla: isScylla},
+		}}
+		// As startupCoordinator.options leaves it: a clause rendered from
+		// ConnectTimeout, before finalizeConnection applies the metadata timeout.
+		c.setSystemRequestTimeout(600 * time.Millisecond)
+		return c
+	}
+
+	t.Run("scylla renders the clause", func(t *testing.T) {
+		require.Equal(t, systemRequestState{
+			timeout:     600 * time.Millisecond,
+			usingClause: " USING TIMEOUT 600ms",
+		}, newConn(true).getSystemRequestState())
+	})
+
+	t.Run("cassandra renders no clause", func(t *testing.T) {
+		require.Equal(t, systemRequestState{timeout: 600 * time.Millisecond},
+			newConn(false).getSystemRequestState())
+	})
+
+	t.Run("a disabled timeout clears the clause", func(t *testing.T) {
+		c := newConn(true)
+		c.setSystemRequestTimeout(0)
+		require.Equal(t, systemRequestState{}, c.getSystemRequestState(),
+			"a zero metadata timeout must not leave the ConnectTimeout clause in force")
+	})
+
+	// The cases above assert the snapshot itself; this one goes through
+	// systemRequestStatement, which is how the query paths reach it.
+	t.Run("the statement carries the clause in force", func(t *testing.T) {
+		c := newConn(true)
+		stmt, timeout := c.systemRequestStatement(qrySystemLocal)
+		require.Equal(t, qrySystemLocal+" USING TIMEOUT 600ms", stmt)
+		require.Equal(t, 600*time.Millisecond, timeout)
+
+		c.setSystemRequestTimeout(0)
+		stmt, timeout = c.systemRequestStatement(qrySystemLocal)
+		require.Equal(t, qrySystemLocal, stmt, "a disabled timeout appends nothing")
+		require.Equal(t, time.Duration(0), timeout)
+	})
+}

--- a/control.go
+++ b/control.go
@@ -553,9 +553,10 @@ func (c *controlConn) writeFrame(w frameBuilder) (frame, error) {
 // query will return nil if the connection is closed or nil
 func (c *controlConn) querySystem(statement string, values ...any) (iter *Iter) {
 	conn := c.getConn().conn.(*Conn)
-	return c.runQuery(c.session.Query(statement+conn.usingTimeoutClause, values...).
+	stmt, timeout := conn.systemRequestStatement(statement)
+	return c.runQuery(c.session.Query(stmt, values...).
 		Consistency(One).
-		SetRequestTimeout(conn.systemRequestTimeout).
+		SetRequestTimeout(timeout).
 		RoutingKey([]byte{}).
 		Trace(nil))
 }

--- a/driver_config.go
+++ b/driver_config.go
@@ -643,7 +643,7 @@ func buildControlPlaneReport(cfg *ClusterConfig, isScyllaConn bool) controlPlane
 		if isScyllaConn {
 			// The USING TIMEOUT clause is ScyllaDB-only, so this key only ever
 			// applies against Scylla -- and it carries whatever
-			// Conn.recalculateSystemRequestTimeout put in the clause, which
+			// Conn.setSystemRequestTimeout put in the clause, which
 			// truncates rather than floors: a sub-millisecond timeout is sent as
 			// "USING TIMEOUT 0ms". Derive it from the same conversion so the
 			// report cannot claim a clause the connection never sends, and omit

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -88,7 +88,7 @@ func TestDriverConfigReporterStartupOptions(t *testing.T) {
 // TestDriverConfigReporterStartupOptions_ScyllaConnGatesServerSideMs pins that
 // control-plane.queries.system.timeout.server-side-ms only appears when the
 // connection is talking to Scylla, mirroring the USING TIMEOUT clause in
-// Conn.recalculateSystemRequestTimeout.
+// Conn.setSystemRequestTimeout.
 func TestDriverConfigReporterStartupOptions_ScyllaConnGatesServerSideMs(t *testing.T) {
 	cfg := *NewCluster("127.0.0.1")
 	s := newTestReportSession(cfg, TokenAwareHostPolicy(RoundRobinHostPolicy()))
@@ -698,7 +698,7 @@ func TestBuildControlPlaneReport(t *testing.T) {
 			},
 		},
 		{
-			// Conn.recalculateSystemRequestTimeout truncates when it builds the
+			// Conn.setSystemRequestTimeout truncates when it builds the
 			// USING TIMEOUT clause, so this connection really is sent
 			// "USING TIMEOUT 0ms". The schema cannot carry that, so the key is
 			// omitted rather than rounded up to a clause never sent.
@@ -816,7 +816,7 @@ func TestBuildReport_SubMillisecondTimeouts(t *testing.T) {
 	}
 
 	// server-side-ms is the exception, and deliberately so: it reports the
-	// USING TIMEOUT clause, which Conn.recalculateSystemRequestTimeout builds by
+	// USING TIMEOUT clause, which Conn.setSystemRequestTimeout builds by
 	// truncating. A sub-millisecond timeout is sent as "USING TIMEOUT 0ms", and
 	// the schema cannot carry a 0 here, so the key is omitted rather than
 	// claiming a 1ms clause the connection never sends.


### PR DESCRIPTION
Conn.systemRequestTimeout and the pre-rendered Conn.usingTimeoutClause were plain fields, but they are written and read concurrently.

finalizeConnection switches them from cfg.ConnectTimeout to cfg.MetadataSchemaRequestTimeout, and for the control connection that call is deferred to the very end of Session.init - long after controlConn.setupConn registered the connection for server push events. A keyspace SCHEMA_CHANGE delivered inside that window makes the event-debouncer goroutine run handleKeyspaceChange -> awaitSchemaAgreement -> querySystem on the connection the main goroutine is mid-write on. Neither side took c.mu, so a reader could observe a torn string header for the clause or a stale timeout. A freshly bootstrapped Scylla cluster still creating its internal keyspaces is enough to hit this, which is how it showed up as a -race abort in the driver matrix.

Guard both with atomics, the way writeTimeout and currentKeyspace on the same struct already are, and route every reader through accessors - including controlConn.querySystem, which reads the same two fields.

Fixes: https://github.com/scylladb/gocql/issues/993