### PR TITLE
docs: prepare v1.19.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add the following line to your project `go.mod` file.
 replace github.com/gocql/gocql => github.com/scylladb/gocql <version>
 ```
 
-Replace `<version>` with a concrete released tag (for example `v1.7.3`) or a
+Replace `<version>` with a concrete released tag (for example `v1.19.0`) or a
 pseudo-version; `latest` is not a valid version in a `replace` directive. Note
 that the module path is `github.com/gocql/gocql` (no `/v2` suffix), so `v2.x`
 tags are not valid replacement versions here — use a `v1` tag or a
@@ -287,24 +287,23 @@ config.Compressor = &lz4.LZ4Compressor{}
 ...
 ```
 
+When explicitly using native protocol v5, use LZ4 compression or no compression.
+`SnappyCompressor` does not support v5 transport segments and is rejected when
+`ProtoVersion` is 5 or newer. Protocol v5 is not selected by automatic protocol
+discovery; it must currently be configured explicitly.
+
 LZ4 support is provided as an optional sub-module with its own `go.mod`. Because it uses the
 same fork pattern as the parent module, add a second `replace` directive alongside the one from
 the Installation section:
 
 ```mod
-replace github.com/gocql/gocql => github.com/scylladb/gocql <version>
-replace github.com/gocql/gocql/lz4 => github.com/scylladb/gocql/lz4 <lz4-version>
+replace github.com/gocql/gocql => github.com/scylladb/gocql v1.19.0
+replace github.com/gocql/gocql/lz4 => github.com/scylladb/gocql/lz4 v1.19.0
 ```
 
-The two versions are independent, and `<lz4-version>` cannot be a release tag today: Go resolves
-a version of a sub-directory module through a tag prefixed with that subdirectory, so `v1.7.3`
-is looked up as the tag `lz4/v1.7.3`. This repository publishes no `lz4/v*` tags, so such a
-directive fails with `invalid version: unknown revision lz4/v1.7.3`. Use a pseudo-version
-instead — this prints one for the current `master`:
-
-```sh
-go list -m github.com/scylladb/gocql/lz4@master   # or @<commit-sha>
-```
+The two modules are versioned independently. The repository tag for the nested module is
+prefixed with its directory (`lz4/v1.19.0`), while the version used in a `go.mod` directive is
+`v1.19.0` as shown above.
 
 Then run `go mod tidy`.
 

--- a/cluster.go
+++ b/cluster.go
@@ -169,11 +169,12 @@ type ClusterConfig struct {
 	MaxWaitSchemaAgreement time.Duration
 	// ProtoVersion sets the version of the native protocol to use, this will
 	// enable features in the driver for specific protocol versions, generally this
-	// should be set to a known version (2,3,4) for the cluster being connected to.
+	// should be set to a supported version (3,4,5) for the cluster being connected to.
 	//
 	// If it is 0 or unset (the default) then the driver will attempt to discover the
-	// highest supported protocol for the cluster. In clusters with nodes of different
-	// versions the protocol selected is not defined (ie, it can be any of the supported in the cluster)
+	// highest supported protocol up to version 4. Protocol version 5 must currently
+	// be selected explicitly. In clusters with nodes of different versions the protocol
+	// selected is not defined (ie, it can be any of the supported in the cluster).
 	ProtoVersion int
 	// Maximum number of inflight requests allowed per connection.
 	// Default: 32768 for CQL v3 and newer


### PR DESCRIPTION
## Summary

- document the v1.19.0 root and nested LZ4 module versions
- document protocol v5 compression constraints and explicit opt-in
- update `ClusterConfig.ProtoVersion` documentation for v5

## Release follow-up

After this merges, create both `v1.19.0` and `lz4/v1.19.0` at the merged release commit.

## Tests

- `go test -tags unit ./...`
- `go test -C lz4 -tags unit ./...`