### PR TITLE
test: make TestOpQueueRun deterministic instead of racy

### DIFF
--- a/tablets/cow_tablet_list_test.go
+++ b/tablets/cow_tablet_list_test.go
@@ -1115,12 +1115,16 @@ func TestOpQueueRun(t *testing.T) {
 		}
 	}
 
-	runQueue := func(send func(q *opQueue), wantTypes []string, validate func(t *testing.T, processed []tabletOp)) {
+	runQueue := func(t *testing.T, seed func(q *opQueue), wantTypes []string, validate func(t *testing.T, processed []tabletOp)) {
 		t.Helper()
 
 		q := newOpQueue()
 		var mu sync.Mutex
 		processed := make([]tabletOp, 0, len(wantTypes))
+		// Enqueue all ops before starting the writer goroutine: coalescing in
+		// next() stops as soon as the channel is momentarily empty, so enqueueing
+		// concurrently with the writer makes the coalesced batch sizes racy.
+		seed(q)
 		go q.run(func(op tabletOp) {
 			mu.Lock()
 			processed = append(processed, op)
@@ -1129,8 +1133,10 @@ func TestOpQueueRun(t *testing.T) {
 				close(flush.done)
 			}
 		})
-
-		send(q)
+		// flush() acts as a barrier: it completes only once every previously
+		// queued op has been processed, so close() cannot race the writer and
+		// drop buffered ops.
+		q.flush()
 		q.close()
 
 		mu.Lock()
@@ -1164,11 +1170,10 @@ func TestOpQueueRun(t *testing.T) {
 	}
 
 	t.Run("CoalescesBufferedAddOps", func(t *testing.T) {
-		runQueue(func(q *opQueue) {
+		runQueue(t, func(q *opQueue) {
 			q.send(opAddTablet{tablet: newTablet(0, 99)})
 			q.send(opAddTablet{tablet: newTablet(100, 199)})
 			q.send(opAddTablet{tablet: newTablet(200, 299)})
-			q.flush()
 		}, []string{"bulk", "flush"}, func(t *testing.T, processed []tabletOp) {
 			bulk := processed[0].(opBulkAddTablets)
 			if len(bulk.tablets) != 3 {
@@ -1178,14 +1183,12 @@ func TestOpQueueRun(t *testing.T) {
 	})
 
 	t.Run("DoesNotCrossFlushOrNonAddBoundaries", func(t *testing.T) {
-		runQueue(func(q *opQueue) {
-			flushDone := make(chan struct{})
+		runQueue(t, func(q *opQueue) {
 			q.send(opAddTablet{tablet: newTablet(0, 99)})
-			q.send(opFlush{done: flushDone})
+			q.send(opFlush{done: make(chan struct{})})
 			q.send(opRemoveHost{hostID: testHostUUID("host-1")})
 			q.send(opAddTablet{tablet: newTablet(100, 199)})
-			<-flushDone
-		}, []string{"bulk", "flush", "removeHost", "bulk"}, func(t *testing.T, processed []tabletOp) {
+		}, []string{"bulk", "flush", "removeHost", "bulk", "flush"}, func(t *testing.T, processed []tabletOp) {
 			first := processed[0].(opBulkAddTablets)
 			second := processed[3].(opBulkAddTablets)
 			if len(first.tablets) != 1 || len(second.tablets) != 1 {


### PR DESCRIPTION
## What

Fixes the flaky `TestOpQueueRun` in `tablets/cow_tablet_list_test.go` (issue #995). The test was born flaky in 0ce72a1c and intermittently reds the CI "Build" job for **unrelated** PRs — it recently failed scylladb/gocql#910, which touches only `marshal.go`.

## Root cause

Three defects, all in the `runQueue` helper:

1. **Coalescing race (primary).** The writer goroutine started *before* ops were enqueued. `opQueue.next()` stops coalescing as soon as the channel is momentarily empty (`default:` branch), so a fast writer emitted each `opAddTablet` as its own `opBulkAddTablets` → `processed 4 ops, want 2`.
2. **close() vs buffered ops.** `q.close()` closes `quit` once in-flight senders drain; `next()` then `select`s between `<-q.quit` and `<-q.ops`, so ops still buffered in the 4096-cap channel could be dropped → `processed 3 ops, want 4`.
3. **FailNow on the parent test.** `runQueue` captured `TestOpQueueRun`'s `*testing.T` and called `t.Fatalf` on it from subtest goroutines, surfacing as the confusing `test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test`.

## Fix (test-only, deterministic)

- Enqueue (seed) all ops **before** starting the writer goroutine, so coalescing is deterministic.
- Use `q.flush()` as a barrier **before** `q.close()`, guaranteeing every queued op is processed before `quit` is closed — no dropped ops.
- Pass the subtest's own `*testing.T` into `runQueue`.

## Verification

- Reproduced the flake pre-fix: `go test -tags unit -race -count=20 -run TestOpQueueRun ./tablets/` (failed with all three variants above).
- Post-fix: `-race -count=1000 -run TestOpQueueRun ./tablets/` passes; whole `./tablets/` package passes `-race -count=3`; `gofmt`/`go vet` clean.