### PR TITLE
dialer: record and replay native protocol v5 connections

### DIFF
--- a/.github/workflows/bench-tests.yml
+++ b/.github/workflows/bench-tests.yml
@@ -5,11 +5,24 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+    # labeled is here because the job below is gated on a label. Without it the gate
+    # is unreachable on an open pull request: the condition reads the label list out
+    # of the triggering event's payload, so adding the label afterwards cannot start
+    # the job, and re-running the old workflow replays the payload that lacked it.
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   bench-tests:
-    if: contains(github.event.pull_request.labels.*.name, 'run-benchmark-tests')
+    # On a push to master the benchmarks always run; that is what the push trigger
+    # above declares, and without this disjunct it was dead, because a push event
+    # carries no pull_request in its payload, so the label condition was always
+    # false. On a pull request the label has to be on it, and a `labeled` event has
+    # to be the one that added it -- otherwise every later label on a pull request
+    # that already carries this one re-runs the whole benchmark suite.
+    if: >-
+      github.event_name == 'push'
+      || (contains(github.event.pull_request.labels.*.name, 'run-benchmark-tests')
+      && (github.event.action != 'labeled' || github.event.label.name == 'run-benchmark-tests'))
     name: Run benchmark tests
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -448,19 +448,46 @@ clean-coverage:
 # themselves belong to test-unit.
 BENCH_OPTS = -tags "bench unit" -run '^$$' -bench=. -benchmem
 
+# Each module's status is captured rather than left to abort the recipe, on both branches.
+# .SHELLFLAGS is -eo pipefail, so a bare failing command takes the whole target down where
+# it stands -- skipping the modules after it, and in the workflow branch the closing fence
+# with them. The tests/bench run is last and is the one that matters most: it is the only
+# end-to-end check that the frame hashing still matches a recording, and a root-module
+# regression must not be what stops it from running. The bench workflow is label-gated, so
+# on most changes the shell branch below is the only one that ever runs this at all.
+# test-unit's workflow branch does the same dance for the same reason; its shell branch
+# does not, so a root-module failure there still skips lz4.
 test-bench:
 	@echo "Run benchmark tests"
 ifeq ($(shell if [[ -n "$${GITHUB_STEP_SUMMARY}" ]]; then echo "running-in-workflow"; else echo "running-in-shell"; fi), running-in-workflow)
 	echo "### Benchmark Results" >>$${GITHUB_STEP_SUMMARY}
 	echo '```' >>"$${GITHUB_STEP_SUMMARY}"
 	echo go test ${BENCH_OPTS} ./...
-	go test ${BENCH_OPTS} ./... | tee -a >>"$${GITHUB_STEP_SUMMARY}"
+	BENCH_STATUS=0
+	go test ${BENCH_OPTS} ./... | tee -a "$${GITHUB_STEP_SUMMARY}" || BENCH_STATUS=$${PIPESTATUS[0]}
 	echo go test -C lz4 ${BENCH_OPTS} ./...
-	go test -C lz4 ${BENCH_OPTS} ./... | tee -a >>"$${GITHUB_STEP_SUMMARY}"
+	LZ4_BENCH_STATUS=0
+	go test -C lz4 ${BENCH_OPTS} ./... | tee -a "$${GITHUB_STEP_SUMMARY}" || LZ4_BENCH_STATUS=$${PIPESTATUS[0]}
+	echo go test -C tests/bench ${BENCH_OPTS} ./...
+	REPLAY_BENCH_STATUS=0
+	go test -C tests/bench ${BENCH_OPTS} ./... | tee -a "$${GITHUB_STEP_SUMMARY}" || REPLAY_BENCH_STATUS=$${PIPESTATUS[0]}
 	echo '```' >>"$${GITHUB_STEP_SUMMARY}"
+	if (( BENCH_STATUS != 0 )); then exit "$${BENCH_STATUS}"; fi
+	if (( LZ4_BENCH_STATUS != 0 )); then exit "$${LZ4_BENCH_STATUS}"; fi
+	exit "$${REPLAY_BENCH_STATUS}"
 else
-	go test ${BENCH_OPTS} ./...
-	go test -C lz4 ${BENCH_OPTS} ./...
+	echo go test ${BENCH_OPTS} ./...
+	BENCH_STATUS=0
+	go test ${BENCH_OPTS} ./... || BENCH_STATUS=$$?
+	echo go test -C lz4 ${BENCH_OPTS} ./...
+	LZ4_BENCH_STATUS=0
+	go test -C lz4 ${BENCH_OPTS} ./... || LZ4_BENCH_STATUS=$$?
+	echo go test -C tests/bench ${BENCH_OPTS} ./...
+	REPLAY_BENCH_STATUS=0
+	go test -C tests/bench ${BENCH_OPTS} ./... || REPLAY_BENCH_STATUS=$$?
+	if (( BENCH_STATUS != 0 )); then exit "$${BENCH_STATUS}"; fi
+	if (( LZ4_BENCH_STATUS != 0 )); then exit "$${LZ4_BENCH_STATUS}"; fi
+	exit "$${REPLAY_BENCH_STATUS}"
 endif
 
 check-go-mod-drift:

--- a/conn.go
+++ b/conn.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gocql/gocql/tablets"
 
 	"github.com/gocql/gocql/internal/lru"
+	"github.com/gocql/gocql/internal/segment"
 	"github.com/gocql/gocql/internal/streams"
 )
 
@@ -202,16 +203,26 @@ type Conn struct {
 	ctx            context.Context
 	errorHandler   ConnErrorHandler
 	compressor     Compressor
-	supported      map[string][]string
-	streams        *streams.IDGenerator
-	host           *HostInfo
+	// segCompressor is compressor narrowed to the two Append methods the v5 segment
+	// codec takes, resolved once by resolveSegmentCompressor during the handshake. The
+	// receive path would otherwise repeat that assertion for every segment it reads,
+	// for a result that cannot change: compressor is written at dial and once more by
+	// startupCoordinator.startup, and never again.
+	//
+	// Nil is the uncompressed segment layout, and is also what a pre-v5 connection
+	// leaves it as -- it never reaches the segment codec, and its compressor need not
+	// support segments at all.
+	segCompressor segment.Compressor
+	supported     map[string][]string
+	streams       *streams.IDGenerator
+	host          *HostInfo
 	// calls stores a map from stream ID to callReq.
 	// This map is protected by mu.
 	// calls should not be used when closed is true, calls is set to nil when closed=true.
 	calls map[int]*callReq
 	// segScratch holds the reusable buffers inbound v5 segments are read into.
 	// Only touched by the receive path, which runs on the serve() goroutine.
-	segScratch segmentScratch
+	segScratch segment.Scratch
 	// headerReader is the reader the current frame or segment header is read
 	// through (see readFrameHeader, readFirstSegmentHeader). Reused rather than
 	// allocated per header, and like segScratch only touched by whichever
@@ -733,6 +744,12 @@ func (s *startupCoordinator) startup(ctx context.Context, startupCompleted *atom
 		if _, ok := m["COMPRESSION"]; !ok {
 			s.conn.compressor = nil
 		}
+	}
+
+	// The compressor is final now. Resolve its v5 segment view here rather than in
+	// initFramerCache: the auth exchange below is already segmented, and runs first.
+	if err := s.conn.resolveSegmentCompressor(); err != nil {
+		return err
 	}
 
 	for _, ext := range s.conn.cqlProtoExts {
@@ -1335,13 +1352,13 @@ func (c *Conn) recvSegment(ctx context.Context) error {
 		return err
 	}
 
-	payload, err := readSegmentPayload(c.r, hdr, c.compressor, &c.segScratch)
+	payload, err := c.readSegmentPayload(hdr)
 	if err != nil {
 		return err
 	}
 	netEnd := c.observedNow()
 
-	if hdr.isSelfContained {
+	if hdr.IsSelfContained {
 		// The segment holds one or more complete CQL frames.
 		return c.processAllFramesInSegment(ctx, bytes.NewReader(payload), netStart, netEnd)
 	}
@@ -1432,7 +1449,7 @@ func (h *headerReader) Read(p []byte) (int, error) {
 // the stream at an unknown offset, so it stays a plain error and takes the
 // connection down rather than mis-framing everything that follows. That is the
 // timeout the re-arm above makes reachable.
-func (c *Conn) readFirstSegmentHeader() (segmentHeader, error) {
+func (c *Conn) readFirstSegmentHeader() (segment.Header, error) {
 	// No type assertion: Conn.r is a connReadSource, so the disarm always applies.
 	c.r.setDisarm(true)
 	defer c.r.setDisarm(false)
@@ -1441,15 +1458,28 @@ func (c *Conn) readFirstSegmentHeader() (segmentHeader, error) {
 	// the count only matters here, where the benign/fatal decision is made.
 	c.headerReader.reset(c.r, c.r)
 
-	hdr, err := readSegmentHeader(&c.headerReader, c.compressor)
+	hdr, err := segment.ReadHeader(&c.headerReader, c.segCompressor != nil)
 	if err != nil {
 		var netErr net.Error
 		if c.headerReader.n == 0 && errors.As(err, &netErr) && netErr.Timeout() {
-			return segmentHeader{}, fmt.Errorf("%w: %w", ErrReadHeaderTimeout, err)
+			return segment.Header{}, fmt.Errorf("%w: %w", ErrReadHeaderTimeout, err)
 		}
-		return segmentHeader{}, err
+		return segment.Header{}, err
 	}
 	return hdr, nil
+}
+
+// readSegmentPayload reads the payload of a segment whose header has already been
+// read, in the layout c.segCompressor selects — nil being the uncompressed one. The
+// narrowing behind that field happened once during the handshake; see
+// Conn.resolveSegmentCompressor.
+//
+// The header readers above take their layout from the same field. They branch on a
+// bool where this branches on the compressor being non-nil, and a connection whose two
+// answers disagreed would read an 8-byte compressed header as a 6-byte uncompressed
+// one and mis-frame everything after it.
+func (c *Conn) readSegmentPayload(hdr segment.Header) ([]byte, error) {
+	return segment.ReadPayload(c.r, hdr, c.segCompressor, &c.segScratch)
 }
 
 // recvSplitFrame reassembles a single CQL frame that the peer split across
@@ -1547,14 +1577,14 @@ func (c *Conn) recvSplitFrame(ctx context.Context, first []byte, netStart, netEn
 // payload), is rejected so a hostile peer cannot drive an infinite reassembly
 // loop.
 func (c *Conn) readContinuationSegment() ([]byte, error) {
-	hdr, err := readSegmentHeader(c.r, c.compressor)
+	hdr, err := segment.ReadHeader(c.r, c.segCompressor != nil)
 	if err != nil {
 		return nil, fmt.Errorf("gocql: failed to read continuation segment header: %w", err)
 	}
-	if hdr.isSelfContained {
+	if hdr.IsSelfContained {
 		return nil, fmt.Errorf("gocql: received self-contained segment, but expected a continuation")
 	}
-	payload, err := readSegmentPayload(c.r, hdr, c.compressor, &c.segScratch)
+	payload, err := c.readSegmentPayload(hdr)
 	if err != nil {
 		return nil, fmt.Errorf("gocql: failed to read continuation segment payload: %w", err)
 	}

--- a/conn.go
+++ b/conn.go
@@ -1071,7 +1071,7 @@ type frameSource struct {
 	// takes the connection down; out of a segment the short read is immediate and
 	// yields io.ErrUnexpectedEOF, which is not a net.Error, so processFrameSource
 	// keeps it per-request and leaves the connection up. A ~20-byte segment could
-	// otherwise buy a maxFrameSize allocation, repeatable for as long as the peer
+	// otherwise buy a frm.MaxFrameSize allocation, repeatable for as long as the peer
 	// cares to send them.
 	//
 	// Nil on the pre-v5 socket path, and nil for a reassembled frame, where
@@ -1492,11 +1492,11 @@ func (c *Conn) readSegmentPayload(hdr segment.Header) ([]byte, error) {
 // reassembly buffer is allocated exactly once, sized to the frame length the peer
 // declared in the CQL frame header, and appending the arriving payloads is bounded
 // by that length. So neither a lying header nor incremental growth can inflate it:
-// growing a buffer to a maxFrameSize frame would end up holding ~512 MiB for a
+// growing a buffer to a frm.MaxFrameSize frame would end up holding ~512 MiB for a
 // valid 256 MiB response. Ownership of the buffer is then handed to the read
 // framer rather than copied into it, so the frame is never resident twice.
 //
-// The declared length itself is the peer's to choose, up to maxFrameSize, so a
+// The declared length itself is the peer's to choose, up to frm.MaxFrameSize, so a
 // small hostile prologue still buys this one allocation before any body byte has
 // arrived. Accepted deliberately, because it is bounded: at most once per
 // connection — the continuation reads run under ReadTimeout, so a peer that
@@ -1536,7 +1536,7 @@ func (c *Conn) recvSplitFrame(ctx context.Context, first []byte, netStart, netEn
 	if err != nil {
 		return err
 	}
-	if head.Length < 0 || head.Length > maxFrameSize {
+	if head.Length < 0 || head.Length > frm.MaxFrameSize {
 		return fmt.Errorf("gocql: invalid frame body length in segmented frame: %d", head.Length)
 	}
 	total := headSize + head.Length

--- a/dialer/framesplitter.go
+++ b/dialer/framesplitter.go
@@ -1,0 +1,221 @@
+package dialer
+
+import (
+	"fmt"
+	"slices"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+// FrameHeaderLen is the CQL frame header these dialers slice on: version, flags, a
+// 2-byte stream id, the opcode and the 4-byte body length.
+//
+// It is fixed at the v3+ layout. Negotiation lands on v4 (discoverProtocol) and v5
+// keeps the same header, so the 1-byte stream id of v1/v2 only appears if a caller
+// pins ProtoVersion to one of them — which these dialers have never handled, here or
+// in the offset math they share with GetFrameHash (scylladb/gocql#1022).
+const FrameHeaderLen = 9
+
+// FrameBodyLen reports the body length that b's header declares, and whether b holds a
+// complete header to read it from.
+//
+// No bound is placed on the value, because the two callers want different answers to an
+// impossible one: FrameSplitter.consume refuses it by name, since a stream whose framing
+// is in doubt is worth failing loudly, while the replayer only asks whether a record is
+// exactly one frame, which an absurd length answers on its own. A length that overflows
+// int comes back negative rather than wrapping into something plausible.
+func FrameBodyLen(b []byte) (int, bool) {
+	if len(b) < FrameHeaderLen {
+		return 0, false
+	}
+	return int(b[5])<<24 | int(b[6])<<16 | int(b[7])<<8 | int(b[8]), true
+}
+
+// latch makes a stream one-shot: the first failure is kept and returned by every later
+// call, including one that carries nothing.
+//
+// A stream that failed a framing rule cannot be resumed without re-feeding the bytes
+// that failed, so both splitters here want the behaviour and each documents its own
+// rules for reaching it. Embedding keeps one implementation of the behaviour itself:
+// the copies this replaced had already disagreed once about whether an empty Feed
+// reports a latched failure.
+//
+// It leads the struct it is embedded in. It holds the only pointer-bearing field, and
+// the fieldalignment vet check wants those contiguous.
+type latch struct {
+	failed error
+}
+
+// fail records err as the failure that ended the stream and returns it. Only the first
+// failure is kept.
+func (l *latch) fail(err error) error {
+	if l.failed == nil {
+		l.failed = err
+	}
+	return l.failed
+}
+
+// failure returns the error that ended the stream, if one did.
+func (l *latch) failure() error {
+	return l.failed
+}
+
+// FrameSplitter reassembles whole CQL frames from a byte stream delivered in
+// arbitrary chunks.
+//
+// Neither side of a connection delivers one frame per call. The driver's read path
+// fills a bufio.Reader, so a single read can carry several frames or end in the
+// middle of one, and either shape has to come back out as the frames that went in.
+// The write side happens to deliver one frame per call today, but only by accident
+// of how net.Buffers.WriteTo dispatches (see the note in the replayer), so it is fed
+// through here too rather than trusting that.
+//
+// On protocol v5 the bytes arriving from the socket are transport segments rather
+// than frames. A SegmentSplitter unwraps those first and feeds their payloads here;
+// this type is only ever handed a CQL frame stream.
+type FrameSplitter struct {
+	// latch makes the splitter one-shot: see Feed. It leads the struct for the reason
+	// given there, which matters more here than elsewhere -- this type is embedded in
+	// the recorder's and replayer's connections, so its layout is theirs too.
+	latch
+	// frame is the frame under construction, complete up to len(frame).
+	frame []byte
+	// bodyLeft counts the body bytes still owed to frame, and is meaningful only
+	// once the header is complete — until then the declared length has not been
+	// read.
+	bodyLeft int
+}
+
+// maxRetainedFrame bounds the buffer kept between frames.
+//
+// The buffer is reused so the common case costs no allocation, but consume admits any
+// body length the peer declares, up to frm.MaxFrameSize — 256 MiB. Reusing that for
+// the life of the connection would pin it in four places at once on a recorded
+// connection (both of the recorder's decoders, the replayer's request decoder, and the
+// splitter inside a SegmentSplitter), so an outlier is handed back instead. The driver
+// does the same for its own framer buffers, which it releases and reallocates rather
+// than growing without bound.
+//
+// It governs the frame buffer only. A SegmentSplitter bounds its own accumulation
+// buffer at one maximum-size segment, which is larger; see Feed there for why.
+const maxRetainedFrame = 64 << 10
+
+// Feed consumes b, calling emit once for each frame it completes.
+//
+// The frame handed to emit is only valid for the duration of the call: the buffer is
+// reused for the next frame. A caller that keeps it must copy it.
+//
+// A frame is emitted before the bytes that follow it are looked at, so a caller that
+// stops at the first error stops with the stream positioned exactly after the frame
+// that failed.
+//
+// A splitter is one-shot: any failure, including one returned by emit, is remembered
+// and returned by every later call. There is no resuming a stream whose framing is in
+// doubt — a recording assembled past a failure is worthless, and the alternative is
+// worse than useless. A frame that fails in emit is complete but unrecorded, and the
+// obvious "leave it buffered for a retry" leaves the splitter owing zero body bytes,
+// so the next call would consume nothing, emit that same frame a second time, and
+// write it into the recording twice.
+// "Every later call" includes one with nothing in it. consume is where the latch is
+// normally read, and it does not run when there is nothing to consume, so an empty
+// buffer would otherwise come back nil and read as a healthy stream — which is how
+// ConnectionReplayer.Write, the one caller with no failure gate of its own, would
+// answer a zero-length write after ObserveRequest had already refused the connection.
+// SegmentSplitter.Feed checks before its own loop for the same reason.
+func (s *FrameSplitter) Feed(b []byte, emit func(frame []byte) error) error {
+	if err := s.failure(); err != nil {
+		return err
+	}
+	for len(b) > 0 {
+		taken, err := s.consume(b, emit)
+		if err != nil {
+			return err
+		}
+		b = b[taken:]
+	}
+	return nil
+}
+
+// Pending reports whether part of a frame is buffered, i.e. whether the stream
+// stopped mid-frame. A segment chain that ends here has not delivered what it
+// promised.
+func (s *FrameSplitter) Pending() bool {
+	return len(s.frame) > 0
+}
+
+// consume appends the prefix of b belonging to the frame in progress and, once that
+// frame is whole, emits it and resets for the next one. It returns how many bytes it
+// took, which is all of b unless b runs on into the following frame.
+func (s *FrameSplitter) consume(b []byte, emit func(frame []byte) error) (int, error) {
+	if err := s.failure(); err != nil {
+		return 0, err
+	}
+
+	// While the header is short the body length is still unknown, so take only what
+	// completes the header: anything past it may belong to the next frame.
+	headerShort := len(s.frame) < FrameHeaderLen
+	want := s.bodyLeft
+	if headerShort {
+		want = FrameHeaderLen - len(s.frame)
+	}
+
+	taken := min(want, len(b))
+	s.frame = append(s.frame, b[:taken]...)
+
+	if headerShort {
+		bodyLen, ok := FrameBodyLen(s.frame)
+		if !ok {
+			return taken, nil
+		}
+
+		// The length is the peer's to choose, or a recording file's. Without this
+		// the splitter would append toward a declared 2 GiB body, one read at a
+		// time, on nothing more than a corrupt header. The driver's own reader
+		// bounds the same field the same way.
+		if bodyLen < 0 || bodyLen > frm.MaxFrameSize {
+			return taken, s.fail(fmt.Errorf("gocql/dialer: frame declares an invalid body length %d", bodyLen))
+		}
+
+		// The whole body is owed and its length is now known, so reserve it in one
+		// step. Left to append the frame regrows geometrically -- from nil whenever
+		// the previous frame was handed back for exceeding maxRetainedFrame -- which
+		// on a large frame is dozens of reallocations, each copying everything read
+		// so far.
+		//
+		// The reservation is capped at what this splitter is willing to retain. The
+		// length is the peer's to choose and nothing has arrived to back it up yet, so
+		// a lone header declaring frm.MaxFrameSize would otherwise pin 256 MiB before a
+		// single body byte -- in each of the four splitters a recorded connection builds
+		// (both of the recorder's decoders, the replayer's request decoder, and the one
+		// inside a SegmentSplitter) -- and hold it until a frame that never completes
+		// does. Past the cap the buffer grows with the bytes actually delivered, which is
+		// what this did before it reserved anything, and costs nothing extra on a frame
+		// that size: it is handed back after emit regardless. bodyLeft keeps the full
+		// declared length; only the reservation is bounded.
+		//
+		// Capped at the constant itself, not the constant less FrameHeaderLen: both
+		// retain the same frames, because maxRetainedFrame bounds the buffer with the
+		// header in it. Capping lower only under-reserves a frame that is about to be
+		// released anyway.
+		s.frame = slices.Grow(s.frame, min(bodyLen, maxRetainedFrame))
+		s.bodyLeft = bodyLen
+	} else {
+		s.bodyLeft -= taken
+	}
+
+	if s.bodyLeft > 0 {
+		return taken, nil
+	}
+
+	if err := emit(s.frame); err != nil {
+		return taken, s.fail(err)
+	}
+
+	if cap(s.frame) > maxRetainedFrame {
+		s.frame = nil
+	} else {
+		s.frame = s.frame[:0]
+	}
+	s.bodyLeft = 0
+	return taken, nil
+}

--- a/dialer/framesplitter_test.go
+++ b/dialer/framesplitter_test.go
@@ -1,0 +1,477 @@
+package dialer
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
+)
+
+// collect feeds the splitter and returns the frames it emitted, copied because the
+// emitted slice aliases the splitter's buffer.
+func collect(t *testing.T, s *FrameSplitter, chunks ...[]byte) [][]byte {
+	t.Helper()
+
+	var got [][]byte
+	for _, chunk := range chunks {
+		if err := s.Feed(chunk, func(frame []byte) error {
+			got = append(got, append([]byte(nil), frame...))
+			return nil
+		}); err != nil {
+			t.Fatalf("Feed: %v", err)
+		}
+	}
+	return got
+}
+
+func TestFrameSplitterReassembles(t *testing.T) {
+	one := frameV4(opOptions, 0x00, nil)
+	two := frameV4(opQuery, 0x00, []byte("0123456789"))
+
+	for _, tc := range []struct {
+		name   string
+		chunks [][]byte
+		want   [][]byte
+	}{
+		{
+			name:   "one whole frame",
+			chunks: [][]byte{one},
+			want:   [][]byte{one},
+		},
+		{
+			name:   "two frames coalesced into one feed",
+			chunks: [][]byte{append(append([]byte(nil), one...), two...)},
+			want:   [][]byte{one, two},
+		},
+		{
+			name:   "frame split mid-header",
+			chunks: [][]byte{two[:5], two[5:]},
+			want:   [][]byte{two},
+		},
+		{
+			name:   "frame split mid-body",
+			chunks: [][]byte{two[:12], two[12:]},
+			want:   [][]byte{two},
+		},
+		{
+			name:   "frame plus the head of the next",
+			chunks: [][]byte{append(append([]byte(nil), one...), two[:4]...), two[4:]},
+			want:   [][]byte{one, two},
+		},
+		{
+			name:   "empty feed",
+			chunks: [][]byte{nil, one},
+			want:   [][]byte{one},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var s FrameSplitter
+			got := collect(t, &s, tc.chunks...)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("emitted %d frames, want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if !bytes.Equal(got[i], tc.want[i]) {
+					t.Errorf("frame %d: got % X, want % X", i, got[i], tc.want[i])
+				}
+			}
+			if s.Pending() {
+				t.Error("splitter still holds a partial frame")
+			}
+		})
+	}
+}
+
+// TestFrameSplitterByteAtATime is the boundary case every other split reduces to: a
+// stream delivered one byte per call must come back out as the same frames.
+func TestFrameSplitterByteAtATime(t *testing.T) {
+	frames := [][]byte{
+		frameV4(opOptions, 0x00, nil),
+		frameV4(opQuery, 0x00, bytes.Repeat([]byte{0x5A}, 300)),
+		frameV4(opStartup, 0x00, []byte{0x00, 0x00}),
+	}
+
+	var stream []byte
+	for _, f := range frames {
+		stream = append(stream, f...)
+	}
+
+	var s FrameSplitter
+	chunks := make([][]byte, 0, len(stream))
+	for i := range stream {
+		chunks = append(chunks, stream[i:i+1])
+	}
+	got := collect(t, &s, chunks...)
+
+	if len(got) != len(frames) {
+		t.Fatalf("emitted %d frames, want %d", len(got), len(frames))
+	}
+	for i := range got {
+		if !bytes.Equal(got[i], frames[i]) {
+			t.Errorf("frame %d: got % X, want % X", i, got[i], frames[i])
+		}
+	}
+}
+
+// TestFrameSplitterPendingReportsPartialFrame pins the signal a segment chain needs:
+// whether the stream stopped mid-frame.
+func TestFrameSplitterPendingReportsPartialFrame(t *testing.T) {
+	frame := frameV4(opQuery, 0x00, []byte("0123456789"))
+
+	for _, tc := range []struct {
+		name string
+		n    int
+		want bool
+	}{
+		{name: "nothing fed", n: 0, want: false},
+		{name: "mid-header", n: 4, want: true},
+		{name: "header exactly", n: FrameHeaderLen, want: true},
+		{name: "mid-body", n: FrameHeaderLen + 3, want: true},
+		{name: "whole frame", n: len(frame), want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var s FrameSplitter
+			collect(t, &s, frame[:tc.n])
+			if got := s.Pending(); got != tc.want {
+				t.Errorf("Pending() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFrameSplitterBoundsDeclaredLength pins that a peer- or file-supplied body
+// length cannot drive an unbounded append. Without the bound a corrupt header alone
+// makes the splitter grow toward a declared 2 GiB body.
+func TestFrameSplitterBoundsDeclaredLength(t *testing.T) {
+	header := func(bodyLen uint32) []byte {
+		return []byte{
+			0x04, 0x00, 0x00, 0x7B, byte(opQuery),
+			byte(bodyLen >> 24), byte(bodyLen >> 16), byte(bodyLen >> 8), byte(bodyLen),
+		}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		bodyLen uint32
+		wantErr bool
+	}{
+		{name: "at the limit", bodyLen: frm.MaxFrameSize, wantErr: false},
+		{name: "one past the limit", bodyLen: frm.MaxFrameSize + 1, wantErr: true},
+		{name: "high bit set", bodyLen: 0xFFFFFFFF, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var s FrameSplitter
+			err := s.Feed(header(tc.bodyLen), func([]byte) error {
+				t.Error("a header-only feed emitted a frame")
+				return nil
+			})
+			if tc.wantErr && err == nil {
+				t.Errorf("declared body length %d was accepted", tc.bodyLen)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("declared body length %d was rejected: %v", tc.bodyLen, err)
+			}
+		})
+	}
+}
+
+// TestFrameSplitterPropagatesEmitError pins that an emit failure stops the feed there
+// and then, so the caller stops with the stream positioned exactly after the frame that
+// failed rather than partway through the rest of the buffer.
+func TestFrameSplitterPropagatesEmitError(t *testing.T) {
+	want := errors.New("recording aborted")
+	one := frameV4(opOptions, 0x00, nil)
+	two := frameV4(opQuery, 0x00, []byte("body"))
+
+	var s FrameSplitter
+	calls := 0
+	err := s.Feed(append(append([]byte(nil), one...), two...), func([]byte) error {
+		calls++
+		return want
+	})
+
+	if !errors.Is(err, want) {
+		t.Fatalf("Feed error = %v, want %v", err, want)
+	}
+	if calls != 1 {
+		t.Errorf("emit called %d times, want 1 — the feed continued past a failure", calls)
+	}
+}
+
+// TestFrameSplitterStaysFailedAfterEmitError pins that a splitter is one-shot.
+//
+// The frame that failed in emit is complete and owes no body bytes, so a splitter that
+// simply kept it buffered would consume nothing on the next call and emit that very
+// frame again -- writing it into the recording twice, where loadFramesFromFile keys by
+// stream id and the duplicate quietly replaces the original. Every later call has to
+// return the original failure instead, whatever it is handed.
+func TestFrameSplitterStaysFailedAfterEmitError(t *testing.T) {
+	want := errors.New("disk full")
+	one := frameV4(opOptions, 0x00, nil)
+	two := frameV4(opQuery, 0x00, []byte("body"))
+
+	var s FrameSplitter
+	calls := 0
+	emit := func([]byte) error {
+		calls++
+		return want
+	}
+	if err := s.Feed(one, emit); !errors.Is(err, want) {
+		t.Fatalf("Feed error = %v, want %v", err, want)
+	}
+
+	// A second feed, of a perfectly good frame.
+	if err := s.Feed(two, func([]byte) error {
+		t.Error("emit called after the splitter failed")
+		return nil
+	}); !errors.Is(err, want) {
+		t.Errorf("second Feed error = %v, want the original %v", err, want)
+	}
+	if calls != 1 {
+		t.Errorf("emit called %d times, want 1", calls)
+	}
+}
+
+// TestFeedReportsALatchedFailureForAnEmptyBuffer pins the one-shot contract against the
+// call that carries nothing.
+//
+// consume is where the latch is normally read, and it does not run when there is nothing
+// to consume, so an empty buffer used to come back nil -- reading as a healthy stream on
+// a splitter whose framing was already in doubt. ConnectionReplayer.Write is the caller
+// that would believe it: it has no failure gate of its own, so a zero-length write after
+// a refused STARTUP answered (0, nil). SegmentSplitter.Feed already checked before its
+// own loop, and startSegments' two refusals were never latched at all, so the four
+// implementations disagreed about one documented contract.
+func TestFeedReportsALatchedFailureForAnEmptyBuffer(t *testing.T) {
+	want := errors.New("disk full")
+
+	t.Run("FrameSplitter", func(t *testing.T) {
+		var s FrameSplitter
+		if err := s.Feed(frameV4(opOptions, 0x00, nil), func([]byte) error { return want }); !errors.Is(err, want) {
+			t.Fatalf("Feed error = %v, want %v", err, want)
+		}
+		if err := s.Feed(nil, mustNotEmit(t)); !errors.Is(err, want) {
+			t.Errorf("Feed(nil) = %v, want the original %v", err, want)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		// drive puts a decoder into its failed state and returns the error it reported.
+		// Each entry is a different way in: through a splitter, and through each of
+		// startSegments' two refusals.
+		drive func(t *testing.T, f *Framing, d *Decoder) error
+		// pending is what Pending must report afterwards. It answers "is anything
+		// buffered", not "has this failed", so it differs by path.
+		pending bool
+	}{
+		{
+			name:    "emit error",
+			pending: true,
+			drive: func(t *testing.T, f *Framing, d *Decoder) error {
+				return d.Feed(frameV4(opOptions, 0x00, nil), func([]byte) error { return want })
+			},
+		},
+		{
+			name:    "switch mid-frame",
+			pending: true,
+			drive: func(t *testing.T, f *Framing, d *Decoder) error {
+				if err := d.Feed(responseV5(opResult)[:5], mustNotEmit(t)); err != nil {
+					t.Fatalf("Feed of a partial frame: %v", err)
+				}
+				f.ObserveResponse(responseV5(opReady))
+				return d.Feed([]byte{0x00, 0x01, 0x02}, mustNotEmit(t))
+			},
+		},
+		{
+			name:    "compressed without a compressor",
+			pending: false,
+			drive: func(t *testing.T, f *Framing, d *Decoder) error {
+				if err := f.ObserveRequest(startupWith([2]string{"COMPRESSION", "lz4"})); err != nil {
+					t.Fatalf("ObserveRequest: %v", err)
+				}
+				f.ObserveResponse(responseV5(opReady))
+				return d.Feed([]byte{0x00, 0x01, 0x02}, mustNotEmit(t))
+			},
+		},
+	} {
+		t.Run("Decoder/"+tc.name, func(t *testing.T) {
+			f := NewFraming(nil)
+			d := f.NewDecoder()
+
+			first := tc.drive(t, f, d)
+			if first == nil {
+				t.Fatal("the decoder was not driven into a failure")
+			}
+
+			// The empty call reaches neither splitter, so only a latch can answer it.
+			if err := d.Feed(nil, mustNotEmit(t)); !errors.Is(err, first) {
+				t.Errorf("Feed(nil) = %v, want the latched %v", err, first)
+			}
+
+			// A later call carrying bytes has to report the same error *value*, not
+			// another one just like it. errors.Is compares identity, which is what tells
+			// a latch apart from a refusal recomputed per call: startSegments' two
+			// refusals produce a fresh, equal-looking error every time they run.
+			if err := d.Feed(frameV4(opOptions, 0x00, nil), mustNotEmit(t)); !errors.Is(err, first) {
+				t.Errorf("a later Feed = %v, want the latched %v", err, first)
+			}
+
+			if got := d.Pending(); got != tc.pending {
+				t.Errorf("Pending() = %v, want %v", got, tc.pending)
+			}
+		})
+	}
+}
+
+// mustNotEmit returns an emit that fails the test if anything reaches it.
+func mustNotEmit(t *testing.T) func([]byte) error {
+	t.Helper()
+	return func([]byte) error {
+		t.Error("emit called; no frame should have come out")
+		return nil
+	}
+}
+
+// TestFrameSplitterReleasesOutsizedBuffer pins that the reused frame buffer does not
+// pin an outlier for the life of the connection. A frame may declare up to
+// frm.MaxFrameSize (256 MiB), and a recorded connection holds four of these splitters.
+func TestFrameSplitterReleasesOutsizedBuffer(t *testing.T) {
+	big := frameV4(opQuery, 0x00, make([]byte, maxRetainedFrame+1))
+	small := frameV4(opQuery, 0x00, []byte("body"))
+
+	var s FrameSplitter
+	if got := collect(t, &s, big); len(got) != 1 {
+		t.Fatalf("emitted %d frames, want 1", len(got))
+	}
+	if cap(s.frame) > maxRetainedFrame {
+		t.Errorf("kept a %d-byte buffer after an outsized frame", cap(s.frame))
+	}
+
+	// Releasing it must not cost the splitter its ability to read the next frame.
+	got := collect(t, &s, small)
+	if len(got) != 1 || !bytes.Equal(got[0], small) {
+		t.Errorf("after the release: emitted %d frames, want the small frame back", len(got))
+	}
+
+	// A frame at or below the bound is still reused, which is what keeps the replay
+	// hot path allocation-free.
+	before := cap(s.frame)
+	if before == 0 || before > maxRetainedFrame {
+		t.Fatalf("unexpected retained capacity %d", before)
+	}
+	if got := collect(t, &s, small); len(got) != 1 {
+		t.Fatalf("emitted %d frames, want 1", len(got))
+	}
+	if cap(s.frame) != before {
+		t.Errorf("buffer capacity changed from %d to %d across a small frame", before, cap(s.frame))
+	}
+}
+
+// TestFrameSplitterZeroLengthBody pins that a body-less frame — OPTIONS, READY —
+// completes on its header alone.
+func TestFrameSplitterZeroLengthBody(t *testing.T) {
+	frame := frameV4(opOptions, 0x00, nil)
+	if len(frame) != FrameHeaderLen {
+		t.Fatalf("expected a header-only frame, got %d bytes", len(frame))
+	}
+
+	var s FrameSplitter
+	got := collect(t, &s, frame)
+	if len(got) != 1 {
+		t.Fatalf("emitted %d frames, want 1", len(got))
+	}
+	if s.Pending() {
+		t.Error("a complete body-less frame left the splitter mid-frame")
+	}
+}
+
+// TestFrameSplitterReservesTheDeclaredBody pins both halves of the reservation rule.
+// A completed header reserves the body it declares, so a large frame is not regrown one
+// read at a time -- but never more than the splitter would be willing to retain, because
+// the declared length is the peer's word and nothing has arrived yet to back it up.
+func TestFrameSplitterReservesTheDeclaredBody(t *testing.T) {
+	t.Run("reserves the declared body", func(t *testing.T) {
+		// Below maxRetainedFrame, so the reservation is the whole body and the buffer
+		// must not move again while it arrives.
+		frame := frameV4(opQuery, 0x00, make([]byte, maxRetainedFrame/2))
+
+		var s FrameSplitter
+		if err := s.Feed(frame[:FrameHeaderLen], mustNotEmit(t)); err != nil {
+			t.Fatalf("Feed(header): %v", err)
+		}
+		reserved := cap(s.frame)
+		if reserved < len(frame) {
+			t.Fatalf("the header reserved %d bytes, want room for the declared %d", reserved, len(frame))
+		}
+
+		// Everything but the last byte, so the frame stays under construction and the
+		// buffer is not released before it can be checked.
+		rest := frame[FrameHeaderLen : len(frame)-1]
+		for len(rest) > 0 {
+			n := min(1024, len(rest))
+			if err := s.Feed(rest[:n], mustNotEmit(t)); err != nil {
+				t.Fatalf("Feed(body): %v", err)
+			}
+			if cap(s.frame) != reserved {
+				t.Fatalf("the buffer regrew from %d to %d while the body arrived", reserved, cap(s.frame))
+			}
+			rest = rest[n:]
+		}
+
+		got := collect(t, &s, frame[len(frame)-1:])
+		if len(got) != 1 || !bytes.Equal(got[0], frame) {
+			t.Fatalf("emitted %d frames, want the whole frame back", len(got))
+		}
+	})
+
+	t.Run("does not reserve what it will not retain", func(t *testing.T) {
+		// A header alone, declaring the largest body the splitter admits, with nothing
+		// behind it -- which is all it takes to pin the allocation for the life of the
+		// connection, since the buffer is handed back only once a frame is emitted.
+		header := frameV4(opQuery, 0x00, nil)
+		header[5] = byte(frm.MaxFrameSize >> 24 & 0xFF)
+		header[6] = byte(frm.MaxFrameSize >> 16 & 0xFF)
+		header[7] = byte(frm.MaxFrameSize >> 8 & 0xFF)
+		header[8] = byte(frm.MaxFrameSize & 0xFF)
+
+		var s FrameSplitter
+		if err := s.Feed(header, mustNotEmit(t)); err != nil {
+			t.Fatalf("Feed(header): %v", err)
+		}
+
+		// Loose enough to survive slices.Grow rounding up to a size class, tight enough
+		// that honouring the declared 256 MiB cannot pass.
+		if want := 2 * (FrameHeaderLen + maxRetainedFrame); cap(s.frame) > want {
+			t.Errorf("a header declaring %d bytes reserved %d, want at most %d", frm.MaxFrameSize, cap(s.frame), want)
+		}
+		if s.bodyLeft != frm.MaxFrameSize {
+			t.Errorf("bodyLeft = %d, want the full declared %d -- only the reservation is capped", s.bodyLeft, frm.MaxFrameSize)
+		}
+	})
+
+	t.Run("keeps the largest frame the bound admits", func(t *testing.T) {
+		// maxRetainedFrame bounds the buffer, header included, so the largest frame kept
+		// is FrameHeaderLen+bodyLen == maxRetainedFrame. One byte more and the buffer is
+		// handed back -- which is the reservation cap doing nothing wrong: capping it at
+		// maxRetainedFrame-FrameHeaderLen instead retains exactly the same frames and
+		// merely regrows for the ones above the bound.
+		frame := frameV4(opQuery, 0x00, make([]byte, maxRetainedFrame-FrameHeaderLen))
+		if len(frame) != maxRetainedFrame {
+			t.Fatalf("built a %d-byte frame, want exactly maxRetainedFrame", len(frame))
+		}
+
+		var s FrameSplitter
+		if got := collect(t, &s, frame); len(got) != 1 {
+			t.Fatalf("emitted %d frames, want 1", len(got))
+		}
+		if cap(s.frame) == 0 {
+			t.Error("handed back the buffer for a frame that fits the bound exactly")
+		}
+		if cap(s.frame) > maxRetainedFrame {
+			t.Errorf("kept a %d-byte buffer, want at most maxRetainedFrame (%d)", cap(s.frame), maxRetainedFrame)
+		}
+	})
+}

--- a/dialer/framing.go
+++ b/dialer/framing.go
@@ -1,0 +1,335 @@
+package dialer
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync/atomic"
+)
+
+// Framing tracks how one connection's bytes are framed, and hands out a decoder per
+// direction.
+//
+// Up to a point in the handshake both directions carry bare CQL frames. Past it, on
+// protocol v5, both carry transport segments. The frame bytes do not say which side of
+// that line they are on, and on a compressed connection they do not say how large a
+// segment header is either, so both facts are latched from the handshake as it goes
+// past.
+//
+// # Where the line is
+//
+// It is one frame earlier than "the handshake finished", which is the detail worth
+// being careful about: getting it wrong by a single frame corrupts every authenticated
+// recording.
+//
+// The driver sets its startupCompleted flag as soon as READY *or* AUTHENTICATE is
+// received, and then writes AUTH_RESPONSE through the same gate that decides whether to
+// segment. So authentication happens after the switch, not before it:
+//
+//	driver writes, unsegmented:  OPTIONS, STARTUP
+//	driver writes, segmented:    AUTH_RESPONSE onward
+//	server writes, unsegmented:  SUPPORTED, READY | AUTHENTICATE
+//	server writes, segmented:    AUTH_SUCCESS | AUTH_CHALLENGE onward
+//
+// native_protocol_v5.spec section 2.3.1 says the same: after sending READY or
+// AUTHENTICATE in response to a STARTUP, the server begins framing everything further.
+//
+// # Why no read or write can straddle it
+//
+// The switch is driven by a response frame, and observed by both directions, so it has
+// to be impossible for a single Read or Write to contain bytes from both sides of it.
+//
+// On the read side the server sends nothing after READY or AUTHENTICATE until the
+// client's next request, so the bytes carrying that frame cannot also carry the first
+// segment. On the write side the startup coordinator is strictly
+// request-response-request, so AUTH_RESPONSE is written only after AUTHENTICATE was
+// read, by which time the latch has flipped.
+//
+// # Concurrency
+//
+// A connection's reads and writes run on different goroutines — the driver's serve()
+// loop and whichever goroutine is executing a query — so the latches are atomic. The
+// decoders are not: each belongs to one direction, and is only ever touched by that
+// direction's goroutine.
+type Framing struct {
+	// comp is the compressor supplied by whoever built the dialer. Immutable.
+	comp SegmentCompressor
+	// algorithm is the compression algorithm the STARTUP named, kept for the error
+	// messages that have to name it. Written by ObserveRequest before compressed is
+	// stored and read only after compressed reports true, so the atomic store below
+	// publishes it.
+	algorithm string
+	// compressed latches when the STARTUP request names a compression algorithm,
+	// which is what decides the segment header layout.
+	compressed atomic.Bool
+	// segmented latches when the handshake passes the point described above.
+	segmented atomic.Bool
+}
+
+// NewFraming returns the framing state for one connection. comp may be nil, in which
+// case a connection that turns out to have negotiated compression is an error rather
+// than a stream silently decoded with the wrong header size.
+//
+// A typed-nil compressor -- a nil *lz4.LZ4Compressor handed over as the interface --
+// is normalized to that same nil. It would pass every comp == nil check and then
+// panic on its first method call, deep in segment decoding, instead of failing as
+// the missing dependency it is (ErrSegmentCompressorRequired).
+//
+// Any nilable kind, not just a pointer: a compressor's methods can sit on a map, func
+// or slice type just as well, and a typed nil of one of those fails in exactly the
+// same place. reflect.Interface cannot occur -- an interface value's dynamic type is
+// never itself an interface -- and an invalid Value means comp was already nil.
+func NewFraming(comp SegmentCompressor) *Framing {
+	switch v := reflect.ValueOf(comp); v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		if v.IsNil() {
+			comp = nil
+		}
+	}
+	return &Framing{comp: comp}
+}
+
+// ObserveRequest inspects a request frame for the handshake facts carried by requests,
+// and reports a negotiated compression this package cannot record or replay.
+//
+// Two such cases exist, and both are refused here at the STARTUP rather than left to
+// surface later as something else:
+//
+//   - Compression below protocol v5, which compresses frame *bodies* rather than
+//     transport segments. Every recorded body would then be compressed bytes, which
+//     GetFrameHash cannot walk; it would fall back to hashing the whole frame, default
+//     timestamp included, so the hash would differ on every run and replay would fail
+//     to find a response for a request it has. Supporting it means decompressing frame
+//     bodies, which is a different feature from segment compression.
+//   - An algorithm that is not the one the supplied compressor implements. The segment
+//     CRCs cover the compressed payload, so they pass either way and the mismatch
+//     surfaces as corrupt CQL frames. Only compressors that report a Name can be
+//     checked -- the interface deliberately requires just the two Append methods --
+//     which is enough to catch the real ones.
+func (f *Framing) ObserveRequest(frame []byte) error {
+	algorithm, ok := StartupCompression(frame)
+	if !ok || algorithm == "" {
+		// An option present but empty names nothing to compress with, and the driver
+		// never writes one; treating it as compression would pick the wrong header
+		// size for an uncompressed stream.
+		return nil
+	}
+
+	if !FrameIsProtoV5OrNewer(frame) {
+		return fmt.Errorf("gocql/dialer: connection negotiated %q compression at protocol v%d, which compresses frame bodies rather than transport segments; the record and replay dialers support compression only from protocol v5",
+			algorithm, frame[0]&protoVersionMask)
+	}
+
+	if named, ok := f.comp.(interface{ Name() string }); ok && !strings.EqualFold(named.Name(), algorithm) {
+		return fmt.Errorf("gocql/dialer: connection negotiated %q compression but the dialer was given a %q compressor",
+			algorithm, named.Name())
+	}
+
+	f.algorithm = algorithm
+	f.compressed.Store(true)
+	return nil
+}
+
+// ObserveResponse inspects a response frame and flips the framing latch once the
+// handshake reaches the point where both directions switch to transport segments.
+//
+// Callers pass every response frame: the recorder the ones it reads from the server,
+// the replayer the ones it serves from a recording. Either way it is the same frame in
+// the same position, which is what lets one implementation serve both.
+func (f *Framing) ObserveResponse(frame []byte) {
+	if f.segmented.Load() || len(frame) < 5 {
+		return
+	}
+
+	// Only v5 and newer segment anything. A v4 connection never switches, so the
+	// latch stays false for its whole life and every decoder stays a FrameSplitter.
+	if !FrameIsProtoV5OrNewer(frame) {
+		return
+	}
+
+	switch frameOp(frame[3+headerShift(frame)]) {
+	case opReady, opAuthenticate:
+		f.segmented.Store(true)
+	}
+}
+
+// Segmented reports whether the connection has passed the point where both directions
+// carry transport segments.
+func (f *Framing) Segmented() bool {
+	return f.segmented.Load()
+}
+
+// Compressed reports whether the connection negotiated compression, and therefore
+// which of the two segment header layouts is on the wire.
+func (f *Framing) Compressed() bool {
+	return f.compressed.Load()
+}
+
+// segmentCompressor returns the compressor the negotiated layout needs.
+//
+// A connection that negotiated compression without one supplied is refused here. The
+// alternative would be to fall back to the uncompressed layout, which differs in
+// header size, so every subsequent offset would be wrong and the failure would surface
+// as corrupt frames rather than as the missing dependency it is.
+func (f *Framing) segmentCompressor() (SegmentCompressor, error) {
+	if !f.compressed.Load() {
+		return nil, nil
+	}
+	if f.comp == nil {
+		return nil, fmt.Errorf("%w (the connection negotiated %q)", ErrSegmentCompressorRequired, f.algorithm)
+	}
+	return f.comp, nil
+}
+
+// EncodeResponse wraps a bare CQL response frame for delivery to the driver, in
+// whatever framing the connection has reached.
+//
+// On error neither the returned slice nor dst may be used. AppendSegmented encodes
+// straight into dst, and the compressed layout reserves a segment header there before
+// calling a compressor that may then fail, so a caller reusing one buffer across
+// responses has to treat a failure as having emptied it.
+func (f *Framing) EncodeResponse(dst, frame []byte) ([]byte, error) {
+	if !f.Segmented() {
+		return append(dst, frame...), nil
+	}
+
+	comp, err := f.segmentCompressor()
+	if err != nil {
+		return nil, err
+	}
+	return AppendSegmented(dst, frame, comp)
+}
+
+// NewDecoder returns a decoder for one direction of the connection.
+func (f *Framing) NewDecoder() *Decoder {
+	return &Decoder{framing: f}
+}
+
+// Decoder recovers bare CQL frames from one direction of a connection, following the
+// framing switch as the handshake goes past it.
+//
+// It is not safe for concurrent use, and does not need to be: a connection's two
+// directions get one each.
+type Decoder struct {
+	framing *Framing
+	// segments de-frames the segmented part of the stream, and is built when the
+	// switch happens because until then the layout it needs is not known.
+	segments *SegmentSplitter
+	// plain de-frames the unsegmented part: the handshake, and the whole of a pre-v5
+	// connection. It is also where a failure of the decoder's own is latched --
+	// startSegments has two refusals that belong to neither splitter -- because it is
+	// the splitter that is always there, and failure() already consults it.
+	plain FrameSplitter
+}
+
+// Feed consumes b, calling emit once for each CQL frame it recovers. The frame handed
+// to emit is only valid for the duration of the call.
+//
+// The framing is re-checked at every frame boundary rather than once per call, because
+// emit is what flips the latch: the recorder observes the READY or AUTHENTICATE it has
+// just been handed. A buffer that carried that frame and the first transport segment
+// together would otherwise have its remainder read as bare frames — a segment's payload
+// length low byte taken for a protocol version, its next four bytes for a body length,
+// and the result written into a recording. Whether one read can ever carry both is
+// argued in Framing, and the argument holds for a directly connected server; it is not
+// worth resting on when following the latch costs a loop.
+//
+// A latched failure is reported even when b is empty. The splitters underneath are
+// one-shot, but both read their latch on the way to consuming something, so neither
+// runs for a zero-length buffer — and a caller that took nil for "still healthy" would
+// carry on against a stream whose framing is already in doubt.
+//
+// startSegments is one-shot by the same latch. Its two refusals are the decoder's own,
+// raised before either splitter is reached, so left unlatched they were reported afresh
+// on every call that carried bytes and not at all on one that did not — a connection
+// whose framing had already been refused answered a zero-length Feed with nil, which is
+// the one reply that reads as healthy.
+func (d *Decoder) Feed(b []byte, emit func(frame []byte) error) error {
+	if err := d.failure(); err != nil {
+		return err
+	}
+	for len(b) > 0 {
+		if d.framing.Segmented() {
+			if err := d.startSegments(); err != nil {
+				return err
+			}
+			return d.segments.Feed(b, emit)
+		}
+
+		taken, err := d.plain.consume(b, emit)
+		if err != nil {
+			return err
+		}
+		b = b[taken:]
+	}
+	return nil
+}
+
+// failure reports the error that ended this decoder's stream, if one did.
+//
+// Both splitters are consulted, not just the one in use: a connection that failed
+// while still unsegmented and then had its latch flipped would otherwise look healthy
+// again the moment the segment decoder was built.
+//
+// It is also where startSegments' own refusals surface. They are latched into plain: on
+// both of those paths segments is nil, and stays nil, because Feed consults this before
+// it would build one.
+func (d *Decoder) failure() error {
+	if d.segments != nil {
+		if err := d.segments.failure(); err != nil {
+			return err
+		}
+	}
+	return d.plain.failure()
+}
+
+// startSegments builds the segment decoder on first use, once the layout it needs is
+// known.
+//
+// Both refusals below are latched, in the plain splitter, and both are terminal: neither
+// is a condition a later call finds changed. The compressed layout was fixed by a STARTUP
+// that has already gone past, and a stream that reached a segment mid-frame does not get
+// back into step by being fed more bytes. plain owns the latch because it is the decoder's
+// only always-present stream state and because failure() already consults it; segments is
+// nil here and stays nil once this has failed.
+func (d *Decoder) startSegments() error {
+	if d.segments != nil {
+		return nil
+	}
+
+	// The switch happens between frames, never inside one — see Framing. Reaching here
+	// mid-frame means either that reasoning is wrong for the connection at hand or the
+	// stream is damaged, and continuing would feed the tail of a bare frame to a
+	// segment decoder and read whatever the next bytes happened to look like as a
+	// segment header.
+	if d.plain.Pending() {
+		return d.plain.fail(fmt.Errorf("gocql/dialer: connection switched to transport segments in the middle of a frame"))
+	}
+
+	comp, err := d.framing.segmentCompressor()
+	if err != nil {
+		// Latched as it is rather than wrapped: ErrSegmentCompressorRequired is a
+		// sentinel, and the round-trip tests reach for it with errors.Is.
+		return d.plain.fail(err)
+	}
+	d.segments = NewSegmentSplitter(comp)
+	return nil
+}
+
+// Pending reports whether the decoder holds anything incomplete: a partial bare
+// frame, or a segment chain that has not yet delivered the frame it promised. A
+// connection that ends while Pending reports true was cut mid-structure, so what
+// its recording holds is truncated.
+//
+// It says nothing about whether the decoder has failed, and deliberately so: the two
+// answer different questions. After startSegments' two refusals it therefore reports what
+// is actually buffered -- true for the mid-frame switch, which is the half frame that
+// caused it, and false for a missing compressor, where nothing was ever buffered.
+// ConnectionRecorder.Close ranks the latched failure above this for that reason: the
+// truncation is a symptom, the failure is the cause.
+func (d *Decoder) Pending() bool {
+	if d.segments != nil {
+		return d.segments.Pending()
+	}
+	return d.plain.Pending()
+}

--- a/dialer/framing_test.go
+++ b/dialer/framing_test.go
@@ -1,0 +1,461 @@
+package dialer
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// responseV5 builds a protocol v5 response frame (direction bit set) with the given
+// opcode and no body.
+func responseV5(op frameOp) []byte {
+	return []byte{0x85, 0x00, 0x00, 0x7B, byte(op), 0x00, 0x00, 0x00, 0x00}
+}
+
+// responseV4 is the same on protocol v4.
+func responseV4(op frameOp) []byte {
+	return []byte{0x84, 0x00, 0x00, 0x7B, byte(op), 0x00, 0x00, 0x00, 0x00}
+}
+
+// startupWith builds a v5 STARTUP request carrying the given options.
+func startupWith(opts ...[2]string) []byte {
+	return frameV5(opStartup, 0x00, stringMap(opts...))
+}
+
+// TestFramingLatchesSegmentedOnReadyOrAuthenticate pins the framing boundary.
+//
+// It is one frame earlier than "the handshake finished": the driver flips its own
+// switch when READY or AUTHENTICATE arrives and then writes AUTH_RESPONSE through it,
+// so authentication traffic is already segmented. A latch that waited for
+// AUTH_SUCCESS would decode AUTH_RESPONSE and AUTH_SUCCESS as bare frames and corrupt
+// every authenticated recording.
+func TestFramingLatchesSegmentedOnReadyOrAuthenticate(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		frame []byte
+		want  bool
+	}{
+		{name: "v5 READY", frame: responseV5(opReady), want: true},
+		{name: "v5 AUTHENTICATE", frame: responseV5(opAuthenticate), want: true},
+
+		// Everything the server sends before them stays unsegmented.
+		{name: "v5 SUPPORTED", frame: responseV5(opSupported), want: false},
+
+		// AUTH_SUCCESS is already past the line; if it were the trigger, the frames
+		// between it and AUTHENTICATE would have been decoded wrongly.
+		{name: "v5 AUTH_SUCCESS", frame: responseV5(opAuthSuccess), want: false},
+
+		// A v4 connection never segments anything.
+		{name: "v4 READY", frame: responseV4(opReady), want: false},
+		{name: "v4 AUTHENTICATE", frame: responseV4(opAuthenticate), want: false},
+
+		{name: "short frame", frame: []byte{0x85, 0x00}, want: false},
+		{name: "empty", frame: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFraming(nil)
+			f.ObserveResponse(tc.frame)
+			if got := f.Segmented(); got != tc.want {
+				t.Errorf("Segmented() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFramingLatchIsSticky pins that the switch is one-way. A later frame that is not
+// READY must not unset it.
+func TestFramingLatchIsSticky(t *testing.T) {
+	f := NewFraming(nil)
+	f.ObserveResponse(responseV5(opReady))
+	f.ObserveResponse(responseV5(opResult))
+	f.ObserveResponse(responseV4(opResult))
+
+	if !f.Segmented() {
+		t.Error("the framing latch was cleared by a later frame")
+	}
+}
+
+// TestFramingLatchesCompressionFromStartup pins where the segment header layout comes
+// from. The two layouts differ in size, so a decoder that guesses wrong misreads every
+// subsequent offset.
+func TestFramingLatchesCompressionFromStartup(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		frame []byte
+		want  bool
+	}{
+		{
+			name:  "STARTUP naming lz4",
+			frame: startupWith([2]string{"CQL_VERSION", "3.0.0"}, [2]string{"COMPRESSION", "lz4"}),
+			want:  true,
+		},
+		{
+			// An option present but empty names nothing to compress with. Latching on
+			// its presence alone would pick the compressed header layout, which is two
+			// bytes longer, for an uncompressed stream.
+			name:  "STARTUP with an empty COMPRESSION",
+			frame: startupWith([2]string{"COMPRESSION", ""}),
+			want:  false,
+		},
+		{
+			name:  "STARTUP without COMPRESSION",
+			frame: startupWith([2]string{"CQL_VERSION", "3.0.0"}),
+			want:  false,
+		},
+		{
+			// A SUPPORTED response advertises COMPRESSION too. Reading it as the
+			// negotiated choice would turn on the compressed layout on a connection
+			// that never asked for it.
+			name:  "SUPPORTED advertising COMPRESSION",
+			frame: frameV5(opSupported, 0x00, stringMap([2]string{"COMPRESSION", "lz4"})),
+			want:  false,
+		},
+		{
+			name:  "OPTIONS",
+			frame: frameV5(opOptions, 0x00, nil),
+			want:  false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFraming(nil)
+			if err := f.ObserveRequest(tc.frame); err != nil {
+				t.Fatalf("ObserveRequest: %v", err)
+			}
+			if got := f.Compressed(); got != tc.want {
+				t.Errorf("Compressed() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFramingRequiresACompressorForCompressedSegments pins that a missing dependency
+// is reported rather than silently decoded with the wrong header size.
+func TestFramingRequiresACompressorForCompressedSegments(t *testing.T) {
+	f := NewFraming(nil)
+	if err := f.ObserveRequest(startupWith([2]string{"COMPRESSION", "lz4"})); err != nil {
+		t.Fatalf("ObserveRequest: %v", err)
+	}
+	f.ObserveResponse(responseV5(opReady))
+
+	d := f.NewDecoder()
+	err := d.Feed([]byte{0x00, 0x01, 0x02}, func([]byte) error { return nil })
+	if !errors.Is(err, ErrSegmentCompressorRequired) {
+		t.Fatalf("Feed error = %v, want ErrSegmentCompressorRequired", err)
+	}
+
+	if _, err := f.EncodeResponse(nil, responseV5(opResult)); !errors.Is(err, ErrSegmentCompressorRequired) {
+		t.Errorf("EncodeResponse error = %v, want ErrSegmentCompressorRequired", err)
+	}
+}
+
+// TestDecoderFollowsTheSwitch walks a decoder across the framing boundary, in the
+// order a real handshake produces, and checks every frame comes back intact.
+func TestDecoderFollowsTheSwitch(t *testing.T) {
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			f := NewFraming(cc.comp)
+
+			startup := startupWith([2]string{"CQL_VERSION", "3.0.0"})
+			if cc.comp != nil {
+				startup = startupWith([2]string{"COMPRESSION", "lz4"})
+			}
+
+			requests := f.NewDecoder()
+			responses := f.NewDecoder()
+
+			var got [][]byte
+			keep := func(frame []byte) error {
+				got = append(got, append([]byte(nil), frame...))
+				return nil
+			}
+			// The response direction is what drives the latch.
+			observe := func(frame []byte) error {
+				f.ObserveResponse(frame)
+				return keep(frame)
+			}
+
+			// OPTIONS and STARTUP: unsegmented requests.
+			options := frameV5(opOptions, 0x00, nil)
+			if err := requests.Feed(options, keep); err != nil {
+				t.Fatalf("OPTIONS: %v", err)
+			}
+			if err := f.ObserveRequest(startup); err != nil {
+				t.Fatalf("ObserveRequest: %v", err)
+			}
+			if err := requests.Feed(startup, keep); err != nil {
+				t.Fatalf("STARTUP: %v", err)
+			}
+
+			// SUPPORTED and AUTHENTICATE: unsegmented responses. AUTHENTICATE flips
+			// the latch as it is observed.
+			supported := frameV5(opSupported, 0x00, nil)
+			authenticate := responseV5(opAuthenticate)
+			if err := responses.Feed(append(append([]byte(nil), supported...), authenticate...), observe); err != nil {
+				t.Fatalf("SUPPORTED+AUTHENTICATE: %v", err)
+			}
+			if !f.Segmented() {
+				t.Fatal("AUTHENTICATE did not flip the framing latch")
+			}
+
+			// AUTH_RESPONSE is the first segmented request, and AUTH_SUCCESS the first
+			// segmented response. This is the boundary that is easy to get wrong.
+			authResponse := frameV5(opAuthResponse, 0x00, []byte{0x00, 0x00, 0x00, 0x00})
+			wire, err := AppendSegmented(nil, authResponse, cc.comp)
+			if err != nil {
+				t.Fatalf("encode AUTH_RESPONSE: %v", err)
+			}
+			if err := requests.Feed(wire, keep); err != nil {
+				t.Fatalf("AUTH_RESPONSE: %v", err)
+			}
+
+			authSuccess := responseV5(opAuthSuccess)
+			if wire, err = f.EncodeResponse(nil, authSuccess); err != nil {
+				t.Fatalf("encode AUTH_SUCCESS: %v", err)
+			}
+			if err := responses.Feed(wire, observe); err != nil {
+				t.Fatalf("AUTH_SUCCESS: %v", err)
+			}
+
+			want := [][]byte{options, startup, supported, authenticate, authResponse, authSuccess}
+			if len(got) != len(want) {
+				t.Fatalf("recovered %d frames, want %d", len(got), len(want))
+			}
+			for i := range want {
+				if !bytes.Equal(got[i], want[i]) {
+					t.Errorf("frame %d: got % X, want % X", i, got[i], want[i])
+				}
+			}
+			if requests.Pending() || responses.Pending() {
+				t.Error("a decoder still holds something incomplete")
+			}
+		})
+	}
+}
+
+// TestEncodeResponseFollowsTheSwitch pins that a response is wrapped only once the
+// connection has switched — before that the driver expects bare frames.
+func TestEncodeResponseFollowsTheSwitch(t *testing.T) {
+	f := NewFraming(nil)
+	frame := responseV5(opSupported)
+
+	before, err := f.EncodeResponse(nil, frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, frame) {
+		t.Error("a pre-switch response was wrapped")
+	}
+
+	f.ObserveResponse(responseV5(opReady))
+
+	after, err := f.EncodeResponse(nil, frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(after, frame) {
+		t.Error("a post-switch response was not wrapped")
+	}
+
+	// And it must decode back to the frame that went in.
+	s := NewSegmentSplitter(nil)
+	got := decode(t, s, after)
+	if len(got) != 1 || !bytes.Equal(got[0], frame) {
+		t.Error("a wrapped response did not decode back to itself")
+	}
+}
+
+// TestObserveRequestRefusesPreV5Compression pins that a compressed connection below
+// protocol v5 is refused up front.
+//
+// Below v5 a negotiated compressor compresses frame *bodies*, not transport segments.
+// Every recorded body would be compressed bytes, which GetFrameHash cannot walk: it
+// falls back to hashing the whole frame, default timestamp included, so the hash
+// differs on every run and the replayer panics looking for a response to a request it
+// was given. Nothing in that failure names compression as the cause.
+func TestObserveRequestRefusesPreV5Compression(t *testing.T) {
+	startupV4 := frameV4(opStartup, 0x00, stringMap(
+		[2]string{"CQL_VERSION", "3.0.0"}, [2]string{"COMPRESSION", "lz4"}))
+
+	f := NewFraming(nil)
+	err := f.ObserveRequest(startupV4)
+	if err == nil {
+		t.Fatal("a v4 STARTUP naming compression was accepted")
+	}
+	for _, want := range []string{"lz4", "v4"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+	if f.Compressed() {
+		t.Error("the refused connection still latched the compressed layout")
+	}
+}
+
+// namedCompressor is a passthrough compressor that reports a name, as the real ones do
+// -- lz4 satisfies gocql.Compressor, so it has a Name. The segment compressor interface
+// deliberately does not require one, so the check is by assertion.
+type namedCompressor struct{ name string }
+
+func (c namedCompressor) Name() string { return c.name }
+
+func (namedCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+func (namedCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// mapCompressor carries the interface on a map type, so a typed nil of it is nilable
+// without being a pointer -- the case a reflect.Pointer test alone would miss.
+type mapCompressor map[string]string
+
+func (mapCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+func (mapCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// TestNewFramingNormalizesATypedNilCompressor pins that a typed-nil compressor -- a
+// nil *lz4.LZ4Compressor handed over as the SegmentCompressor interface -- behaves
+// like no compressor at all. The interface value is non-nil, so it passes every
+// comp == nil check, and the real compressors declare their methods on the value
+// type, so the first call through it panics -- where the absence has a name,
+// ErrSegmentCompressorRequired, and should keep it.
+//
+// Every nilable kind, not only the pointer the real compressors use: nothing stops an
+// implementation from hanging the methods on a map, func or slice type, and a typed
+// nil of one of those panics in the same place.
+func TestNewFramingNormalizesATypedNilCompressor(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		comp SegmentCompressor
+	}{
+		{"pointer", (*namedCompressor)(nil)},
+		{"map", mapCompressor(nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewFraming(tc.comp)
+
+			if err := f.ObserveRequest(startupWith([2]string{"COMPRESSION", "lz4"})); err != nil {
+				t.Fatalf("ObserveRequest: %v", err)
+			}
+			if _, err := f.segmentCompressor(); !errors.Is(err, ErrSegmentCompressorRequired) {
+				t.Errorf("segmentCompressor error = %v, want ErrSegmentCompressorRequired", err)
+			}
+		})
+	}
+}
+
+// TestObserveRequestChecksTheCompressorName pins that a recording naming one algorithm
+// is not replayed with a compressor for another.
+//
+// The segment CRCs cover the compressed payload, so they pass whatever the payload was
+// compressed with, and the mismatch surfaces further on as corrupt CQL frames -- the
+// outcome ErrSegmentCompressorRequired exists to avoid.
+func TestObserveRequestChecksTheCompressorName(t *testing.T) {
+	startup := startupWith([2]string{"COMPRESSION", "snappy"})
+
+	t.Run("mismatch", func(t *testing.T) {
+		f := NewFraming(namedCompressor{name: "lz4"})
+		err := f.ObserveRequest(startup)
+		if err == nil {
+			t.Fatal("a snappy connection was accepted with an lz4 compressor")
+		}
+		for _, want := range []string{"snappy", "lz4"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("match, case-insensitively", func(t *testing.T) {
+		f := NewFraming(namedCompressor{name: "SNAPPY"})
+		if err := f.ObserveRequest(startup); err != nil {
+			t.Fatalf("ObserveRequest: %v", err)
+		}
+		if !f.Compressed() {
+			t.Error("a matching compressor did not latch the compressed layout")
+		}
+	})
+
+	t.Run("a compressor without a name is taken as given", func(t *testing.T) {
+		f := NewFraming(passthroughCompressor{})
+		if err := f.ObserveRequest(startup); err != nil {
+			t.Fatalf("ObserveRequest: %v", err)
+		}
+		if !f.Compressed() {
+			t.Error("an unnamed compressor did not latch the compressed layout")
+		}
+	})
+}
+
+// TestDecoderFollowsTheLatchWithinOneFeed pins that the framing is re-checked at every
+// frame boundary, not once per call.
+//
+// emit is what flips the latch -- the recorder observes the READY it has just been
+// handed -- so a buffer carrying READY and the first transport segment together would
+// otherwise have its remainder read as bare frames: the segment's payload length low
+// byte taken for a protocol version, its next four bytes for a body length, and the
+// result recorded.
+func TestDecoderFollowsTheLatchWithinOneFeed(t *testing.T) {
+	f := NewFraming(nil)
+	d := f.NewDecoder()
+
+	ready := responseV5(opReady)
+	result := responseV5(opResult)
+	segmented, err := AppendSegmented(nil, result, nil)
+	if err != nil {
+		t.Fatalf("AppendSegmented: %v", err)
+	}
+
+	var got [][]byte
+	err = d.Feed(append(append([]byte(nil), ready...), segmented...), func(frame []byte) error {
+		got = append(got, append([]byte(nil), frame...))
+		f.ObserveResponse(frame)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Feed: %v", err)
+	}
+
+	want := [][]byte{ready, result}
+	if len(got) != len(want) {
+		t.Fatalf("recovered %d frames, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(got[i], want[i]) {
+			t.Errorf("frame %d: got % X, want % X", i, got[i], want[i])
+		}
+	}
+	if d.Pending() {
+		t.Error("the decoder still holds something incomplete")
+	}
+}
+
+// TestDecoderRefusesASwitchMidFrame pins the other side of it: the switch happens
+// between frames, so reaching a segment with half a bare frame buffered means either
+// that reasoning is wrong or the stream is damaged, and reading on would take whatever
+// the next bytes look like as a segment header.
+func TestDecoderRefusesASwitchMidFrame(t *testing.T) {
+	f := NewFraming(nil)
+	d := f.NewDecoder()
+
+	partial := responseV5(opResult)[:5]
+	if err := d.Feed(partial, func([]byte) error {
+		t.Error("a partial frame was emitted")
+		return nil
+	}); err != nil {
+		t.Fatalf("Feed of a partial frame: %v", err)
+	}
+
+	f.ObserveResponse(responseV5(opReady))
+
+	err := d.Feed([]byte{0x00, 0x01, 0x02}, func([]byte) error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "middle of a frame") {
+		t.Errorf("Feed error = %v, want a mid-frame switch to be refused", err)
+	}
+}

--- a/dialer/recorder/recorder.go
+++ b/dialer/recorder/recorder.go
@@ -3,36 +3,59 @@ package recorder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"path"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/dialer"
 )
 
-func NewRecordDialer(dir string) *RecordDialer {
-	return &RecordDialer{
-		dir: dir,
+// Option configures a RecordDialer.
+type Option func(*RecordDialer)
+
+// WithSegmentCompressor supplies the compressor a protocol v5 connection's transport
+// segments are compressed with.
+//
+// It has to be supplied rather than derived: the only implementation, lz4, lives in a
+// separate Go module, so neither the driver nor this package can construct one. Pass
+// the same compressor the ClusterConfig uses. Recording or replaying a v5 connection
+// that negotiated compression without one fails with
+// dialer.ErrSegmentCompressorRequired rather than decoding the stream with the wrong
+// segment header size.
+//
+// It is ignored on a connection that did not negotiate compression. Compression below
+// protocol v5 is not ignored but refused: there it compresses frame bodies rather than
+// transport segments, which is a different thing this package does not implement, and
+// left alone it would surface as a recording whose hashes never match on replay.
+func WithSegmentCompressor(comp dialer.SegmentCompressor) Option {
+	return func(d *RecordDialer) { d.comp = comp }
+}
+
+func NewRecordDialer(dir string, opts ...Option) *RecordDialer {
+	d := &RecordDialer{dir: dir}
+	for _, opt := range opts {
+		opt(d)
 	}
+	return d
 }
 
 type RecordDialer struct {
-	dir string
+	dir  string
+	comp dialer.SegmentCompressor
 	net.Dialer
 }
 
 func (d *RecordDialer) DialContext(ctx context.Context, network, addr string) (conn net.Conn, err error) {
-	fmt.Println("Dial Context Record Dialer")
 	sourcePort := gocql.ScyllaGetSourcePort(ctx)
-	fmt.Println("Source port: ", sourcePort)
 	dialerWithLocalAddr := d.Dialer
 	dialerWithLocalAddr.LocalAddr, err = net.ResolveTCPAddr(network, fmt.Sprintf(":%d", sourcePort))
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 
@@ -41,64 +64,128 @@ func (d *RecordDialer) DialContext(ctx context.Context, network, addr string) (c
 		return nil, err
 	}
 
-	return NewConnectionRecorder(path.Join(d.dir, fmt.Sprintf("%s-%d", addr, sourcePort)), conn)
+	rec, err := NewConnectionRecorder(path.Join(d.dir, fmt.Sprintf("%s-%d", addr, sourcePort)), conn, d.comp)
+	if err != nil {
+		// Nothing else will close conn: the recorder never took ownership of it, and
+		// the caller is handed a nil net.Conn alongside the error. Left open it strands
+		// the socket and its peer on the server, and the driver answers a failed dial
+		// by redialing -- so that is one stranded pair per attempt, for as long as the
+		// recording directory stays unwritable. The same leak the constructor below
+		// closes on its own file descriptors, and Close on all three of its handles.
+		//
+		// The close error is dropped rather than joined: err is what explains this
+		// dial, and there is no recording here for a close to be truthful about.
+		conn.Close()
+		return nil, err
+	}
+	return rec, nil
 }
 
-func NewConnectionRecorder(fname string, conn net.Conn) (net.Conn, error) {
+// NewConnectionRecorder wraps conn, recording every frame in both directions.
+//
+// comp may be nil; see WithSegmentCompressor for when it is needed.
+//
+// # One recording directory per run
+//
+// The files are opened O_APPEND under a name derived from the address and the source
+// port, and RecordDialer takes that port from the context -- which is 0 unless
+// shard-awareness is on. Every connection to a host therefore appends to the same pair
+// of files, and a directory reused across runs keeps accumulating. The loader survives
+// that only because it keys records by stream id and keeps the last one for each: the
+// recordings checked into tests/bench hold 345 records from 23 stacked sessions, and
+// load as the 15 that survive. Anything the last session did not overwrite is a record
+// from an older one, paired with whatever response now shares its stream id.
+//
+// So a recording directory has to be per run. Making the file name unique per
+// connection instead would need the replayer to stop deriving the same name from the
+// same two values, which is a different design than the one here.
+func NewConnectionRecorder(fname string, conn net.Conn, comp dialer.SegmentCompressor) (net.Conn, error) {
 	fd_writes, err := os.OpenFile(fname+"Writes", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		return nil, err
 	}
 	fd_reads, err2 := os.OpenFile(fname+"Reads", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err2 != nil {
+		fd_writes.Close()
 		return nil, err2
 	}
-	return &ConnectionRecorder{fd_writes: fd_writes, fd_reads: fd_reads, orig: conn}, nil
+	// Both directions share one Framing: the handshake fact that switches them to
+	// transport segments is carried by a response, and applies to requests too.
+	framing := dialer.NewFraming(comp)
+	return &ConnectionRecorder{
+		fd_writes:    fd_writes,
+		fd_reads:     fd_reads,
+		orig:         conn,
+		read_record:  FrameWriter{framing: framing, decoder: framing.NewDecoder(), response: true},
+		write_record: FrameWriter{framing: framing, decoder: framing.NewDecoder()},
+	}, nil
 }
 
-// FrameWriter records the CQL frames it is fed, one JSON object per line.
+// FrameWriter records the CQL frames of one direction of a connection, one JSON
+// object per line.
 //
-// The frame boundaries come from dialer.FrameSplitter, which both this and the
-// replayer use: a read can carry several frames or end in the middle of one, and
-// either shape has to come back out of the recording as the frames that went in.
+// Frame boundaries come from a dialer.Decoder, which follows the connection across the
+// handshake: bare CQL frames to begin with, transport segments once a protocol v5
+// connection switches. Recordings hold bare frames either way, so the format does not
+// depend on the protocol version and a v5 recording is stored unwrapped and
+// decompressed.
 type FrameWriter struct {
-	splitter dialer.FrameSplitter
+	framing *dialer.Framing
+	decoder *dialer.Decoder
+	// response reports whether this direction carries responses. It decides which of
+	// the two handshake facts this direction can observe.
+	response bool
 	// useMetadataID latches once a STARTUP frame on this connection opts into the
 	// SCYLLA_USE_METADATA_ID extension, so every subsequent recorded frame is
-	// stamped with the negotiated state (the driver only sends the opt-in when
-	// the server advertised it, so its presence means the extension is active).
+	// stamped with the negotiated state (the driver only sends the opt-in when the
+	// server advertised it, so its presence means the extension is active).
+	//
+	// Deliberately per-direction rather than on Framing: only requests carry a
+	// STARTUP, so sharing it would start stamping the flag into the Reads recording
+	// as well. Nothing reads it from there, and the checked-in recordings do not
+	// carry the field at all.
 	useMetadataID bool
 }
 
 // Write records the frames in b[:n].
 func (f *FrameWriter) Write(b []byte, n int, file *os.File) error {
-	return f.splitter.Feed(b[:n], func(frame []byte) error {
+	return f.decoder.Feed(b[:n], func(frame []byte) error {
 		return f.record(frame, file)
 	})
 }
 
 // record appends one complete frame to the recording.
 func (f *FrameWriter) record(frame []byte, file *os.File) error {
-	// A frame's first byte is its protocol version, and the driver's handshake
-	// frames are never segment-framed — so on a v5+ connection this fires on the
-	// first frame of the handshake, before any transport segment reaches the
-	// fixed-offset frame slicing and is recorded as garbage.
-	if dialer.FrameIsProtoV5OrNewer(frame) {
-		return dialer.ErrProtoV5NotSupported
-	}
+	if f.response {
+		// Flips the framing latch when the handshake reaches READY or AUTHENTICATE,
+		// so both directions decode what follows as transport segments. The frame
+		// carrying that news is itself unsegmented, and has already been decoded as
+		// such by the time this runs.
+		f.framing.ObserveResponse(frame)
+	} else {
+		// Reads the COMPRESSION option, which decides the segment header layout, and
+		// refuses the negotiated compressions a recording cannot represent -- body
+		// compression below v5, or an algorithm the supplied compressor does not
+		// implement. Both are fatal to the recording rather than to the connection, but
+		// there is nothing useful to write once either is true, so it stops here.
+		if err := f.framing.ObserveRequest(frame); err != nil {
+			return err
+		}
 
-	// The latch reads a whole STARTUP, which is the reason frames are assembled
-	// before being recorded rather than each write being appended as it arrives.
-	// Missing the opt-in here would stamp every later EXECUTE false and turn replay
-	// into silent hash mismatches rather than an error.
-	if !f.useMetadataID && dialer.StartupNegotiatesMetadataID(frame) {
-		f.useMetadataID = true
+		// The latch reads a whole STARTUP, which is the reason frames are assembled
+		// before being recorded rather than each write being appended as it arrives.
+		// Missing the opt-in here would stamp every later EXECUTE false and turn
+		// replay into silent hash mismatches rather than an error.
+		if !f.useMetadataID && dialer.StartupNegotiatesMetadataID(frame) {
+			f.useMetadataID = true
+		}
 	}
 
 	record := dialer.Record{
 		Data:          frame,
 		StreamID:      int(frame[2])<<8 | int(frame[3]),
 		UseMetadataID: f.useMetadataID,
+		Proto:         dialer.FrameProtoVersion(frame),
 	}
 
 	jsonData, err := json.Marshal(record)
@@ -112,57 +199,267 @@ func (f *FrameWriter) record(frame []byte, file *os.File) error {
 }
 
 type ConnectionRecorder struct {
-	fd_writes    *os.File
-	fd_reads     *os.File
-	orig         net.Conn
+	fd_writes *os.File
+	fd_reads  *os.File
+	orig      net.Conn
+	// verdict is what Close reported the first time it ran, returned by every later
+	// call; see Close.
+	verdict error
+	// fatal latches the first recording failure, so both directions fail from then
+	// on: there is nothing useful to record past it, and a connection that carries
+	// on writes a recording with a silent hole. Atomic because reads and writes run
+	// on different goroutines (the driver's serve loop and the query's).
+	fatal        atomic.Pointer[error]
 	read_record  FrameWriter
 	write_record FrameWriter
+	// mu serialises everything that touches a recording: the two FrameWriters above,
+	// the files under them, and closed. A net.Conn may be closed while its reader is
+	// still in flight -- gocql closes from whichever goroutine finished with the
+	// connection while serve() sits in Read -- so Close would otherwise pull the files
+	// out from under a recording write, and read decoder state that Feed was still
+	// appending to.
+	//
+	// It sits after the FrameWriters, not next to fatal where it reads better: it holds
+	// no pointers, and the fieldalignment vet check counts every byte before the last
+	// pointer as one the GC has to scan. Splitting the pointer-bearing fields with it
+	// costs 8 such bytes and fails make check.
+	mu sync.Mutex
+	// closeOnce runs the teardown once, whatever a caller does; see Close.
+	closeOnce sync.Once
+	// closed is set by Close, under mu, before it closes the socket. Recording stops
+	// there: the truncation verdict is about to be taken, so a later write would
+	// invalidate the answer already given and would land on files that are closing. It
+	// is also how Write knows that a send failure from this point on is the close
+	// itself rather than anything about the recording.
+	closed bool
+}
+
+// fail latches err as the recording's terminal failure and returns the latched failure:
+// err itself when it won the race, the earlier one otherwise.
+//
+// Returning the latched value rather than the argument is what keeps one recording to one
+// cause. Read and Write hand this straight back to the driver and Close ranks the same
+// value first, so a write that fails after the read goroutine has already latched -- the
+// ordinary way a broken recording unwinds -- reports why the recording ended rather than
+// the symptom that followed it.
+func (c *ConnectionRecorder) fail(err error) error {
+	c.fatal.CompareAndSwap(nil, &err)
+	return c.failed()
+}
+
+// isClosed reports whether Close has begun.
+func (c *ConnectionRecorder) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
+// failed returns the latched failure, if any.
+func (c *ConnectionRecorder) failed() error {
+	if p := c.fatal.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// recordRead appends the frames in b[:n] to the Reads recording.
+//
+// It is a no-op once Close has run: the file is gone by then, and the truncation
+// verdict has already been taken.
+func (c *ConnectionRecorder) recordRead(b []byte, n int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	return c.read_record.Write(b, n, c.fd_reads)
+}
+
+// recordWrite appends the frames in b to the Writes recording. See recordRead.
+func (c *ConnectionRecorder) recordWrite(b []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	return c.write_record.Write(b, len(b), c.fd_writes)
 }
 
 func (c *ConnectionRecorder) Read(b []byte) (n int, err error) {
+	if err := c.failed(); err != nil {
+		return 0, err
+	}
+
 	n, err = c.orig.Read(b)
-	if err != nil && err != io.EOF {
-		return n, err
-	}
 
-	return n, c.read_record.Write(b, n, c.fd_reads)
+	// Whatever arrived is recorded, whatever came back with it. A net.Conn may return
+	// n > 0 alongside an error, and in this driver that is routine rather than
+	// terminal: connReader.Read resumes a read that timed out while still making
+	// progress, up to maxReadAttempts times, so a large body over a slow link arrives
+	// in pieces on a connection that carries straight on. Returning before recording
+	// those bytes left them out of the recording *and* the read decoder mid-frame at a
+	// stale offset, so every frame after them was assembled from the wrong bytes --
+	// silently, because nothing was latched and the driver was never told.
+	//
+	// This subsumes the io.EOF case that used to be spelled out here: a conn between
+	// this one and the socket is free to wrap its io.EOF, and an identity test against
+	// it took the early return, dropping the frames the last read carried.
+	if n > 0 {
+		if recErr := c.recordRead(b, n); recErr != nil {
+			// None of it is handed on, the way an unrecordable write sends nothing. The
+			// failure is terminal and latched, and these are bytes the driver would act
+			// on that no replay of the recording can reproduce.
+			return 0, c.fail(recErr)
+		}
+	}
+	// err reaches the caller untouched, io.EOF included: swallowed, a server-closed
+	// connection reads as (0, nil) forever, which the driver's io.ReadFull treats as
+	// no progress and spins on at full speed, never noticing the connection died. It
+	// is deliberately not latched either -- the read it ended may yet be resumed.
+	return n, err
 }
 
+// Write records the frames in b, then forwards them to the wrapped connection.
+//
+// Recording first is load-bearing. The write decoder has to consume the STARTUP
+// before the server can answer READY, because that answer -- observed by the read
+// goroutine -- flips the shared framing latch, and a write decoder still short of
+// the STARTUP would then misparse it as a transport segment (see Framing). It also
+// means a refused STARTUP (ObserveRequest) is refused before anything reaches the
+// server, and that a failure to record sends nothing and returns (0, err): the
+// driver's write coalescer attributes success by bytes written, so bytes-then-error
+// would be reported upstream as a clean write and the recording would be silently
+// short.
+//
+// The cost is that a request recorded here can still fail to send, and that record
+// cannot be recalled. It does not simply go unpaired: the loader keys records by
+// stream id and keeps the last one for each, and the driver reuses stream ids, so an
+// unsent request displaces whatever was recorded on that stream before it and is
+// paired at load time with that earlier exchange's response. So a send failure is
+// latched like a recording failure -- the recording ends where it stopped being true,
+// rather than growing more records around a hole. Once Close has begun it is not: see
+// below.
 func (c *ConnectionRecorder) Write(b []byte) (n int, err error) {
-	n, err = c.orig.Write(b)
-	if err != nil {
-		return n, err
+	if err := c.failed(); err != nil {
+		return 0, err
 	}
 
-	return n, c.write_record.Write(b, n, c.fd_writes)
+	if err := c.recordWrite(b); err != nil {
+		return 0, c.fail(err)
+	}
+
+	n, err = c.orig.Write(b)
+	// Not once Close has begun. gocql closes a connection from whichever goroutine
+	// noticed it was done, while the write coalescer may still be inside WriteTo, so a
+	// perfectly ordinary close fails an in-flight write with net.ErrClosed. Latching
+	// that would outrank the recording's real verdict in Close -- and on a graceful
+	// close Conn.closeWithError hands Close's error to errorHandler.HandleError, so a
+	// complete recording would report its own teardown as the reason it ended.
+	if err != nil && !c.isClosed() {
+		c.fail(err)
+	}
+	return n, err
 }
 
-func (c ConnectionRecorder) Close() error {
+// Close closes the wrapped connection and both recording files, and reports what went
+// wrong with the recording.
+//
+// It is idempotent: the teardown runs once and every later call reports the same verdict.
+// A net.Conn is closed more than once routinely -- an explicit Close alongside a deferred
+// one is the ordinary shape -- and re-running the body below turned a healthy recording's
+// nil into os.ErrClosed for each file plus net.ErrClosed for the socket, which on the
+// driver route is the string Conn.closeWithError hands to errorHandler.HandleError. So a
+// complete recording reported its own second close as the reason it was broken.
+//
+// sync.Once rather than the closed flag, which is already set before the files are
+// touched: a second caller arriving mid-teardown waits for the verdict instead of reading
+// one that is not built yet.
+func (c *ConnectionRecorder) Close() error {
+	c.closeOnce.Do(func() { c.verdict = c.close() })
+	return c.verdict
+}
+
+// close is Close's one-shot teardown.
+//
+// The socket is closed before the files, and closed is set before either. gocql closes a
+// connection from whichever goroutine noticed it was done while serve() may still be
+// inside Read, so closing the files first pulled them out from under a recording write
+// that was already in flight: its frames were lost and it latched a "file already closed"
+// naming nothing. Closing the socket first unblocks that read so it can finish. Marking
+// closed ahead of both is what stops the write that same close interrupts from latching
+// its net.ErrClosed as the recording's verdict; see Write.
+//
+// Every close is then attempted whatever the ones before it did, and every failure is
+// reported. Returning at the first would leave the other recording file and the socket
+// open, and under the driver's redial loop that is one descriptor and one connection
+// stranded per attempt -- the same leak NewConnectionRecorder had on its setup path.
+// Keeping only the first was that same mistake one step further in: a Writes file that
+// would not close discarded the Reads file's failure and the socket's alike, and the
+// socket's is the one closeWithError hands to errorHandler.HandleError.
+//
+// A read that had already returned from the socket but not yet reached recordRead is
+// dropped rather than raced: it finds closed set and gives up. Those are bytes from a
+// connection being torn down, and the alternative is a verdict below that depends on
+// which goroutine got there first.
+func (c *ConnectionRecorder) close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+
+	connErr := c.orig.Close()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var errs []error
 	if err := c.fd_writes.Close(); err != nil {
-		return fmt.Errorf("failed to close the file: %w", err)
+		errs = append(errs, fmt.Errorf("failed to close the Writes file: %w", err))
 	}
 	if err := c.fd_reads.Close(); err != nil {
-		return fmt.Errorf("failed to close the file: %w", err)
+		errs = append(errs, fmt.Errorf("failed to close the Reads file: %w", err))
 	}
-	return c.orig.Close()
+	if connErr != nil {
+		errs = append(errs, connErr)
+	}
+	closeErr := errors.Join(errs...)
+
+	// Ordered by what it tells the caller. A latched failure is why the recording
+	// stopped being true, so it outranks both of the others: reporting a truncated
+	// stream instead named the symptom of the very failure that caused it, and left
+	// the cause -- the one thing that says which write or which read went wrong --
+	// unreported on every path out of here.
+	if err := c.failed(); err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	// A stream that ends inside a frame or an unfinished segment chain produced a
+	// recording that looks complete but is not, and at load time the loss surfaces
+	// only as an unpaired stream or an unmatched hash, with nothing pointing at this
+	// session.
+	if c.read_record.decoder.Pending() || c.write_record.decoder.Pending() {
+		return fmt.Errorf("gocql/dialer: the connection closed in the middle of a frame or segment chain; the recording is truncated")
+	}
+	return nil
 }
 
-func (c ConnectionRecorder) LocalAddr() net.Addr {
+func (c *ConnectionRecorder) LocalAddr() net.Addr {
 	return c.orig.LocalAddr()
 }
 
-func (c ConnectionRecorder) RemoteAddr() net.Addr {
+func (c *ConnectionRecorder) RemoteAddr() net.Addr {
 	return c.orig.RemoteAddr()
 }
 
-func (c ConnectionRecorder) SetDeadline(t time.Time) error {
+func (c *ConnectionRecorder) SetDeadline(t time.Time) error {
 	return c.orig.SetDeadline(t)
 }
 
-func (c ConnectionRecorder) SetReadDeadline(t time.Time) error {
+func (c *ConnectionRecorder) SetReadDeadline(t time.Time) error {
 	return c.orig.SetReadDeadline(t)
 }
 
-func (c ConnectionRecorder) SetWriteDeadline(t time.Time) error {
+func (c *ConnectionRecorder) SetWriteDeadline(t time.Time) error {
 	return c.orig.SetWriteDeadline(t)
 }

--- a/dialer/recorder/recorder.go
+++ b/dialer/recorder/recorder.go
@@ -56,20 +56,13 @@ func NewConnectionRecorder(fname string, conn net.Conn) (net.Conn, error) {
 	return &ConnectionRecorder{fd_writes: fd_writes, fd_reads: fd_reads, orig: conn}, nil
 }
 
-// headerLen is the CQL frame header the recorder slices on: version, flags, a
-// 2-byte stream id, the opcode and the 4-byte body length. It is fixed, as it has
-// always been here. Negotiation lands on v4 (discoverProtocol) and v5+ is refused
-// outright (dialer.ErrProtoV5NotSupported), so the 1-byte stream id of v1/v2 only
-// appears if a caller pins ProtoVersion to one of them — which these dialers have
-// never handled, here or in the offset math they share with dialer.GetFrameHash.
-const headerLen = 9
-
+// FrameWriter records the CQL frames it is fed, one JSON object per line.
+//
+// The frame boundaries come from dialer.FrameSplitter, which both this and the
+// replayer use: a read can carry several frames or end in the middle of one, and
+// either shape has to come back out of the recording as the frames that went in.
 type FrameWriter struct {
-	record dialer.Record
-	// bodyLeft counts the body bytes still owed to the frame in record, and is
-	// meaningful only once that frame's header is complete — until then the
-	// declared length has not been read.
-	bodyLeft int
+	splitter dialer.FrameSplitter
 	// useMetadataID latches once a STARTUP frame on this connection opts into the
 	// SCYLLA_USE_METADATA_ID extension, so every subsequent recorded frame is
 	// stamped with the negotiated state (the driver only sends the opt-in when
@@ -77,80 +70,44 @@ type FrameWriter struct {
 	useMetadataID bool
 }
 
-// Write records the frames in b[:n]. Neither side of a connection delivers one
-// frame per call: the driver's read path fills a bufio.Reader, so a read can carry
-// several frames or end in the middle of one, and either shape has to come back out
-// of the recording as the frames that went in.
+// Write records the frames in b[:n].
 func (f *FrameWriter) Write(b []byte, n int, file *os.File) error {
-	for rest := b[:n]; len(rest) > 0; {
-		taken, err := f.consume(rest, file)
-		if err != nil {
-			return err
-		}
-		rest = rest[taken:]
-	}
-	return nil
+	return f.splitter.Feed(b[:n], func(frame []byte) error {
+		return f.record(frame, file)
+	})
 }
 
-// consume appends the prefix of b belonging to the frame in progress and, once that
-// frame is whole, records it and resets for the next one. It returns how many bytes
-// it took, which is all of b unless b runs on into the following frame.
-func (f *FrameWriter) consume(b []byte, file *os.File) (int, error) {
-	// While the header is short the body length is still unknown, so take only what
-	// completes the header: anything past it may belong to the next frame.
-	headerShort := len(f.record.Data) < headerLen
-	want := f.bodyLeft
-	if headerShort {
-		want = headerLen - len(f.record.Data)
+// record appends one complete frame to the recording.
+func (f *FrameWriter) record(frame []byte, file *os.File) error {
+	// A frame's first byte is its protocol version, and the driver's handshake
+	// frames are never segment-framed — so on a v5+ connection this fires on the
+	// first frame of the handshake, before any transport segment reaches the
+	// fixed-offset frame slicing and is recorded as garbage.
+	if dialer.FrameIsProtoV5OrNewer(frame) {
+		return dialer.ErrProtoV5NotSupported
 	}
 
-	taken := min(want, len(b))
-	f.record.Data = append(f.record.Data, b[:taken]...)
-
-	if headerShort {
-		// A frame's first byte is its protocol version, and the driver's handshake
-		// frames are never segment-framed — so on a v5+ connection this fires during
-		// the handshake, before any transport segment reaches the fixed-offset frame
-		// slicing here and is recorded as garbage.
-		if dialer.FrameIsProtoV5OrNewer(f.record.Data) {
-			return taken, dialer.ErrProtoV5NotSupported
-		}
-		if len(f.record.Data) < headerLen {
-			return taken, nil
-		}
-		f.bodyLeft = int(f.record.Data[5])<<24 | int(f.record.Data[6])<<16 | int(f.record.Data[7])<<8 | int(f.record.Data[8])
-		f.record.StreamID = int(f.record.Data[2])<<8 | int(f.record.Data[3])
-	} else {
-		f.bodyLeft -= taken
-	}
-
-	if f.bodyLeft > 0 {
-		return taken, nil
-	}
-	return taken, f.flush(file)
-}
-
-// flush writes the completed frame in record and starts a fresh one.
-func (f *FrameWriter) flush(file *os.File) error {
-	// The latch reads a whole STARTUP, which is the reason the frame is assembled
-	// before it is recorded rather than each call being written as it arrives.
+	// The latch reads a whole STARTUP, which is the reason frames are assembled
+	// before being recorded rather than each write being appended as it arrives.
 	// Missing the opt-in here would stamp every later EXECUTE false and turn replay
 	// into silent hash mismatches rather than an error.
-	if !f.useMetadataID && dialer.StartupNegotiatesMetadataID(f.record.Data) {
+	if !f.useMetadataID && dialer.StartupNegotiatesMetadataID(frame) {
 		f.useMetadataID = true
 	}
-	f.record.UseMetadataID = f.useMetadataID
 
-	jsonData, err := json.Marshal(f.record)
+	record := dialer.Record{
+		Data:          frame,
+		StreamID:      int(frame[2])<<8 | int(frame[3]),
+		UseMetadataID: f.useMetadataID,
+	}
+
+	jsonData, err := json.Marshal(record)
 	if err != nil {
 		return fmt.Errorf("failed to encode JSON record: %w", err)
 	}
 	if _, err := file.Write(append(jsonData, '\n')); err != nil {
 		return fmt.Errorf("failed to record: %w", err)
 	}
-
-	f.record = dialer.Record{}
-	f.bodyLeft = 0
 	return nil
 }
 

--- a/dialer/recorder/recorder_test.go
+++ b/dialer/recorder/recorder_test.go
@@ -2,22 +2,53 @@ package recorder
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gocql/gocql/dialer"
 )
 
+// TestConnectionRecorderFailKeepsOneCause pins that fail reports the latched failure
+// rather than its argument. Read and Write hand what fail returns straight back to the
+// driver while Close ranks the latched value first, so returning the argument would have
+// the driver's error handler and the Close caller naming different causes for the same
+// recording -- and the later one is always the symptom, never the cause.
+func TestConnectionRecorderFailKeepsOneCause(t *testing.T) {
+	var c ConnectionRecorder
+
+	first := errors.New("the segment payload failed its CRC32")
+	later := errors.New("write tcp: broken pipe")
+
+	if got := c.fail(first); !errors.Is(got, first) {
+		t.Fatalf("fail(first) = %v, want the first failure back", got)
+	}
+	if got := c.fail(later); !errors.Is(got, first) {
+		t.Errorf("fail(later) = %v, want the latched %v", got, first)
+	}
+	if got := c.failed(); !errors.Is(got, first) {
+		t.Errorf("failed() = %v, want the latched %v", got, first)
+	}
+}
+
 // stubConn is a net.Conn whose Read serves a fixed byte stream and whose Write
 // accepts everything, so the recorder's own behaviour is all a test observes.
 type stubConn struct {
 	readData []byte
+	written  []byte
+	writeErr error
+	closeErr error
+	closed   bool
+	// closes counts every Close, so a test can tell one teardown from two.
+	closes int
 }
 
 func (c *stubConn) Read(b []byte) (int, error) {
@@ -29,8 +60,14 @@ func (c *stubConn) Read(b []byte) (int, error) {
 	return n, nil
 }
 
-func (c *stubConn) Write(b []byte) (int, error)      { return len(b), nil }
-func (c *stubConn) Close() error                     { return nil }
+func (c *stubConn) Write(b []byte) (int, error) {
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
+	c.written = append(c.written, b...)
+	return len(b), nil
+}
+func (c *stubConn) Close() error                     { c.closes++; c.closed = true; return c.closeErr }
 func (c *stubConn) LocalAddr() net.Addr              { return nil }
 func (c *stubConn) RemoteAddr() net.Addr             { return nil }
 func (c *stubConn) SetDeadline(time.Time) error      { return nil }
@@ -76,6 +113,13 @@ func recordedFrames(t *testing.T, fname string) []dialer.Record {
 		t.Fatalf("reading %s: %v", fname, err)
 	}
 
+	// An empty file is a recording of nothing, which is a frame count the caller can
+	// assert on. Splitting it yields one zero-length line that json.Unmarshal refuses,
+	// so this used to fail here as "unexpected end of JSON input" instead.
+	if len(data) == 0 {
+		return nil
+	}
+
 	var records []dialer.Record
 	for _, line := range bytes.Split(bytes.TrimRight(data, "\n"), []byte{'\n'}) {
 		var record dialer.Record
@@ -85,6 +129,213 @@ func recordedFrames(t *testing.T, fname string) []dialer.Record {
 		records = append(records, record)
 	}
 	return records
+}
+
+// TestConnectionRecorderPropagatesEOF pins that a server-closed connection reports
+// io.EOF. The recorder must record on EOF too -- a final read can carry data -- but
+// it used to return the recording step's error in its place, which is nil, so a dead
+// connection read as (0, nil) forever: the driver reads through io.ReadFull, which
+// loops while err is nil, and spun at full speed instead of tearing the
+// connection down.
+func TestConnectionRecorderPropagatesEOF(t *testing.T) {
+	response := optionsFrame(0x84)
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), &stubConn{readData: response}, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	defer rec.Close()
+
+	buf := make([]byte, len(response))
+	if n, err := rec.Read(buf); err != nil || n != len(response) {
+		t.Fatalf("Read = (%d, %v), want (%d, nil)", n, err, len(response))
+	}
+	if _, err := rec.Read(buf); err != io.EOF {
+		t.Fatalf("Read at end of stream = %v, want io.EOF", err)
+	}
+}
+
+// timeoutErr is a net.Error reporting a timeout -- the shape connReader.Read treats as
+// resumable when the read that hit it still delivered bytes.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+// scriptedRead is one result a scriptedConn hands back: some bytes, and the error
+// returned with them.
+type scriptedRead struct {
+	data []byte
+	err  error
+}
+
+// scriptedConn serves a fixed sequence of Read results, so a test can hand the recorder
+// the (n > 0, err) pair a real socket is allowed to return.
+type scriptedConn struct {
+	stubConn
+	reads []scriptedRead
+}
+
+func (c *scriptedConn) Read(b []byte) (int, error) {
+	if len(c.reads) == 0 {
+		return 0, io.EOF
+	}
+	next := c.reads[0]
+	c.reads = c.reads[1:]
+	return copy(b, next.data), next.err
+}
+
+// TestConnectionRecorderRecordsAPartialReadThatErrored pins that bytes delivered
+// alongside a non-EOF error still reach the recording.
+//
+// A net.Conn may return n > 0 together with an error, and in this driver that is
+// routine rather than terminal: connReader.Read arms a deadline per attempt and resumes
+// a read that timed out while still making progress, up to maxReadAttempts times, so a
+// large frame body over a slow link arrives in pieces on a connection that carries
+// straight on. Returning before recording those bytes dropped them from the recording
+// and left the read decoder mid-frame at a stale offset, so every frame after them was
+// assembled from the wrong bytes -- and nothing was latched, so neither the driver nor
+// Close ever said so.
+func TestConnectionRecorderRecordsAPartialReadThatErrored(t *testing.T) {
+	response := optionsFrame(0x84)
+	const split = 4 // mid-header, so a dropped prefix mis-frames everything after it
+
+	conn := &scriptedConn{reads: []scriptedRead{
+		{data: response[:split], err: timeoutErr{}},
+		{data: response[split:]},
+	}}
+
+	dir := t.TempDir()
+	rec, err := NewConnectionRecorder(filepath.Join(dir, "conn"), conn, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+
+	buf := make([]byte, len(response))
+	n, err := rec.Read(buf)
+	if n != split {
+		t.Fatalf("first Read = %d bytes, want %d", n, split)
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("first Read error = %v, want a timeout the driver would resume", err)
+	}
+
+	if n, err := rec.Read(buf); err != nil || n != len(response)-split {
+		t.Fatalf("second Read = (%d, %v), want (%d, nil)", n, err, len(response)-split)
+	}
+
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	records := recordedFrames(t, filepath.Join(dir, "connReads"))
+	if len(records) != 1 {
+		t.Fatalf("recorded %d frames, want 1", len(records))
+	}
+	if !bytes.Equal(records[0].Data, response) {
+		t.Errorf("recorded frame = %x, want %x", records[0].Data, response)
+	}
+}
+
+// endlessConn serves one whole frame per Read until it is closed.
+//
+// It records being closed in the embedded stubConn's own field rather than adding a
+// second one that shadows it: a test reaching for stubConn.closed -- which is what
+// TestConnectionRecorderCloseClosesEverything asserts on -- would otherwise read a
+// field this type never sets and pass for the wrong reason. Both accesses are under
+// mu because Close here races the read goroutine, which the unsynchronised
+// stubConn.Close this one overrides does not have to consider.
+type endlessConn struct {
+	stubConn
+	frame []byte
+	mu    sync.Mutex
+}
+
+func (c *endlessConn) Read(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stubConn.closed {
+		return 0, net.ErrClosed
+	}
+	return copy(b, c.frame), nil
+}
+
+func (c *endlessConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stubConn.closed = true
+	return nil
+}
+
+// TestConnectionRecorderCloseIsSafeWhileReading pins that Close may run while the read
+// goroutine is still inside Read. Worth running under -race, which is what catches it.
+//
+// gocql closes a connection from whichever goroutine noticed it was finished while
+// serve() can still be in Read, so a net.Conn has to tolerate the overlap. Close used to
+// shut the recording files before the socket and then read decoder state that Feed was
+// concurrently appending to: the in-flight frames were lost to an "file already closed"
+// that named nothing, and the truncation verdict came out differently depending on which
+// goroutine got there first.
+func TestConnectionRecorderCloseIsSafeWhileReading(t *testing.T) {
+	response := optionsFrame(0x84)
+	conn := &endlessConn{frame: response}
+
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), conn, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, len(response))
+		for {
+			if _, err := rec.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Long enough for the reader to be somewhere inside Read.
+	time.Sleep(time.Millisecond)
+
+	if err := rec.Close(); err != nil {
+		t.Errorf("Close while reading: %v", err)
+	}
+	<-done
+
+	// Spelled through the embedded struct on purpose: that is the field a helper
+	// written against stubConn reads, and endlessConn used to declare a second one
+	// that shadowed it, so its Close left this one false with nothing to notice.
+	if !conn.stubConn.closed {
+		t.Error("Close left the wrapped connection open")
+	}
+}
+
+// TestConnectionRecorderCloseReportsATruncatedStream pins that a stream ending in
+// the middle of a frame is reported at Close. On disk that recording looks complete,
+// and at load time the loss surfaces only as an unpaired stream or an unmatched
+// hash, with nothing pointing at the session that was cut short.
+func TestConnectionRecorderCloseReportsATruncatedStream(t *testing.T) {
+	startup := startupFrame()
+
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), &stubConn{}, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+
+	if _, err := rec.Write(startup[:len(startup)-3]); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	err = rec.Close()
+	if err == nil {
+		t.Fatal("closing a connection mid-frame reported nothing")
+	}
+	if !strings.Contains(err.Error(), "truncated") {
+		t.Errorf("error %q does not say the recording is truncated", err)
+	}
 }
 
 // TestConnectionRecorderReassemblesSplitFrames pins that a frame delivered over
@@ -109,7 +360,7 @@ func TestConnectionRecorderReassemblesSplitFrames(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fname := filepath.Join(t.TempDir(), "conn")
-			rec, err := NewConnectionRecorder(fname, &stubConn{})
+			rec, err := NewConnectionRecorder(fname, &stubConn{}, nil)
 			if err != nil {
 				t.Fatalf("NewConnectionRecorder: %v", err)
 			}
@@ -160,7 +411,7 @@ func TestConnectionRecorderSplitsCoalescedFrames(t *testing.T) {
 		second[3] = 0x02 // a different stream id, so the two records are telling apart
 
 		fname := filepath.Join(t.TempDir(), "conn")
-		rec, err := NewConnectionRecorder(fname, &stubConn{readData: append(append([]byte{}, first...), second...)})
+		rec, err := NewConnectionRecorder(fname, &stubConn{readData: append(append([]byte{}, first...), second...)}, nil)
 		if err != nil {
 			t.Fatalf("NewConnectionRecorder: %v", err)
 		}
@@ -188,7 +439,7 @@ func TestConnectionRecorderSplitsCoalescedFrames(t *testing.T) {
 		startup, options := startupFrame(), optionsFrame(0x04)
 
 		fname := filepath.Join(t.TempDir(), "conn")
-		rec, err := NewConnectionRecorder(fname, &stubConn{})
+		rec, err := NewConnectionRecorder(fname, &stubConn{}, nil)
 		if err != nil {
 			t.Fatalf("NewConnectionRecorder: %v", err)
 		}
@@ -221,43 +472,42 @@ func TestConnectionRecorderSplitsCoalescedFrames(t *testing.T) {
 	})
 }
 
-// TestConnectionRecorderRejectsProtoV5 pins the rejection path dkropachev asked
-// for: on v5+ the byte stream carries transport segments after the handshake,
-// which the recorder's fixed-offset frame slicing would record as garbage. The
-// version byte of the handshake frames is genuine (they are never segmented),
-// so both directions fail there, before any segment flows.
-func TestConnectionRecorderRejectsProtoV5(t *testing.T) {
-	t.Run("write side", func(t *testing.T) {
-		rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), &stubConn{})
-		if err != nil {
-			t.Fatalf("NewConnectionRecorder: %v", err)
-		}
-		defer rec.Close()
+// TestConnectionRecorderRecordsUnsegmentedProtoV5 pins that a v5 connection is
+// recorded rather than refused.
+//
+// It used to be refused outright, because the recorder sliced the byte stream on fixed
+// CQL header offsets and a v5 transport segment has none of them. The handshake is
+// still unsegmented on v5, so these frames go through the plain path; what changed is
+// that reaching them is no longer an error.
+func TestConnectionRecorderRecordsUnsegmentedProtoV5(t *testing.T) {
+	fname := filepath.Join(t.TempDir(), "conn")
+	rec, err := NewConnectionRecorder(fname, &stubConn{readData: optionsFrame(0x85)}, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	defer rec.Close()
 
-		if _, err := rec.Write(optionsFrame(0x05)); !errors.Is(err, dialer.ErrProtoV5NotSupported) {
-			t.Fatalf("Write(v5 frame) error = %v, want ErrProtoV5NotSupported", err)
-		}
-	})
+	if _, err := rec.Write(optionsFrame(0x05)); err != nil {
+		t.Fatalf("Write(v5 frame) error = %v, want nil", err)
+	}
+	buf := make([]byte, 64)
+	if _, err := rec.Read(buf); err != nil {
+		t.Fatalf("Read(v5 response) error = %v, want nil", err)
+	}
 
-	t.Run("read side", func(t *testing.T) {
-		rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), &stubConn{readData: optionsFrame(0x85)})
-		if err != nil {
-			t.Fatalf("NewConnectionRecorder: %v", err)
+	for _, suffix := range []string{"Writes", "Reads"} {
+		got := recordedFrames(t, fname+suffix)
+		if len(got) != 1 {
+			t.Fatalf("%s: recorded %d frames, want 1", suffix, len(got))
 		}
-		defer rec.Close()
-
-		buf := make([]byte, 64)
-		if _, err := rec.Read(buf); !errors.Is(err, dialer.ErrProtoV5NotSupported) {
-			t.Fatalf("Read(v5 response) error = %v, want ErrProtoV5NotSupported", err)
-		}
-	})
+	}
 }
 
 // TestConnectionRecorderAcceptsProtoV4 pins that the rejection is scoped to
 // v5+: a v4 frame (with and without the direction bit) is recorded normally.
 func TestConnectionRecorderAcceptsProtoV4(t *testing.T) {
 	fname := filepath.Join(t.TempDir(), "conn")
-	rec, err := NewConnectionRecorder(fname, &stubConn{readData: optionsFrame(0x84)})
+	rec, err := NewConnectionRecorder(fname, &stubConn{readData: optionsFrame(0x84)}, nil)
 	if err != nil {
 		t.Fatalf("NewConnectionRecorder: %v", err)
 	}
@@ -279,5 +529,283 @@ func TestConnectionRecorderAcceptsProtoV4(t *testing.T) {
 		if len(data) == 0 {
 			t.Errorf("the v4 frame was not recorded to the %s file", suffix)
 		}
+	}
+}
+
+// TestConnectionRecorderCloseClosesEverything pins that one failing close does not
+// strand the rest. Close used to return at the first error, leaving the other
+// recording file and the socket itself open -- under the driver's redial loop, one
+// descriptor and one connection per attempt, which is the leak NewConnectionRecorder
+// was fixed for on its setup path.
+func TestConnectionRecorderCloseClosesEverything(t *testing.T) {
+	conn := &stubConn{}
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), conn, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	recorder := rec.(*ConnectionRecorder)
+
+	// Closing the Writes file underneath is what a full disk or an I/O error looks
+	// like from Close: the first close it makes reports one.
+	if err := recorder.fd_writes.Close(); err != nil {
+		t.Fatalf("closing the Writes file: %v", err)
+	}
+
+	if err := rec.Close(); err == nil {
+		t.Error("Close reported success although the Writes file was already closed")
+	}
+	if !conn.closed {
+		t.Error("Close left the wrapped connection open")
+	}
+	if err := recorder.fd_reads.Close(); err == nil {
+		t.Error("Close left the Reads file open")
+	}
+}
+
+// TestConnectionRecorderCloseReportsEveryFailure pins that the close that failed first
+// does not silence the ones after it. Close kept only the first file error and then
+// dropped the socket's entirely -- and the socket's is the one closeWithError hands to
+// errorHandler.HandleError, so a Writes file that would not close hid the connection
+// failure the driver was about to be told about.
+func TestConnectionRecorderCloseReportsEveryFailure(t *testing.T) {
+	sockErr := errors.New("closing the socket")
+	conn := &stubConn{closeErr: sockErr}
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), conn, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	recorder := rec.(*ConnectionRecorder)
+
+	if err := recorder.fd_writes.Close(); err != nil {
+		t.Fatalf("closing the Writes file: %v", err)
+	}
+
+	closeErr := rec.Close()
+	if closeErr == nil {
+		t.Fatal("Close reported success although the Writes file was already closed")
+	}
+	if !strings.Contains(closeErr.Error(), "Writes file") {
+		t.Errorf("Close reported %v, which does not say which file it was", closeErr)
+	}
+	if !errors.Is(closeErr, sockErr) {
+		t.Errorf("Close reported %v, which drops the socket's own failure", closeErr)
+	}
+}
+
+// TestConnectionRecorderCloseIsIdempotent pins that a second Close runs no second
+// teardown and reports what the first one did. Closing an already-closed everything
+// turned a healthy recording's nil into os.ErrClosed for each file joined with the
+// socket's net.ErrClosed -- and on the driver route Conn.closeWithError hands that to
+// errorHandler.HandleError, so a complete recording was reported as the reason the
+// connection ended. An explicit Close alongside a deferred one is the ordinary shape.
+func TestConnectionRecorderCloseIsIdempotent(t *testing.T) {
+	startup := startupFrame()
+
+	for _, tc := range []struct {
+		name  string
+		write []byte
+		want  string
+	}{
+		{name: "a complete recording", write: startup},
+		{name: "a truncated recording", write: startup[:len(startup)-3], want: "truncated"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &stubConn{}
+			rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), conn, nil)
+			if err != nil {
+				t.Fatalf("NewConnectionRecorder: %v", err)
+			}
+			if _, err := rec.Write(tc.write); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			first := rec.Close()
+			if tc.want == "" && first != nil {
+				t.Fatalf("Close reported %v for a complete recording", first)
+			}
+			if tc.want != "" && (first == nil || !strings.Contains(first.Error(), tc.want)) {
+				t.Fatalf("Close reported %v, want one mentioning %q", first, tc.want)
+			}
+
+			if second := rec.Close(); second != first {
+				t.Errorf("the second Close reported %v, want the first one's %v", second, first)
+			}
+			if conn.closes != 1 {
+				t.Errorf("the socket was closed %d times, want once", conn.closes)
+			}
+		})
+	}
+}
+
+// TestRecordDialerClosesTheSocketWhenRecordingCannotStart pins that a dial whose
+// recording cannot be opened does not strand the connection it has already made.
+//
+// NewConnectionRecorder returns (nil, err) for anything os.OpenFile refuses -- a
+// missing recording directory, a read-only volume, a full disk, EMFILE -- and hands
+// the caller no net.Conn to close. The driver answers a failed dial by redialing, so
+// a socket left behind here is one stranded pair per attempt.
+func TestRecordDialerClosesTheSocketWhenRecordingCannotStart(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			close(accepted)
+			return
+		}
+		accepted <- conn
+	}()
+
+	d := NewRecordDialer(filepath.Join(t.TempDir(), "no-such-directory"))
+	if conn, err := d.DialContext(context.Background(), "tcp", ln.Addr().String()); err == nil {
+		conn.Close()
+		t.Fatal("DialContext succeeded although the recording directory does not exist")
+	}
+
+	server := <-accepted
+	if server == nil {
+		t.Fatal("the dial never reached the listener")
+	}
+	defer server.Close()
+
+	// The far end reading EOF is the only thing that can be observed about a socket
+	// the dialer no longer hands out. Deadlined so a leak fails this test rather than
+	// hanging it until the package timeout.
+	if err := server.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if _, err := server.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+		t.Errorf("server-side read = %v, want io.EOF; the dialed socket was left open", err)
+	}
+}
+
+// TestRecorderLatchesASendFailure pins that a request recorded but not sent ends the
+// recording rather than being left behind in it.
+//
+// Recording happens before the send, so that record is already on disk and cannot be
+// recalled. The loader keys records by stream id and keeps the last one, and the
+// driver reuses stream ids, so left to run the connection would hand the loader an
+// unsent request paired with an earlier exchange's response -- served on replay as a
+// plausible answer to a question nobody asked.
+func TestRecorderLatchesASendFailure(t *testing.T) {
+	sendErr := errors.New("connection reset by peer")
+	conn := &stubConn{readData: optionsFrame(0x84), writeErr: sendErr}
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), conn, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	defer rec.Close()
+
+	if _, err := rec.Write(startupFrame()); !errors.Is(err, sendErr) {
+		t.Fatalf("Write error = %v, want %v", err, sendErr)
+	}
+
+	// The connection healing afterwards is what the latch is for: recording resumes
+	// only if nothing remembers that a request went unsent.
+	conn.writeErr = nil
+	if _, err := rec.Write(optionsFrame(0x04)); !errors.Is(err, sendErr) {
+		t.Errorf("Write after a failed send = %v, want the latched %v", err, sendErr)
+	}
+	if _, err := rec.Read(make([]byte, 64)); !errors.Is(err, sendErr) {
+		t.Errorf("Read after a failed send = %v, want the latched %v", err, sendErr)
+	}
+}
+
+// TestRecorderHandsOnNothingItCouldNotRecord pins the read path's half of the
+// contract TestRecorderSendsNothingItCouldNotRecord pins for writes: a frame that
+// could not be recorded does not reach the driver either. It used to return the bytes
+// alongside the error, and a bufio.Reader hands those on before it reports the error
+// -- so the driver parsed and acted on frames the recording does not hold, and the
+// Reads and Writes files disagreed about what crossed the wire.
+func TestRecorderHandsOnNothingItCouldNotRecord(t *testing.T) {
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), &stubConn{readData: optionsFrame(0x84)}, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	recorder := rec.(*ConnectionRecorder)
+
+	// Closing the Reads file underneath is what a full disk looks like from record:
+	// the frame decodes, and writing it out is what fails.
+	if err := recorder.fd_reads.Close(); err != nil {
+		t.Fatalf("closing the Reads file: %v", err)
+	}
+
+	n, err := rec.Read(make([]byte, 64))
+	if err == nil {
+		t.Fatal("a frame that could not be recorded was handed to the driver")
+	}
+	if n != 0 {
+		t.Errorf("Read = (%d, %v), want (0, err)", n, err)
+	}
+	if _, err := rec.Write(optionsFrame(0x04)); err == nil {
+		t.Error("the recording failure was not latched")
+	}
+}
+
+// closeRacingConn is a net.Conn whose Write is still in flight when Close arrives and
+// fails the way a real socket does once that close has landed.
+//
+// Close releases the write and then waits for it to have decided what to do with the
+// error, so the ordering the test is about is pinned rather than raced: the recorder
+// must have marked itself closed before the socket goes, not after.
+type closeRacingConn struct {
+	stubConn
+	inWrite  chan struct{}
+	release  chan struct{}
+	observed chan struct{}
+}
+
+func (c *closeRacingConn) Write([]byte) (int, error) {
+	close(c.inWrite)
+	<-c.release
+	return 0, net.ErrClosed
+}
+
+func (c *closeRacingConn) Close() error {
+	close(c.release)
+	<-c.observed
+	return c.stubConn.Close()
+}
+
+// TestConnectionRecorderCloseDoesNotLatchItsOwnTeardown pins that the close's own
+// casualties are not reported as the reason the recording ended.
+//
+// gocql closes a connection from whichever goroutine noticed it was done, while the
+// write coalescer may still be inside WriteTo, so a graceful close routinely fails an
+// in-flight write with net.ErrClosed. Latched, that outranks everything else Close has
+// to say -- and closeWithError hands Close's error to errorHandler.HandleError, so a
+// complete recording reported its own teardown as a connection failure.
+func TestConnectionRecorderCloseDoesNotLatchItsOwnTeardown(t *testing.T) {
+	conn := &closeRacingConn{
+		inWrite:  make(chan struct{}),
+		release:  make(chan struct{}),
+		observed: make(chan struct{}),
+	}
+
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), conn, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := rec.Write(startupFrame())
+		close(conn.observed)
+		writeErr <- err
+	}()
+
+	<-conn.inWrite
+	if err := rec.Close(); err != nil {
+		t.Errorf("Close reported %v; nothing was wrong with the recording", err)
+	}
+
+	// The caller still learns its write failed. Only the latch is skipped.
+	if err := <-writeErr; !errors.Is(err, net.ErrClosed) {
+		t.Errorf("Write returned %v, want the socket error to reach the caller", err)
 	}
 }

--- a/dialer/recorder/roundtrip_test.go
+++ b/dialer/recorder/roundtrip_test.go
@@ -1,0 +1,342 @@
+package recorder
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gocql/gocql/dialer"
+	"github.com/gocql/gocql/dialer/replayer"
+	"github.com/gocql/gocql/internal/segment"
+)
+
+// passthroughCompressor is a no-op compressor that honours the append contract. A real
+// lz4 lives in a separate Go module; what these tests need is the compressed segment
+// *layout*, not compression.
+type passthroughCompressor struct{}
+
+func (passthroughCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+func (passthroughCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// v5Frame builds a protocol v5 frame with the given opcode, direction and body.
+func v5Frame(op byte, response bool, streamID int, body []byte) []byte {
+	version := byte(0x05)
+	if response {
+		version = 0x85
+	}
+	frame := []byte{
+		version, 0x00,
+		byte(streamID >> 8), byte(streamID & 0xFF),
+		op,
+		byte(len(body) >> 24), byte(len(body) >> 16), byte(len(body) >> 8), byte(len(body)),
+	}
+	return append(frame, body...)
+}
+
+// startupV5 builds a v5 STARTUP, optionally naming a compression algorithm, which is
+// what tells the dialers the segment header layout.
+func startupV5(compression string) []byte {
+	opts := [][2]string{{"CQL_VERSION", "3.0.0"}}
+	if compression != "" {
+		opts = append(opts, [2]string{"COMPRESSION", compression})
+	}
+
+	var body []byte
+	body = append(body, byte(len(opts)>>8), byte(len(opts)))
+	for _, kv := range opts {
+		for _, s := range kv {
+			body = append(body, byte(len(s)>>8), byte(len(s)))
+			body = append(body, s...)
+		}
+	}
+	return v5Frame(0x01, false, 0x0040, body)
+}
+
+// exchange is one request/response pair of a simulated connection.
+type exchange struct {
+	request  []byte
+	response []byte
+	// segmented reports whether these frames are on the wire as transport segments,
+	// which for the handshake frames they are not.
+	segmented bool
+}
+
+// v5Conversation is a v5 connection from OPTIONS through to a couple of queries,
+// including authentication — which is where the framing boundary is easy to get wrong,
+// because AUTH_RESPONSE is already segmented.
+func v5Conversation(compression string) []exchange {
+	big := bytes.Repeat([]byte{0x5A}, 2*segment.MaxPayloadSize+11)
+
+	return []exchange{
+		// Unsegmented handshake.
+		{request: v5Frame(0x05, false, 0x0001, nil), response: v5Frame(0x06, true, 0x0001, nil)},
+		{request: startupV5(compression), response: v5Frame(0x03, true, 0x0040, []byte{0x00, 0x04, 'n', 'o', 'n', 'e'})},
+
+		// Segmented from AUTH_RESPONSE onward.
+		{request: v5Frame(0x0F, false, 0x0080, []byte{0x00, 0x00, 0x00, 0x02, 0x01, 0x02}), response: v5Frame(0x10, true, 0x0080, nil), segmented: true},
+		{request: v5Frame(0x09, false, 0x00C0, []byte{0x00, 0x00, 0x00, 0x03, 'a', 'b', 'c'}), response: v5Frame(0x08, true, 0x00C0, []byte{0x00, 0x00, 0x00, 0x01}), segmented: true},
+
+		// An EXECUTE (a v5 QUERY is refused by name until scylladb/gocql#1000) whose
+		// response is far larger than one segment can carry, so the chain path runs.
+		{request: v5Frame(0x0A, false, 0x0100, []byte{
+			0x00, 0x02, 'h', 'i', // preparedID, [short bytes]
+			0x00, 0x00, // resultMetadataID, empty [short bytes]
+			0x00, 0x01, // consistency ONE
+			0x00, 0x00, 0x00, 0x00, // v5 flags, none set
+		}), response: v5Frame(0x08, true, 0x0100, big), segmented: true},
+	}
+}
+
+// onWire renders one frame as the bytes that would cross the socket for it.
+func onWire(t *testing.T, frame []byte, segmented bool, comp dialer.SegmentCompressor) []byte {
+	t.Helper()
+
+	if !segmented {
+		return frame
+	}
+	out, err := dialer.AppendSegmented(nil, frame, comp)
+	if err != nil {
+		t.Fatalf("encoding a frame: %v", err)
+	}
+	return out
+}
+
+// wire renders one direction of a conversation as the whole byte stream, which is what
+// the recorder's stub connection hands back.
+func wire(t *testing.T, conv []exchange, comp dialer.SegmentCompressor, responses bool) []byte {
+	t.Helper()
+
+	var out []byte
+	for _, ex := range conv {
+		frame := ex.request
+		if responses {
+			frame = ex.response
+		}
+		out = append(out, onWire(t, frame, ex.segmented, comp)...)
+	}
+	return out
+}
+
+// readExactly drains n bytes from conn in small chunks, so a recorder has to reassemble
+// segments across reads rather than being handed each one whole.
+func readExactly(t *testing.T, conn net.Conn, n int) {
+	t.Helper()
+
+	buf := make([]byte, 37)
+	for read := 0; read < n; {
+		got, err := conn.Read(buf[:min(len(buf), n-read)])
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		read += got
+	}
+}
+
+// TestProtocolV5RoundTrip records a v5 connection and replays it, which is the whole
+// point of the segment support: the recorder is handed transport segments and has to
+// store the frames inside them, and the replayer has to put them back on the wire in
+// the framing the driver expects.
+//
+// It cannot be done against a real cluster. controlConn.discoverProtocol pins
+// negotiation to v4 and ScyllaDB does not speak v5, so `go test -C tests/bench
+// -update-golden` can never produce a v5 recording. This drives both dialers in
+// process instead.
+func TestProtocolV5RoundTrip(t *testing.T) {
+	for _, cc := range []struct {
+		name        string
+		compression string
+		comp        dialer.SegmentCompressor
+	}{
+		{name: "uncompressed", compression: ""},
+		{name: "compressed", compression: "lz4", comp: passthroughCompressor{}},
+	} {
+		t.Run(cc.name, func(t *testing.T) {
+			conv := v5Conversation(cc.compression)
+			fname := filepath.Join(t.TempDir(), "conn")
+
+			// Record: feed the recorder the bytes a socket would have carried.
+			rec, err := NewConnectionRecorder(fname, &stubConn{readData: wire(t, conv, cc.comp, true)}, cc.comp)
+			if err != nil {
+				t.Fatalf("NewConnectionRecorder: %v", err)
+			}
+
+			// Request, response, request — in that order. The framing switch is
+			// announced by a response and applies to the requests after it, so
+			// recording every request up front would never see it.
+			for i, ex := range conv {
+				if _, err := rec.Write(onWire(t, ex.request, ex.segmented, cc.comp)); err != nil {
+					t.Fatalf("exchange %d: recording the request: %v", i, err)
+				}
+				readExactly(t, rec, len(onWire(t, ex.response, ex.segmented, cc.comp)))
+			}
+			if err := rec.Close(); err != nil {
+				t.Fatalf("closing the recorder: %v", err)
+			}
+
+			// The recording must hold bare frames, decompressed and unwrapped, so the
+			// format does not depend on the protocol version.
+			for _, side := range []struct {
+				suffix string
+				want   func(exchange) []byte
+			}{
+				{suffix: "Writes", want: func(e exchange) []byte { return e.request }},
+				{suffix: "Reads", want: func(e exchange) []byte { return e.response }},
+			} {
+				got := recordedFrames(t, fname+side.suffix)
+				if len(got) != len(conv) {
+					t.Fatalf("%s: recorded %d frames, want %d", side.suffix, len(got), len(conv))
+				}
+				for i, ex := range conv {
+					if !bytes.Equal(got[i].Data, side.want(ex)) {
+						t.Errorf("%s: frame %d was not recorded as a bare CQL frame", side.suffix, i)
+					}
+				}
+			}
+
+			// Replay: the responses must come back framed the way the driver expects.
+			rep, err := replayer.NewConnectionReplayer(fname, cc.comp)
+			if err != nil {
+				t.Fatalf("NewConnectionReplayer: %v", err)
+			}
+
+			for i, ex := range conv {
+				if _, err := rep.Write(onWire(t, ex.request, ex.segmented, cc.comp)); err != nil {
+					t.Fatalf("exchange %d: replaying the request: %v", i, err)
+				}
+
+				want, err := expectedResponseWire(ex, cc.comp)
+				if err != nil {
+					t.Fatalf("exchange %d: %v", i, err)
+				}
+
+				got := make([]byte, 0, len(want))
+				chunk := make([]byte, 53)
+				for len(got) < len(want) {
+					n, err := rep.Read(chunk)
+					if err != nil {
+						t.Fatalf("exchange %d: reading the response: %v", i, err)
+					}
+					got = append(got, chunk[:n]...)
+				}
+				if !bytes.Equal(got, want) {
+					t.Errorf("exchange %d: replayed %d bytes, want %d", i, len(got), len(want))
+				}
+			}
+		})
+	}
+}
+
+// expectedResponseWire is what the replayer should put on the wire for one exchange.
+func expectedResponseWire(ex exchange, comp dialer.SegmentCompressor) ([]byte, error) {
+	if !ex.segmented {
+		return ex.response, nil
+	}
+	return dialer.AppendSegmented(nil, ex.response, comp)
+}
+
+// TestProtocolV5RoundTripNeedsACompressor pins that a compressed v5 connection with no
+// compressor supplied says so, rather than decoding the stream with the wrong segment
+// header size and reporting corrupt frames.
+func TestProtocolV5RoundTripNeedsACompressor(t *testing.T) {
+	conv := v5Conversation("lz4")
+	fname := filepath.Join(t.TempDir(), "conn")
+
+	rec, err := NewConnectionRecorder(fname, &stubConn{readData: wire(t, conv, passthroughCompressor{}, true)}, nil)
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	defer rec.Close()
+
+	// The handshake goes through unsegmented; the first segmented write is where the
+	// missing compressor is discovered.
+	for i, ex := range conv[:2] {
+		if _, err := rec.Write(ex.request); err != nil {
+			t.Fatalf("exchange %d: %v", i, err)
+		}
+		readExactly(t, rec, len(ex.response))
+	}
+
+	_, err = rec.Write(onWire(t, conv[2].request, true, passthroughCompressor{}))
+	if err == nil {
+		t.Fatal("a compressed v5 connection was recorded without a compressor")
+	}
+	if !errors.Is(err, dialer.ErrSegmentCompressorRequired) {
+		t.Errorf("error = %v, want dialer.ErrSegmentCompressorRequired", err)
+	}
+}
+
+// TestRecorderSendsNothingItCouldNotRecord pins the write path's order: the frame
+// is recorded before it is sent, so a request the recording refuses -- here a
+// pre-v5 compressed STARTUP -- never reaches the server, Write reports (0, err)
+// rather than success with a trailing error the write coalescer would swallow, and
+// the failure is latched so both directions return it from then on: the connection
+// comes down at the failure instead of past it, recording a lie.
+func TestRecorderSendsNothingItCouldNotRecord(t *testing.T) {
+	startup := startupV5("lz4")
+	startup[0] = 0x04
+
+	conn := &stubConn{}
+	rec, err := NewConnectionRecorder(filepath.Join(t.TempDir(), "conn"), conn, passthroughCompressor{})
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	defer rec.Close()
+
+	n, err := rec.Write(startup)
+	if err == nil {
+		t.Fatal("a compressed protocol v4 connection was recorded")
+	}
+	if n != 0 {
+		t.Errorf("Write = %d bytes, want 0", n)
+	}
+	if len(conn.written) != 0 {
+		t.Errorf("%d bytes reached the connection after the recording refused the frame", len(conn.written))
+	}
+
+	if _, err := rec.Write(optionsFrame(0x04)); err == nil {
+		t.Error("a Write after the recording failed was accepted")
+	}
+	if _, err := rec.Read(make([]byte, 8)); err == nil {
+		t.Error("a Read after the recording failed was accepted")
+	}
+}
+
+// TestRecorderRefusesPreV5Compression pins that a compressed connection below protocol
+// v5 is refused where the cause is still visible.
+//
+// Below v5 a negotiated compressor compresses frame bodies, not transport segments, so
+// nothing here would fail: the recorder would write the frames out with compressed
+// bodies and look successful. The cost lands on whoever replays that recording, as a
+// panic from GetFrameHash finding no match -- because a compressed body carries the
+// encoded default timestamp, so the hash differs on every run -- with nothing in it
+// pointing at compression.
+func TestRecorderRefusesPreV5Compression(t *testing.T) {
+	// A v4 STARTUP naming lz4: same body as the v5 one, one version byte apart.
+	startup := startupV5("lz4")
+	startup[0] = 0x04
+
+	fname := filepath.Join(t.TempDir(), "conn")
+	rec, err := NewConnectionRecorder(fname, &stubConn{}, passthroughCompressor{})
+	if err != nil {
+		t.Fatalf("NewConnectionRecorder: %v", err)
+	}
+	defer rec.Close()
+
+	_, err = rec.Write(startup)
+	if err == nil {
+		t.Fatal("a compressed protocol v4 connection was recorded")
+	}
+	for _, want := range []string{"lz4", "v4"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}

--- a/dialer/replayer/fixtures_test.go
+++ b/dialer/replayer/fixtures_test.go
@@ -1,0 +1,66 @@
+package replayer
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// fixtureRecordings are the recordings checked into tests/bench, which the replay
+// benchmarks run against.
+//
+// They can only be regenerated with `go test -C tests/bench -update-golden` against a
+// live node at the address the recorder hardcodes, so nothing in ordinary CI can
+// rebuild them — which is exactly why the invariants they depend on are worth asserting
+// from the always-run unit lane rather than only from the benchmark job, which is gated
+// behind a label.
+var fixtureRecordings = []string{
+	"rec_insert/192.168.100.11:9042-0",
+	"rec_select/192.168.100.11:9042-0",
+}
+
+// TestCheckedInRecordingsStillLoad pins the two properties the replay benchmarks
+// depend on, against the actual bytes they replay.
+//
+// Neither is about a particular hash value. The hash function may change — a recording
+// stores raw frames and is rehashed at load time with the same function applied to the
+// live request, so both sides move together. What it may not do is stop telling the
+// recording's own requests apart: the replayer scans for the first matching hash, so a
+// collision serves the wrong response, silently, and with `map` iteration deciding
+// which one.
+func TestCheckedInRecordingsStillLoad(t *testing.T) {
+	for _, name := range fixtureRecordings {
+		t.Run(name, func(t *testing.T) {
+			base := filepath.Join("..", "..", "tests", "bench", name)
+
+			frames, proto, err := loadResponseFramesFromFiles(base+"Reads", base+"Writes")
+			if err != nil {
+				t.Fatalf("loading the recording: %v", err)
+			}
+			if len(frames) == 0 {
+				t.Fatal("the recording paired no requests with responses")
+			}
+			if proto == 0 {
+				t.Error("no protocol version was read from the recording")
+			}
+
+			seen := make(map[int64]int, len(frames))
+			for i, frame := range frames {
+				if first, dup := seen[frame.Hash]; dup {
+					t.Errorf("frames %d and %d hash alike (%d), so the replayer would serve whichever it reached first",
+						first, i, frame.Hash)
+					continue
+				}
+				seen[frame.Hash] = i
+
+				// materialise refuses any record that is not one whole frame, and a
+				// short one cannot be refused later: the driver reads a frame with
+				// io.ReadFull and ConnectionReplayer's SetReadDeadline is a no-op, so
+				// it blocks mid-frame forever. An empty response is only the loudest
+				// case of that.
+				if !wholeFrame(frame.Response) {
+					t.Errorf("frame %d holds %d bytes, which is not one whole CQL frame", i, len(frame.Response))
+				}
+			}
+		})
+	}
+}

--- a/dialer/replayer/replayer.go
+++ b/dialer/replayer/replayer.go
@@ -10,34 +10,79 @@ import (
 	"net"
 	"os"
 	"path"
+	"slices"
 	"time"
 
 	"github.com/gocql/gocql"
 	"github.com/gocql/gocql/dialer"
 )
 
-func NewReplayDialer(dir string) *ReplayDialer {
-	return &ReplayDialer{
-		dir: dir,
+// Option configures a ReplayDialer.
+type Option func(*ReplayDialer)
+
+// WithSegmentCompressor supplies the compressor a protocol v5 connection's transport
+// segments are compressed with.
+//
+// It has to be supplied rather than derived: the only implementation, lz4, lives in a
+// separate Go module, so neither the driver nor this package can construct one. Pass
+// the same compressor the ClusterConfig being replayed against uses -- the layout
+// follows what the replaying driver negotiates, not what was recorded, because
+// recordings hold bare frames.
+//
+// Its name is checked against the algorithm the STARTUP names, when it reports one, and
+// a compressed connection below protocol v5 is refused outright: there compression
+// applies to frame bodies rather than transport segments, which this package does not
+// implement, and left alone it would surface as a replay whose hashes never match.
+func WithSegmentCompressor(comp dialer.SegmentCompressor) Option {
+	return func(d *ReplayDialer) { d.comp = comp }
+}
+
+func NewReplayDialer(dir string, opts ...Option) *ReplayDialer {
+	d := &ReplayDialer{dir: dir}
+	for _, opt := range opts {
+		opt(d)
 	}
+	return d
 }
 
 type ReplayDialer struct {
-	dir string
+	dir  string
+	comp dialer.SegmentCompressor
 	net.Dialer
 }
 
 func (d *ReplayDialer) DialContext(ctx context.Context, network, addr string) (conn net.Conn, err error) {
 	sourcePort := gocql.ScyllaGetSourcePort(ctx)
-	return NewConnectionReplayer(path.Join(d.dir, fmt.Sprintf("%s-%d", addr, sourcePort)))
+	return NewConnectionReplayer(path.Join(d.dir, fmt.Sprintf("%s-%d", addr, sourcePort)), d.comp)
 }
 
-func NewConnectionReplayer(fname string) (net.Conn, error) {
-	frames, err := loadResponseFramesFromFiles(fname+"Reads", fname+"Writes")
+// NewConnectionReplayer answers requests from the recording at fname.
+//
+// comp may be nil; see WithSegmentCompressor for when it is needed.
+func NewConnectionReplayer(fname string, comp dialer.SegmentCompressor) (net.Conn, error) {
+	frames, proto, err := loadResponseFramesFromFiles(fname+"Reads", fname+"Writes")
 	if err != nil {
 		return nil, err
 	}
-	return &ConnectionReplayer{frames: frames, frameIdsToReplay: []int{}, streamIdsToReplay: []int{}, gotRequest: make(chan struct{}, 1)}, nil
+	// Refused here rather than in the loader, which reports the protocol version off a
+	// recording that pairs nothing on purpose -- a version check that disarms itself
+	// exactly when the recording is damaged is not a check. A replayer over zero frames
+	// is a different matter: the dial succeeds and the first request then panics with
+	// nothing naming the recording, which is what a mistyped directory, or a source port
+	// this recording never saw, produces.
+	if len(frames) == 0 {
+		return nil, fmt.Errorf("gocql/dialer: %sReads and %sWrites pair no requests with responses; there is nothing to replay", fname, fname)
+	}
+	framing := dialer.NewFraming(comp)
+	return &ConnectionReplayer{
+		frames:            frames,
+		recordedProto:     proto,
+		frameIdsToReplay:  []int{},
+		streamIdsToReplay: []int{},
+		gotRequest:        make(chan struct{}, 1),
+		framing:           framing,
+		requests:          framing.NewDecoder(),
+	}, nil
 }
 
 type ConnectionReplayer struct {
@@ -65,25 +110,34 @@ type ConnectionReplayer struct {
 	frames            []*FrameRecorded
 	frameIdsToReplay  []int
 	streamIdsToReplay []int
-	// outgoing is the response currently being served: a copy of the recorded frame
-	// with its stream id patched, handed out across as many Read calls as it takes.
-	// Materialising it once is what makes the stream id right regardless of how the
-	// caller's buffer is sized.
-	outgoing []byte
-	// splitter turns the bytes the driver writes into whole CQL frames. The write
-	// path happens to deliver exactly one frame per Write today — there is no
-	// bufio.Writer on it, and although write coalescing is on by default,
+	// framing tracks how this connection's bytes are framed, and is shared by the
+	// request decoder and the response encoder: the handshake fact that switches them
+	// is carried by a response but applies to requests too.
+	framing *dialer.Framing
+	// requests turns the bytes the driver writes into whole CQL frames, following the
+	// connection across the switch to transport segments.
+	//
+	// The write path happens to deliver exactly one frame per Write today -- there is
+	// no bufio.Writer on it, and although write coalescing is on by default,
 	// net.Buffers.WriteTo only uses writev when the writer implements the unexported
 	// buffersWriter, which this type does not, because it holds its net.Conn as a
 	// named field rather than embedding it. That is an implementation detail of the
 	// standard library plus a struct-layout choice, not a contract: embedding
 	// net.Conn here would silently start coalescing several frames into one Write.
-	// The exported Conn.Write passes arbitrary bytes regardless. So the assumption
-	// is not relied on.
-	splitter    dialer.FrameSplitter
-	outgoingPos int
-	frameIdx    int
-	closed      bool
+	// The exported Conn.Write passes arbitrary bytes regardless. So the assumption is
+	// not relied on.
+	requests *dialer.Decoder
+	// patched is the recorded response with its stream id rewritten, before framing.
+	patched []byte
+	// outgoing is what is actually served: patched, wrapped in whatever framing the
+	// connection has reached, handed out across as many Read calls as it takes.
+	// Materialising it once is what makes the stream id right regardless of how the
+	// caller's buffer is sized.
+	outgoing      []byte
+	outgoingPos   int
+	frameIdx      int
+	recordedProto byte
+	closed        bool
 	// useMetadataID latches once the STARTUP request on this connection opts into
 	// SCYLLA_USE_METADATA_ID, matching how the recorder stamped the frames so live
 	// and load-time hashes agree (see GetFrameHash / Record.UseMetadataID).
@@ -116,8 +170,21 @@ func (c *ConnectionReplayer) getPendingFrame() *FrameRecorded {
 	return c.frames[frameId]
 }
 
+// twoByteStreamID reports whether b's protocol version carries the 2-byte stream id of
+// v3+ rather than the single byte of v1/v2.
+//
+// dialer.FrameProtoVersion rather than b[0] directly: the top bit of a frame's first
+// byte is the request/response direction, so an unmasked comparison reads every
+// response as a far newer protocol. replaceFrameStreamID is handed exactly that -- a
+// recorded response -- where a v1/v2 frame arrives as 0x81 or 0x82, takes the v3+ branch
+// and writes the low half of the stream id over the opcode. dialer/utils.go warns about
+// this in the note above headerShift, and matchRequest already uses the masked helper.
+func twoByteStreamID(b []byte) bool {
+	return dialer.FrameProtoVersion(b) > 0x02
+}
+
 func (c *ConnectionReplayer) pushStreamIDToReplay(b []byte, idx int) {
-	if b[0] > 0x02 {
+	if twoByteStreamID(b) {
 		c.streamIdsToReplay = append(c.streamIdsToReplay, int(b[2])<<8|int(b[3]))
 	} else {
 		c.streamIdsToReplay = append(c.streamIdsToReplay, int(b[2]))
@@ -130,22 +197,13 @@ func (c *ConnectionReplayer) pushStreamIDToReplay(b []byte, idx int) {
 	}
 }
 
-// headerLen is the v3+ CQL frame header: version, flags, a 2-byte stream id, the
-// opcode and the 4-byte body length.
+// maxRetainedResponse bounds the buffers kept between responses.
 //
-// A local constant: the dialer package keeps its own copy unexported. Fixed at the v3+
-// layout like the rest of this pipeline -- the frame splitter feeding the recorder
-// slices on the same nine bytes, so a v1/v2 stream never reaches a recording intact
-// anyway (scylladb/gocql#1022).
-const headerLen = 9
-
-// maxRetainedResponse bounds the buffer kept between responses.
-//
-// It is reused so that serving a response costs no allocation, but a recording may hold
-// one of any size the driver's own frame limit allows, and reusing that for the life of
-// the connection would pin it there. So an outlier is handed back instead, the way the
-// dialer's frame splitter hands back an outsized frame. Its constant is unexported,
-// hence this one.
+// They are reused so that serving a response costs no allocation, but a recording may
+// hold one of any size the driver's own frame limit allows, and reusing that for the
+// life of the connection would pin it twice over -- once patched, once encoded. So an
+// outlier is handed back instead, the way the dialer's frame splitter hands back an
+// outsized frame. Its constant is unexported, hence this one.
 const maxRetainedResponse = 64 << 10
 
 // wholeFrame reports whether b is exactly one CQL frame: a full v3+ header followed by
@@ -153,15 +211,12 @@ const maxRetainedResponse = 64 << 10
 // in one record, which the recorder cannot write -- it records what its decoder hands
 // it, one whole frame at a time.
 func wholeFrame(b []byte) bool {
-	if len(b) < headerLen {
-		return false
-	}
-	declared := int64(b[5])<<24 | int64(b[6])<<16 | int64(b[7])<<8 | int64(b[8])
-	return int64(len(b))-headerLen == declared
+	declared, ok := dialer.FrameBodyLen(b)
+	return ok && len(b)-dialer.FrameHeaderLen == declared
 }
 
 func replaceFrameStreamID(b []byte, stream int) {
-	if b[0] > 0x02 {
+	if twoByteStreamID(b) {
 		b[2] = byte(stream >> 8)
 		b[3] = byte(stream)
 	} else {
@@ -190,7 +245,7 @@ func (c *ConnectionReplayer) Read(b []byte) (n int, err error) {
 
 	if c.outgoingPos == len(c.outgoing) {
 		// The response served last has drained, so an outsized buffer goes back before
-		// the next one is copied into it, and before the wait below rather than after
+		// the next one is encoded into it, and before the wait below rather than after
 		// it: a connection parked for the next request should not be holding it. See
 		// maxRetainedResponse.
 		if cap(c.outgoing) > maxRetainedResponse {
@@ -229,6 +284,10 @@ func (c *ConnectionReplayer) Read(b []byte) (n int, err error) {
 // stream id it was recorded with. Unreachable with the checked-in recordings, whose
 // largest response is well under the driver's 4 KiB read buffer, which is why it went
 // unnoticed.
+//
+// On failure it leaves nothing servable behind: outgoingPos == len(outgoing), so Read
+// finds the branch it would take anyway rather than a buffer half describing a response
+// that was never encoded.
 func (c *ConnectionReplayer) materialise(frame *FrameRecorded) error {
 	// A record that is not one whole frame cannot be served at all, and the driver
 	// cannot be left to reject it. It reads a frame with io.ReadFull twice -- the nine
@@ -249,15 +308,42 @@ func (c *ConnectionReplayer) materialise(frame *FrameRecorded) error {
 		return fmt.Errorf("gocql/dialer: recording holds %d bytes for stream %d, which is not one whole CQL frame", len(frame.Response), c.frameStreamID())
 	}
 
-	c.outgoing = append(c.outgoing[:0], frame.Response...)
+	c.patched = append(c.patched[:0], frame.Response...)
+	replaceFrameStreamID(c.patched, c.frameStreamID())
+
+	// Encode before observing. The frame that flips the framing latch -- READY or
+	// AUTHENTICATE -- is itself unsegmented; the switch applies to what comes after
+	// it. Observing first would wrap the very frame that announces the change.
+	//
+	// A failure empties outgoing rather than leaving it as it was. EncodeResponse encodes
+	// straight into the buffer it is handed, and AppendSegmented documents that the
+	// compressed layout can fail after writing into it -- segment.AppendCompressed
+	// reserves the segment header in dst before calling a compressor that may then error.
+	// Left alone, outgoing would keep the previous response's length over bytes that are
+	// no longer that response. Nothing serves them today, because outgoingPos ==
+	// len(outgoing) on the way in here and Read latches the failure on the way out, but
+	// that is two invariants elsewhere holding up one line here.
+	out, err := c.framing.EncodeResponse(c.outgoing[:0], c.patched)
+	if err != nil {
+		c.outgoing, c.outgoingPos = c.outgoing[:0], 0
+		return err
+	}
+	c.outgoing = out
 	c.outgoingPos = 0
 
-	replaceFrameStreamID(c.outgoing, c.frameStreamID())
+	c.framing.ObserveResponse(c.patched)
+
+	// patched has no reader until the next response, so an outsized one is handed back
+	// here rather than pinned for the life of the connection. outgoing is released in
+	// Read instead, once the caller has drained it.
+	if cap(c.patched) > maxRetainedResponse {
+		c.patched = nil
+	}
 	return nil
 }
 
 func (c *ConnectionReplayer) Write(b []byte) (n int, err error) {
-	if err := c.splitter.Feed(b, c.matchRequest); err != nil {
+	if err := c.requests.Feed(b, c.matchRequest); err != nil {
 		return 0, err
 	}
 	return len(b), nil
@@ -265,13 +351,37 @@ func (c *ConnectionReplayer) Write(b []byte) (n int, err error) {
 
 // matchRequest finds the recorded response for one request frame and queues it.
 func (c *ConnectionReplayer) matchRequest(frame []byte) error {
-	// A request frame's first byte is its protocol version, and the driver's
-	// handshake frames are never segment-framed — so a v5+ connection is
-	// rejected here during the handshake. Past it, v5 switches to transport
-	// segments, which this replayer can neither hash for matching nor patch
-	// stream ids into without breaking the segment CRCs.
-	if dialer.FrameIsProtoV5OrNewer(frame) {
-		return dialer.ErrProtoV5NotSupported
+	// A recording holds bare frames, so nothing about it announces which protocol
+	// version produced them; replaying a v5 recording against a v4 driver would
+	// otherwise serve it responses whose version byte it rejects deep inside
+	// readHeader, far from the cause.
+	if live := dialer.FrameProtoVersion(frame); c.recordedProto != 0 && live != c.recordedProto {
+		return fmt.Errorf("gocql/dialer: recording is protocol v%d but the driver is replaying it at protocol v%d", c.recordedProto, live)
+	}
+
+	// Reads the COMPRESSION option, which decides the segment header layout for the
+	// rest of the connection, and refuses the negotiated compressions a recording
+	// cannot represent -- body compression below v5, or an algorithm the supplied
+	// compressor does not implement. Reported before the hash is taken, because on a
+	// pre-v5 compressed connection the hash is exactly what goes wrong, and the panic
+	// it leads to names nothing.
+	if err := c.framing.ObserveRequest(frame); err != nil {
+		return err
+	}
+
+	// KNOWN GAP, tracked in scylladb/gocql#1000 and refused by name here: every
+	// QUERY hashes alike, because GetFrameHash hands the parameter walk the body
+	// start rather than the position past the query text, and on protocol v5 the
+	// misaligned walk falls back to hashing the whole frame -- default timestamp
+	// included -- so a v5 QUERY can never match its recording. Falling through would
+	// surface that as the anonymous panic below. Delete this when #1000 lands.
+	//
+	// A panic for the same reason as that one, and unlike the two checks above: those
+	// fire on the handshake, where the error comes back out of the dial, while a QUERY
+	// arrives mid-session, where an error is a connection failure the driver answers by
+	// reconnecting and replaying the same recording into the same refusal.
+	if dialer.FrameIsProtoV5OrNewer(frame) && dialer.FrameIsQuery(frame) {
+		panic(fmt.Errorf("gocql/dialer: cannot replay a protocol v5 QUERY: its hash cannot match any recording until scylladb/gocql#1000 is fixed"))
 	}
 
 	if !c.useMetadataID && dialer.StartupNegotiatesMetadataID(frame) {
@@ -368,7 +478,11 @@ func loadFramesFromFile(filename string) (map[int]dialer.Record, error) {
 			// a record that does not decode is reported and skipped rather than
 			// failing the whole file — the frames around it still replay.
 			if err := json.Unmarshal(line, &record); err != nil {
-				fmt.Printf("Error decoding JSON in %s: %s\n", filename, err)
+				// Stderr, not stdout: this is a library, and a caller whose own output
+				// is the point should not find a warning about a recording file in the
+				// middle of it. It is still reported rather than dropped -- it is the
+				// only sign that a record went missing from the pairing below.
+				fmt.Fprintf(os.Stderr, "Error decoding JSON in %s: %s\n", filename, err)
 			} else {
 				records[record.StreamID] = record
 			}
@@ -385,23 +499,95 @@ func loadFramesFromFile(filename string) (map[int]dialer.Record, error) {
 	return records, nil
 }
 
-func loadResponseFramesFromFiles(read_file, write_file string) ([]*FrameRecorded, error) {
+// loadResponseFramesFromFiles pairs each recorded response with the request that
+// produced it, and reports the protocol version the recording was made at.
+func loadResponseFramesFromFiles(read_file, write_file string) ([]*FrameRecorded, byte, error) {
 	read_records, err := loadFramesFromFile(read_file)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	write_records, err := loadFramesFromFile(write_file)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	var frames = []*FrameRecorded{}
-	for streamID, record1 := range read_records {
-		if record2, exists := write_records[streamID]; exists {
-			frames = append(frames, &FrameRecorded{Response: record1.Data, Hash: dialer.GetFrameHash(record2.Data, record2.UseMetadataID)})
+	var (
+		frames []*FrameRecorded
+		proto  byte
+	)
+
+	// Pair by stream id in sorted order, not in map order. matchRequest scans frames
+	// for the first hash that matches and hashes do collide -- #1000 makes every QUERY
+	// collide, and addCustomPayload documents another -- so this slice's order decides
+	// which response a colliding request is served. Ranging a map made that decision
+	// afresh on every run of the same binary, which is not something a replay benchmark
+	// or a fixture failure can be reproduced from.
+	paired := make([]int, 0, len(read_records))
+	for streamID := range read_records {
+		if _, exists := write_records[streamID]; exists {
+			paired = append(paired, streamID)
 		}
 	}
-	return frames, nil
+	slices.Sort(paired)
+
+	// The protocol version comes from the records that will actually be replayed, and
+	// only from them. The recorder appends every connection to one file (see
+	// NewConnectionRecorder), so a record the last session did not overwrite is a
+	// leftover from an earlier one -- and a leftover that negotiated a different
+	// version, a downgrade probe say, would otherwise refuse a recording that replays
+	// perfectly well.
+	//
+	// Nothing pairing at all is the exception: there the whole Writes file is used
+	// instead, because a version check that disarms itself exactly when the recording
+	// is damaged is not a check.
+	//
+	// Every request on a connection shares one version, so any record answers -- take
+	// each record's stamp where it has one and its frame's own version byte where it
+	// does not, for recordings that predate the field. Per record, not per file: a
+	// single stamped record among unstamped leftovers would otherwise answer for all of
+	// them and the rest would never be looked at, which is exactly the file a directory
+	// reused across a recorder upgrade holds. Records that disagree are refused rather
+	// than resolved: settling it here would settle it by iteration order, arming or
+	// disarming the check in matchRequest from run to run.
+	source := paired
+	if len(source) == 0 {
+		source = make([]int, 0, len(write_records))
+		for streamID := range write_records {
+			source = append(source, streamID)
+		}
+		slices.Sort(source)
+	}
+
+	agree := func(have, seen byte) (byte, error) {
+		if have != 0 && have != seen {
+			return 0, fmt.Errorf("gocql/dialer: %s holds records from protocol v%d and protocol v%d; a recording is one connection at one version", write_file, have, seen)
+		}
+		return seen, nil
+	}
+	for _, streamID := range source {
+		record := write_records[streamID]
+		seen := record.Proto
+		if seen == 0 {
+			seen = dialer.FrameProtoVersion(record.Data)
+		}
+		// 0 at this point is a record whose data did not survive the file, which says
+		// nothing about the version rather than disagreeing with it.
+		if seen == 0 {
+			continue
+		}
+		if proto, err = agree(proto, seen); err != nil {
+			return nil, 0, err
+		}
+	}
+
+	for _, streamID := range paired {
+		request := write_records[streamID]
+		frames = append(frames, &FrameRecorded{
+			Response: read_records[streamID].Data,
+			Hash:     dialer.GetFrameHash(request.Data, request.UseMetadataID),
+		})
+	}
+	return frames, proto, nil
 }
 
 type FrameRecorded struct {

--- a/dialer/replayer/replayer.go
+++ b/dialer/replayer/replayer.go
@@ -37,14 +37,39 @@ func NewConnectionReplayer(fname string) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ConnectionReplayer{frames: frames, frameIdsToReplay: []int{}, streamIdsToReplay: []int{}, frameIdx: 0, frameResponsePosition: 0, gotRequest: make(chan struct{}, 1)}, nil
+	return &ConnectionReplayer{frames: frames, frameIdsToReplay: []int{}, streamIdsToReplay: []int{}, gotRequest: make(chan struct{}, 1)}, nil
 }
 
 type ConnectionReplayer struct {
+	// failed is the failure that ended this connection, if one did. Only materialise
+	// raises one, and nothing it refuses is repairable by trying again -- while frameIdx
+	// is not advanced past a record that failed, so without this Read would fetch that
+	// same record on every call and hand the driver an unbounded stream of errors:
+	// identical to read, and distinct as values, one fresh fmt.Errorf per call.
+	//
+	// A plain field rather than an atomic, and read by nothing outside Read. Write runs
+	// on another goroutine and deliberately does not consult it. The recorder gates both
+	// its directions, but it holds its latch in an atomic.Pointer because it had to; this
+	// connection's cross-goroutine state -- frameIdsToReplay, streamIdsToReplay, closed
+	// and the gotRequest handshake around them -- is being replaced wholesale by a mutex
+	// and a sync.Cond in scylladb/gocql#1020, and a fourth shared field here would be one
+	// more thing for that change to unpick. Gating Write would also cost the guarantee
+	// dialer.FrameSplitter.Feed rests on: that this type's Write is the one Feed caller
+	// with no failure gate of its own.
+	//
+	// It leads the struct only to keep the pointer-bearing fields contiguous, which the
+	// fieldalignment vet check requires -- an error is two words of pointers.
+	failed error
+
 	gotRequest        chan struct{}
 	frames            []*FrameRecorded
 	frameIdsToReplay  []int
 	streamIdsToReplay []int
+	// outgoing is the response currently being served: a copy of the recorded frame
+	// with its stream id patched, handed out across as many Read calls as it takes.
+	// Materialising it once is what makes the stream id right regardless of how the
+	// caller's buffer is sized.
+	outgoing []byte
 	// splitter turns the bytes the driver writes into whole CQL frames. The write
 	// path happens to deliver exactly one frame per Write today — there is no
 	// bufio.Writer on it, and although write coalescing is on by default,
@@ -55,14 +80,25 @@ type ConnectionReplayer struct {
 	// net.Conn here would silently start coalescing several frames into one Write.
 	// The exported Conn.Write passes arbitrary bytes regardless. So the assumption
 	// is not relied on.
-	splitter              dialer.FrameSplitter
-	frameIdx              int
-	frameResponsePosition int
-	closed                bool
+	splitter    dialer.FrameSplitter
+	outgoingPos int
+	frameIdx    int
+	closed      bool
 	// useMetadataID latches once the STARTUP request on this connection opts into
 	// SCYLLA_USE_METADATA_ID, matching how the recorder stamped the frames so live
 	// and load-time hashes agree (see GetFrameHash / Record.UseMetadataID).
 	useMetadataID bool
+}
+
+// fail latches err as the failure that ended this connection and returns it. Only the
+// first is kept, as in dialer.FrameSplitter.fail: a caller can never be handed a second
+// error, so a later Read reporting the same value is what says the connection was latched
+// rather than retried.
+func (c *ConnectionReplayer) fail(err error) error {
+	if c.failed == nil {
+		c.failed = err
+	}
+	return c.failed
 }
 
 func (c *ConnectionReplayer) frameStreamID() int {
@@ -94,6 +130,36 @@ func (c *ConnectionReplayer) pushStreamIDToReplay(b []byte, idx int) {
 	}
 }
 
+// headerLen is the v3+ CQL frame header: version, flags, a 2-byte stream id, the
+// opcode and the 4-byte body length.
+//
+// A local constant: the dialer package keeps its own copy unexported. Fixed at the v3+
+// layout like the rest of this pipeline -- the frame splitter feeding the recorder
+// slices on the same nine bytes, so a v1/v2 stream never reaches a recording intact
+// anyway (scylladb/gocql#1022).
+const headerLen = 9
+
+// maxRetainedResponse bounds the buffer kept between responses.
+//
+// It is reused so that serving a response costs no allocation, but a recording may hold
+// one of any size the driver's own frame limit allows, and reusing that for the life of
+// the connection would pin it there. So an outlier is handed back instead, the way the
+// dialer's frame splitter hands back an outsized frame. Its constant is unexported,
+// hence this one.
+const maxRetainedResponse = 64 << 10
+
+// wholeFrame reports whether b is exactly one CQL frame: a full v3+ header followed by
+// the body length that header declares, no more and no less. More would mean two frames
+// in one record, which the recorder cannot write -- it records what its decoder hands
+// it, one whole frame at a time.
+func wholeFrame(b []byte) bool {
+	if len(b) < headerLen {
+		return false
+	}
+	declared := int64(b[5])<<24 | int64(b[6])<<16 | int64(b[7])<<8 | int64(b[8])
+	return int64(len(b))-headerLen == declared
+}
+
 func replaceFrameStreamID(b []byte, stream int) {
 	if b[0] > 0x02 {
 		b[2] = byte(stream >> 8)
@@ -103,31 +169,91 @@ func replaceFrameStreamID(b []byte, stream int) {
 	}
 }
 
+// Read serves the recorded response to the request most recently matched, across as
+// many calls as the caller's buffer needs.
+//
+// A latched failure ends it. materialise fails on a record no amount of retrying repairs,
+// and it fails before frameIdx moves, so the branch below would fetch that same record
+// again on the next call and the driver -- which answers a read error by tearing the
+// connection down and redialling -- would be handed the same failure for as long as it
+// kept reading. It is reported ahead of the zero-length shortcut for the same reason
+// dialer.Decoder.Feed reports one for an empty buffer: (0, nil) is the answer that reads
+// as a healthy connection with nothing ready yet. io.EOF after Close is deliberately not
+// latched -- it is not a failure, and it is already idempotent.
 func (c *ConnectionReplayer) Read(b []byte) (n int, err error) {
-	frame := c.getPendingFrame()
-	for frame == nil {
-		<-c.gotRequest
-		frame = c.getPendingFrame()
+	if c.failed != nil {
+		return 0, c.failed
 	}
-	if c.Closed() {
-		return 0, io.EOF
-	}
-	response := frame.Response[c.frameResponsePosition:]
-
-	if len(b) < len(response) {
-		copy(b, response[:len(b)])
-		c.frameResponsePosition = c.frameResponsePosition + len(b)
-		return len(b), err
+	if len(b) == 0 {
+		return 0, nil
 	}
 
-	copy(b, response)
-	if c.frameResponsePosition == 0 {
-		replaceFrameStreamID(b, c.frameStreamID())
+	if c.outgoingPos == len(c.outgoing) {
+		// The response served last has drained, so an outsized buffer goes back before
+		// the next one is copied into it, and before the wait below rather than after
+		// it: a connection parked for the next request should not be holding it. See
+		// maxRetainedResponse.
+		if cap(c.outgoing) > maxRetainedResponse {
+			c.outgoing, c.outgoingPos = nil, 0
+		}
+
+		frame := c.getPendingFrame()
+		for frame == nil {
+			<-c.gotRequest
+			frame = c.getPendingFrame()
+		}
+		if c.Closed() {
+			return 0, io.EOF
+		}
+		if err := c.materialise(frame); err != nil {
+			return 0, c.fail(err)
+		}
+		c.frameIdx = c.frameIdx + 1
 	}
 
-	c.frameIdx = c.frameIdx + 1
-	c.frameResponsePosition = 0
-	return len(response), err
+	n = copy(b, c.outgoing[c.outgoingPos:])
+	c.outgoingPos = c.outgoingPos + n
+	return n, nil
+}
+
+// materialise prepares the bytes for one recorded response, reading the stream id to
+// patch in from the request that matched it.
+//
+// The frame is copied first. FrameRecorded is shared and served once per benchmark
+// iteration, so patching it in place would rewrite the recording's own copy with the
+// stream id of whichever request arrived first and leave every later iteration
+// depending on that.
+//
+// This used to patch the caller's buffer instead, once per response and only when the
+// whole response fitted, so a response larger than the buffer was replayed with the
+// stream id it was recorded with. Unreachable with the checked-in recordings, whose
+// largest response is well under the driver's 4 KiB read buffer, which is why it went
+// unnoticed.
+func (c *ConnectionReplayer) materialise(frame *FrameRecorded) error {
+	// A record that is not one whole frame cannot be served at all, and the driver
+	// cannot be left to reject it. It reads a frame with io.ReadFull twice -- the nine
+	// header bytes, then exactly the body length that header declares -- and this
+	// connection's SetReadDeadline does nothing, so anything short of a whole frame
+	// leaves the driver blocked mid-frame with no deadline to end it, while Read parks
+	// waiting for a request whose response has already been counted as delivered. A
+	// record holding no bytes at all is the same failure one step earlier: Read copies
+	// nothing into a buffer with room in it and returns (0, nil).
+	//
+	// If another goroutine's request does arrive, the outcome is worse than the hang:
+	// the next response's bytes are served as the remainder of this one.
+	//
+	// Only a damaged recording produces either. loadFramesFromFile skips lines that do
+	// not decode, but `{"data":null}` decodes fine, and a recording is a file on disk
+	// that can be truncated mid-frame.
+	if !wholeFrame(frame.Response) {
+		return fmt.Errorf("gocql/dialer: recording holds %d bytes for stream %d, which is not one whole CQL frame", len(frame.Response), c.frameStreamID())
+	}
+
+	c.outgoing = append(c.outgoing[:0], frame.Response...)
+	c.outgoingPos = 0
+
+	replaceFrameStreamID(c.outgoing, c.frameStreamID())
+	return nil
 }
 
 func (c *ConnectionReplayer) Write(b []byte) (n int, err error) {

--- a/dialer/replayer/replayer.go
+++ b/dialer/replayer/replayer.go
@@ -41,10 +41,21 @@ func NewConnectionReplayer(fname string) (net.Conn, error) {
 }
 
 type ConnectionReplayer struct {
-	gotRequest            chan struct{}
-	frames                []*FrameRecorded
-	frameIdsToReplay      []int
-	streamIdsToReplay     []int
+	gotRequest        chan struct{}
+	frames            []*FrameRecorded
+	frameIdsToReplay  []int
+	streamIdsToReplay []int
+	// splitter turns the bytes the driver writes into whole CQL frames. The write
+	// path happens to deliver exactly one frame per Write today — there is no
+	// bufio.Writer on it, and although write coalescing is on by default,
+	// net.Buffers.WriteTo only uses writev when the writer implements the unexported
+	// buffersWriter, which this type does not, because it holds its net.Conn as a
+	// named field rather than embedding it. That is an implementation detail of the
+	// standard library plus a struct-layout choice, not a contract: embedding
+	// net.Conn here would silently start coalescing several frames into one Write.
+	// The exported Conn.Write passes arbitrary bytes regardless. So the assumption
+	// is not relied on.
+	splitter              dialer.FrameSplitter
 	frameIdx              int
 	frameResponsePosition int
 	closed                bool
@@ -120,26 +131,41 @@ func (c *ConnectionReplayer) Read(b []byte) (n int, err error) {
 }
 
 func (c *ConnectionReplayer) Write(b []byte) (n int, err error) {
+	if err := c.splitter.Feed(b, c.matchRequest); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+// matchRequest finds the recorded response for one request frame and queues it.
+func (c *ConnectionReplayer) matchRequest(frame []byte) error {
 	// A request frame's first byte is its protocol version, and the driver's
 	// handshake frames are never segment-framed — so a v5+ connection is
 	// rejected here during the handshake. Past it, v5 switches to transport
 	// segments, which this replayer can neither hash for matching nor patch
 	// stream ids into without breaking the segment CRCs.
-	if dialer.FrameIsProtoV5OrNewer(b) {
-		return 0, dialer.ErrProtoV5NotSupported
+	if dialer.FrameIsProtoV5OrNewer(frame) {
+		return dialer.ErrProtoV5NotSupported
 	}
 
-	if !c.useMetadataID && dialer.StartupNegotiatesMetadataID(b) {
+	if !c.useMetadataID && dialer.StartupNegotiatesMetadataID(frame) {
 		c.useMetadataID = true
 	}
-	writeHash := dialer.GetFrameHash(b, c.useMetadataID)
+	writeHash := dialer.GetFrameHash(frame, c.useMetadataID)
 
 	for i, q := range c.frames {
 		if q.Hash == writeHash {
-			c.pushStreamIDToReplay(b, i)
-			return len(b), nil
+			c.pushStreamIDToReplay(frame, i)
+			return nil
 		}
 	}
+
+	// Deliberately a panic rather than a returned error. A request with no recorded
+	// response means the recording does not match the driver that is replaying it,
+	// which no amount of retrying fixes — and returning an error here would be
+	// handled as a connection failure and retried or reported far from the cause.
+	// The replay benchmarks depend on this being loud: it is what makes them a
+	// regression test for the frame hashing rather than a timing measurement.
 	panic(fmt.Errorf("unable to find a response to replay"))
 }
 
@@ -205,7 +231,7 @@ func loadFramesFromFile(filename string) (map[int]dialer.Record, error) {
 	// record holds one whole frame, which encoding/json base64-inflates by 4/3, so
 	// any frame over ~48 KiB exceeds the scanner's default bufio.MaxScanTokenSize
 	// and fails the load. A frame's length is the peer's to choose (up to the
-	// driver's own maxFrameSize), so no fixed line cap is the right one; ReadBytes
+	// driver's own frm.MaxFrameSize), so no fixed line cap is the right one; ReadBytes
 	// grows to the line in front of it and nothing larger.
 	reader := bufio.NewReader(file)
 	for {

--- a/dialer/replayer/replayer_test.go
+++ b/dialer/replayer/replayer_test.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gocql/gocql/dialer"
@@ -15,6 +17,15 @@ import (
 // optionsFrame builds a body-less OPTIONS frame with the given version byte.
 func optionsFrame(version byte) []byte {
 	return []byte{version, 0x00, 0x00, 0x01, 0x05, 0x00, 0x00, 0x00, 0x00}
+}
+
+// requestFrame builds a body-less v4 request with the given opcode and stream id.
+//
+// The opcode is what tells two requests apart here: GetFrameHash blanks the stream id
+// before hashing, so two OPTIONS frames on different streams hash alike and would be
+// served the same recorded response.
+func requestFrame(opcode byte, streamID int) []byte {
+	return []byte{0x04, 0x00, byte(streamID >> 8), byte(streamID), opcode, 0x00, 0x00, 0x00, 0x00}
 }
 
 // TestConnectionReplayerRejectsProtoV5 pins the rejection path dkropachev asked
@@ -143,5 +154,321 @@ func TestLoadFramesFromFileSkipsDamagedRecord(t *testing.T) {
 	}
 	if !bytes.Equal(records[3].Data, last.Data) {
 		t.Errorf("record 3 = %+v, want %+v, so a record without a trailing newline is still read", records[3], last)
+	}
+}
+
+// responseFrame builds a body-carrying response frame with the given stream id, so a
+// test can check which stream id came back out.
+func responseFrame(streamID int, bodyLen int) []byte {
+	frame := []byte{
+		0x84, 0x00,
+		byte(streamID >> 8), byte(streamID),
+		0x08, // RESULT
+		byte(bodyLen >> 24), byte(bodyLen >> 16), byte(bodyLen >> 8), byte(bodyLen),
+	}
+	return append(frame, bytes.Repeat([]byte{0x5A}, bodyLen)...)
+}
+
+// readAll drains the replayer until it has delivered n bytes, using a buffer of
+// exactly chunk bytes so the response has to be served across several calls.
+func readAll(t *testing.T, c *ConnectionReplayer, n, chunk int) []byte {
+	t.Helper()
+
+	got := make([]byte, 0, n)
+	buf := make([]byte, chunk)
+	for len(got) < n {
+		read, err := c.Read(buf)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		if read == 0 {
+			t.Fatal("Read returned 0 bytes without an error")
+		}
+		got = append(got, buf[:read]...)
+	}
+	return got
+}
+
+// TestConnectionReplayerPatchesStreamIDAcrossPartialReads pins the stream-id patch
+// against a caller whose buffer is smaller than the response.
+//
+// The patch used to be applied to the caller's buffer, and only on the branch where
+// the whole response fitted — so a response larger than the buffer was replayed
+// carrying the stream id it was recorded with, and the driver matched it to the wrong
+// in-flight request or to none. It went unnoticed because the largest response in the
+// checked-in recordings is well under the driver's 4 KiB read buffer, so the short
+// branch never ran.
+func TestConnectionReplayerPatchesStreamIDAcrossPartialReads(t *testing.T) {
+	const (
+		recordedStreamID = 0x0040
+		liveStreamID     = 0x01F4
+		bodyLen          = 500
+	)
+
+	request := optionsFrame(0x04)
+	request[2] = byte(liveStreamID >> 8)
+	request[3] = byte(liveStreamID & 0xFF)
+
+	for _, chunk := range []int{1, 7, 64, 512, 4096} {
+		t.Run(fmt.Sprintf("buffer of %d", chunk), func(t *testing.T) {
+			response := responseFrame(recordedStreamID, bodyLen)
+			c := &ConnectionReplayer{
+				gotRequest: make(chan struct{}, 1),
+				frames: []*FrameRecorded{{
+					Response: append([]byte(nil), response...),
+					Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+				}},
+			}
+
+			if _, err := c.Write(append([]byte(nil), request...)); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			got := readAll(t, c, len(response), chunk)
+
+			if len(got) != len(response) {
+				t.Fatalf("served %d bytes, want %d", len(got), len(response))
+			}
+			if gotID := int(got[2])<<8 | int(got[3]); gotID != liveStreamID {
+				t.Errorf("served stream id %#04x, want the live request's %#04x", gotID, liveStreamID)
+			}
+			// Everything except the stream id must be byte-for-byte the recording.
+			if !bytes.Equal(got[4:], response[4:]) || got[0] != response[0] || got[1] != response[1] {
+				t.Error("the response body was altered")
+			}
+		})
+	}
+}
+
+// TestConnectionReplayerDoesNotMutateTheRecording pins that the patch goes into a copy.
+// A FrameRecorded is shared and served once per benchmark iteration, so patching it in
+// place would rewrite the recording with the first request's stream id and leave every
+// later iteration depending on that.
+func TestConnectionReplayerDoesNotMutateTheRecording(t *testing.T) {
+	const bodyLen = 32
+
+	recorded := responseFrame(0x0040, bodyLen)
+	pristine := append([]byte(nil), recorded...)
+
+	frame := &FrameRecorded{Response: recorded}
+
+	for i, streamID := range []int{0x0100, 0x0200, 0x0300} {
+		request := optionsFrame(0x04)
+		request[2] = byte(streamID >> 8)
+		request[3] = byte(streamID & 0xFF)
+
+		c := &ConnectionReplayer{
+			gotRequest: make(chan struct{}, 1),
+			frames:     []*FrameRecorded{frame},
+		}
+		frame.Hash = dialer.GetFrameHash(append([]byte(nil), request...), false)
+
+		if _, err := c.Write(append([]byte(nil), request...)); err != nil {
+			t.Fatalf("iteration %d: Write: %v", i, err)
+		}
+		got := readAll(t, c, len(recorded), 4096)
+
+		if gotID := int(got[2])<<8 | int(got[3]); gotID != streamID {
+			t.Errorf("iteration %d: served stream id %#04x, want %#04x", i, gotID, streamID)
+		}
+		if !bytes.Equal(frame.Response, pristine) {
+			t.Fatalf("iteration %d: the recorded response was mutated in place", i)
+		}
+	}
+}
+
+// TestConnectionReplayerRejectsAnEmptyRecord pins the one damaged record that cannot
+// be served at all.
+//
+// A record with no bytes would have Read copy nothing into a buffer with room in it and
+// return (0, nil), having already counted the response as delivered -- so the driver
+// retries, finds nothing pending, and blocks for a request whose response is gone. A
+// line like {"data":null,"stream_id":5} decodes cleanly, so only this check stands
+// between a damaged recording and a hung test. It is the same check that catches a
+// record truncated part-way through a frame; see the test below.
+func TestConnectionReplayerRejectsAnEmptyRecord(t *testing.T) {
+	request := optionsFrame(0x04)
+
+	c := &ConnectionReplayer{
+		gotRequest: make(chan struct{}, 1),
+		frames: []*FrameRecorded{{
+			Response: nil,
+			Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+		}},
+	}
+
+	if _, err := c.Write(append([]byte(nil), request...)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	n, err := c.Read(make([]byte, 16))
+	if err == nil {
+		t.Fatalf("Read returned (%d, nil) for an empty record, want an error", n)
+	}
+	if n != 0 {
+		t.Errorf("Read returned %d bytes alongside its error", n)
+	}
+	if !strings.Contains(err.Error(), "not one whole CQL frame") {
+		t.Errorf("error %q does not say the recording is at fault", err)
+	}
+}
+
+// TestConnectionReplayerRejectsATruncatedRecord pins that a record which is not one
+// whole frame is refused rather than served.
+//
+// Serving it used to be the documented behaviour, on the grounds that the driver would
+// reject it as a protocol error. It cannot: the driver reads a frame with io.ReadFull
+// twice -- the nine header bytes, then the body length that header declares -- and this
+// connection's SetReadDeadline does nothing, so a record stopping short of a whole frame
+// leaves it blocked mid-frame while Read waits for a request that is never coming.
+//
+// The second case is the one a length-only check misses: a complete header whose body
+// arrived short hangs exactly the same way.
+func TestConnectionReplayerRejectsATruncatedRecord(t *testing.T) {
+	full := responseFrame(0x0040, 32)
+
+	for _, tc := range []struct {
+		name     string
+		response []byte
+	}{
+		{"shorter than a header", []byte{0x84, 0x00}},
+		{"header declares more body than arrived", full[:headerLen+16]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := optionsFrame(0x04)
+
+			c := &ConnectionReplayer{
+				gotRequest: make(chan struct{}, 1),
+				frames: []*FrameRecorded{{
+					Response: append([]byte(nil), tc.response...),
+					Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+				}},
+			}
+
+			if _, err := c.Write(append([]byte(nil), request...)); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			n, err := c.Read(make([]byte, 64))
+			if err == nil {
+				t.Fatalf("Read returned (%d, nil) for a truncated record, want an error", n)
+			}
+			if n != 0 {
+				t.Errorf("Read returned %d bytes alongside its error", n)
+			}
+			if !strings.Contains(err.Error(), "not one whole CQL frame") {
+				t.Errorf("error %q does not say the recording is at fault", err)
+			}
+		})
+	}
+}
+
+// TestConnectionReplayerReleasesAnOutsizedResponseBuffer pins that the reused buffer
+// does not keep an outlier's capacity for the life of the connection.
+//
+// It is reused so that serving a response allocates nothing, and a recording may hold a
+// response of any size the driver's frame limit allows -- so without a bound one large
+// response pins that much for as long as the connection lives.
+func TestConnectionReplayerReleasesAnOutsizedResponseBuffer(t *testing.T) {
+	const (
+		big   = 2 * maxRetainedResponse
+		small = 8
+	)
+
+	first := requestFrame(0x05, 0x0001)  // OPTIONS
+	second := requestFrame(0x0B, 0x0002) // REGISTER
+
+	c := &ConnectionReplayer{
+		gotRequest: make(chan struct{}, 1),
+		frames: []*FrameRecorded{
+			{
+				Response: responseFrame(0x0040, big),
+				Hash:     dialer.GetFrameHash(append([]byte(nil), first...), false),
+			},
+			{
+				Response: responseFrame(0x0041, small),
+				Hash:     dialer.GetFrameHash(append([]byte(nil), second...), false),
+			},
+		},
+	}
+
+	if _, err := c.Write(append([]byte(nil), first...)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	readAll(t, c, headerLen+big, 4096)
+
+	// Still here: it is what is being served, until the next response needs the buffer.
+	if cap(c.outgoing) <= maxRetainedResponse {
+		t.Fatalf("outgoing holds %d bytes, want the response just served", cap(c.outgoing))
+	}
+
+	if _, err := c.Write(append([]byte(nil), second...)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	readAll(t, c, headerLen+small, 4096)
+
+	if cap(c.outgoing) > maxRetainedResponse {
+		t.Errorf("outgoing still holds %d bytes after the outsized response drained", cap(c.outgoing))
+	}
+	// The bound must not cost the reuse it exists to protect: an ordinary response keeps
+	// its buffer.
+	if cap(c.outgoing) == 0 {
+		t.Error("outgoing was released although it is within the bound")
+	}
+}
+
+// TestConnectionReplayerLatchesAMaterialiseFailure pins that a response that cannot be
+// materialised ends the connection rather than being served up as an error forever.
+//
+// frameIdx is advanced only once the response is ready, so a failure leaves Read's branch
+// condition -- outgoingPos == len(outgoing) -- still true and the same record still
+// pending: the next Read fetches it again and fails the same way. The recorder latches the
+// analogous failure; this is the same latch, on the one goroutine that owns Read.
+func TestConnectionReplayerLatchesAMaterialiseFailure(t *testing.T) {
+	full := responseFrame(0x0040, 32)
+
+	for _, tc := range []struct {
+		name     string
+		response []byte
+	}{
+		{name: "empty record", response: nil},
+		{name: "truncated record", response: full[:headerLen+16]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := optionsFrame(0x04)
+			c := &ConnectionReplayer{
+				gotRequest: make(chan struct{}, 1),
+				frames: []*FrameRecorded{{
+					Response: append([]byte(nil), tc.response...),
+					Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+				}},
+			}
+			if _, err := c.Write(append([]byte(nil), request...)); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+
+			n, first := c.Read(make([]byte, 64))
+			if first == nil {
+				t.Fatalf("Read returned (%d, nil) for a record that is not one whole frame", n)
+			}
+
+			// The latch is reported even for a zero-length read, the way dialer.Feed
+			// reports one for an empty buffer: a caller that took (0, nil) for "nothing
+			// yet, still healthy" would park on a connection that is finished.
+			if n, err := c.Read(nil); err == nil || !errors.Is(err, first) {
+				t.Errorf("Read(nil) = (%d, %v), want the latched %v", n, err, first)
+			}
+
+			// And every later read is the same error value, not another one just like
+			// it -- a fresh fmt.Errorf per call is exactly what the unlatched loop
+			// produced, and errors.Is compares identity, which is what tells them apart.
+			n, second := c.Read(make([]byte, 64))
+			if !errors.Is(second, first) {
+				t.Errorf("second Read = (%d, %v), want the latched %v", n, second, first)
+			}
+			if n != 0 {
+				t.Errorf("second Read returned %d bytes alongside its error", n)
+			}
+		})
 	}
 }

--- a/dialer/replayer/replayer_test.go
+++ b/dialer/replayer/replayer_test.go
@@ -28,32 +28,105 @@ func requestFrame(opcode byte, streamID int) []byte {
 	return []byte{0x04, 0x00, byte(streamID >> 8), byte(streamID), opcode, 0x00, 0x00, 0x00, 0x00}
 }
 
-// TestConnectionReplayerRejectsProtoV5 pins the rejection path dkropachev asked
-// for: past the handshake a v5+ connection carries transport segments, which
-// the replayer can neither hash for matching nor patch stream ids into without
-// breaking the segment CRCs. The handshake frames are never segmented, so the
-// version byte of the first write is genuine and the connection fails there —
-// with an explicit error, not the unmatched-response panic.
-func TestConnectionReplayerRejectsProtoV5(t *testing.T) {
-	c := &ConnectionReplayer{gotRequest: make(chan struct{}, 1)}
+// newTestReplayer builds a ConnectionReplayer the way NewConnectionReplayer does,
+// without going through a file on disk. Constructing the literal directly is a trap:
+// the request decoder and the framing state come as a pair, and a replayer missing
+// either panics on the first write.
+func newTestReplayer(proto byte, frames ...*FrameRecorded) *ConnectionReplayer {
+	return newTestReplayerWith(nil, proto, frames...)
+}
 
-	n, err := c.Write(optionsFrame(0x05))
-	if !errors.Is(err, dialer.ErrProtoV5NotSupported) {
-		t.Fatalf("Write(v5 frame) error = %v, want ErrProtoV5NotSupported", err)
-	}
-	if n != 0 {
-		t.Errorf("Write(v5 frame) reported %d bytes written, want 0", n)
+// newTestReplayerWith is the same for a connection given a segment compressor.
+func newTestReplayerWith(comp dialer.SegmentCompressor, proto byte, frames ...*FrameRecorded) *ConnectionReplayer {
+	framing := dialer.NewFraming(comp)
+	return &ConnectionReplayer{
+		gotRequest:        make(chan struct{}, 1),
+		frames:            frames,
+		frameIdsToReplay:  []int{},
+		streamIdsToReplay: []int{},
+		recordedProto:     proto,
+		framing:           framing,
+		requests:          framing.NewDecoder(),
 	}
 }
 
-// TestConnectionReplayerAcceptsProtoV4 pins that the rejection is scoped to
-// v5+: a v4 frame with a matching recorded hash replays normally.
+// TestConnectionReplayerReplaysUnsegmentedProtoV5 pins that a v5 request is matched
+// rather than refused.
+//
+// It used to be refused outright, because the replayer could neither hash a transport
+// segment for matching nor patch a stream id into one without invalidating its CRC.
+// The handshake is still unsegmented on v5, so this frame goes through the plain path;
+// what changed is that reaching it is no longer an error.
+func TestConnectionReplayerReplaysUnsegmentedProtoV5(t *testing.T) {
+	req := optionsFrame(0x05)
+	c := newTestReplayer(0x05, &FrameRecorded{
+		Response: optionsFrame(0x85),
+		Hash:     dialer.GetFrameHash(append([]byte(nil), req...), false),
+	})
+
+	if _, err := c.Write(append([]byte(nil), req...)); err != nil {
+		t.Fatalf("Write(v5 frame) error = %v, want nil", err)
+	}
+}
+
+// TestConnectionReplayerRefusesAProtoV5Query pins that the one request the hashing
+// cannot yet locate on protocol v5 is refused by name, rather than surfacing as the
+// anonymous unable-to-find-a-response panic (scylladb/gocql#1000).
+//
+// It panics like that one, and for the same reason: a QUERY arrives mid-session,
+// where a returned error is a connection failure the driver answers by reconnecting
+// and replaying the same recording into the same refusal, reporting it far from the
+// cause if at all.
+func TestConnectionReplayerRefusesAProtoV5Query(t *testing.T) {
+	query := []byte{
+		0x05, 0x00, // version, flags
+		0x00, 0x01, // stream id
+		0x07,                   // opQuery
+		0x00, 0x00, 0x00, 0x00, // body length
+	}
+	c := newTestReplayer(0x05)
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("a protocol v5 QUERY was accepted for replay")
+			return
+		}
+		err, ok := r.(error)
+		if !ok {
+			t.Fatalf("panic value %v is not an error", r)
+		}
+		if !strings.Contains(err.Error(), "QUERY") || !strings.Contains(err.Error(), "#1000") {
+			t.Errorf("panic %q does not name QUERY and scylladb/gocql#1000", err)
+		}
+	}()
+
+	_, _ = c.Write(query)
+}
+
+// TestConnectionReplayerRejectsAProtocolMismatch pins that replaying a recording at
+// the wrong protocol version says so, rather than serving responses the driver rejects
+// deep inside its own header parsing.
+func TestConnectionReplayerRejectsAProtocolMismatch(t *testing.T) {
+	c := newTestReplayer(0x05)
+
+	_, err := c.Write(optionsFrame(0x04))
+	if err == nil {
+		t.Fatal("a v4 request against a v5 recording was accepted")
+	}
+	if !strings.Contains(err.Error(), "protocol v5") || !strings.Contains(err.Error(), "protocol v4") {
+		t.Errorf("error %q does not name both protocol versions", err)
+	}
+}
+
+// TestConnectionReplayerAcceptsProtoV4 pins that a v4 frame with a matching recorded
+// hash replays normally.
 func TestConnectionReplayerAcceptsProtoV4(t *testing.T) {
 	req := optionsFrame(0x04)
-	c := &ConnectionReplayer{
-		frames:     []*FrameRecorded{{Response: optionsFrame(0x84), Hash: dialer.GetFrameHash(req, false)}},
-		gotRequest: make(chan struct{}, 1),
-	}
+	c := newTestReplayer(0x04, &FrameRecorded{
+		Response: optionsFrame(0x84),
+		Hash:     dialer.GetFrameHash(req, false),
+	})
 
 	n, err := c.Write(req)
 	if err != nil {
@@ -68,6 +141,13 @@ func TestConnectionReplayerAcceptsProtoV4(t *testing.T) {
 // JSON object per line, and returns its path.
 func writeRecords(t *testing.T, name string, records ...dialer.Record) string {
 	t.Helper()
+	return writeRecordsTo(t, filepath.Join(t.TempDir(), name), records...)
+}
+
+// writeRecordsTo writes the records to an exact path, for the tests that need both
+// halves of one recording to share a directory.
+func writeRecordsTo(t *testing.T, path string, records ...dialer.Record) string {
+	t.Helper()
 
 	var buf bytes.Buffer
 	for _, record := range records {
@@ -78,11 +158,121 @@ func writeRecords(t *testing.T, name string, records ...dialer.Record) string {
 		buf.Write(append(line, '\n'))
 	}
 
-	path := filepath.Join(t.TempDir(), name)
 	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
 		t.Fatalf("writing %s: %v", path, err)
 	}
 	return path
+}
+
+// TestNewConnectionReplayerRefusesARecordingThatPairsNothing pins that a recording with
+// nothing to replay fails at the dial.
+//
+// The loader accepts one deliberately -- it still has a protocol version to report off a
+// truncated Reads file, and a version check that disarms itself exactly when the recording
+// is damaged is not a check -- so the refusal belongs here instead. Without it the dial
+// succeeds and the first request panics with "unable to find a response to replay", naming
+// neither file, which is what a mistyped directory or a source port this recording never
+// saw produces.
+func TestNewConnectionReplayerRefusesARecordingThatPairsNothing(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "rec")
+	writeRecordsTo(t, base+"Writes", dialer.Record{Data: optionsFrame(0x04), StreamID: 1, Proto: 0x04})
+	writeRecordsTo(t, base+"Reads")
+
+	conn, err := NewConnectionReplayer(base, nil)
+	if err == nil {
+		t.Fatalf("a recording pairing no requests with responses was replayed as %T", conn)
+	}
+	for _, want := range []string{base + "Reads", base + "Writes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}
+
+// TestLoadFramesPrefersTheStampedProto pins where a recording's protocol version
+// comes from: the Proto field the recorder stamps, read from any request record,
+// rather than from the request/response pairing -- a truncated Reads file pairs
+// nothing, and a version check that disarms itself exactly when the recording is
+// damaged is not a check. A record that predates the field (Proto 0) still derives
+// the version from the frame's own bytes.
+func TestLoadFramesPrefersTheStampedProto(t *testing.T) {
+	t.Run("stamped, nothing paired", func(t *testing.T) {
+		writes := writeRecords(t, "Writes", dialer.Record{Data: optionsFrame(0x05), StreamID: 1, Proto: 0x05})
+		reads := writeRecords(t, "Reads")
+
+		_, proto, err := loadResponseFramesFromFiles(reads, writes)
+		if err != nil {
+			t.Fatalf("loadResponseFramesFromFiles: %v", err)
+		}
+		if proto != 0x05 {
+			t.Errorf("proto = %d, want 5 (the stamped version, despite nothing pairing)", proto)
+		}
+	})
+
+	t.Run("stamped versions disagree", func(t *testing.T) {
+		writes := writeRecords(t, "Writes",
+			dialer.Record{Data: optionsFrame(0x04), StreamID: 1, Proto: 0x04},
+			dialer.Record{Data: optionsFrame(0x05), StreamID: 2, Proto: 0x05})
+		reads := writeRecords(t, "Reads")
+
+		_, _, err := loadResponseFramesFromFiles(reads, writes)
+		if err == nil {
+			t.Fatal("a file holding two protocol versions was loaded")
+		}
+		for _, want := range []string{"v4", "v5"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not name %q", err, want)
+			}
+		}
+	})
+
+	t.Run("derived versions disagree", func(t *testing.T) {
+		writes := writeRecords(t, "Writes",
+			dialer.Record{Data: optionsFrame(0x04), StreamID: 1},
+			dialer.Record{Data: optionsFrame(0x05), StreamID: 2})
+		reads := writeRecords(t, "Reads")
+
+		if _, _, err := loadResponseFramesFromFiles(reads, writes); err == nil {
+			t.Fatal("a file holding two protocol versions was loaded")
+		}
+	})
+
+	t.Run("one stamped record does not answer for the unstamped ones", func(t *testing.T) {
+		// What a recording directory reused across a recorder upgrade holds: the
+		// recorder appends every connection to one addr-sourcePort file, so a v4
+		// session recorded before the Proto field existed survives underneath a
+		// later stamped one. Taking the version from the stamped record alone left
+		// the rest unchecked.
+		writes := writeRecords(t, "Writes",
+			dialer.Record{Data: optionsFrame(0x05), StreamID: 1, Proto: 0x05},
+			dialer.Record{Data: optionsFrame(0x04), StreamID: 2})
+		reads := writeRecords(t, "Reads",
+			dialer.Record{Data: optionsFrame(0x85), StreamID: 1},
+			dialer.Record{Data: optionsFrame(0x84), StreamID: 2})
+
+		_, _, err := loadResponseFramesFromFiles(reads, writes)
+		if err == nil {
+			t.Fatal("a file mixing a stamped v5 record with an unstamped v4 leftover was loaded")
+		}
+		for _, want := range []string{"v4", "v5"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not name %q", err, want)
+			}
+		}
+	})
+
+	t.Run("unstamped legacy record", func(t *testing.T) {
+		writes := writeRecords(t, "Writes", dialer.Record{Data: optionsFrame(0x04), StreamID: 1})
+		reads := writeRecords(t, "Reads", dialer.Record{Data: optionsFrame(0x84), StreamID: 1})
+
+		_, proto, err := loadResponseFramesFromFiles(reads, writes)
+		if err != nil {
+			t.Fatalf("loadResponseFramesFromFiles: %v", err)
+		}
+		if proto != 0x04 {
+			t.Errorf("proto = %d, want 4 (derived from the frame bytes)", proto)
+		}
+	})
 }
 
 // TestLoadFramesFromFileLargeRecord pins that a record is bounded by the frame it
@@ -212,13 +402,10 @@ func TestConnectionReplayerPatchesStreamIDAcrossPartialReads(t *testing.T) {
 	for _, chunk := range []int{1, 7, 64, 512, 4096} {
 		t.Run(fmt.Sprintf("buffer of %d", chunk), func(t *testing.T) {
 			response := responseFrame(recordedStreamID, bodyLen)
-			c := &ConnectionReplayer{
-				gotRequest: make(chan struct{}, 1),
-				frames: []*FrameRecorded{{
-					Response: append([]byte(nil), response...),
-					Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
-				}},
-			}
+			c := newTestReplayer(0x04, &FrameRecorded{
+				Response: append([]byte(nil), response...),
+				Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+			})
 
 			if _, err := c.Write(append([]byte(nil), request...)); err != nil {
 				t.Fatalf("Write: %v", err)
@@ -257,10 +444,7 @@ func TestConnectionReplayerDoesNotMutateTheRecording(t *testing.T) {
 		request[2] = byte(streamID >> 8)
 		request[3] = byte(streamID & 0xFF)
 
-		c := &ConnectionReplayer{
-			gotRequest: make(chan struct{}, 1),
-			frames:     []*FrameRecorded{frame},
-		}
+		c := newTestReplayer(0x04, frame)
 		frame.Hash = dialer.GetFrameHash(append([]byte(nil), request...), false)
 
 		if _, err := c.Write(append([]byte(nil), request...)); err != nil {
@@ -289,13 +473,10 @@ func TestConnectionReplayerDoesNotMutateTheRecording(t *testing.T) {
 func TestConnectionReplayerRejectsAnEmptyRecord(t *testing.T) {
 	request := optionsFrame(0x04)
 
-	c := &ConnectionReplayer{
-		gotRequest: make(chan struct{}, 1),
-		frames: []*FrameRecorded{{
-			Response: nil,
-			Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
-		}},
-	}
+	c := newTestReplayer(0x04, &FrameRecorded{
+		Response: nil,
+		Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+	})
 
 	if _, err := c.Write(append([]byte(nil), request...)); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -332,18 +513,15 @@ func TestConnectionReplayerRejectsATruncatedRecord(t *testing.T) {
 		response []byte
 	}{
 		{"shorter than a header", []byte{0x84, 0x00}},
-		{"header declares more body than arrived", full[:headerLen+16]},
+		{"header declares more body than arrived", full[:dialer.FrameHeaderLen+16]},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			request := optionsFrame(0x04)
 
-			c := &ConnectionReplayer{
-				gotRequest: make(chan struct{}, 1),
-				frames: []*FrameRecorded{{
-					Response: append([]byte(nil), tc.response...),
-					Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
-				}},
-			}
+			c := newTestReplayer(0x04, &FrameRecorded{
+				Response: append([]byte(nil), tc.response...),
+				Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+			})
 
 			if _, err := c.Write(append([]byte(nil), request...)); err != nil {
 				t.Fatalf("Write: %v", err)
@@ -363,13 +541,13 @@ func TestConnectionReplayerRejectsATruncatedRecord(t *testing.T) {
 	}
 }
 
-// TestConnectionReplayerReleasesAnOutsizedResponseBuffer pins that the reused buffer
-// does not keep an outlier's capacity for the life of the connection.
+// TestConnectionReplayerReleasesOutsizedResponseBuffers pins that neither reused buffer
+// keeps an outlier's capacity for the life of the connection.
 //
-// It is reused so that serving a response allocates nothing, and a recording may hold a
-// response of any size the driver's frame limit allows -- so without a bound one large
-// response pins that much for as long as the connection lives.
-func TestConnectionReplayerReleasesAnOutsizedResponseBuffer(t *testing.T) {
+// Both are reused so that serving a response allocates nothing, and a recording may hold
+// a response of any size the driver's frame limit allows -- so without a bound one large
+// response pins it twice over, patched and encoded, for as long as the connection lives.
+func TestConnectionReplayerReleasesOutsizedResponseBuffers(t *testing.T) {
 	const (
 		big   = 2 * maxRetainedResponse
 		small = 8
@@ -378,26 +556,28 @@ func TestConnectionReplayerReleasesAnOutsizedResponseBuffer(t *testing.T) {
 	first := requestFrame(0x05, 0x0001)  // OPTIONS
 	second := requestFrame(0x0B, 0x0002) // REGISTER
 
-	c := &ConnectionReplayer{
-		gotRequest: make(chan struct{}, 1),
-		frames: []*FrameRecorded{
-			{
-				Response: responseFrame(0x0040, big),
-				Hash:     dialer.GetFrameHash(append([]byte(nil), first...), false),
-			},
-			{
-				Response: responseFrame(0x0041, small),
-				Hash:     dialer.GetFrameHash(append([]byte(nil), second...), false),
-			},
+	c := newTestReplayer(0x04,
+		&FrameRecorded{
+			Response: responseFrame(0x0040, big),
+			Hash:     dialer.GetFrameHash(append([]byte(nil), first...), false),
 		},
-	}
+		&FrameRecorded{
+			Response: responseFrame(0x0041, small),
+			Hash:     dialer.GetFrameHash(append([]byte(nil), second...), false),
+		},
+	)
 
 	if _, err := c.Write(append([]byte(nil), first...)); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	readAll(t, c, headerLen+big, 4096)
+	readAll(t, c, dialer.FrameHeaderLen+big, 4096)
 
-	// Still here: it is what is being served, until the next response needs the buffer.
+	// patched is released as soon as the response has been encoded out of it.
+	if cap(c.patched) > maxRetainedResponse {
+		t.Errorf("patched still holds %d bytes after an outsized response", cap(c.patched))
+	}
+	// outgoing is what is being served, so it is still here until the next response
+	// needs the buffer.
 	if cap(c.outgoing) <= maxRetainedResponse {
 		t.Fatalf("outgoing holds %d bytes, want the response just served", cap(c.outgoing))
 	}
@@ -405,7 +585,7 @@ func TestConnectionReplayerReleasesAnOutsizedResponseBuffer(t *testing.T) {
 	if _, err := c.Write(append([]byte(nil), second...)); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	readAll(t, c, headerLen+small, 4096)
+	readAll(t, c, dialer.FrameHeaderLen+small, 4096)
 
 	if cap(c.outgoing) > maxRetainedResponse {
 		t.Errorf("outgoing still holds %d bytes after the outsized response drained", cap(c.outgoing))
@@ -432,17 +612,14 @@ func TestConnectionReplayerLatchesAMaterialiseFailure(t *testing.T) {
 		response []byte
 	}{
 		{name: "empty record", response: nil},
-		{name: "truncated record", response: full[:headerLen+16]},
+		{name: "truncated record", response: full[:dialer.FrameHeaderLen+16]},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			request := optionsFrame(0x04)
-			c := &ConnectionReplayer{
-				gotRequest: make(chan struct{}, 1),
-				frames: []*FrameRecorded{{
-					Response: append([]byte(nil), tc.response...),
-					Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
-				}},
-			}
+			c := newTestReplayer(0x04, &FrameRecorded{
+				Response: append([]byte(nil), tc.response...),
+				Hash:     dialer.GetFrameHash(append([]byte(nil), request...), false),
+			})
 			if _, err := c.Write(append([]byte(nil), request...)); err != nil {
 				t.Fatalf("Write: %v", err)
 			}
@@ -468,6 +645,89 @@ func TestConnectionReplayerLatchesAMaterialiseFailure(t *testing.T) {
 			}
 			if n != 0 {
 				t.Errorf("second Read returned %d bytes alongside its error", n)
+			}
+		})
+	}
+}
+
+// failAfterWriting appends what it was given and then reports a failure. That is the shape
+// segment.AppendCompressed warns about: by the time a compressor is called the segment
+// header has already been reserved in the destination buffer, so an error leaves bytes
+// behind whatever the compressor itself did.
+type failAfterWriting struct{ err error }
+
+func (c failAfterWriting) AppendCompressed(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), c.err
+}
+
+func (failAfterWriting) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// startupV5 builds a v5 STARTUP naming a compression algorithm, which is what fixes the
+// segment header layout for the rest of the connection.
+func startupV5(streamID int, algorithm string) []byte {
+	body := []byte{0x00, 0x01} // a [string map] of one entry
+	for _, s := range []string{"COMPRESSION", algorithm} {
+		body = append(body, byte(len(s)>>8), byte(len(s)))
+		body = append(body, s...)
+	}
+	frame := []byte{
+		0x05, 0x00, byte(streamID >> 8), byte(streamID), 0x01, // STARTUP
+		byte(len(body) >> 24), byte(len(body) >> 16), byte(len(body) >> 8), byte(len(body)),
+	}
+	return append(frame, body...)
+}
+
+// TestMaterialiseLeavesNothingServableWhenEncodingFails pins what materialise owes its
+// caller when the framing refuses to encode a response.
+//
+// EncodeResponse encodes into the buffer it is handed and can fail after having written
+// into it, so on the error path outgoing's length described bytes that were no longer the
+// response it named. Nothing serves them -- outgoingPos == len(outgoing) on the way in,
+// and Read latches the failure on the way out -- which is exactly why this is asserted on
+// the fields: there is no way left to observe it from outside, and an invariant nothing
+// can see is the kind that decays quietly.
+func TestMaterialiseLeavesNothingServableWhenEncodingFails(t *testing.T) {
+	const previous = 64
+
+	for _, tc := range []struct {
+		name string
+		// comp covers both ways EncodeResponse fails: nil is refused before anything is
+		// written, the other fails after.
+		comp dialer.SegmentCompressor
+	}{
+		{name: "no compressor for a compressed connection", comp: nil},
+		{name: "compressor fails after writing", comp: failAfterWriting{err: errors.New("compressor failed")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestReplayerWith(tc.comp, 0x05)
+
+			// Drive the framing to where a response is segmented: a STARTUP naming an
+			// algorithm fixes the layout, a READY flips the switch.
+			if err := c.framing.ObserveRequest(startupV5(1, "lz4")); err != nil {
+				t.Fatalf("ObserveRequest: %v", err)
+			}
+			c.framing.ObserveResponse([]byte{0x85, 0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00})
+
+			// The state materialise is entered in: a previous response, served and
+			// drained, whose buffer is the one the next encode is handed.
+			c.streamIdsToReplay = []int{0x0007}
+			c.outgoing = make([]byte, previous, 4096)
+			c.outgoingPos = previous
+
+			response := responseFrame(0x0040, 32)
+			response[0] = 0x85 // the connection is v5; a v4 frame here would be a lie
+			if err := c.materialise(&FrameRecorded{Response: response}); err == nil {
+				t.Fatal("a response the framing cannot encode was materialised")
+			}
+
+			if len(c.outgoing) != 0 {
+				t.Errorf("outgoing still reports %d bytes after a failed encode; they are not the response it names", len(c.outgoing))
+			}
+			if c.outgoingPos != len(c.outgoing) {
+				t.Errorf("outgoingPos = %d with len(outgoing) = %d: Read would serve bytes materialise never wrote",
+					c.outgoingPos, len(c.outgoing))
 			}
 		})
 	}

--- a/dialer/segment.go
+++ b/dialer/segment.go
@@ -1,0 +1,247 @@
+package dialer
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/gocql/gocql/internal/segment"
+)
+
+// SegmentCompressor compresses and decompresses protocol v5 transport segment
+// payloads.
+//
+// It is structurally identical to gocql.SegmentCompressor, and a value of that type
+// satisfies this directly. It is redeclared rather than imported because this package
+// does not depend on the driver, and because the only compressor that implements it —
+// lz4 — lives in a separate module that the driver cannot construct for itself. A
+// caller that wants compressed v5 recordings therefore has to hand one in.
+//
+// A nil SegmentCompressor means the uncompressed segment layout. Note that a typed
+// nil is not nil as an interface, so pass an untyped nil rather than a nil variable
+// of a concrete compressor type.
+type SegmentCompressor interface {
+	// AppendCompressed compresses src and appends the compressed bytes to dst.
+	AppendCompressed(dst, src []byte) ([]byte, error)
+
+	// AppendDecompressed decompresses src (whose decompressed size is supplied
+	// out-of-band as decompressedLength) and appends the result to dst.
+	AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error)
+}
+
+// SegmentSplitter recovers CQL frames from a protocol v5 transport-segment byte
+// stream delivered in arbitrary chunks.
+//
+// From v5 the driver wraps each CQL frame in one or more segments: a header carrying
+// a 17-bit payload length and a self-contained flag, a header CRC24, the payload
+// (optionally compressed) and a payload CRC32. A segment is either self-contained,
+// carrying one or more complete frames, or a link in a chain carrying a slice of one
+// large frame.
+//
+// Recovering the frames needs no separate reassembly path for the two shapes. The
+// spec (section 2) gives a split frame its own sequence of segments, so a chain never
+// shares a segment with anything else, and the ordered concatenation of every
+// payload is exactly the frame stream. Feeding that concatenation to a FrameSplitter,
+// which already tolerates arbitrary chunk boundaries, therefore handles both several
+// frames in one self-contained segment and a frame whose 9-byte header straddles a
+// segment boundary.
+//
+// What concatenation alone loses is the ability to notice a stream that does not mean
+// what it says, so the flag is checked rather than ignored — see Feed. Without those
+// checks a corrupt or truncated chain does not fail, it silently re-aligns at the
+// wrong offset and yields plausible garbage, which in a recording is worse than an
+// error.
+// The field order is dictated by the fieldalignment vet check, which wants the
+// pointer-bearing fields contiguous, so it does not group them by what they do.
+type SegmentSplitter struct {
+	comp SegmentCompressor
+	// latch makes the splitter one-shot, like the frame splitter it wraps: see Feed.
+	// A failure here means the segment stream cannot be trusted from this point --
+	// the buffer is positioned at a segment that did not decode, or whose payload was
+	// already handed on before the check that rejected it -- so resuming would re-feed
+	// those bytes.
+	latch
+	// frames turns the concatenated payloads back into CQL frames.
+	frames FrameSplitter
+	// scratch is the payload buffer the codec reads into, reused across segments.
+	scratch segment.Scratch
+	// buf holds the bytes that do not yet add up to a whole segment.
+	buf []byte
+	// rdr is the io.Reader the codec reads through, pointed at a window of buf. It is
+	// a field so that decoding a segment costs no allocation: the codec takes an
+	// io.Reader, and a fresh bytes.Reader per header and per payload would be two
+	// allocations per segment on the path the replay benchmarks measure.
+	rdr bytes.Reader
+	// hdr is the header of the segment being accumulated, decoded once its bytes have
+	// all arrived; hdrValid says whether it holds one. Keeping it means a segment that
+	// arrives in ten chunks verifies its header CRC24 once rather than ten times, and
+	// a corrupt header is reported once rather than per chunk.
+	hdr      segment.Header
+	hdrValid bool
+}
+
+// NewSegmentSplitter returns a splitter for a stream in the layout implied by comp:
+// the compressed segment layout when it is non-nil, the uncompressed one otherwise.
+func NewSegmentSplitter(comp SegmentCompressor) *SegmentSplitter {
+	return &SegmentSplitter{comp: comp}
+}
+
+// compressed reports whether the stream uses the compressed segment layout.
+func (s *SegmentSplitter) compressed() bool {
+	return s.comp != nil
+}
+
+// Pending reports whether the splitter holds anything incomplete: a partial segment,
+// or a chain whose frame has not finished arriving. A stream that ends here ended
+// mid-structure.
+func (s *SegmentSplitter) Pending() bool {
+	return len(s.buf) > 0 || s.frames.Pending()
+}
+
+// Feed consumes b, calling emit once for each CQL frame it recovers.
+//
+// The frame handed to emit is only valid for the duration of the call.
+//
+// Four rules govern the self-contained flag, and together they are what stops a
+// damaged stream from re-aligning silently:
+//
+//   - A self-contained segment may not arrive while a chain is in progress. This is
+//     the same rejection the driver's own reader makes, and the case that matters
+//     most: without it an over-running chain does not error, it resumes reading
+//     frames at the wrong offset.
+//   - A self-contained segment must not end mid-frame. It promised whole frames.
+//   - A chain segment must carry a non-empty payload, so a peer cannot drive an
+//     endless chain that never progresses. An empty *self-contained* segment is
+//     accepted and yields nothing, which looks like the same defect but is not: the
+//     driver's own reader accepts it too (processAllFramesInSegment loops while bytes
+//     remain, so an empty payload is zero frames and no error), and a splitter that
+//     refused what the connection it records accepts would fail a stream gocql itself
+//     handles. Only a chain is owed progress, and recvSplitFrame enforces that there.
+//   - A chain must yield exactly one frame and nothing after it, since a split frame
+//     gets a sequence of segments to itself. A chain here is bounded by the frame it
+//     carries, not by the run of continuation segments: the segment that completes a
+//     frame ends the chain, so a following continuation segment begins a new one. That
+//     matches the driver's own reader, which returns from recvSplitFrame as soon as the
+//     frame is whole -- a chain of one segment included.
+//
+// A splitter is one-shot: any failure is remembered and returned by every later call,
+// because a stream that has failed one of those rules cannot be resumed without
+// re-feeding the bytes that failed.
+func (s *SegmentSplitter) Feed(b []byte, emit func(frame []byte) error) error {
+	if err := s.failure(); err != nil {
+		return err
+	}
+	s.buf = append(s.buf, b...)
+
+	headerSize := segment.HeaderSize(s.compressed())
+
+	for {
+		if !s.hdrValid {
+			if len(s.buf) < headerSize {
+				return nil
+			}
+			s.rdr.Reset(s.buf[:headerSize])
+			hdr, err := segment.ReadHeader(&s.rdr, s.compressed())
+			if err != nil {
+				return s.fail(fmt.Errorf("gocql/dialer: failed to decode segment header: %w", err))
+			}
+			s.hdr, s.hdrValid = hdr, true
+		}
+
+		total := headerSize + s.hdr.PayloadLen + segment.Crc32Size
+		if len(s.buf) < total {
+			return nil
+		}
+
+		chainInProgress := s.frames.Pending()
+		if s.hdr.IsSelfContained && chainInProgress {
+			return s.fail(fmt.Errorf("gocql/dialer: received a self-contained segment while a split frame was still being reassembled"))
+		}
+		if !s.hdr.IsSelfContained && s.hdr.PayloadLen == 0 {
+			return s.fail(fmt.Errorf("gocql/dialer: segment chain made no progress (empty payload)"))
+		}
+
+		s.rdr.Reset(s.buf[headerSize:total])
+		payload, err := segment.ReadPayload(&s.rdr, s.hdr, s.comp, &s.scratch)
+		if err != nil {
+			return s.fail(fmt.Errorf("gocql/dialer: failed to decode segment payload: %w", err))
+		}
+
+		emitted := 0
+		if err := s.frames.Feed(payload, func(frame []byte) error {
+			emitted++
+			return emit(frame)
+		}); err != nil {
+			return s.fail(err)
+		}
+
+		if s.hdr.IsSelfContained && s.frames.Pending() {
+			return s.fail(fmt.Errorf("gocql/dialer: self-contained segment ended in the middle of a frame"))
+		}
+		if !s.hdr.IsSelfContained && (emitted > 1 || (emitted == 1 && s.frames.Pending())) {
+			return s.fail(fmt.Errorf("gocql/dialer: segment chain carried more than the one frame it was split from"))
+		}
+
+		// Drop the consumed segment, keeping whatever came after it. Copying the
+		// remainder down rather than re-slicing keeps the buffer from growing without
+		// bound over the life of a connection.
+		s.buf = append(s.buf[:0], s.buf[total:]...)
+
+		// Copying down bounds the length, not the capacity, and Feed appends whatever
+		// it is handed: one large Write or read buffer leaves this holding far more
+		// than decoding a segment ever needs, for the life of the connection, in each
+		// of the three of these a recorded connection builds. So an outsized buffer is
+		// handed back once it has drained, the way the frame splitter inside this one
+		// hands back an outsized frame.
+		//
+		// The bound is one whole segment at the largest the format allows, not
+		// maxRetainedFrame: a segment payload is 17 bits, so a stream of maximum-size
+		// segments would sit just above that constant and reallocate per segment. For
+		// the same reason segment.Scratch is left alone -- both of its buffers are
+		// bounded by that payload length already, and releasing them would cost a
+		// reallocation per outsized segment on the path the replay benchmarks measure.
+		if len(s.buf) == 0 && cap(s.buf) > headerSize+segment.MaxPayloadSize+segment.Crc32Size {
+			s.buf = nil
+		}
+		s.hdrValid = false
+	}
+}
+
+// AppendSegmented encodes one CQL frame as a transport-segment chain appended to dst
+// and returns the extended slice.
+//
+// The split rule mirrors framer.prepareModernLayout exactly, because a recording is
+// replayed to a driver that decodes what that function produces: fixed maximum-size
+// chain segments while more than one is needed, then a remainder, and the whole frame
+// is self-contained only when no split happened. A frame of exactly the maximum
+// payload size is therefore one self-contained segment, not a chain.
+//
+// On error the returned slice must not be used; the compressed layout can fail after
+// having written into dst.
+func AppendSegmented(dst, frame []byte, comp SegmentCompressor) ([]byte, error) {
+	var err error
+
+	// Reserve the whole encoding up front. Each segment.Append below otherwise grows
+	// dst by append alone, so a frame spanning several segments re-grows and copies
+	// the buffer once per doubling -- on the path the replay benchmarks measure, and
+	// for the replayer on the first large response of every connection, since that is
+	// where its reused buffer gets its capacity. framer.prepareModernLayout sizes its
+	// wire buffer from the same function for the same reason.
+	if need := segment.EncodedSize(len(frame), comp != nil); cap(dst)-len(dst) < need {
+		grown := make([]byte, len(dst), len(dst)+need)
+		copy(grown, dst)
+		dst = grown
+	}
+
+	src := frame
+	selfContained := true
+
+	for len(src) > segment.MaxPayloadSize {
+		if dst, err = segment.Append(dst, src[:segment.MaxPayloadSize], false, comp); err != nil {
+			return nil, err
+		}
+		src = src[segment.MaxPayloadSize:]
+		selfContained = false
+	}
+
+	return segment.Append(dst, src, selfContained, comp)
+}

--- a/dialer/segment_test.go
+++ b/dialer/segment_test.go
@@ -1,0 +1,532 @@
+package dialer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gocql/gocql/internal/segment"
+)
+
+// passthroughCompressor is a no-op compressor that still honours the append
+// contract. Using a real lz4 would drag in a separate module; what these tests need
+// is the compressed *layout*, not compression.
+type passthroughCompressor struct{}
+
+func (passthroughCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+func (passthroughCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// compressors is the set every decoder test runs against: both segment layouts.
+func compressors() []struct {
+	name string
+	comp SegmentCompressor
+} {
+	return []struct {
+		name string
+		comp SegmentCompressor
+	}{
+		{name: "uncompressed", comp: nil},
+		{name: "compressed", comp: passthroughCompressor{}},
+	}
+}
+
+// mustSegment builds one segment, failing the test if the codec rejects it.
+func mustSegment(t *testing.T, payload []byte, selfContained bool, comp SegmentCompressor) []byte {
+	t.Helper()
+
+	seg, err := segment.Append(nil, payload, selfContained, comp)
+	if err != nil {
+		t.Fatalf("build segment: %v", err)
+	}
+	return seg
+}
+
+// decode feeds chunks to a splitter and returns the frames it recovered.
+func decode(t *testing.T, s *SegmentSplitter, chunks ...[]byte) [][]byte {
+	t.Helper()
+
+	var got [][]byte
+	for _, chunk := range chunks {
+		if err := s.Feed(chunk, func(frame []byte) error {
+			got = append(got, append([]byte(nil), frame...))
+			return nil
+		}); err != nil {
+			t.Fatalf("Feed: %v", err)
+		}
+	}
+	return got
+}
+
+func TestSegmentSplitterSelfContained(t *testing.T) {
+	one := frameV4(opOptions, 0x00, nil)
+	two := frameV4(opQuery, 0x00, []byte("SELECT 1"))
+
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name    string
+				payload []byte
+				want    [][]byte
+			}{
+				{name: "one frame", payload: one, want: [][]byte{one}},
+				{
+					name:    "several frames in one segment",
+					payload: bytes.Join([][]byte{one, two, one}, nil),
+					want:    [][]byte{one, two, one},
+				},
+				// Accepted, not refused: the driver's own processAllFramesInSegment
+				// loops while bytes remain, so it reads an empty self-contained
+				// segment as zero frames and no error. Refusing it here would fail
+				// a stream gocql handles. The chain rule is the asymmetric one; see
+				// Feed.
+				{name: "no frames", payload: nil, want: nil},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					s := NewSegmentSplitter(cc.comp)
+					got := decode(t, s, mustSegment(t, tc.payload, true, cc.comp))
+
+					if len(got) != len(tc.want) {
+						t.Fatalf("recovered %d frames, want %d", len(got), len(tc.want))
+					}
+					for i := range got {
+						if !bytes.Equal(got[i], tc.want[i]) {
+							t.Errorf("frame %d: got % X, want % X", i, got[i], tc.want[i])
+						}
+					}
+					if s.Pending() {
+						t.Error("splitter still holds something incomplete")
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSegmentSplitterChain covers a frame split across chain segments, including the
+// case that needs no special handling here but does in the driver's own reader: a
+// frame whose 9-byte CQL header does not fit in the first segment.
+func TestSegmentSplitterChain(t *testing.T) {
+	frame := frameV4(opQuery, 0x00, bytes.Repeat([]byte{0x5A}, 500))
+
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name  string
+				split []int // payload sizes of the chain segments
+			}{
+				{name: "two segments", split: []int{200, len(frame) - 200}},
+				{name: "header straddles the boundary", split: []int{4, len(frame) - 4}},
+				{name: "one byte at a time in the header", split: []int{1, 1, 1, len(frame) - 3}},
+				{name: "many segments", split: []int{50, 50, 50, 50, len(frame) - 200}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					var stream []byte
+					offset := 0
+					for i, n := range tc.split {
+						last := i == len(tc.split)-1
+						stream = append(stream, mustSegment(t, frame[offset:offset+n], false, cc.comp)...)
+						offset += n
+						if last && offset != len(frame) {
+							t.Fatalf("split covers %d of %d bytes", offset, len(frame))
+						}
+					}
+
+					s := NewSegmentSplitter(cc.comp)
+					got := decode(t, s, stream)
+
+					if len(got) != 1 {
+						t.Fatalf("recovered %d frames, want 1", len(got))
+					}
+					if !bytes.Equal(got[0], frame) {
+						t.Errorf("frame did not survive the chain")
+					}
+					if s.Pending() {
+						t.Error("splitter still holds something incomplete")
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSegmentSplitterOversizedFrame covers a frame larger than one segment can carry,
+// which is the only way the driver itself produces a chain.
+func TestSegmentSplitterOversizedFrame(t *testing.T) {
+	body := bytes.Repeat([]byte{0x42}, 2*segment.MaxPayloadSize+7)
+	frame := frameV4(opQuery, 0x00, body)
+
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			// Encode exactly as the driver would, then decode it back.
+			stream, err := AppendSegmented(nil, frame, cc.comp)
+			if err != nil {
+				t.Fatalf("AppendSegmented: %v", err)
+			}
+
+			s := NewSegmentSplitter(cc.comp)
+			got := decode(t, s, stream)
+
+			if len(got) != 1 {
+				t.Fatalf("recovered %d frames, want 1", len(got))
+			}
+			if !bytes.Equal(got[0], frame) {
+				t.Error("a multi-segment frame did not survive the round trip")
+			}
+		})
+	}
+}
+
+// TestSegmentSplitterArbitraryChunks pins that the splitter does not care where the
+// stream is cut, which is the whole reason it buffers: it is fed whatever a socket
+// read happened to return.
+func TestSegmentSplitterArbitraryChunks(t *testing.T) {
+	frames := [][]byte{
+		frameV4(opOptions, 0x00, nil),
+		frameV4(opQuery, 0x00, bytes.Repeat([]byte{0x11}, 400)),
+		frameV4(opStartup, 0x00, []byte{0x00, 0x00}),
+	}
+
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			// A self-contained segment with two frames, then a chain for the third.
+			var stream []byte
+			stream = append(stream, mustSegment(t, bytes.Join(frames[:2], nil), true, cc.comp)...)
+			stream = append(stream, mustSegment(t, frames[2][:5], false, cc.comp)...)
+			stream = append(stream, mustSegment(t, frames[2][5:], false, cc.comp)...)
+
+			for _, chunk := range []int{1, 2, 7, 13, len(stream)} {
+				t.Run(fmt.Sprintf("chunks of %d", chunk), func(t *testing.T) {
+					s := NewSegmentSplitter(cc.comp)
+					var chunks [][]byte
+					for i := 0; i < len(stream); i += chunk {
+						end := min(i+chunk, len(stream))
+						chunks = append(chunks, stream[i:end])
+					}
+					got := decode(t, s, chunks...)
+
+					if len(got) != len(frames) {
+						t.Fatalf("chunk %d: recovered %d frames, want %d", chunk, len(got), len(frames))
+					}
+					for i := range got {
+						if !bytes.Equal(got[i], frames[i]) {
+							t.Errorf("chunk %d: frame %d differs", chunk, i)
+						}
+					}
+					if s.Pending() {
+						t.Errorf("chunk %d: splitter still holds something incomplete", chunk)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSegmentSplitterRejectsMalformedStreams pins the four self-contained-flag rules.
+// Each of these is a stream that concatenation alone would accept, re-aligning at the
+// wrong offset and yielding plausible garbage.
+func TestSegmentSplitterRejectsMalformedStreams(t *testing.T) {
+	frame := frameV4(opQuery, 0x00, bytes.Repeat([]byte{0x33}, 100))
+	other := frameV4(opOptions, 0x00, nil)
+
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name   string
+				stream func() []byte
+				want   string
+			}{
+				{
+					name: "self-contained segment interrupts a chain",
+					stream: func() []byte {
+						s := mustSegment(t, frame[:40], false, cc.comp)
+						return append(s, mustSegment(t, other, true, cc.comp)...)
+					},
+					want: "while a split frame was still being reassembled",
+				},
+				{
+					name: "self-contained segment ends mid-frame",
+					stream: func() []byte {
+						return mustSegment(t, frame[:40], true, cc.comp)
+					},
+					want: "ended in the middle of a frame",
+				},
+				{
+					name: "chain segment with an empty payload",
+					stream: func() []byte {
+						s := mustSegment(t, frame[:40], false, cc.comp)
+						return append(s, mustSegment(t, nil, false, cc.comp)...)
+					},
+					want: "made no progress",
+				},
+				{
+					name: "chain carries two frames",
+					stream: func() []byte {
+						both := append(append([]byte(nil), other...), other...)
+						s := mustSegment(t, both[:6], false, cc.comp)
+						return append(s, mustSegment(t, both[6:], false, cc.comp)...)
+					},
+					want: "more than the one frame it was split from",
+				},
+				{
+					name: "chain over-runs its frame",
+					stream: func() []byte {
+						overrun := append(append([]byte(nil), other...), 0x04, 0x00)
+						s := mustSegment(t, overrun[:6], false, cc.comp)
+						return append(s, mustSegment(t, overrun[6:], false, cc.comp)...)
+					},
+					want: "more than the one frame it was split from",
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					s := NewSegmentSplitter(cc.comp)
+					err := s.Feed(tc.stream(), func([]byte) error { return nil })
+					if err == nil {
+						t.Fatalf("malformed stream was accepted")
+					}
+					if !strings.Contains(err.Error(), tc.want) {
+						t.Errorf("error %q does not mention %q", err, tc.want)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSegmentSplitterRejectsCorruptChecksums pins that the codec's CRC checks are
+// actually reached through the splitter, since a recording is a file on disk and can
+// be truncated or edited.
+func TestSegmentSplitterRejectsCorruptChecksums(t *testing.T) {
+	frame := frameV4(opOptions, 0x00, nil)
+
+	t.Run("header crc24", func(t *testing.T) {
+		seg := mustSegment(t, frame, true, nil)
+		seg[0] ^= 0xFF
+		s := NewSegmentSplitter(nil)
+		if err := s.Feed(seg, func([]byte) error { return nil }); err == nil {
+			t.Error("a corrupt segment header was accepted")
+		}
+	})
+
+	t.Run("payload crc32", func(t *testing.T) {
+		seg := mustSegment(t, frame, true, nil)
+		seg[segment.UncompressedHeaderSize] ^= 0xFF
+		s := NewSegmentSplitter(nil)
+		if err := s.Feed(seg, func([]byte) error { return nil }); err == nil {
+			t.Error("a corrupt segment payload was accepted")
+		}
+	})
+}
+
+// TestSegmentSplitterPropagatesEmitError pins that a caller aborting stops the feed.
+func TestSegmentSplitterPropagatesEmitError(t *testing.T) {
+	want := errors.New("recording aborted")
+	frame := frameV4(opOptions, 0x00, nil)
+
+	s := NewSegmentSplitter(nil)
+	seg := mustSegment(t, append(append([]byte(nil), frame...), frame...), true, nil)
+
+	calls := 0
+	err := s.Feed(seg, func([]byte) error {
+		calls++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Feed error = %v, want %v", err, want)
+	}
+	if calls != 1 {
+		t.Errorf("emit called %d times, want 1", calls)
+	}
+}
+
+// TestSegmentSplitterDecodesAHeaderOnce pins that a segment arriving in pieces has its
+// header decoded when its bytes have all arrived, and not once per chunk.
+//
+// A corrupt header is the observable: the error has to appear on the feed that completes
+// the header, and every later feed has to return that same error rather than decoding
+// the bad header again.
+func TestSegmentSplitterDecodesAHeaderOnce(t *testing.T) {
+	seg := mustSegment(t, frameV4(opOptions, 0x00, nil), true, nil)
+	seg[0] ^= 0xFF
+
+	s := NewSegmentSplitter(nil)
+	emit := func([]byte) error {
+		t.Error("a frame was emitted from a segment with a corrupt header")
+		return nil
+	}
+
+	// Every chunk short of the header decodes nothing, so there is nothing to reject.
+	for i := 0; i < segment.UncompressedHeaderSize-1; i++ {
+		if err := s.Feed(seg[i:i+1], emit); err != nil {
+			t.Fatalf("feeding byte %d returned %v, want no error before the header is whole", i, err)
+		}
+	}
+
+	first := s.Feed(seg[segment.UncompressedHeaderSize-1:segment.UncompressedHeaderSize], emit)
+	if first == nil {
+		t.Fatal("the corrupt header was accepted once all of its bytes had arrived")
+	}
+
+	// The rest of the segment, and then a perfectly good one.
+	if err := s.Feed(seg[segment.UncompressedHeaderSize:], emit); err == nil || err.Error() != first.Error() {
+		t.Errorf("later Feed error = %v, want the original %v", err, first)
+	}
+	if err := s.Feed(mustSegment(t, frameV4(opOptions, 0x00, nil), true, nil), emit); err == nil || err.Error() != first.Error() {
+		t.Errorf("Feed of a valid segment after the failure = %v, want the original %v", err, first)
+	}
+}
+
+// TestSegmentSplitterFeedReusesItsBuffers pins that decoding a segment costs no
+// per-segment allocation.
+//
+// The codec takes an io.Reader, so the obvious spelling is a bytes.NewReader per header
+// and per payload -- two allocations per segment on the path the replay benchmarks
+// measure, in a decoder that otherwise reuses every buffer it has.
+func TestSegmentSplitterFeedReusesItsBuffers(t *testing.T) {
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			payload := bytes.Repeat([]byte{0x5A}, 8192)
+			frame := frameV4(opQuery, 0x00, payload)
+			seg := mustSegment(t, frame, true, cc.comp)
+
+			s := NewSegmentSplitter(cc.comp)
+			feed := func() {
+				if err := s.Feed(seg, func([]byte) error { return nil }); err != nil {
+					t.Fatalf("Feed: %v", err)
+				}
+			}
+
+			// The first feed legitimately allocates the buffers the rest reuse.
+			feed()
+
+			// Allocation count via testing.AllocsPerRun, not a byte budget taken from
+			// runtime.MemStats. TotalAlloc counts every allocation in the process
+			// between the two reads -- the testing package's own, the runtime's
+			// bookkeeping, and whatever -race or a -coverpkg=./... build adds on top --
+			// so the threshold it needs is a guess that drifts with the toolchain and
+			// the lane. AllocsPerRun attributes allocations to the call instead.
+			//
+			// Two allocations are the codec's steady state, not a leak: the
+			// fixed-size header array and the CRC32 array in internal/segment escape
+			// into io.ReadFull's interface call. The spelling this test exists to
+			// catch made a bytes.Reader per header and per payload on top of those,
+			// which lands at four.
+			const allowedAllocs = 2
+			if got := testing.AllocsPerRun(8, feed); got > allowedAllocs {
+				t.Errorf("decoding a segment made %v allocations, want at most %d — a buffer is not being reused",
+					got, allowedAllocs)
+			}
+		})
+	}
+}
+
+// TestAppendSegmentedMatchesTheDriversSplitRule pins the encoder against the rule
+// framer.prepareModernLayout uses, since the driver decodes what this produces. The
+// boundary values are what a mismatch would show up at.
+func TestAppendSegmentedMatchesTheDriversSplitRule(t *testing.T) {
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			for _, size := range []int{0, 1, segment.MaxPayloadSize - 1, segment.MaxPayloadSize, segment.MaxPayloadSize + 1, 2*segment.MaxPayloadSize + 7} {
+				payload := bytes.Repeat([]byte{0x5A}, size)
+
+				// The reference: chain segments of exactly the maximum size while more
+				// than one is needed, then a remainder, self-contained only if nothing
+				// split.
+				var want []byte
+				src := payload
+				selfContained := true
+				for len(src) > segment.MaxPayloadSize {
+					want = append(want, mustSegment(t, src[:segment.MaxPayloadSize], false, cc.comp)...)
+					src = src[segment.MaxPayloadSize:]
+					selfContained = false
+				}
+				want = append(want, mustSegment(t, src, selfContained, cc.comp)...)
+
+				got, err := AppendSegmented(nil, payload, cc.comp)
+				if err != nil {
+					t.Fatalf("size %d: %v", size, err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Errorf("size %d: encoded %d bytes, want %d", size, len(got), len(want))
+				}
+				if bound := segment.EncodedSize(size, cc.comp != nil); len(got) > bound {
+					t.Errorf("size %d: encoded %d bytes, segment.EncodedSize reported %d", size, len(got), bound)
+				}
+			}
+		})
+	}
+}
+
+// TestAppendSegmentedAppends pins that the encoder extends dst rather than replacing
+// it, so a caller can build a stream of several frames in one buffer.
+func TestAppendSegmentedAppends(t *testing.T) {
+	first := frameV4(opOptions, 0x00, nil)
+	second := frameV4(opQuery, 0x00, []byte("SELECT 1"))
+
+	stream, err := AppendSegmented(nil, first, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err = AppendSegmented(stream, second, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewSegmentSplitter(nil)
+	got := decode(t, s, stream)
+
+	if len(got) != 2 {
+		t.Fatalf("recovered %d frames, want 2", len(got))
+	}
+	if !bytes.Equal(got[0], first) || !bytes.Equal(got[1], second) {
+		t.Error("frames did not survive being appended into one stream")
+	}
+}
+
+// TestSegmentSplitterReleasesOutsizedBuffer pins that the accumulation buffer does not
+// pin an outlier for the life of the connection. Feed appends whatever it is handed, so
+// one large read buffer or Write is enough to leave it holding far more than decoding a
+// segment needs -- in each of the three splitters a recorded connection builds.
+func TestSegmentSplitterReleasesOutsizedBuffer(t *testing.T) {
+	// Several maximum-size segments arriving as one chunk.
+	frame := frameV4(opQuery, 0x00, bytes.Repeat([]byte{0x7E}, 3*segment.MaxPayloadSize))
+	stream, err := AppendSegmented(nil, frame, nil)
+	if err != nil {
+		t.Fatalf("AppendSegmented: %v", err)
+	}
+
+	s := NewSegmentSplitter(nil)
+	if got := decode(t, s, stream); len(got) != 1 || !bytes.Equal(got[0], frame) {
+		t.Fatalf("emitted %d frames, want the one that was split", len(got))
+	}
+
+	bound := segment.HeaderSize(false) + segment.MaxPayloadSize + segment.Crc32Size
+	if cap(s.buf) > bound {
+		t.Errorf("kept a %d-byte buffer, want at most one maximum-size segment (%d)", cap(s.buf), bound)
+	}
+
+	// Releasing it must not cost the splitter its ability to read the next segment.
+	small := frameV4(opQuery, 0x00, []byte("body"))
+	if got := decode(t, s, mustSegment(t, small, true, nil)); len(got) != 1 || !bytes.Equal(got[0], small) {
+		t.Errorf("after the release: emitted %d frames, want the small frame back", len(got))
+	}
+
+	// A buffer within the bound is kept, which is what keeps the decode path
+	// allocation-free.
+	before := cap(s.buf)
+	if before == 0 || before > bound {
+		t.Fatalf("unexpected retained capacity %d", before)
+	}
+	if got := decode(t, s, mustSegment(t, small, true, nil)); len(got) != 1 {
+		t.Fatalf("emitted %d frames, want 1", len(got))
+	}
+	if cap(s.buf) != before {
+		t.Errorf("buffer capacity changed from %d to %d across a small segment", before, cap(s.buf))
+	}
+}

--- a/dialer/utils.go
+++ b/dialer/utils.go
@@ -26,6 +26,14 @@ import (
 // https://github.com/scylladb/gocql/issues/937.
 var ErrProtoV5NotSupported = errors.New("gocql/dialer: protocol v5+ uses transport segments, which the record/replay dialers do not support (see scylladb/gocql#937)")
 
+// ErrSegmentCompressorRequired is returned when a connection negotiated compression
+// on protocol v5 but no compressor was supplied to the dialer.
+//
+// The driver's only segment compressor, lz4, lives in a separate Go module, so this
+// module cannot construct one for itself; a caller recording or replaying a compressed
+// v5 connection has to hand one in (see recorder.WithSegmentCompressor).
+var ErrSegmentCompressorRequired = errors.New("gocql/dialer: protocol v5 connection negotiated compression, but no SegmentCompressor was supplied to the dialer")
+
 // FrameIsProtoV5OrNewer reports whether b starts a CQL frame whose protocol
 // version is v5 or newer. It is only meaningful for bytes at a frame boundary.
 // The driver's handshake frames are never segment-framed, so checking each
@@ -50,20 +58,25 @@ type Record struct {
 // SCYLLA_USE_METADATA_ID protocol extension (see gocql/scylla.go).
 const scyllaUseMetadataIDKey = "SCYLLA_USE_METADATA_ID"
 
-// StartupNegotiatesMetadataID reports whether the given raw request frame is a
-// STARTUP that opts into the SCYLLA_USE_METADATA_ID extension. The driver
-// serializes the extension as the key SCYLLA_USE_METADATA_ID in the STARTUP
-// [string map]. Detection is restricted to STARTUP requests so the same key
-// appearing in a SUPPORTED response (a read frame) never trips it.
+// compressionKey is the STARTUP option key naming the algorithm a connection's
+// frames are compressed with (see gocql's startupOptions).
+const compressionKey = "COMPRESSION"
+
+// forEachStartupOption walks a STARTUP request's [string map] body, calling fn with
+// each key and value until fn returns true. It reports whether fn stopped it.
 //
-// The body is walked as a proper [string map] and only keys are compared, rather
-// than scanning the frame for the literal: gocql's startupOptions puts
-// caller-influenced values into the same map — DRIVER_NAME, DRIVER_VERSION,
-// DRIVER_CONFIG, SESSION_ID and whatever ApplicationInfo adds — so a substring
-// match lets a caller latch this by naming their application after the extension.
-// The list keeps growing, which is the point: matching on keys does not care.
-// A malformed or truncated map reads as "not negotiated".
-func StartupNegotiatesMetadataID(frame []byte) bool {
+// The body is walked as a proper [string map] rather than scanning the frame for a
+// literal, and callers compare keys rather than the whole frame: gocql's
+// startupOptions puts caller-influenced values into the same map — DRIVER_NAME,
+// DRIVER_VERSION, DRIVER_CONFIG, SESSION_ID and whatever ApplicationInfo adds — so a
+// substring match would let a caller latch an option by naming their application
+// after it. The list keeps growing, which is the point: matching on keys does not
+// care.
+//
+// Detection is restricted to STARTUP requests, so the same key appearing in a
+// SUPPORTED response never trips a caller. A malformed or truncated map stops the
+// walk, which reads as "the option is not there".
+func forEachStartupOption(frame []byte, fn func(key, value []byte) bool) bool {
 	if len(frame) < 5 {
 		return false
 	}
@@ -101,14 +114,49 @@ func StartupNegotiatesMetadataID(frame []byte) bool {
 		if !ok {
 			return false
 		}
-		if _, ok := readString(); !ok { // value, skipped
+		value, ok := readString()
+		if !ok {
 			return false
 		}
-		if string(key) == scyllaUseMetadataIDKey {
+		if fn(key, value) {
 			return true
 		}
 	}
 	return false
+}
+
+// StartupNegotiatesMetadataID reports whether the given raw request frame is a
+// STARTUP that opts into the SCYLLA_USE_METADATA_ID extension. The driver serializes
+// the extension as the key SCYLLA_USE_METADATA_ID in the STARTUP [string map].
+func StartupNegotiatesMetadataID(frame []byte) bool {
+	return forEachStartupOption(frame, func(key, _ []byte) bool {
+		return string(key) == scyllaUseMetadataIDKey
+	})
+}
+
+// StartupCompression returns the compression algorithm a STARTUP request opts into,
+// and whether it named one at all.
+//
+// This is how the record/replay dialers learn whether a v5 connection's transport
+// segments are compressed, which the segment bytes themselves cannot reveal: the two
+// layouts differ in header size, so a decoder has to be told which it is reading.
+// Reading it from the STARTUP is exact rather than a guess, because the driver only
+// sends the option when it is going to use it — it drops its own compressor if the
+// server's SUPPORTED did not advertise the algorithm (see startupCoordinator.startup),
+// and STARTUP is written after that decision.
+//
+// The STARTUP frame is always unsegmented, on every protocol version, so it is
+// readable before any of this matters.
+func StartupCompression(frame []byte) (string, bool) {
+	var algorithm string
+	found := forEachStartupOption(frame, func(key, value []byte) bool {
+		if string(key) != compressionKey {
+			return false
+		}
+		algorithm = string(value)
+		return true
+	})
+	return algorithm, found
 }
 
 // A CQL frame carries the protocol version in the low 7 bits of frame[0]; the

--- a/dialer/utils.go
+++ b/dialer/utils.go
@@ -197,19 +197,133 @@ func addBytes(frame []byte, index int) (int, bool) {
 	return index, true
 }
 
-func addQueryParams(frame []byte, index int) (int, bool) {
-	//use consistency
+// addLongString advances index past a [long string]: a 4-byte length followed by
+// that many bytes.
+//
+// The length is read as signed for the same reason addBytes does: a negative value
+// is a damaged frame rather than a null, and reading it unsigned would turn one into
+// a 4 GB field that the walk never recovers from.
+func addLongString(frame []byte, index int) (int, bool) {
+	if !fits(frame, index, 4) {
+		return 0, false
+	}
+	length := int(int32(uint32(frame[index+0])<<24 | uint32(frame[index+1])<<16 | uint32(frame[index+2])<<8 | uint32(frame[index+3])))
+	index = index + 4
+	if length < 0 || !fits(frame, index, length) {
+		return 0, false
+	}
+	return index + length, true
+}
+
+// addShortBytes advances index past a [short bytes] value: a 2-byte length followed
+// by that many bytes.
+func addShortBytes(frame []byte, index int) (int, bool) {
 	if !fits(frame, index, 2) {
 		return 0, false
+	}
+	length := int(frame[index])<<8 | int(frame[index+1])
+	if !fits(frame, index, 2+length) {
+		return 0, false
+	}
+	return index + 2 + length, true
+}
+
+// addBatchQueries advances index past a BATCH body's type, query count and queries,
+// leaving it on the consistency field that starts the batch's parameter block.
+//
+// That block is laid out exactly like a QUERY's <query_parameters> minus the fields
+// a batch never carries, so addQueryParams walks it unchanged: writeBatchFrame only
+// ever sets the serial-consistency, default-timestamp, keyspace and now_in_seconds
+// flags, so the values, page-size and paging-state branches cannot fire.
+//
+// Named values need no handling here. writeBatchFrame rejects them outright on every
+// protocol version, because Cassandra never implemented them (CASSANDRA-10246).
+func addBatchQueries(frame []byte, index int) (int, bool) {
+	// batch type
+	if !fits(frame, index, 1) {
+		return 0, false
+	}
+	index = index + 1
+
+	if !fits(frame, index, 2) {
+		return 0, false
+	}
+	queryCount := int(frame[index])<<8 | int(frame[index+1])
+	index = index + 2
+
+	for i := 0; i < queryCount; i++ {
+		if !fits(frame, index, 1) {
+			return 0, false
+		}
+		kind := frame[index]
+		index = index + 1
+
+		var ok bool
+		switch kind {
+		case 0:
+			// A query string, as a [long string].
+			if index, ok = addLongString(frame, index); !ok {
+				return 0, false
+			}
+		case 1:
+			// A prepared statement id, as [short bytes].
+			if index, ok = addShortBytes(frame, index); !ok {
+				return 0, false
+			}
+		default:
+			// Not a kind the driver writes, so the rest of the body cannot be
+			// located. A damaged recording, which the caller hashes raw.
+			return 0, false
+		}
+
+		if !fits(frame, index, 2) {
+			return 0, false
+		}
+		valuesLen := int(frame[index])<<8 | int(frame[index+1])
+		index = index + 2
+
+		for j := 0; j < valuesLen; j++ {
+			// A null or unset value carries no payload; addBytes reads the length as
+			// signed so both advance by just the length field.
+			if index, ok = addBytes(frame, index); !ok {
+				return 0, false
+			}
+		}
+	}
+
+	return index, true
+}
+
+// addQueryParams walks a <query_parameters> block starting at index, which must
+// point at the consistency field.
+//
+// It reports two ranges rather than one position. end is where the fields that
+// belong in a frame's hash stop: consistency through serial consistency. tailStart
+// and tailEnd bracket the protocol v5 keyspace override and now_in_seconds fields,
+// which also identify a request but are not contiguous with end, because the
+// default timestamp sits between them and must stay out of the hash — it is
+// time.Now() at send time (framer.writeQueryParams), so hashing it would make a
+// recorded frame never match its replay. An empty tail is reported as
+// tailStart == tailEnd.
+//
+// The v5 fields are walked only on v5+, which is what keeps this change invisible
+// to protocol v4: framer.validateV5Options rejects a keyspace override and
+// now_in_seconds below v5, and FlagWithNowInSeconds (0x100) is not even
+// representable in v4's one-byte flags field, so no v4 frame can reach the tail.
+func addQueryParams(frame []byte, index int) (end, tailStart, tailEnd int, ok bool) {
+	//use consistency
+	if !fits(frame, index, 2) {
+		return 0, 0, 0, false
 	}
 	index = index + 2
 
 	//use query flags
 	var flags uint32
-	if frame[0]&protoVersionMask > protoVersion4 {
+	protoV5OrNewer := frame[0]&protoVersionMask > protoVersion4
+	if protoV5OrNewer {
 		// For protocol v5+, flags are a 4-byte big-endian uint32
 		if !fits(frame, index, 4) {
-			return 0, false
+			return 0, 0, 0, false
 		}
 		flags = uint32(frame[index])<<24 |
 			uint32(frame[index+1])<<16 |
@@ -218,7 +332,7 @@ func addQueryParams(frame []byte, index int) (int, bool) {
 		index = index + 4
 	} else {
 		if !fits(frame, index, 1) {
-			return 0, false
+			return 0, 0, 0, false
 		}
 		flags = uint32(frame[index])
 		index = index + 1
@@ -235,7 +349,7 @@ func addQueryParams(frame []byte, index int) (int, bool) {
 
 	if flags&frm.FlagValues == frm.FlagValues {
 		if !fits(frame, index, 2) {
-			return 0, false
+			return 0, 0, 0, false
 		}
 		valuesLen := int(frame[index])<<8 | int(frame[index+1])
 		index = index + 2
@@ -243,25 +357,25 @@ func addQueryParams(frame []byte, index int) (int, bool) {
 		for i := 0; i < valuesLen; i++ {
 			if names {
 				if !fits(frame, index, 2) {
-					return 0, false
+					return 0, 0, 0, false
 				}
 				stringLenght := int(frame[index])<<8 | int(frame[index+1])
 				if !fits(frame, index, 2+stringLenght) {
-					return 0, false
+					return 0, 0, 0, false
 				}
 				index = index + 2 + stringLenght
 			}
 
 			var ok bool
 			if index, ok = addBytes(frame, index); !ok {
-				return 0, false
+				return 0, 0, 0, false
 			}
 		}
 	}
 
 	if flags&frm.FlagPageSize == frm.FlagPageSize {
 		if !fits(frame, index, 4) {
-			return 0, false
+			return 0, 0, 0, false
 		}
 		index = index + 4
 	}
@@ -269,42 +383,89 @@ func addQueryParams(frame []byte, index int) (int, bool) {
 	if flags&frm.FlagWithPagingState == frm.FlagWithPagingState {
 		var ok bool
 		if index, ok = addBytes(frame, index); !ok {
-			return 0, false
+			return 0, 0, 0, false
 		}
 	}
 
 	if flags&frm.FlagWithSerialConsistency == frm.FlagWithSerialConsistency {
 		if !fits(frame, index, 2) {
-			return 0, false
+			return 0, 0, 0, false
 		}
 		index = index + 2
 	}
 
-	// do not use timelaps and keyspace
-	return index, true
+	end = index
+
+	// Everything below is protocol v5 only. On v4 the tail is empty and end is the
+	// whole answer, exactly as before this function grew a tail.
+	if !protoV5OrNewer {
+		return end, index, index, true
+	}
+
+	// Skipped, never hashed: see the note on the default timestamp above.
+	if flags&frm.FlagDefaultTimestamp == frm.FlagDefaultTimestamp {
+		if !fits(frame, index, 8) {
+			return 0, 0, 0, false
+		}
+		index = index + 8
+	}
+
+	tailStart = index
+
+	if flags&frm.FlagWithKeyspace == frm.FlagWithKeyspace {
+		var ok bool
+		if index, ok = addShortBytes(frame, index); !ok {
+			return 0, 0, 0, false
+		}
+	}
+
+	if flags&frm.FlagWithNowInSeconds == frm.FlagWithNowInSeconds {
+		if !fits(frame, index, 4) {
+			return 0, 0, 0, false
+		}
+		index = index + 4
+	}
+
+	return end, tailStart, index, true
 }
 
 func addHeader(index int) int {
 	return index + 8
 }
 
-func addCustomPayload(frame []byte, index int, p int) (int, bool) {
-	if !fits(frame, 8+p, 2) {
+// addCustomPayload walks the [bytes map] a frame carries when FlagCustomPayload is
+// set, and returns the index just past it.
+//
+// It derives that map's offset from p with addHeader rather than taking it as well,
+// so the offset it reads the entry count from and the offset it walks on from cannot
+// disagree. Every caller passed addHeader(p) for both, which held only by convention:
+// a caller passing an index already advanced past something would have read the count
+// from the body start and walked from somewhere else, and the walk would be
+// plausible-but-wrong in the way the empty-map case below was.
+func addCustomPayload(frame []byte, p int) (int, bool) {
+	index := addHeader(p)
+	if !fits(frame, index, 2) {
 		return 0, false
 	}
-	customPayloadLenght := int(frame[8+p])<<8 | int(frame[9+p])
-	if customPayloadLenght > 0 {
-		index = index + 2
-	}
-	for i := 0; i < customPayloadLenght; i++ {
+	customPayloadLength := int(frame[index])<<8 | int(frame[index+1])
+	// Skip the [bytes map] count itself unconditionally. A map of zero entries still
+	// spends the two bytes that say so, and stopping short of them leaves the walk
+	// reading that count as the next field: for a BATCH, its type, then its own second
+	// byte as half of the statement count. That misreading is plausible rather than
+	// detectably wrong — type LOGGED, zero statements, consistency ONE — so no bounds
+	// check fails and nothing falls back to the raw bytes. It simply hashes a handful
+	// of bytes of the wrong field, the same handful for every batch, which is a
+	// collision the replayer resolves by serving whichever response it finds first.
+	index = index + 2
+	for i := 0; i < customPayloadLength; i++ {
 		if !fits(frame, index, 2) {
 			return 0, false
 		}
-		stringLenght := int(frame[index])<<8 | int(frame[index+1])
-		if !fits(frame, index, 2+stringLenght) {
+		stringLength := int(frame[index])<<8 | int(frame[index+1])
+		if !fits(frame, index, 2+stringLength) {
 			return 0, false
 		}
-		index = index + 2 + stringLenght
+		index = index + 2 + stringLength
 
 		var ok bool
 		if index, ok = addBytes(frame, index); !ok {
@@ -315,41 +476,83 @@ func addCustomPayload(frame []byte, index int, p int) (int, bool) {
 	return index, true
 }
 
+// foldHash mixes add into h, so a frame's identity can span two byte ranges that
+// are not contiguous.
+//
+// murmur.Murmur3H1 hashes one slice and has no incremental form, and the ranges a
+// request's identity spans are separated by bytes that must not be hashed (the
+// default timestamp). Copying them together into a scratch buffer would allocate on
+// every request, and GetFrameHash runs per request inside a benchmark harness. The
+// mix is boost's hash_combine; the hash only has to be deterministic and collide
+// rarely across the handful of frames in a recording, not be cryptographic.
+func foldHash(h, add int64) int64 {
+	const goldenRatio = 0x9E3779B97F4A7C15
+	return int64(uint64(h) ^ (uint64(add) + goldenRatio + uint64(h)<<6 + uint64(h)>>2))
+}
+
+// hashWithTail hashes frame[start:end], folding in frame[tailStart:tailEnd] when
+// that second range is non-empty. An empty tail returns exactly the single-range
+// hash, which is what keeps protocol v4 frames — where the tail is always empty —
+// byte-for-byte identical to a plain Murmur3H1 of the range.
+func hashWithTail(frame []byte, start, end, tailStart, tailEnd int) int64 {
+	h := murmur.Murmur3H1(frame[start:end])
+	if tailEnd > tailStart {
+		h = foldHash(h, murmur.Murmur3H1(frame[tailStart:tailEnd]))
+	}
+	return h
+}
+
+// hashParams finishes hashing a request whose body ends in a <query_parameters>
+// block: it walks the block at paramsStart and hashes frame[hashStart:] up to the
+// block's end, folding in the protocol v5 tail. A block that cannot be walked means
+// the frame cannot be located either, so it falls back to hashing the raw bytes,
+// matching the fallbacks at its call sites.
+func hashParams(frame []byte, hashStart, paramsStart int) int64 {
+	end, tailStart, tailEnd, ok := addQueryParams(frame, paramsStart)
+	if !ok {
+		return murmur.Murmur3H1(frame)
+	}
+	return hashWithTail(frame, hashStart, end, tailStart, tailEnd)
+}
+
 func GetFrameHash(frame []byte, useMetadataID bool) int64 {
+	// GetFrameHash parses a bare CQL request frame, of any protocol version the
+	// driver speaks, and returns a hash standing for the request's identity: enough
+	// of it to tell it apart from the other requests on the connection, and no byte
+	// that differs between the moment it was recorded and the moment it is replayed.
+	// Those two requirements are what every choice below is answering to.
+	//
 	// useMetadataID reports whether the SCYLLA_USE_METADATA_ID extension was
 	// negotiated on the connection. On protocol v4 the extension adds a
 	// resultMetadataID short-bytes field to EXECUTE requests (the same field v5
 	// always carries); it cannot be inferred from the frame bytes, so it is
 	// plumbed in by the recorder/replayer (see Record.UseMetadataID).
 	//
-	// GetFrameHash parses raw CQL request frames. On protocol v5+ the on-wire
-	// bytes recorded by the replayer are not a CQL frame but a transport
-	// segment produced by framer.prepareModernLayout (segment header, optional
-	// CRC/compression, possibly split across segments), so frame[0] is segment
-	// data rather than the CQL version byte. Parsing it as a CQL frame would
-	// hash the wrong byte range.
+	// A bare CQL frame is the caller's responsibility. From protocol v5 the driver
+	// wraps each frame in transport segments (framer.prepareModernLayout), and those
+	// on-wire bytes are not a frame: frame[0] is segment-header data rather than the
+	// CQL version byte. This function does not detect that and cannot — for a v5
+	// segment frame[0] is the low byte of a 17-bit length, so it is not
+	// distinguishable from a version byte without protocol context the bytes do not
+	// carry. Handing it segment bytes hashes a meaningless range. The record/replay
+	// dialers refuse v5 connections outright today (ErrProtoV5NotSupported) and will
+	// unwrap the segments instead once the dialer half of
+	// https://github.com/scylladb/gocql/issues/937 lands.
 	//
-	// This is currently dormant because Scylla negotiates at most protocol v4,
-	// so v5 segment framing is never produced. Proper segment unwrapping is
-	// tracked in https://github.com/scylladb/gocql/issues/937.
+	// Note the empty and short-frame guards hash the frame as given, while the
+	// raw-bytes fallbacks inside the switch hash it with the stream id already
+	// blanked. Both are stable between record and replay, which is all the hash has
+	// to be — but they are not interchangeable, so a new fallback has to match the
+	// one next to it rather than whichever reads better. The two guards have no
+	// choice: they run before, or on frames too short to contain, the stream id they
+	// would have to blank.
 	//
-	// The check below is only a best-effort heuristic: for a v5 segment,
-	// frame[0] is the low byte of the 17-bit segment length, NOT a CQL version
-	// byte. It reliably diverts inputs whose first byte looks like a v5+ version
-	// (>= 5), but a segment whose length low-byte is < 5 will still fall into
-	// the legacy parser below and be mis-hashed. Correctly distinguishing the
-	// two requires protocol context that is not plumbed here.
-	//
-	// TODO(#937): replace this heuristic with real protocol context.
-	//
-	// Note this guard, and the short-frame guard below it, hash the frame as given,
-	// while the raw-bytes fallbacks inside the switch hash it with the stream id
-	// already blanked. Both are stable between record and replay, which is all the
-	// hash has to be — but they are not interchangeable, so a new fallback has to
-	// match the one next to it rather than whichever reads better. The two guards
-	// here have no choice: they run before, or on frames too short to contain, the
-	// stream id they would have to blank.
-	if len(frame) == 0 || frame[0]&protoVersionMask >= protoVersion5 {
+	// One known gap, tracked rather than papered over: every QUERY frame hashes
+	// alike, because the parameter walk is handed the body start instead of the
+	// position past the query text (scylladb/gocql#1000). On v5 that costs replay
+	// outright, since the failed walk falls back to hashing the frame whole, default
+	// timestamp included.
+	if len(frame) == 0 {
 		return murmur.Murmur3H1(frame)
 	}
 
@@ -398,23 +601,36 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 		var ok bool
 		index := addHeader(p)
 		if frame[1]&frm.FlagCustomPayload == frm.FlagCustomPayload {
-			if index, ok = addCustomPayload(frame, index, p); !ok {
+			if index, ok = addCustomPayload(frame, p); !ok {
 				return murmur.Murmur3H1(frame)
 			}
 		}
-		endIndex := index
-		if endIndex, ok = addQueryParams(frame, endIndex); !ok {
-			return murmur.Murmur3H1(frame)
-		}
-		if index > endIndex {
-			return murmur.Murmur3H1(frame)
-		}
-		return murmur.Murmur3H1(frame[index:endIndex])
+
+		// KNOWN BUG, deferred to scylladb/gocql#1000: addQueryParams wants the
+		// consistency field, but a QUERY body is the query text as a [long string]
+		// followed by the query parameters, so what it is handed here is the text's
+		// 4-byte length. It reads the length's first two bytes as the consistency and
+		// the third as the flags, which are 0x00 0x00 0x00 for every query shorter than
+		// 16 MiB, so the walk stops at once and every QUERY frame hashes those same
+		// three zero bytes — the query text and the bound values fall outside the
+		// hashed range entirely.
+		//
+		// It is not fixed here because the correct offset makes the checked-in
+		// recordings in tests/bench unmatchable: their control-connection query text
+		// predates the explicit column list the driver sends today, and only the
+		// collision hides that. Regenerating them needs a live node, so both go
+		// together in #1000.
+		//
+		// The consequence for protocol v5 is worse than a collision and is called out
+		// in #1000: the 4-byte v5 flags field makes the misaligned walk fail a bounds
+		// check, falling back to hashing the whole frame — default timestamp included —
+		// so a v5 QUERY cannot match its recording. v5 EXECUTE is unaffected.
+		return hashParams(frame, index, index)
 	case byte(opExecute):
 		var ok bool
 		index := addHeader(p)
 		if frame[1]&frm.FlagCustomPayload == frm.FlagCustomPayload {
-			if index, ok = addCustomPayload(frame, index, p); !ok {
+			if index, ok = addCustomPayload(frame, p); !ok {
 				return murmur.Murmur3H1(frame)
 			}
 		}
@@ -454,30 +670,49 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 		}
 
 		if frame[0]&protoVersionMask > protoVersion1 {
-			if endIndex, ok = addQueryParams(frame, endIndex); !ok {
+			return hashParams(frame, index, endIndex)
+		}
+
+		// Protocol v1 has no <query_parameters> block: the values follow the
+		// preparedID directly. Bounded by the preparedID length check above, which
+		// read the same two bytes at the same index: nothing between here and there
+		// moves it.
+		valuesLen := int(frame[index])<<8 | int(frame[index+1])
+		index = index + 2
+		for i := 0; i < valuesLen; i++ {
+			if index, ok = addBytes(frame, index); !ok {
 				return murmur.Murmur3H1(frame)
 			}
-		} else {
-			// Bounded by the preparedID length check above, which read the same two
-			// bytes at the same index: nothing between here and there moves it.
-			valuesLen := int(frame[index])<<8 | int(frame[index+1])
-			index = index + 2
-			for i := 0; i < valuesLen; i++ {
-				if index, ok = addBytes(frame, index); !ok {
-					return murmur.Murmur3H1(frame)
-				}
-			}
-			index = index + 2
 		}
-		// The v1 branch above walks index independently of endIndex and can leave it
-		// past the end of the range, so the two still have to be ordered before the
-		// slice. endIndex itself is now bounded by the helpers.
+		index = index + 2
+		// The walk above moves index independently of endIndex and can leave it past
+		// the end of the range, so the two still have to be ordered before the slice.
+		// endIndex itself is bounded by the helpers.
 		if index > endIndex {
 			return murmur.Murmur3H1(frame)
 		}
 		return murmur.Murmur3H1(frame[index:endIndex])
 	case byte(opBatch):
-		return murmur.Murmur3H1(frame)
+		var ok bool
+		index := addHeader(p)
+		if frame[1]&frm.FlagCustomPayload == frm.FlagCustomPayload {
+			if index, ok = addCustomPayload(frame, p); !ok {
+				return murmur.Murmur3H1(frame)
+			}
+		}
+
+		// A BATCH used to be hashed whole, which put its default timestamp in the
+		// hash. writeBatchFrame fills that field with time.Now() unless the caller
+		// pinned a value, so a recorded BATCH hashed differently on every run and
+		// replaying one could only ever fail to find its response. Walking the body
+		// to the end of the parameter block leaves the timestamp out, the same way
+		// QUERY and EXECUTE do.
+		paramsStart, ok := addBatchQueries(frame, index)
+		if !ok {
+			return murmur.Murmur3H1(frame)
+		}
+
+		return hashParams(frame, index, paramsStart)
 	case byte(opOptions):
 		return murmur.Murmur3H1(frame)
 	case byte(opRegister):

--- a/dialer/utils.go
+++ b/dialer/utils.go
@@ -17,15 +17,6 @@ import (
 	"github.com/gocql/gocql/internal/murmur"
 )
 
-// ErrProtoV5NotSupported is returned by the record/replay dialers for protocol
-// v5+ connections. After the handshake v5 switches to transport segments
-// (framer.prepareModernLayout), which these dialers would silently corrupt:
-// the recorder slices the byte stream into frames by the fixed CQL header
-// offsets, and the replayer patches stream ids in place, invalidating segment
-// CRCs. Segment-aware record/replay is tracked in
-// https://github.com/scylladb/gocql/issues/937.
-var ErrProtoV5NotSupported = errors.New("gocql/dialer: protocol v5+ uses transport segments, which the record/replay dialers do not support (see scylladb/gocql#937)")
-
 // ErrSegmentCompressorRequired is returned when a connection negotiated compression
 // on protocol v5 but no compressor was supplied to the dialer.
 //
@@ -34,13 +25,35 @@ var ErrProtoV5NotSupported = errors.New("gocql/dialer: protocol v5+ uses transpo
 // v5 connection has to hand one in (see recorder.WithSegmentCompressor).
 var ErrSegmentCompressorRequired = errors.New("gocql/dialer: protocol v5 connection negotiated compression, but no SegmentCompressor was supplied to the dialer")
 
-// FrameIsProtoV5OrNewer reports whether b starts a CQL frame whose protocol
-// version is v5 or newer. It is only meaningful for bytes at a frame boundary.
-// The driver's handshake frames are never segment-framed, so checking each
-// frame's first byte rejects a v5+ connection during the handshake, before any
-// transport segment flows.
+// FrameProtoVersion returns the protocol version of the CQL frame b starts, or 0 if
+// b is empty.
+//
+// The direction bit is masked off: the top bit of frame[0] distinguishes a request
+// from a response, and folding it into the version makes every response look like a
+// far newer protocol. It is only meaningful for bytes at a frame boundary.
+func FrameProtoVersion(b []byte) byte {
+	if len(b) == 0 {
+		return 0
+	}
+	return b[0] & protoVersionMask
+}
+
+// FrameIsProtoV5OrNewer reports whether b starts a CQL frame whose protocol version is
+// v5 or newer, and therefore whether the connection segments anything at all.
 func FrameIsProtoV5OrNewer(b []byte) bool {
-	return len(b) > 0 && b[0]&protoVersionMask >= protoVersion5
+	return FrameProtoVersion(b) >= protoVersion5
+}
+
+// FrameIsQuery reports whether b starts a QUERY request.
+//
+// The opcode's offset comes from headerShift rather than a constant of its own, so a
+// caller cannot drift from the parsers here when #1022 changes what v1/v2 looks like.
+func FrameIsQuery(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	i := 3 + headerShift(b)
+	return i < len(b) && frameOp(b[i]) == opQuery
 }
 
 type Record struct {
@@ -52,6 +65,10 @@ type Record struct {
 	// v4 (see GetFrameHash). The recorder stamps it per connection; the frame
 	// bytes alone cannot reveal it.
 	UseMetadataID bool `json:"use_metadata_id"`
+	// Proto is the protocol version of the connection the frame was recorded on,
+	// direction bit masked off. Recordings made before the field existed decode it
+	// as 0, "unstamped"; the loader falls back to the frame's own version byte.
+	Proto byte `json:"proto,omitempty"`
 }
 
 // scyllaUseMetadataIDKey is the STARTUP/SUPPORTED option key for the
@@ -583,9 +600,7 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 	// segment frame[0] is the low byte of a 17-bit length, so it is not
 	// distinguishable from a version byte without protocol context the bytes do not
 	// carry. Handing it segment bytes hashes a meaningless range. The record/replay
-	// dialers refuse v5 connections outright today (ErrProtoV5NotSupported) and will
-	// unwrap the segments instead once the dialer half of
-	// https://github.com/scylladb/gocql/issues/937 lands.
+	// dialers unwrap the segments first, which is what Decoder is for.
 	//
 	// Note the empty and short-frame guards hash the frame as given, while the
 	// raw-bytes fallbacks inside the switch hash it with the stream id already

--- a/dialer/utils_hashlock_test.go
+++ b/dialer/utils_hashlock_test.go
@@ -1,0 +1,577 @@
+package dialer
+
+import (
+	"testing"
+
+	frm "github.com/gocql/gocql/internal/frame"
+	"github.com/gocql/gocql/internal/murmur"
+)
+
+// This file pins GetFrameHash's output for a spread of real frame shapes, as a
+// blast-radius detector for changes to the offset math.
+//
+// It is deliberately not a claim that these numbers may never change. The
+// recordings under tests/bench store raw frames and are rehashed at load time
+// (loadResponseFramesFromFiles) with the same function applied to the live request,
+// so the hash function itself can change freely. What a recording actually depends
+// on is narrower, and neither half is visible in a single hash value:
+//
+//   - the hash must not cover bytes that differ between record time and replay
+//     time — the default timestamp is time.Now() at send, and the STARTUP option
+//     map grows as the driver gains options — or a recording stops matching itself;
+//   - the hash must cover enough of a request to tell it apart from the other
+//     requests in the same recording, or the replayer's first-match scan serves the
+//     wrong response.
+//
+// Those two properties are asserted directly elsewhere in this package. What this
+// table adds is that any edit to the walk has to state which frame shapes it moved:
+// a diff here is the change describing itself, which is how the QUERY collision in
+// scylladb/gocql#1000 was found.
+//
+// So a moved value is not automatically a bug — but it is never incidental, and an
+// unexplained one is.
+
+// murmur3OfStreamBlanked is the raw-bytes fallback the arms of the opcode switch
+// produce. They run after the stream id has been blanked and before the deferred
+// restore, so the bytes they hash are the frame with 0x30 0x30 at offsets 2 and 3 —
+// not the frame as the caller passed it, which is what the two guards ahead of the
+// switch hash. The two are not interchangeable.
+func murmur3OfStreamBlanked(frame []byte) int64 {
+	normalised := append([]byte(nil), frame...)
+	normalised[2], normalised[3] = byte('0'), byte('0')
+	return murmur.Murmur3H1(normalised)
+}
+
+// longString encodes a CQL [long string]: a 4-byte length followed by the bytes.
+func longString(s string) []byte {
+	return append([]byte{byte(len(s) >> 24), byte(len(s) >> 16), byte(len(s) >> 8), byte(len(s))}, s...)
+}
+
+// shortString encodes a CQL [string]: a 2-byte length followed by the bytes.
+func shortString(s string) []byte {
+	return append([]byte{byte(len(s) >> 8), byte(len(s))}, s...)
+}
+
+// bytesValue encodes a CQL [bytes]: a 4-byte signed length followed by the bytes.
+func bytesValue(b []byte) []byte {
+	return append([]byte{byte(len(b) >> 24), byte(len(b) >> 16), byte(len(b) >> 8), byte(len(b))}, b...)
+}
+
+// queryBody assembles a QUERY body: the query as a [long string], then the query
+// parameters — consistency, a one-byte flags field (v4 and below), and whatever
+// optional fields those flags announce.
+func queryBody(query string, flags byte, optional ...[]byte) []byte {
+	body := longString(query)
+	body = append(body, 0x00, 0x01) // consistency ONE
+	body = append(body, flags)
+	for _, o := range optional {
+		body = append(body, o...)
+	}
+	return body
+}
+
+// batchBody assembles a minimal BATCH body: type, one query count, one simple
+// query with no values, consistency, and a flags byte plus whatever it announces.
+func batchBody(flags byte, optional ...[]byte) []byte {
+	body := []byte{0x00}            // type: LOGGED
+	body = append(body, 0x00, 0x01) // one query
+	body = append(body, 0x00)       // kind: query string
+	body = append(body, longString("INSERT INTO t (pk) VALUES (1)")...)
+	body = append(body, 0x00, 0x00) // zero values
+	body = append(body, 0x00, 0x01) // consistency ONE
+	body = append(body, flags)
+	for _, o := range optional {
+		body = append(body, o...)
+	}
+	return body
+}
+
+type hashLockCase struct {
+	name          string
+	frame         []byte
+	useMetadataID bool
+}
+
+// hashLockCases is the frame spread the lock covers. Every arm of the
+// GetFrameHash opcode switch is represented, along with the query-parameter
+// flags that move the extracted range and the truncation paths that fall back to
+// hashing raw bytes.
+func hashLockCases() []hashLockCase {
+	customPayload := func() []byte {
+		body := []byte{0x00, 0x01} // one entry
+		body = append(body, shortString("k")...)
+		body = append(body, bytesValue([]byte{0xAB, 0xCD})...)
+		return append(body, queryBody("SELECT * FROM system.local", 0x00)...)
+	}
+
+	return []hashLockCase{
+		{name: "options", frame: frameV4(opOptions, 0x00, nil)},
+		{name: "startup-short", frame: startupFrameV4([]byte{0x00, 0x01})},
+		{name: "startup-long", frame: startupFrameV4(make([]byte, 512))},
+		{name: "prepare", frame: frameV4(opPrepare, 0x00, longString("SELECT v FROM t WHERE pk = ?"))},
+		{name: "register", frame: frameV4(opRegister, 0x00, append([]byte{0x00, 0x01}, shortString("TOPOLOGY_CHANGE")...))},
+		{name: "auth-response", frame: frameV4(opAuthResponse, 0x00, bytesValue([]byte{0xDE, 0xAD, 0xBE, 0xEF}))},
+
+		{name: "query-bare", frame: frameV4(opQuery, 0x00, queryBody("SELECT * FROM system.local", 0x00))},
+		{name: "query-values", frame: frameV4(opQuery, 0x00, queryBody("SELECT v FROM t WHERE pk = ?", 0x01,
+			[]byte{0x00, 0x01}, bytesValue([]byte{0x00, 0x00, 0x00, 0x2A})))},
+		{name: "query-null-value", frame: frameV4(opQuery, 0x00, queryBody("SELECT v FROM t WHERE pk = ?", 0x01,
+			[]byte{0x00, 0x01}, []byte{0xFF, 0xFF, 0xFF, 0xFF}))},
+		{name: "query-page-size", frame: frameV4(opQuery, 0x00, queryBody("SELECT * FROM t", 0x04,
+			[]byte{0x00, 0x00, 0x13, 0x88}))},
+		{name: "query-paging-state", frame: frameV4(opQuery, 0x00, queryBody("SELECT * FROM t", 0x08,
+			bytesValue([]byte{0x01, 0x02, 0x03})))},
+		{name: "query-serial-consistency", frame: frameV4(opQuery, 0x00, queryBody("SELECT * FROM t", 0x10,
+			[]byte{0x00, 0x09}))},
+		{name: "query-default-timestamp", frame: frameV4(opQuery, 0x00, queryBody("SELECT * FROM t", 0x20,
+			[]byte{0x00, 0x06, 0x26, 0x52, 0xBF, 0xD6, 0xE5, 0x3F}))},
+		{name: "query-values-page-size-serial", frame: frameV4(opQuery, 0x00, queryBody("SELECT v FROM t WHERE pk = ?", 0x01|0x04|0x10,
+			[]byte{0x00, 0x01}, bytesValue([]byte{0x2A}), []byte{0x00, 0x00, 0x13, 0x88}, []byte{0x00, 0x09}))},
+		{name: "query-named-values", frame: frameV4(opQuery, 0x00, queryBody("SELECT v FROM t WHERE pk = :pk", 0x01|0x40,
+			[]byte{0x00, 0x01}, shortString("pk"), bytesValue([]byte{0x2A})))},
+		{name: "query-custom-payload", frame: frameV4(opQuery, frm.FlagCustomPayload, customPayload())},
+
+		{name: "execute-no-metadata-id", frame: v4ExecuteFrame(false)},
+		{name: "execute-metadata-id", frame: v4ExecuteFrame(true), useMetadataID: true},
+		{name: "execute-metadata-id-flag-off", frame: v4ExecuteFrame(true)},
+
+		{name: "batch", frame: frameV4(opBatch, 0x00, batchBody(0x00))},
+		{name: "batch-default-timestamp", frame: frameV4(opBatch, 0x00, batchBody(0x20,
+			[]byte{0x00, 0x06, 0x26, 0x52, 0xBF, 0xD6, 0xE5, 0x3F}))},
+
+		{name: "v2-options", frame: frameV2(opOptions, nil)},
+		{name: "v2-query", frame: frameV2(opQuery, queryBody("SELECT * FROM system.local", 0x00))},
+
+		{name: "truncated-execute-prepared-id-len", frame: v4ExecuteFrame(true)[:10], useMetadataID: true},
+		{name: "truncated-execute-metadata-id-len", frame: v4ExecuteFrame(true)[:15], useMetadataID: true},
+		{name: "short-header", frame: frameV4(opQuery, 0x00, nil)[:5]},
+		{name: "empty", frame: nil},
+		{name: "unknown-opcode", frame: frameV4(frameOp(0x7F), 0x00, []byte{0x01, 0x02, 0x03})},
+	}
+}
+
+// TestGetFrameHashIsStable is the load-bearing regression lock described above.
+func TestGetFrameHashIsStable(t *testing.T) {
+	for _, tc := range hashLockCases() {
+		want, ok := hashLockWant[tc.name]
+		if !ok {
+			t.Errorf("%s: no pinned hash — add one rather than deleting the case", tc.name)
+			continue
+		}
+		if got := GetFrameHash(tc.frame, tc.useMetadataID); got != want {
+			t.Errorf("%s: GetFrameHash = %d, pinned %d", tc.name, got, want)
+		}
+	}
+
+	if len(hashLockWant) != len(hashLockCases()) {
+		t.Errorf("pinned %d hashes for %d cases", len(hashLockWant), len(hashLockCases()))
+	}
+}
+
+// hashLockWant pins the hash of every case above.
+//
+// Captured against the implementation as it stood before protocol v5 query-parameter
+// support was added, and unchanged by it: the v5 tail walk is gated on v5, so every
+// value here — all of them v4 or below — is byte-identical to that baseline.
+var hashLockWant = map[string]int64{
+	"auth-response":                     -5612286604398787175,
+	"empty":                             0,
+	"execute-metadata-id":               8953623736212654883,
+	"execute-metadata-id-flag-off":      -8761464023806847249,
+	"execute-no-metadata-id":            -7853075121273079524,
+	"options":                           359591853454385582,
+	"prepare":                           7009575819196046835,
+	"register":                          2208904296610557021,
+	"short-header":                      -4915946318166194245,
+	"startup-long":                      -4554951338151526776,
+	"startup-short":                     -4554951338151526776,
+	"truncated-execute-metadata-id-len": 1641695519491433123,
+	"truncated-execute-prepared-id-len": -2990148397469877668,
+	"unknown-opcode":                    -8681368666721584811,
+	"v2-options":                        2835211771060518081,
+
+	// Both BATCH values moved when the arm stopped hashing the frame whole and
+	// started walking the body to the end of the parameter block. That is the point
+	// of the change: hashing it whole covered the default timestamp, which
+	// writeBatchFrame fills with time.Now(), so a recorded BATCH never matched its
+	// own replay. No recording had to be regenerated for it — the checked-in
+	// fixtures contain no BATCH frame.
+	"batch":                   -8625060010961602230,
+	"batch-default-timestamp": -8987577148391256339,
+
+	// Every QUERY case collapses to Murmur3H1({0x00, 0x00, 0x00}). That is the
+	// scylladb/gocql#1000 collision, pinned here as it stands rather than hidden:
+	// the parameter walk starts at the body start, so it hashes the top three bytes
+	// of the query text's length and nothing else. When #1000 is fixed these values
+	// move and become distinct, and that diff is the point of this table.
+	"query-bare":                    8779008611884021576,
+	"query-custom-payload":          8779008611884021576,
+	"query-default-timestamp":       8779008611884021576,
+	"query-named-values":            8779008611884021576,
+	"query-null-value":              8779008611884021576,
+	"query-page-size":               8779008611884021576,
+	"query-paging-state":            8779008611884021576,
+	"query-serial-consistency":      8779008611884021576,
+	"query-values":                  8779008611884021576,
+	"query-values-page-size-serial": 8779008611884021576,
+	"v2-query":                      8779008611884021576,
+}
+
+// frameV5 builds a protocol v5 request frame. The header layout is v3+'s, so only
+// the version byte differs from frameV4 — what changes on v5 is the body: the query
+// flags become a 4-byte field and EXECUTE always carries a resultMetadataID.
+func frameV5(op frameOp, headerFlags byte, body []byte) []byte {
+	frame := []byte{
+		0x05,
+		headerFlags,
+		0x00, 0x7B, // stream id
+		byte(op),
+		byte(len(body) >> 24), byte(len(body) >> 16), byte(len(body) >> 8), byte(len(body)),
+	}
+	return append(frame, body...)
+}
+
+// v5ExecuteFrame builds a protocol v5 EXECUTE frame whose query parameters carry
+// exactly the fields flags announces, in the order writeQueryParams emits them.
+func v5ExecuteFrame(flags uint32, optional ...[]byte) []byte {
+	body := []byte{0x00, 0x03, 0xAA, 0xBB, 0xCC} // preparedID
+	body = append(body, 0x00, 0x02, 0xDE, 0xAD)  // resultMetadataID, always present on v5
+	body = append(body, 0x00, 0x01)              // consistency ONE
+	body = append(body, byte(flags>>24), byte(flags>>16), byte(flags>>8), byte(flags))
+	for _, o := range optional {
+		body = append(body, o...)
+	}
+	return frameV5(opExecute, 0x00, body)
+}
+
+// timestamp8 is an 8-byte default-timestamp field.
+func timestamp8(v int64) []byte {
+	return []byte{byte(v >> 56), byte(v >> 48), byte(v >> 40), byte(v >> 32),
+		byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+// nowInSeconds4 is a 4-byte now_in_seconds field.
+func nowInSeconds4(v int32) []byte {
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+// TestGetFrameHashV5DistinguishesTailFields pins that the protocol v5 keyspace
+// override and now_in_seconds are part of a request's identity.
+//
+// Both sit after the default timestamp in the parameter block, so a walk that stops
+// at serial consistency leaves them out and two requests differing only there hash
+// the same. The replayer picks the first hash match, so that is not a near miss: it
+// serves the response recorded for the other keyspace.
+func TestGetFrameHashV5DistinguishesTailFields(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		flags uint32
+		a, b  [][]byte
+	}{
+		{
+			name:  "keyspace override",
+			flags: frm.FlagWithKeyspace,
+			a:     [][]byte{shortString("ks_a")},
+			b:     [][]byte{shortString("ks_b")},
+		},
+		{
+			name:  "now_in_seconds",
+			flags: frm.FlagWithNowInSeconds,
+			a:     [][]byte{nowInSeconds4(1000)},
+			b:     [][]byte{nowInSeconds4(2000)},
+		},
+		{
+			// The keyspace sits behind the timestamp, so this only differs from the
+			// first case if the walk steps over the timestamp rather than stopping.
+			name:  "keyspace override behind a default timestamp",
+			flags: frm.FlagDefaultTimestamp | frm.FlagWithKeyspace,
+			a:     [][]byte{timestamp8(111), shortString("ks_a")},
+			b:     [][]byte{timestamp8(111), shortString("ks_b")},
+		},
+		{
+			name:  "both, behind a default timestamp",
+			flags: frm.FlagDefaultTimestamp | frm.FlagWithKeyspace | frm.FlagWithNowInSeconds,
+			a:     [][]byte{timestamp8(111), shortString("ks"), nowInSeconds4(1000)},
+			b:     [][]byte{timestamp8(111), shortString("ks"), nowInSeconds4(2000)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := GetFrameHash(v5ExecuteFrame(tc.flags, tc.a...), false)
+			b := GetFrameHash(v5ExecuteFrame(tc.flags, tc.b...), false)
+			if a == b {
+				t.Errorf("frames differing in %s hash the same (%d); the replayer would serve the wrong response", tc.name, a)
+			}
+		})
+	}
+}
+
+// TestGetFrameHashV5IgnoresDefaultTimestamp pins the other half of the contract: the
+// default timestamp must stay out of the hash even though the fields behind it are in
+// it. It is time.Now() at send time (framer.writeQueryParams), so hashing it would
+// make every recorded frame fail to match its own replay.
+func TestGetFrameHashV5IgnoresDefaultTimestamp(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		flags uint32
+		a, b  [][]byte
+	}{
+		{
+			name:  "timestamp alone",
+			flags: frm.FlagDefaultTimestamp,
+			a:     [][]byte{timestamp8(1)},
+			b:     [][]byte{timestamp8(999999)},
+		},
+		{
+			name:  "timestamp ahead of a keyspace override",
+			flags: frm.FlagDefaultTimestamp | frm.FlagWithKeyspace,
+			a:     [][]byte{timestamp8(1), shortString("ks")},
+			b:     [][]byte{timestamp8(999999), shortString("ks")},
+		},
+		{
+			name:  "timestamp ahead of now_in_seconds",
+			flags: frm.FlagDefaultTimestamp | frm.FlagWithNowInSeconds,
+			a:     [][]byte{timestamp8(1), nowInSeconds4(7)},
+			b:     [][]byte{timestamp8(999999), nowInSeconds4(7)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := GetFrameHash(v5ExecuteFrame(tc.flags, tc.a...), false)
+			b := GetFrameHash(v5ExecuteFrame(tc.flags, tc.b...), false)
+			if a != b {
+				t.Errorf("the default timestamp reached the hash: %d != %d", a, b)
+			}
+		})
+	}
+}
+
+// TestGetFrameHashV5BoundsTailFields walks every truncation of a v5 EXECUTE whose
+// parameters end in the tail fields. Each length there is file-supplied — a recording
+// is JSON on disk — so a truncated one must fall back to hashing the frame rather
+// than index past it.
+func TestGetFrameHashV5BoundsTailFields(t *testing.T) {
+	full := v5ExecuteFrame(frm.FlagDefaultTimestamp|frm.FlagWithKeyspace|frm.FlagWithNowInSeconds,
+		timestamp8(111), shortString("ks"), nowInSeconds4(7))
+
+	for n := 0; n < len(full); n++ {
+		truncated := append([]byte(nil), full[:n]...)
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("GetFrameHash panicked on a %d-byte prefix: %v", n, r)
+				}
+			}()
+			GetFrameHash(truncated, false)
+		}()
+	}
+
+	// An overstated keyspace length must not be walked either.
+	bad := v5ExecuteFrame(frm.FlagWithKeyspace, []byte{0x7F, 0xFF, 'k', 's'})
+	if got, want := GetFrameHash(bad, false), murmur3OfStreamBlanked(bad); got != want {
+		t.Errorf("overstated keyspace length: GetFrameHash = %d, want the raw-bytes fallback %d", got, want)
+	}
+}
+
+// batchBodyV5 assembles a BATCH body with a 4-byte flags field, as protocol v5
+// writes it, carrying exactly the fields flags announces.
+func batchBodyV5(statement string, flags uint32, optional ...[]byte) []byte {
+	body := []byte{0x00}            // type: LOGGED
+	body = append(body, 0x00, 0x01) // one query
+	body = append(body, 0x00)       // kind: query string
+	body = append(body, longString(statement)...)
+	body = append(body, 0x00, 0x00) // zero values
+	body = append(body, 0x00, 0x01) // consistency ONE
+	body = append(body, byte(flags>>24), byte(flags>>16), byte(flags>>8), byte(flags))
+	for _, o := range optional {
+		body = append(body, o...)
+	}
+	return body
+}
+
+// TestGetFrameHashBatchIgnoresDefaultTimestamp pins the reason the BATCH arm walks
+// its body at all.
+//
+// writeBatchFrame fills the default-timestamp field with time.Now() unless the caller
+// pinned a value, and the flag defaults to on. Hashing a BATCH whole therefore
+// produced a different hash on every run, so a recorded BATCH could only ever fail to
+// find its response — the replayer panics with "unable to find a response to replay".
+func TestGetFrameHashBatchIgnoresDefaultTimestamp(t *testing.T) {
+	a := frameV4(opBatch, 0x00, batchBody(byte(frm.FlagDefaultTimestamp), timestamp8(1)))
+	b := frameV4(opBatch, 0x00, batchBody(byte(frm.FlagDefaultTimestamp), timestamp8(999999)))
+
+	if GetFrameHash(a, false) != GetFrameHash(b, false) {
+		t.Error("the default timestamp reached a BATCH's hash, so a recorded BATCH cannot match its replay")
+	}
+}
+
+// TestGetFrameHashBatchDistinguishesStatements pins the other half: walking the body
+// has to cover the statements, or every batch of the same shape hashes alike and the
+// replayer serves the first one it finds.
+func TestGetFrameHashBatchDistinguishesStatements(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a, b []byte
+	}{
+		{
+			name: "query text",
+			a:    batchBody(0x00),
+			b: func() []byte {
+				body := []byte{0x00, 0x00, 0x01, 0x00}
+				body = append(body, longString("INSERT INTO t (pk) VALUES (2)")...)
+				body = append(body, 0x00, 0x00, 0x00, 0x01, 0x00)
+				return body
+			}(),
+		},
+		{
+			name: "statement count",
+			a:    batchBody(0x00),
+			b: func() []byte {
+				body := []byte{0x00, 0x00, 0x02}
+				for i := 0; i < 2; i++ {
+					body = append(body, 0x00)
+					body = append(body, longString("INSERT INTO t (pk) VALUES (1)")...)
+					body = append(body, 0x00, 0x00)
+				}
+				return append(body, 0x00, 0x01, 0x00)
+			}(),
+		},
+		{
+			name: "bound values",
+			a: func() []byte {
+				body := []byte{0x00, 0x00, 0x01, 0x00}
+				body = append(body, longString("INSERT INTO t (pk) VALUES (?)")...)
+				body = append(body, 0x00, 0x01)
+				body = append(body, bytesValue([]byte{0x2A})...)
+				return append(body, 0x00, 0x01, 0x00)
+			}(),
+			b: func() []byte {
+				body := []byte{0x00, 0x00, 0x01, 0x00}
+				body = append(body, longString("INSERT INTO t (pk) VALUES (?)")...)
+				body = append(body, 0x00, 0x01)
+				body = append(body, bytesValue([]byte{0x2B})...)
+				return append(body, 0x00, 0x01, 0x00)
+			}(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := GetFrameHash(frameV4(opBatch, 0x00, tc.a), false)
+			b := GetFrameHash(frameV4(opBatch, 0x00, tc.b), false)
+			if a == b {
+				t.Errorf("batches differing in %s hash the same (%d)", tc.name, a)
+			}
+		})
+	}
+}
+
+// TestGetFrameHashBatchPreparedStatements pins that a batch of prepared statements —
+// [short bytes] ids rather than query strings — is walked too, and that the ids are
+// what tells two such batches apart.
+func TestGetFrameHashBatchPreparedStatements(t *testing.T) {
+	preparedBatch := func(id []byte) []byte {
+		body := []byte{0x00, 0x00, 0x01, 0x01} // type, one query, kind: prepared
+		body = append(body, byte(len(id)>>8), byte(len(id)))
+		body = append(body, id...)
+		body = append(body, 0x00, 0x00)                                 // zero values
+		return append(body, 0x00, 0x01, byte(frm.FlagDefaultTimestamp)) // consistency + flags
+	}
+
+	a := frameV4(opBatch, 0x00, append(preparedBatch([]byte{0xAA, 0xBB}), timestamp8(1)...))
+	b := frameV4(opBatch, 0x00, append(preparedBatch([]byte{0xCC, 0xDD}), timestamp8(2)...))
+	same := frameV4(opBatch, 0x00, append(preparedBatch([]byte{0xAA, 0xBB}), timestamp8(3)...))
+
+	if GetFrameHash(a, false) == GetFrameHash(b, false) {
+		t.Error("batches with different prepared ids hash the same")
+	}
+	if GetFrameHash(a, false) != GetFrameHash(same, false) {
+		t.Error("the same prepared batch hashed differently across two timestamps")
+	}
+}
+
+// TestGetFrameHashBatchV5TailFields pins that a v5 batch's keyspace override and
+// now_in_seconds are covered, and its default timestamp still is not.
+func TestGetFrameHashBatchV5TailFields(t *testing.T) {
+	const flags = frm.FlagDefaultTimestamp | frm.FlagWithKeyspace | frm.FlagWithNowInSeconds
+	frame := func(keyspace string, now int32, ts int64) []byte {
+		return frameV5(opBatch, 0x00, batchBodyV5("INSERT INTO t (pk) VALUES (1)", flags,
+			timestamp8(ts), shortString(keyspace), nowInSeconds4(now)))
+	}
+
+	base := GetFrameHash(frame("ks_a", 1000, 111), false)
+
+	if GetFrameHash(frame("ks_b", 1000, 111), false) == base {
+		t.Error("a v5 batch's keyspace override is not hashed")
+	}
+	if GetFrameHash(frame("ks_a", 2000, 111), false) == base {
+		t.Error("a v5 batch's now_in_seconds is not hashed")
+	}
+	if GetFrameHash(frame("ks_a", 1000, 999999), false) != base {
+		t.Error("a v5 batch's default timestamp reached the hash")
+	}
+}
+
+// TestGetFrameHashBatchBounds walks every truncation of a BATCH frame, plus a few
+// overstated lengths. Every length in a batch body is file-supplied, so none of them
+// may index past the frame.
+func TestGetFrameHashBatchBounds(t *testing.T) {
+	full := frameV4(opBatch, 0x00, batchBody(byte(frm.FlagDefaultTimestamp), timestamp8(111)))
+
+	for n := 0; n <= len(full); n++ {
+		truncated := append([]byte(nil), full[:n]...)
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("GetFrameHash panicked on a %d-byte prefix: %v", n, r)
+				}
+			}()
+			GetFrameHash(truncated, false)
+		}()
+	}
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{name: "overstated statement count", body: []byte{0x00, 0x7F, 0xFF, 0x00}},
+		{name: "overstated query length", body: []byte{0x00, 0x00, 0x01, 0x00, 0x7F, 0xFF, 0xFF, 0xFF, 'x'}},
+		{name: "overstated prepared id length", body: []byte{0x00, 0x00, 0x01, 0x01, 0x7F, 0xFF, 'x'}},
+		{name: "overstated value count", body: append(append([]byte{0x00, 0x00, 0x01, 0x00}, longString("q")...), 0x7F, 0xFF)},
+		{name: "unknown statement kind", body: []byte{0x00, 0x00, 0x01, 0x09, 0x00}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			frame := frameV4(opBatch, 0x00, tc.body)
+			if got, want := GetFrameHash(frame, false), murmur3OfStreamBlanked(frame); got != want {
+				t.Errorf("GetFrameHash = %d, want the raw-bytes fallback %d", got, want)
+			}
+		})
+	}
+}
+
+// TestGetFrameHashBatchEmptyCustomPayload pins that an empty custom payload map is
+// skipped like any other.
+//
+// A [bytes map] of zero entries still spends the two bytes that say so. Stopping short
+// of them left the walk reading that count as the batch type, its own second byte as
+// the top half of the statement count, and so on: for the frames below that misreading
+// is entirely plausible — type LOGGED, zero statements, consistency ONE, no flags — so
+// nothing fails a bounds check and nothing falls back to the raw bytes. It just hashes
+// six bytes of the wrong field, identically for every batch that carries a custom
+// payload, and the replayer serves whichever of them it finds first.
+func TestGetFrameHashBatchEmptyCustomPayload(t *testing.T) {
+	emptyCustomPayload := func(statement string) []byte {
+		body := []byte{0x00, 0x00}      // custom payload: zero entries
+		body = append(body, 0x00)       // type: LOGGED
+		body = append(body, 0x00, 0x01) // one query
+		body = append(body, 0x00)       // kind: query string
+		body = append(body, longString(statement)...)
+		body = append(body, 0x00, 0x00) // zero values
+		body = append(body, 0x00, 0x01) // consistency ONE
+		body = append(body, byte(frm.FlagDefaultTimestamp))
+		return append(body, timestamp8(111)...)
+	}
+
+	a := frameV4(opBatch, frm.FlagCustomPayload, emptyCustomPayload("INSERT INTO t (pk) VALUES (1)"))
+	b := frameV4(opBatch, frm.FlagCustomPayload, emptyCustomPayload("INSERT INTO t (pk) VALUES (2)"))
+
+	if GetFrameHash(a, false) == GetFrameHash(b, false) {
+		t.Error("batches differing in their statement hash the same: the empty custom payload map was not skipped")
+	}
+}

--- a/dialer/utils_test.go
+++ b/dialer/utils_test.go
@@ -72,22 +72,36 @@ func TestGetFrameHashStartupIgnoresBodyLength(t *testing.T) {
 	}
 }
 
-// TestGetFrameHashGuardsProtoV5Segments verifies that GetFrameHash does not
-// attempt to parse protocol v5+ input as a CQL frame. On v5 the recorded bytes
-// are a transport segment (see prepareModernLayout), so frame[0] is segment
-// data, not a CQL version byte. The function must fall back to hashing the raw
-// bytes instead of walking CQL offsets. Tracked: scylladb/gocql#937.
-func TestGetFrameHashGuardsProtoV5Segments(t *testing.T) {
-	// First byte has the low 7 bits >= 5, i.e. a v5+ version (or arbitrary
-	// segment header data). The remaining bytes are deliberately too short to
-	// contain a valid CQL request body; the pre-guard code would index past
-	// them and panic.
-	segment := []byte{0x05, 0x00, 0x11, 0x22}
+// TestGetFrameHashParsesProtoV5Frames pins that a protocol v5 request frame is
+// parsed rather than diverted to a whole-frame hash.
+//
+// It used to be diverted, by a guard that treated any frame[0] whose low 7 bits were
+// >= 5 as transport-segment data. That guard was unsound in both directions: a v5
+// segment whose length low-byte is < 5 slipped past it into the CQL parser anyway,
+// and a genuine v5 frame — which the driver does produce, unsegmented, throughout the
+// handshake — was hashed whole, default timestamp included, so it could never match
+// its own replay. Telling the two apart needs protocol context the bytes do not
+// carry, so it is the caller's job to pass a bare frame; see GetFrameHash's contract.
+func TestGetFrameHashParsesProtoV5Frames(t *testing.T) {
+	// A v5 EXECUTE with a keyspace override. Parsed, the hashed range stops before
+	// the frame's end; diverted, the hash is the whole frame.
+	frame := v5ExecuteFrame(frm.FlagWithKeyspace, shortString("ks"))
 
-	got := GetFrameHash(segment, false)
-	want := murmur.Murmur3H1(segment)
-	if got != want {
-		t.Fatalf("GetFrameHash(v5 segment) = %d, want raw-bytes hash %d", got, want)
+	if got, whole := GetFrameHash(frame, false), murmur3OfStreamBlanked(frame); got == whole {
+		t.Error("v5 frame was hashed whole rather than parsed")
+	}
+	if got, asGiven := GetFrameHash(frame, false), murmur.Murmur3H1(frame); got == asGiven {
+		t.Error("v5 frame fell through to a guard that hashes it as given")
+	}
+}
+
+// TestGetFrameHashShortProtoV5Input pins that v5 input too short to hold a header
+// still reaches the short-frame guard, which hashes it as given.
+func TestGetFrameHashShortProtoV5Input(t *testing.T) {
+	short := []byte{0x05, 0x00, 0x11, 0x22}
+
+	if got, want := GetFrameHash(short, false), murmur.Murmur3H1(short); got != want {
+		t.Fatalf("GetFrameHash(short v5) = %d, want %d", got, want)
 	}
 }
 
@@ -329,9 +343,7 @@ func TestGetFrameHashBoundsTruncatedExecute(t *testing.T) {
 			// The fallback hashes the frame as the parser left it, i.e. with the stream
 			// id blanked — which is what makes the hash stable between record and replay,
 			// where the stream ids differ. Mirror that here.
-			normalised := append([]byte(nil), tc.frame...)
-			normalised[2], normalised[3] = byte('0'), byte('0')
-			want := murmur.Murmur3H1(normalised)
+			want := murmur3OfStreamBlanked(tc.frame)
 
 			got := GetFrameHash(frame, tc.useMetadataID)
 			if got != want {
@@ -468,9 +480,7 @@ func TestGetFrameHashBoundsTruncatedBody(t *testing.T) {
 
 			// These fall back from inside the switch, i.e. with the stream id already
 			// blanked — see TestGetFrameHashBoundsTruncatedExecute.
-			normalised := append([]byte(nil), tc.frame...)
-			normalised[2], normalised[3] = byte('0'), byte('0')
-			want := murmur.Murmur3H1(normalised)
+			want := murmur3OfStreamBlanked(tc.frame)
 
 			if got := GetFrameHash(frame, tc.useMetadataID); got != want {
 				t.Errorf("GetFrameHash(%s) = %d, want raw-bytes hash %d", tc.name, got, want)

--- a/dialer/utils_test.go
+++ b/dialer/utils_test.go
@@ -502,3 +502,27 @@ func TestGetFrameHashBoundsTruncatedBody(t *testing.T) {
 		}
 	})
 }
+
+// TestFrameIsQueryDerivesTheOpcodeOffset pins that the opcode is read through
+// headerShift rather than at a fixed index, which is what stops this from drifting
+// from the parsers it shares utils.go with.
+func TestFrameIsQueryDerivesTheOpcodeOffset(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		frame []byte
+		want  bool
+	}{
+		{"v4 QUERY", frameV4(opQuery, 0x00, []byte("select")), true},
+		{"v4 EXECUTE", frameV4(opExecute, 0x00, []byte("x")), false},
+		{"v2 QUERY", frameV2(opQuery, []byte("select")), true},
+		{"v2 EXECUTE", frameV2(opExecute, []byte("x")), false},
+		{"empty", nil, false},
+		{"opcode has not arrived", frameV4(opQuery, 0x00, nil)[:3], false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FrameIsQuery(tc.frame); got != tc.want {
+				t.Errorf("FrameIsQuery = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/frame.go
+++ b/frame.go
@@ -86,8 +86,6 @@ const (
 	// CASSGO-88 (https://issues.apache.org/jira/browse/CASSGO-88). Supporting a
 	// beta dialect would need an explicit opt-in bound to that specific dialect.
 	protoVersion5 = 0x05
-
-	maxFrameSize = 256 * 1024 * 1024
 )
 
 // DEPRECATED use Consistency type, SerialConsistency is now an alias for backwards compatibility.
@@ -406,7 +404,7 @@ func (f *framer) readFrame(r io.Reader, head *frm.FrameHeader) error {
 	// callers that synthesise a header.
 	if head.Length < 0 {
 		return fmt.Errorf("frame body length can not be less than 0: %d", head.Length)
-	} else if head.Length > maxFrameSize {
+	} else if head.Length > frm.MaxFrameSize {
 		// need to free up the connection to be used again
 		_, err := io.CopyN(io.Discard, r, int64(head.Length))
 		if err != nil {
@@ -455,7 +453,7 @@ func (f *framer) readFrame(r io.Reader, head *frm.FrameHeader) error {
 // instead of reading and copying it as readFrame does. It is used for a v5 frame
 // reassembled from several transport segments (Conn.recvSplitFrame): that buffer
 // is already exactly frame-sized, so copying it would mean holding the frame twice
-// — 512 MiB for a maxFrameSize response.
+// — 512 MiB for a frm.MaxFrameSize response.
 //
 // f.readBuffer is deliberately left pointing at the pooled buffer, so releasing
 // the framer drops the adopted body instead of retaining an outsized buffer in the
@@ -680,7 +678,7 @@ func (f *framer) setLength(length int) {
 
 func (f *framer) finish() error {
 	bufLen := len(f.buf)
-	if bufLen > maxFrameSize {
+	if bufLen > frm.MaxFrameSize {
 		// huge app frame, lets remove it so it doesn't bloat the heap
 		f.buf = make([]byte, defaultBufSize)
 		return ErrFrameTooBig

--- a/frame.go
+++ b/frame.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	frm "github.com/gocql/gocql/internal/frame"
+	"github.com/gocql/gocql/internal/segment"
 )
 
 type unsetColumn struct{}
@@ -87,16 +88,6 @@ const (
 	protoVersion5 = 0x05
 
 	maxFrameSize = 256 * 1024 * 1024
-
-	// maxSegmentPayloadSize is the largest payload a single v5 transport segment
-	// may carry (2^17 - 1). Used as a bound check when building segments.
-	maxSegmentPayloadSize = 0x1FFFF
-
-	// segmentPayloadLenMask extracts the 17-bit payload-length field from a
-	// decoded segment header. Numerically equal to maxSegmentPayloadSize, but
-	// kept separate: one is a limit, the other is a bit mask, and conflating
-	// them obscures why no explicit bound check is needed after masking.
-	segmentPayloadLenMask = 0x1FFFF
 )
 
 // DEPRECATED use Consistency type, SerialConsistency is now an alias for backwards compatibility.
@@ -2152,44 +2143,49 @@ func (f *framer) prepareModernLayout() error {
 		return fmt.Errorf("gocql: modern layout is not supported with protocol version %d (requires v5+)", f.proto)
 	}
 
+	// Narrow the compressor once per frame rather than once per segment: a frame past
+	// segment.MaxPayloadSize is segmented by the loop below, and every one of those
+	// segments takes the same layout from the same compressor, which is fixed for the
+	// life of the framer.
+	//
+	// The narrowing is defensive — ClusterConfig.Validate rejects a compressor without
+	// segment support on v5 before a connection is dialed, and
+	// Conn.resolveSegmentCompressor re-checks it at the handshake — and is reported
+	// rather than ignored, because falling back to the uncompressed layout would
+	// produce segments the peer decodes with the wrong one.
+	segComp, err := asSegmentCompressor(f.compressor)
+	if err != nil {
+		return err
+	}
+
 	// Segment the frame via a local cursor rather than mutating f.buf as we go,
 	// and only swap the buffers once the whole frame has been segmented
 	// successfully, so that an error partway through leaves f.buf byte-for-byte
 	// intact.
 	src := f.buf
-	wire := f.growWireBuf(segmentedFrameSize(len(src), f.compressor != nil))
+	wire := f.growWireBuf(segment.EncodedSize(len(src), segComp != nil))
 
-	var err error
 	selfContained := true
 
 	// Process the buffer in chunks if it exceeds the max payload size
-	for len(src) > maxSegmentPayloadSize {
-		wire, err = f.appendSegment(wire, src[:maxSegmentPayloadSize], false)
+	for len(src) > segment.MaxPayloadSize {
+		wire, err = segment.Append(wire, src[:segment.MaxPayloadSize], false, segComp)
 		if err != nil {
 			return err
 		}
 
-		src = src[maxSegmentPayloadSize:]
+		src = src[segment.MaxPayloadSize:]
 		selfContained = false
 	}
 
 	// Process the remaining buffer
-	if wire, err = f.appendSegment(wire, src, selfContained); err != nil {
+	if wire, err = segment.Append(wire, src, selfContained, segComp); err != nil {
 		return err
 	}
 
 	f.wireBuf, f.buf = f.buf, wire
 
 	return nil
-}
-
-// appendSegment encodes payload as one transport segment appended to dst, in the
-// layout matching the framer's compressor.
-func (f *framer) appendSegment(dst, payload []byte, isSelfContained bool) ([]byte, error) {
-	if f.compressor != nil {
-		return appendCompressedSegment(dst, payload, isSelfContained, f.compressor)
-	}
-	return appendUncompressedSegment(dst, payload, isSelfContained)
 }
 
 // growWireBuf returns f.wireBuf emptied and with room for at least n bytes,
@@ -2199,29 +2195,4 @@ func (f *framer) growWireBuf(n int) []byte {
 		f.wireBuf = make([]byte, 0, n)
 	}
 	return f.wireBuf[:0]
-}
-
-// segmentedFrameSize returns how many bytes a rawLen-byte CQL frame occupies once
-// segmented, so the wire buffer can be sized before anything is encoded into it.
-// For the compressed layout this is an upper bound rather than the exact size:
-// compressed payloads are usually smaller, but a compressor may also return more
-// bytes than it was given, so room for one segment's worth of expansion is added.
-func segmentedFrameSize(rawLen int, compressed bool) int {
-	const (
-		// 3-byte header + CRC24 + payload CRC32.
-		uncompressedSegmentOverhead = 3 + crc24Size + crc32Size
-		// 5-byte header + CRC24 + payload CRC32.
-		compressedSegmentOverhead = 5 + crc24Size + crc32Size
-		// Room for a maximum-size payload growing under compression, matching
-		// lz4's block bound (len + len/255 + 16). A compressor that expands more
-		// than this is still handled correctly, it only makes the wire buffer grow
-		// once.
-		compressionSlack = maxSegmentPayloadSize/255 + 16
-	)
-
-	segments := rawLen/maxSegmentPayloadSize + 1
-	if compressed {
-		return rawLen + segments*compressedSegmentOverhead + compressionSlack
-	}
-	return rawLen + segments*uncompressedSegmentOverhead
 }

--- a/frame_test.go
+++ b/frame_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	frm "github.com/gocql/gocql/internal/frame"
+	"github.com/gocql/gocql/internal/segment"
 )
 
 func TestFuzzBugs(t *testing.T) {
@@ -1297,10 +1298,10 @@ func (c *failingCompressor) Decode(data []byte) ([]byte, error) {
 func TestPrepareModernLayoutLeavesBufIntactOnError(t *testing.T) {
 	t.Parallel()
 
-	// A payload spanning more than one maxSegmentPayloadSize chunk forces the
+	// A payload spanning more than one segment.MaxPayloadSize chunk forces the
 	// chunk loop to run, so failing on the second AppendCompressed call fails
 	// after the first chunk has already been appended to the local buffer.
-	original := bytes.Repeat([]byte{0xAB}, maxSegmentPayloadSize+100)
+	original := bytes.Repeat([]byte{0xAB}, segment.MaxPayloadSize+100)
 
 	f := newFramer(&failingCompressor{failAt: 2}, protoVersion5)
 	f.buf = append([]byte(nil), original...)
@@ -1336,20 +1337,20 @@ func TestPrepareModernLayoutRejectsPreV5ProtocolWithError(t *testing.T) {
 func TestPrepareModernLayoutSuccessUnchanged(t *testing.T) {
 	t.Parallel()
 
-	for _, size := range []int{1, maxSegmentPayloadSize - 1, maxSegmentPayloadSize, maxSegmentPayloadSize + 1, 2*maxSegmentPayloadSize + 7} {
+	for _, size := range []int{1, segment.MaxPayloadSize - 1, segment.MaxPayloadSize, segment.MaxPayloadSize + 1, 2*segment.MaxPayloadSize + 7} {
 		original := bytes.Repeat([]byte{0x5A}, size)
 
 		// Reference output computed directly from the segment helpers.
 		var want []byte
 		src := original
 		selfContained := true
-		for len(src) > maxSegmentPayloadSize {
-			seg, err := newUncompressedSegment(src[:maxSegmentPayloadSize], false)
+		for len(src) > segment.MaxPayloadSize {
+			seg, err := newUncompressedSegment(src[:segment.MaxPayloadSize], false)
 			if err != nil {
 				t.Fatalf("size %d: reference segment: %v", size, err)
 			}
 			want = append(want, seg...)
-			src = src[maxSegmentPayloadSize:]
+			src = src[segment.MaxPayloadSize:]
 			selfContained = false
 		}
 		seg, err := newUncompressedSegment(src, selfContained)
@@ -1386,7 +1387,7 @@ func (expandingCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
 		copy(grown, dst)
 		dst = grown
 	}
-	// Expand slightly, so every segment takes appendCompressedSegment's
+	// Expand slightly, so every segment takes segment.AppendCompressed's
 	// "compression was not worth it" fallback back to the raw payload.
 	out := dst[:oldLen+len(src)+len(src)/255+1]
 	copy(out[oldLen:], src)
@@ -1406,7 +1407,7 @@ func (expandingCompressor) Decode(data []byte) ([]byte, error) { return data, ni
 // allocated the whole wire output, plus a temporary per segment, per request).
 //
 // The expanding cases additionally cover a multi-segment compressed frame whose
-// every payload grows under compression, which is what segmentedFrameSize's
+// every payload grows under compression, which is what segment.EncodedSize's
 // one-segment slack is for. Expansion does not accumulate across segments: only
 // one segment is ever mid-compression, and a segment whose compressed form came
 // out larger is rewritten as its raw payload before the next one starts. Note
@@ -1420,10 +1421,10 @@ func TestPrepareModernLayoutReusesBuffers(t *testing.T) {
 		size       int
 	}{
 		{"single segment", nil, 4096},
-		{"multi segment", nil, 2*maxSegmentPayloadSize + 7},
+		{"multi segment", nil, 2*segment.MaxPayloadSize + 7},
 		{"compressed", testMockedCompressor{}, 4096},
-		{"expanding compressed, single segment", expandingCompressor{}, maxSegmentPayloadSize - 1},
-		{"expanding compressed, multi segment", expandingCompressor{}, 5*maxSegmentPayloadSize - 1},
+		{"expanding compressed, single segment", expandingCompressor{}, segment.MaxPayloadSize - 1},
+		{"expanding compressed, multi segment", expandingCompressor{}, 5*segment.MaxPayloadSize - 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			payload := bytes.Repeat([]byte{0x5A}, tc.size)

--- a/frame_test.go
+++ b/frame_test.go
@@ -105,7 +105,7 @@ func TestFrameWriteTooLong(t *testing.T) {
 	framer := newFramer(nil, 3)
 
 	framer.writeHeader(0, frm.OpStartup, 1)
-	framer.writeBytes(make([]byte, maxFrameSize+1))
+	framer.writeBytes(make([]byte, frm.MaxFrameSize+1))
 	err := framer.finish()
 	if err != ErrFrameTooBig {
 		t.Fatalf("expected to get %v got %v", ErrFrameTooBig, err)
@@ -120,7 +120,7 @@ func TestFrameReadTooLong(t *testing.T) {
 	}
 
 	r := &bytes.Buffer{}
-	r.Write(make([]byte, maxFrameSize+1))
+	r.Write(make([]byte, frm.MaxFrameSize+1))
 	// write a new header right after this frame to verify that we can read it
 	r.Write([]byte{0x03, 0x00, 0x00, 0x00, byte(frm.OpReady), 0x00, 0x00, 0x00, 0x00})
 
@@ -193,7 +193,7 @@ func TestReadFrameDiscardErrorKeepsNetError(t *testing.T) {
 	t.Parallel()
 
 	f := newFramer(nil, protoVersion4)
-	head := frm.FrameHeader{Version: protoVersion4 | protoDirectionMask, Op: frm.OpReady, Length: maxFrameSize + 1}
+	head := frm.FrameHeader{Version: protoVersion4 | protoDirectionMask, Op: frm.OpReady, Length: frm.MaxFrameSize + 1}
 
 	err := f.readFrame(errReader{timeoutErr{}}, &head)
 	require.Error(t, err)

--- a/internal/frame/frames.go
+++ b/internal/frame/frames.go
@@ -37,9 +37,14 @@ const (
 	protoVersion3      = 0x03
 	protoVersion4      = 0x04
 	protoVersion5      = 0x05
-
-	maxFrameSize = 256 * 1024 * 1024
 )
+
+// MaxFrameSize is the largest CQL frame body the driver will accept or produce, and
+// the bound every reader checks a peer-declared body length against.
+//
+// It is here, rather than in the packages that use it, because both the driver and
+// the record/replay dialers de-frame a byte stream and neither can import the other.
+const MaxFrameSize = 256 * 1024 * 1024
 
 const (
 	// result kind

--- a/internal/segment/segment.go
+++ b/internal/segment/segment.go
@@ -1,0 +1,436 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package segment implements native protocol v5 ("modern framing") transport
+// segments. A segment is a self-describing, CRC-protected envelope that carries
+// one or more complete CQL frames (self-contained) or a slice of a single large
+// CQL frame split across several segments (non-self-contained). See the CQL
+// native protocol v5 spec, section 2 ("Framing"), for the wire layout.
+//
+// The codec lives here, apart from the driver, because two packages decode the
+// same wire format for different reasons: the connection read path, which reads
+// a header and a payload in two phases so it can re-arm its read deadline in
+// between, and the record/replay dialers, which are handed arbitrary slices of a
+// byte stream and have to buffer until a segment is whole. Sharing the codec is
+// what keeps the 17-bit field extraction, the CRC24/CRC32 checks, the
+// store-as-is rule for incompressible payloads and the split threshold from
+// being implemented twice and drifting.
+//
+// Errors are prefixed "gocql:" rather than with this package's name: they reach
+// driver users, for whom this package is an implementation detail.
+package segment
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/gocql/gocql/internal/crc"
+)
+
+const (
+	// Crc24Size is the width of a segment header's CRC24 checksum.
+	Crc24Size = 3
+	// Crc32Size is the width of a segment payload's CRC32 checksum.
+	Crc32Size = 4
+
+	// UncompressedHeaderSize is the total size of an uncompressed segment's
+	// header: a 3-byte length-and-flag field plus its CRC24.
+	UncompressedHeaderSize = 3 + Crc24Size
+	// CompressedHeaderSize is the total size of a compressed segment's header: a
+	// 5-byte field carrying both lengths and the flag, plus its CRC24.
+	CompressedHeaderSize = 5 + Crc24Size
+
+	// MaxPayloadSize is the largest payload a single transport segment may carry
+	// (2^17 - 1). Used as a bound check when building segments.
+	MaxPayloadSize = 0x1FFFF
+
+	// PayloadLenMask extracts the 17-bit payload-length field from a decoded
+	// segment header. Numerically equal to MaxPayloadSize, but kept separate: one
+	// is a limit, the other is a bit mask, and conflating them obscures why no
+	// explicit bound check is needed after masking.
+	PayloadLenMask = 0x1FFFF
+)
+
+// Compressor compresses and decompresses segment payloads.
+//
+// It is deliberately a structural interface rather than a reference to the
+// driver's SegmentCompressor: this package cannot import the root package, and
+// the lz4 compressor lives in a separate module that cannot import internal
+// packages either. Both satisfy this implicitly, and must keep doing so.
+//
+// A nil Compressor means the uncompressed segment layout. The driver's
+// Compressor.Name is not needed here — the one place that wants it for an error
+// message is the narrowing in the root package.
+type Compressor interface {
+	// AppendCompressed compresses src and appends the compressed bytes to dst.
+	AppendCompressed(dst, src []byte) ([]byte, error)
+
+	// AppendDecompressed decompresses src (whose decompressed size is supplied
+	// out-of-band as decompressedLength) and appends the result to dst.
+	AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error)
+}
+
+// Header is the decoded fixed-size header of a transport segment.
+//
+// The header and the payload are read in two phases (ReadHeader then ReadPayload)
+// so a caller can re-arm a read deadline between the possibly-idle wait for the
+// header and the bounded read of the payload.
+type Header struct {
+	// PayloadLen is the number of payload bytes on the wire that follow the
+	// header (the post-compression size for compressed segments).
+	PayloadLen int
+	// UncompressedLen is the size of the payload after decompression. It is 0
+	// for uncompressed segments, and also 0 for compressed segments whose
+	// payload is stored as-is because compression was not worth it.
+	UncompressedLen int
+	IsSelfContained bool
+}
+
+// Scratch holds the buffers a segment payload is read into. Every inbound
+// segment would otherwise allocate its wire payload, plus a second buffer for the
+// decompressed bytes of a compressed segment — one or two allocations of up to
+// MaxPayloadSize (~128 KiB) each, per segment. A connection's receive path runs
+// entirely on its serve() goroutine, so it can reuse one instance for every
+// segment it reads.
+//
+// The consequence is that a payload returned by ReadPayload aliases these
+// buffers and is only valid until the next segment is read with the same Scratch.
+// Every caller either copies the payload (reassembly) or fully consumes it (frame
+// parsing copies the body into a pooled framer) before reading the next segment.
+type Scratch struct {
+	// wire holds the payload bytes as they arrive on the wire, which for a
+	// compressed segment means the still-compressed bytes.
+	wire []byte
+	// decompressed holds the payload of a compressed segment after decompression.
+	decompressed []byte
+}
+
+// wireBuf returns the wire buffer resized to exactly n bytes, ready to be read
+// into, reallocating only when what it already holds is too small. n comes from a
+// segment header, where both layouts carry the payload length in 17 bits, so it is
+// inherently bounded by MaxPayloadSize.
+func (s *Scratch) wireBuf(n int) []byte {
+	if cap(s.wire) < n {
+		s.wire = make([]byte, n)
+	}
+	s.wire = s.wire[:n]
+	return s.wire
+}
+
+// decompress decompresses src into the reusable decompressed buffer.
+func (s *Scratch) decompress(comp Compressor, src []byte, decompressedLen int) ([]byte, error) {
+	if cap(s.decompressed) < decompressedLen {
+		s.decompressed = make([]byte, 0, decompressedLen)
+	}
+	out, err := comp.AppendDecompressed(s.decompressed[:0], src, uint32(decompressedLen))
+	if err != nil {
+		return nil, err
+	}
+	// Keep whatever buffer the compressor ended up using, so that a compressor
+	// which had to grow it does not have to grow it again for the next segment.
+	s.decompressed = out
+	return out, nil
+}
+
+// HeaderSize returns how many bytes ReadHeader consumes for the given layout. A
+// caller that has to buffer a whole header before it can decode one — as the
+// record/replay dialers do, being handed arbitrary slices of a byte stream — needs
+// this before it has a Header to look at.
+func HeaderSize(compressed bool) int {
+	if compressed {
+		return CompressedHeaderSize
+	}
+	return UncompressedHeaderSize
+}
+
+// ReadHeader reads and validates the fixed-size header of the next segment,
+// consuming only the header bytes.
+//
+// It takes a bool rather than a Compressor because that is all a header depends on:
+// which of the two layouts is on the wire. Only the payload needs the codec itself.
+func ReadHeader(r io.Reader, compressed bool) (Header, error) {
+	if compressed {
+		return ReadCompressedHeader(r)
+	}
+	return ReadUncompressedHeader(r)
+}
+
+// ReadPayload reads and verifies the payload and trailing CRC32 that follow a
+// header previously read by ReadHeader, returning the reconstructed (decompressed,
+// if applicable) payload bytes. The result aliases scratch; see Scratch.
+func ReadPayload(r io.Reader, h Header, comp Compressor, scratch *Scratch) ([]byte, error) {
+	if comp != nil {
+		return ReadCompressedPayload(r, h, comp, scratch)
+	}
+	return ReadUncompressedPayload(r, h, scratch)
+}
+
+// ReadUncompressedHeader decodes an uncompressed segment header.
+func ReadUncompressedHeader(r io.Reader) (Header, error) {
+	const headerSize = 3
+
+	var header [headerSize + Crc24Size]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return Header{}, fmt.Errorf("gocql: failed to read uncompressed frame, err: %w", err)
+	}
+
+	// Compute and verify the header CRC24
+	computedHeaderCRC24 := crc.Crc24(header[:headerSize])
+	readHeaderCRC24 := uint32(header[3]) | uint32(header[4])<<8 | uint32(header[5])<<16
+	if computedHeaderCRC24 != readHeaderCRC24 {
+		return Header{}, fmt.Errorf("gocql: crc24 mismatch in frame header, computed: %d, got: %d", computedHeaderCRC24, readHeaderCRC24)
+	}
+
+	headerInt := uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16
+	return Header{
+		PayloadLen:      int(headerInt & PayloadLenMask),
+		IsSelfContained: (headerInt & (1 << 17)) != 0,
+	}, nil
+}
+
+// ReadUncompressedPayload reads the payload of an uncompressed segment and
+// verifies its CRC32. The result aliases scratch.
+func ReadUncompressedPayload(r io.Reader, h Header, scratch *Scratch) ([]byte, error) {
+	payload := scratch.wireBuf(h.PayloadLen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, fmt.Errorf("gocql: failed to read uncompressed frame payload, err: %w", err)
+	}
+
+	// Read and verify the payload CRC32
+	var crcBuf [Crc32Size]byte
+	if _, err := io.ReadFull(r, crcBuf[:]); err != nil {
+		return nil, fmt.Errorf("gocql: failed to read payload crc32, err: %w", err)
+	}
+
+	computedPayloadCRC32 := crc.Crc32(payload)
+	readPayloadCRC32 := binary.LittleEndian.Uint32(crcBuf[:])
+	if computedPayloadCRC32 != readPayloadCRC32 {
+		return nil, fmt.Errorf("gocql: payload crc32 mismatch, computed: %d, got: %d", computedPayloadCRC32, readPayloadCRC32)
+	}
+
+	return payload, nil
+}
+
+// ReadCompressedHeader decodes a compressed segment header.
+func ReadCompressedHeader(r io.Reader) (Header, error) {
+	const headerSize = 5
+
+	var headerBuf [headerSize + Crc24Size]byte
+	if _, err := io.ReadFull(r, headerBuf[:]); err != nil {
+		return Header{}, fmt.Errorf("gocql: failed to read compressed frame header, err: %w", err)
+	}
+
+	// Reading checksum from frame header
+	readHeaderChecksum := uint32(headerBuf[5]) | uint32(headerBuf[6])<<8 | uint32(headerBuf[7])<<16
+	if computedHeaderChecksum := crc.Crc24(headerBuf[:headerSize]); computedHeaderChecksum != readHeaderChecksum {
+		return Header{}, fmt.Errorf("gocql: crc24 mismatch in frame header, read: %d, computed: %d", readHeaderChecksum, computedHeaderChecksum)
+	}
+
+	// First 17 bits - payload size after compression
+	compressedLen := uint32(headerBuf[0]) | uint32(headerBuf[1])<<8 | uint32(headerBuf[2]&0x1)<<16
+
+	// The next 17 bits - payload size before compression
+	uncompressedLen := (uint32(headerBuf[2]) >> 1) | uint32(headerBuf[3])<<7 | uint32(headerBuf[4]&0b11)<<15
+
+	// Both fields are extracted with a 17-bit mask, so each is inherently bounded
+	// by MaxPayloadSize (0x1FFFF, ~128 KiB). The payload allocations in
+	// ReadCompressedPayload/ReadUncompressedPayload are therefore bounded without
+	// an explicit check, and the int() conversions below are safe on 32-bit
+	// platforms. TestReadCompressedHeaderLengthsBoundedTo17Bits locks this invariant.
+
+	return Header{
+		PayloadLen:      int(compressedLen),
+		UncompressedLen: int(uncompressedLen),
+		IsSelfContained: (headerBuf[4] & 0b100) != 0,
+	}, nil
+}
+
+// ReadCompressedPayload reads the payload of a compressed segment, verifies its
+// CRC32 and decompresses it. The result aliases scratch.
+func ReadCompressedPayload(r io.Reader, h Header, comp Compressor, scratch *Scratch) ([]byte, error) {
+	compressedPayload := scratch.wireBuf(h.PayloadLen)
+	if _, err := io.ReadFull(r, compressedPayload); err != nil {
+		return nil, fmt.Errorf("gocql: failed to read compressed frame payload, err: %w", err)
+	}
+
+	var crcBuf [Crc32Size]byte
+	if _, err := io.ReadFull(r, crcBuf[:]); err != nil {
+		return nil, fmt.Errorf("gocql: failed to read payload crc32, err: %w", err)
+	}
+
+	// Ensuring if payload checksum matches
+	readPayloadChecksum := binary.LittleEndian.Uint32(crcBuf[:])
+	if computedPayloadChecksum := crc.Crc32(compressedPayload); readPayloadChecksum != computedPayloadChecksum {
+		return nil, fmt.Errorf("gocql: crc32 mismatch in payload, read: %d, computed: %d", readPayloadChecksum, computedPayloadChecksum)
+	}
+
+	// An uncompressed length of 0 signals that the payload is stored as-is and
+	// must not be decompressed (native_protocol_v5.spec 2.2).
+	if h.UncompressedLen == 0 {
+		return compressedPayload, nil
+	}
+
+	uncompressedPayload, err := scratch.decompress(comp, compressedPayload, h.UncompressedLen)
+	if err != nil {
+		return nil, err
+	}
+	if len(uncompressedPayload) != h.UncompressedLen {
+		return nil, fmt.Errorf("gocql: length mismatch after payload decoding, got %d, expected %d", len(uncompressedPayload), h.UncompressedLen)
+	}
+
+	return uncompressedPayload, nil
+}
+
+// Append encodes payload as one transport segment appended to dst, in the layout
+// matching comp. On error the returned slice must not be used: the compressed
+// variant can fail after having written into dst.
+func Append(dst, payload []byte, isSelfContained bool, comp Compressor) ([]byte, error) {
+	if comp != nil {
+		return AppendCompressed(dst, payload, isSelfContained, comp)
+	}
+	return AppendUncompressed(dst, payload, isSelfContained)
+}
+
+// AppendUncompressed encodes payload as one uncompressed transport segment
+// (header, CRC24, payload, payload CRC32) directly into dst and returns the
+// extended slice.
+func AppendUncompressed(dst, payload []byte, isSelfContained bool) ([]byte, error) {
+	const selfContainedBit = 1 << 17
+
+	payloadLen := len(payload)
+	if payloadLen > MaxPayloadSize {
+		return nil, fmt.Errorf("gocql: payload length (%d) exceeds maximum size of %d", payloadLen, MaxPayloadSize)
+	}
+
+	// First 3 bytes: payload length and self-contained flag, as a single
+	// little-endian integer.
+	headerInt := uint32(payloadLen)
+	if isSelfContained {
+		headerInt |= selfContainedBit
+	}
+	var header [3]byte
+	header[0] = byte(headerInt)
+	header[1] = byte(headerInt >> 8)
+	header[2] = byte(headerInt >> 16)
+
+	// The next 3 bytes are the CRC24 of the header.
+	checksum := crc.Crc24(header[:])
+	dst = append(dst, header[0], header[1], header[2],
+		byte(checksum), byte(checksum>>8), byte(checksum>>16))
+
+	dst = append(dst, payload...)
+	return binary.LittleEndian.AppendUint32(dst, crc.Crc32(payload)), nil
+}
+
+// AppendCompressed encodes payload as one compressed transport segment directly
+// into dst and returns the extended slice. The compressed payload is written into
+// dst before its length is known, so the header is reserved first and filled in
+// afterwards. See AppendUncompressed for the error contract.
+func AppendCompressed(dst, payload []byte, isSelfContained bool, comp Compressor) ([]byte, error) {
+	const (
+		headerSize       = 5
+		selfContainedBit = 1 << 34
+	)
+
+	uncompressedLen := len(payload)
+	if uncompressedLen > MaxPayloadSize {
+		return nil, fmt.Errorf("gocql: payload length (%d) exceeds maximum size of %d", uncompressedLen, MaxPayloadSize)
+	}
+
+	var reserved [headerSize + Crc24Size]byte
+	headerStart := len(dst)
+	dst = append(dst, reserved[:]...)
+	payloadStart := len(dst)
+
+	var err error
+	dst, err = comp.AppendCompressed(dst, payload)
+	if err != nil {
+		return nil, err
+	}
+	// Compressor requires appending to dst. A custom implementation that instead
+	// returns only its own output would leave the reserved header out of the
+	// returned slice; report that rather than slicing out of range below. The
+	// compressor is not named, because this interface deliberately does not require
+	// a Name method — the root package names it when rejecting the wrong type.
+	if len(dst) < payloadStart {
+		return nil, fmt.Errorf("gocql: segment compressor returned %d bytes, it must append to the %d bytes it was given", len(dst), payloadStart)
+	}
+	compressedLen := len(dst) - payloadStart
+
+	// Fall back to sending the payload uncompressed when compression did not
+	// shrink it, or (defensively) if a Compressor returns an empty result for
+	// non-empty input. The built-in LZ4Compressor never returns empty given a
+	// CompressBlockBound-sized buffer, but a segment with compressedLen==0 and a
+	// nonzero uncompressedLen is undecodable by the peer, so guard against it for
+	// arbitrary Compressor implementations.
+	//
+	// This is also why compressedLen needs no bound of its own: a compressor that
+	// expanded the payload past MaxPayloadSize lands here, and comes out with
+	// compressedLen == uncompressedLen, which was bounded on entry.
+	if compressedLen == 0 || uncompressedLen < compressedLen {
+		// native_protocol_v5.spec
+		// 2.2
+		//  An uncompressed length of 0 signals that the compressed payload
+		//  should be used as-is and not decompressed.
+		dst = append(dst[:payloadStart], payload...)
+		compressedLen = uncompressedLen
+		uncompressedLen = 0
+	}
+
+	// Combine compressed and uncompressed lengths and set the self-contained flag
+	// if needed. The value occupies 35 bits at most, so the 3 bytes PutUint64
+	// writes past the 5-byte header are zero and are then overwritten by the CRC24.
+	combined := uint64(compressedLen) | uint64(uncompressedLen)<<17
+	if isSelfContained {
+		combined |= selfContainedBit
+	}
+	header := dst[headerStart:payloadStart]
+	binary.LittleEndian.PutUint64(header, combined)
+	headerChecksum := crc.Crc24(header[:headerSize])
+	header[headerSize] = byte(headerChecksum)
+	header[headerSize+1] = byte(headerChecksum >> 8)
+	header[headerSize+2] = byte(headerChecksum >> 16)
+
+	return binary.LittleEndian.AppendUint32(dst, crc.Crc32(dst[payloadStart:])), nil
+}
+
+// EncodedSize returns how many bytes a rawLen-byte CQL frame occupies once
+// segmented, so a wire buffer can be sized before anything is encoded into it.
+// For the compressed layout this is an upper bound rather than the exact size:
+// compressed payloads are usually smaller, but a compressor may also return more
+// bytes than it was given, so room for one segment's worth of expansion is added.
+func EncodedSize(rawLen int, compressed bool) int {
+	const (
+		// 3-byte header + CRC24 + payload CRC32.
+		uncompressedSegmentOverhead = UncompressedHeaderSize + Crc32Size
+		// 5-byte header + CRC24 + payload CRC32.
+		compressedSegmentOverhead = CompressedHeaderSize + Crc32Size
+		// Room for a maximum-size payload growing under compression, matching
+		// lz4's block bound (len + len/255 + 16). A compressor that expands more
+		// than this is still handled correctly, it only makes the wire buffer grow
+		// once.
+		compressionSlack = MaxPayloadSize/255 + 16
+	)
+
+	segments := rawLen/MaxPayloadSize + 1
+	if compressed {
+		return rawLen + segments*compressedSegmentOverhead + compressionSlack
+	}
+	return rawLen + segments*uncompressedSegmentOverhead
+}

--- a/internal/segment/segment_test.go
+++ b/internal/segment/segment_test.go
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package segment
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/gocql/gocql/internal/crc"
+)
+
+// The helpers below build or read one whole segment in a single call, each with
+// buffers of its own. Neither caller of this package works a segment at a time: the
+// driver's receive loop reads a header and a payload in two phases so it can re-arm
+// its read deadline in between (sharing one Scratch across segments), the send path
+// encodes segments directly into the framer's wire buffer, and the record/replay
+// dialers buffer a byte stream until a segment is whole. So these live here rather
+// than in segment.go — they exist for the tests, and they model an allocation
+// contract the production callers deliberately do not follow.
+
+// readUncompressed reads a full uncompressed segment (header + payload) in one
+// call, into a payload buffer of its own.
+func readUncompressed(r io.Reader) ([]byte, bool, error) {
+	var scratch Scratch
+
+	h, err := ReadUncompressedHeader(r)
+	if err != nil {
+		return nil, false, err
+	}
+	payload, err := ReadUncompressedPayload(r, h, &scratch)
+	if err != nil {
+		return nil, false, err
+	}
+	return payload, h.IsSelfContained, nil
+}
+
+// newUncompressed returns payload as a standalone uncompressed segment.
+func newUncompressed(payload []byte, isSelfContained bool) ([]byte, error) {
+	return AppendUncompressed(nil, payload, isSelfContained)
+}
+
+// newCompressed returns payload as a standalone compressed segment.
+func newCompressed(payload []byte, isSelfContained bool, comp Compressor) ([]byte, error) {
+	return AppendCompressed(nil, payload, isSelfContained, comp)
+}
+
+// makeCompressedHeaderRaw builds a valid 5-byte compressed-segment header (with a
+// correct CRC24) from a raw 40-bit combined value, without any clamping. It is used
+// to feed deliberately wide inputs and observe how the reader's 17-bit extraction
+// masks them.
+func makeCompressedHeaderRaw(combined uint64) []byte {
+	const headerSize = 5
+
+	var wide [8]byte
+	binary.LittleEndian.PutUint64(wide[:], combined)
+
+	header := make([]byte, headerSize+Crc24Size)
+	copy(header[:headerSize], wide[:headerSize])
+
+	checksum := crc.Crc24(header[:headerSize])
+	header[headerSize+0] = byte(checksum)
+	header[headerSize+1] = byte(checksum >> 8)
+	header[headerSize+2] = byte(checksum >> 16)
+
+	return header
+}
+
+// makeCompressedHeader builds a valid 5-byte compressed-segment header (with a
+// correct CRC24) for the given lengths and self-contained flag, using the same bit
+// layout as AppendCompressed: compressedLen in bits 0-16, uncompressedLen in bits
+// 17-33, self-contained flag at bit 34.
+func makeCompressedHeader(compressedLen, uncompressedLen uint64, isSelfContained bool) []byte {
+	const selfContainedBit = 1 << 34
+
+	combined := compressedLen | uncompressedLen<<17
+	if isSelfContained {
+		combined |= selfContainedBit
+	}
+	return makeCompressedHeaderRaw(combined)
+}
+
+// incompressibleCompressor mimics compressors (e.g. pierrec/lz4's CompressBlock)
+// that report incompressible input by returning an empty result with a nil error.
+type incompressibleCompressor struct{}
+
+func (incompressibleCompressor) AppendCompressed(dst, _ []byte) ([]byte, error) {
+	return dst, nil
+}
+
+func (incompressibleCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// passthroughCompressor is a no-op "compressor" that still honours the contract of
+// appending to dst and returning the extended slice. Returning src alone would let
+// it pass while a caller that encodes segments directly into dst breaks.
+type passthroughCompressor struct{}
+
+func (passthroughCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+func (passthroughCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// shortAppendCompressor violates the append contract by discarding what it was
+// given, which would leave the reserved header outside the returned slice.
+type shortAppendCompressor struct{}
+
+func (shortAppendCompressor) AppendCompressed(_, src []byte) ([]byte, error) {
+	return src, nil
+}
+
+func (shortAppendCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return append(dst, src...), nil
+}
+
+// TestAppendCompressedIncompressiblePayloadFallsBackToRaw locks the case where the
+// compressor reports the payload as incompressible (empty result). The segment must
+// be emitted as raw (UncompressedLen==0, PayloadLen equal to the source length)
+// rather than with compressedLen==0 and a nonzero uncompressedLen, which the peer
+// cannot decode.
+func TestAppendCompressedIncompressiblePayloadFallsBackToRaw(t *testing.T) {
+	payload := []byte("this payload is reported as incompressible")
+
+	seg, err := newCompressed(payload, true, incompressibleCompressor{})
+	if err != nil {
+		t.Fatalf("newCompressed: %v", err)
+	}
+
+	h, err := ReadCompressedHeader(bytes.NewReader(seg))
+	if err != nil {
+		t.Fatalf("ReadCompressedHeader: %v", err)
+	}
+	// UncompressedLen==0 signals "use the payload as-is, do not decompress".
+	if h.UncompressedLen != 0 {
+		t.Fatalf("UncompressedLen = %d, want 0 (raw fallback)", h.UncompressedLen)
+	}
+	if h.PayloadLen != len(payload) {
+		t.Fatalf("PayloadLen = %d, want %d", h.PayloadLen, len(payload))
+	}
+	if !h.IsSelfContained {
+		t.Fatalf("IsSelfContained = false, want true")
+	}
+}
+
+// TestAppendCompressedRejectsShortAppend pins that a Compressor which discards the
+// bytes it was handed is reported rather than slicing out of range.
+func TestAppendCompressedRejectsShortAppend(t *testing.T) {
+	if _, err := newCompressed([]byte("payload"), true, shortAppendCompressor{}); err == nil {
+		t.Fatal("a compressor that dropped the reserved header was accepted")
+	}
+}
+
+// TestReadPayloadReusesScratch pins that reading consecutive segments with one
+// scratch does not allocate. A connection's receive loop is serialized on its
+// serve() goroutine, so the payload buffers are reused; allocating them per segment
+// costs one (uncompressed) or two (compressed) buffers of up to MaxPayloadSize for
+// every segment received.
+func TestReadPayloadReusesScratch(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x5A}, 8192)
+
+	for _, tc := range []struct {
+		name string
+		comp Compressor
+	}{
+		{"uncompressed", nil},
+		{"compressed", passthroughCompressor{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				seg []byte
+				err error
+			)
+			if tc.comp != nil {
+				seg, err = newCompressed(payload, true, tc.comp)
+			} else {
+				seg, err = newUncompressed(payload, true)
+			}
+			if err != nil {
+				t.Fatalf("build segment: %v", err)
+			}
+
+			var scratch Scratch
+			r := bytes.NewReader(seg)
+			read := func() {
+				r.Reset(seg)
+				h, err := ReadHeader(r, tc.comp != nil)
+				if err != nil {
+					t.Fatalf("ReadHeader: %v", err)
+				}
+				got, err := ReadPayload(r, h, tc.comp, &scratch)
+				if err != nil {
+					t.Fatalf("ReadPayload: %v", err)
+				}
+				if len(got) != len(payload) {
+					t.Fatalf("payload length %d, want %d", len(got), len(payload))
+				}
+			}
+
+			// The first read legitimately allocates the scratch buffers.
+			read()
+
+			// Watch the backing arrays themselves rather than a byte budget.
+			// runtime.MemStats.TotalAlloc counts every allocation in the process
+			// during the window -- the testing package's own, the runtime's
+			// bookkeeping, and whatever a -race or -cover build adds on top -- so any
+			// threshold it is compared against is a guess that drifts with the
+			// toolchain and the build flags. Buffer identity is the invariant this
+			// test is named for, and it is exact.
+			wire := &scratch.wire[0]
+			var decompressed *byte
+			if len(scratch.decompressed) > 0 {
+				decompressed = &scratch.decompressed[0]
+			}
+
+			const reads = 8
+			for i := 0; i < reads; i++ {
+				read()
+				if got := &scratch.wire[0]; got != wire {
+					t.Fatalf("read %d reallocated the wire buffer", i+1)
+				}
+				if decompressed == nil {
+					continue
+				}
+				if got := &scratch.decompressed[0]; got != decompressed {
+					t.Fatalf("read %d reallocated the decompressed buffer", i+1)
+				}
+			}
+		})
+	}
+}
+
+func TestReadCompressedHeaderLengthsBoundedTo17Bits(t *testing.T) {
+	// Set every bit in the length/self-contained region. The reader extracts
+	// compressedLen and uncompressedLen with a 17-bit mask each, so both must come
+	// back clamped to MaxPayloadSize regardless of the wider input. This
+	// regression-locks the inherent bound that keeps segment payload allocations
+	// safe without an explicit runtime check.
+	allBits := uint64(1)<<35 - 1 // bits 0..34 set (both 17-bit fields + self-contained bit)
+	header := makeCompressedHeaderRaw(allBits)
+
+	h, err := ReadCompressedHeader(bytes.NewReader(header))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.PayloadLen != MaxPayloadSize {
+		t.Fatalf("PayloadLen = %d, want %d", h.PayloadLen, MaxPayloadSize)
+	}
+	if h.UncompressedLen != MaxPayloadSize {
+		t.Fatalf("UncompressedLen = %d, want %d", h.UncompressedLen, MaxPayloadSize)
+	}
+	if !h.IsSelfContained {
+		t.Fatalf("IsSelfContained = false, want true")
+	}
+}
+
+func TestReadCompressedHeaderAcceptsMaxLengths(t *testing.T) {
+	// The maximum in-range value for both 17-bit fields must be accepted.
+	header := makeCompressedHeader(MaxPayloadSize, MaxPayloadSize, false)
+
+	h, err := ReadCompressedHeader(bytes.NewReader(header))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.PayloadLen != MaxPayloadSize {
+		t.Fatalf("PayloadLen = %d, want %d", h.PayloadLen, MaxPayloadSize)
+	}
+	if h.UncompressedLen != MaxPayloadSize {
+		t.Fatalf("UncompressedLen = %d, want %d", h.UncompressedLen, MaxPayloadSize)
+	}
+	if h.IsSelfContained {
+		t.Fatalf("IsSelfContained = true, want false")
+	}
+}
+
+// TestHeaderSizeMatchesWhatReadHeaderConsumes pins the two constants the buffering
+// callers size their reads with against what the decoders actually read. A caller
+// that has to collect a whole header before decoding it — the record/replay dialers
+// — corrupts the stream if these disagree by even a byte.
+func TestHeaderSizeMatchesWhatReadHeaderConsumes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		compressed bool
+		segment    func() ([]byte, error)
+	}{
+		{
+			name:       "uncompressed",
+			compressed: false,
+			segment:    func() ([]byte, error) { return newUncompressed([]byte("payload"), true) },
+		},
+		{
+			name:       "compressed",
+			compressed: true,
+			segment:    func() ([]byte, error) { return newCompressed([]byte("payload"), true, passthroughCompressor{}) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			seg, err := tc.segment()
+			if err != nil {
+				t.Fatalf("build segment: %v", err)
+			}
+
+			r := bytes.NewReader(seg)
+			if _, err := ReadHeader(r, tc.compressed); err != nil {
+				t.Fatalf("ReadHeader: %v", err)
+			}
+
+			consumed := len(seg) - r.Len()
+			if want := HeaderSize(tc.compressed); consumed != want {
+				t.Errorf("ReadHeader consumed %d bytes, HeaderSize reports %d", consumed, want)
+			}
+		})
+	}
+}
+
+// TestEncodedSizeIsAnUpperBound pins that the size EncodedSize reports is enough for
+// what Append actually writes, across the split boundary. Under-reporting it makes
+// the framer's wire buffer grow mid-encode, which is the allocation the two-buffer
+// design exists to avoid.
+func TestEncodedSizeIsAnUpperBound(t *testing.T) {
+	for _, rawLen := range []int{0, 1, 1024, MaxPayloadSize - 1, MaxPayloadSize, MaxPayloadSize + 1, 2*MaxPayloadSize + 7} {
+		for _, comp := range []Compressor{nil, passthroughCompressor{}} {
+			payload := bytes.Repeat([]byte{0x42}, rawLen)
+
+			// Mirror how the framer segments a frame: fixed-size continuation
+			// chunks, then a remainder that is self-contained only if nothing split.
+			var (
+				wire          []byte
+				err           error
+				src           = payload
+				selfContained = true
+			)
+			for len(src) > MaxPayloadSize {
+				if wire, err = Append(wire, src[:MaxPayloadSize], false, comp); err != nil {
+					t.Fatalf("rawLen=%d: %v", rawLen, err)
+				}
+				src = src[MaxPayloadSize:]
+				selfContained = false
+			}
+			if wire, err = Append(wire, src, selfContained, comp); err != nil {
+				t.Fatalf("rawLen=%d: %v", rawLen, err)
+			}
+
+			if bound := EncodedSize(rawLen, comp != nil); len(wire) > bound {
+				t.Errorf("rawLen=%d compressed=%v: encoded to %d bytes, EncodedSize reported %d",
+					rawLen, comp != nil, len(wire), bound)
+			}
+		}
+	}
+}
+
+// TestAppendRoundTrip pins that what Append writes is what the readers read back,
+// for both layouts and both values of the self-contained flag.
+func TestAppendRoundTrip(t *testing.T) {
+	payload := []byte("a payload that survives a round trip")
+
+	for _, selfContained := range []bool{true, false} {
+		seg, err := newUncompressed(payload, selfContained)
+		if err != nil {
+			t.Fatalf("newUncompressed: %v", err)
+		}
+		got, gotSelfContained, err := readUncompressed(bytes.NewReader(seg))
+		if err != nil {
+			t.Fatalf("readUncompressed: %v", err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Errorf("uncompressed round trip: got %q, want %q", got, payload)
+		}
+		if gotSelfContained != selfContained {
+			t.Errorf("uncompressed round trip: self-contained %v, want %v", gotSelfContained, selfContained)
+		}
+
+		comp := passthroughCompressor{}
+		seg, err = newCompressed(payload, selfContained, comp)
+		if err != nil {
+			t.Fatalf("newCompressed: %v", err)
+		}
+		var scratch Scratch
+		r := bytes.NewReader(seg)
+		h, err := ReadCompressedHeader(r)
+		if err != nil {
+			t.Fatalf("ReadCompressedHeader: %v", err)
+		}
+		got, err = ReadCompressedPayload(r, h, comp, &scratch)
+		if err != nil {
+			t.Fatalf("ReadCompressedPayload: %v", err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Errorf("compressed round trip: got %q, want %q", got, payload)
+		}
+		if h.IsSelfContained != selfContained {
+			t.Errorf("compressed round trip: self-contained %v, want %v", h.IsSelfContained, selfContained)
+		}
+	}
+}
+
+// TestAppendRejectsOversizedPayload pins the one bound Append needs, since a payload
+// longer than the 17-bit length field would otherwise be silently truncated.
+func TestAppendRejectsOversizedPayload(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x01}, MaxPayloadSize+1)
+
+	if _, err := newUncompressed(payload, true); err == nil {
+		t.Error("AppendUncompressed accepted an oversized payload")
+	}
+	if _, err := newCompressed(payload, true, passthroughCompressor{}); err == nil {
+		t.Error("AppendCompressed accepted an oversized payload")
+	}
+}
+
+// TestReadRejectsCorruptChecksums pins that both CRCs are actually verified.
+func TestReadRejectsCorruptChecksums(t *testing.T) {
+	payload := []byte("a payload whose checksums matter")
+
+	t.Run("header crc24", func(t *testing.T) {
+		seg, err := newUncompressed(payload, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		seg[0] ^= 0xFF // corrupt the length field, leaving its CRC24 stale
+		if _, _, err := readUncompressed(bytes.NewReader(seg)); err == nil {
+			t.Error("a corrupt header CRC24 was accepted")
+		}
+	})
+
+	t.Run("payload crc32", func(t *testing.T) {
+		seg, err := newUncompressed(payload, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		seg[UncompressedHeaderSize] ^= 0xFF // corrupt a payload byte
+		if _, _, err := readUncompressed(bytes.NewReader(seg)); err == nil {
+			t.Error("a corrupt payload CRC32 was accepted")
+		}
+	})
+}

--- a/segment.go
+++ b/segment.go
@@ -16,192 +16,36 @@
  * limitations under the License.
  */
 
-// Native protocol v5 ("modern framing") transport segments. A segment is a
-// self-describing, CRC-protected envelope that carries one or more complete CQL
-// frames (self-contained) or a slice of a single large CQL frame split across
-// several segments (non-self-contained). See the CQL native protocol v5 spec,
-// section 2 ("Framing"), for the wire layout.
+// Native protocol v5 ("modern framing") transport segments. The wire codec lives
+// in internal/segment, which the record/replay dialers share; what remains here is
+// the one thing that cannot move, because it needs this package's Compressor
+// interface.
 
 package gocql
 
 import (
-	"encoding/binary"
 	"fmt"
-	"io"
 
-	"github.com/gocql/gocql/internal/crc"
+	"github.com/gocql/gocql/internal/segment"
 )
 
-const (
-	crc24Size = 3
-	crc32Size = 4
-)
-
-// segmentHeader is the decoded fixed-size header of a v5 transport segment.
+// asSegmentCompressor asserts that compressor supports native protocol v5 segment
+// (de)compression, narrowing it to the interface the segment codec takes.
 //
-// The header and the payload are read in two phases (readSegmentHeader then
-// readSegmentPayload) so the caller can re-arm the read deadline between the
-// possibly-idle wait for the header and the bounded read of the payload.
-type segmentHeader struct {
-	// payloadLen is the number of payload bytes on the wire that follow the
-	// header (the post-compression size for compressed segments).
-	payloadLen int
-	// uncompressedLen is the size of the payload after decompression. It is 0
-	// for uncompressed segments, and also 0 for compressed segments whose
-	// payload is stored as-is because compression was not worth it.
-	uncompressedLen int
-	isSelfContained bool
-}
-
-// segmentScratch holds the buffers a segment payload is read into. Every inbound
-// segment would otherwise allocate its wire payload, plus a second buffer for the
-// decompressed bytes of a compressed segment — one or two allocations of up to
-// maxSegmentPayloadSize (~128 KiB) each, per segment. A connection's receive path
-// runs entirely on its serve() goroutine, so it can reuse one instance for every
-// segment it reads.
+// The ClusterConfig validation already rejects a non-segment compressor on v5, so
+// this is a defensive check whose error should never surface in practice. It stays
+// in this package because it is the only part of the segment path that needs
+// Compressor.Name, and naming the offending compressor is the whole value of the
+// message; internal/segment deliberately requires only the two Append methods, so
+// that the lz4 compressor — a separate module, which cannot import internal
+// packages — keeps satisfying it structurally.
 //
-// The consequence is that a payload returned by readSegmentPayload aliases these
-// buffers and is only valid until the next segment is read with the same scratch.
-// Every caller either copies the payload (reassembly) or fully consumes it (frame
-// parsing copies the body into a pooled framer) before reading the next segment.
-type segmentScratch struct {
-	// wire holds the payload bytes as they arrive on the wire, which for a
-	// compressed segment means the still-compressed bytes.
-	wire []byte
-	// decompressed holds the payload of a compressed segment after decompression.
-	decompressed []byte
-}
-
-// wireBuf returns the wire buffer resized to exactly n bytes, ready to be read
-// into, reallocating only when what it already holds is too small. n comes from a
-// segment header, where both layouts carry the payload length in 17 bits, so it is
-// inherently bounded by maxSegmentPayloadSize.
-func (s *segmentScratch) wireBuf(n int) []byte {
-	if cap(s.wire) < n {
-		s.wire = make([]byte, n)
+// A nil compressor is not a failure: it is the uncompressed layout, and yields a nil
+// segment.Compressor, which is exactly how internal/segment spells that.
+func asSegmentCompressor(compressor Compressor) (segment.Compressor, error) {
+	if compressor == nil {
+		return nil, nil
 	}
-	s.wire = s.wire[:n]
-	return s.wire
-}
-
-// decompress decompresses src into the reusable decompressed buffer.
-func (s *segmentScratch) decompress(segComp SegmentCompressor, src []byte, decompressedLen int) ([]byte, error) {
-	if cap(s.decompressed) < decompressedLen {
-		s.decompressed = make([]byte, 0, decompressedLen)
-	}
-	out, err := segComp.AppendDecompressed(s.decompressed[:0], src, uint32(decompressedLen))
-	if err != nil {
-		return nil, err
-	}
-	// Keep whatever buffer the compressor ended up using, so that a compressor
-	// which had to grow it does not have to grow it again for the next segment.
-	s.decompressed = out
-	return out, nil
-}
-
-// readSegmentHeader reads and validates the fixed-size header of the next
-// segment, consuming only the header bytes. When compressor is non-nil the
-// compressed-segment layout is used, otherwise the uncompressed layout.
-func readSegmentHeader(r io.Reader, compressor Compressor) (segmentHeader, error) {
-	if compressor != nil {
-		return readCompressedSegmentHeader(r)
-	}
-	return readUncompressedSegmentHeader(r)
-}
-
-// readSegmentPayload reads and verifies the payload and trailing CRC32 that
-// follow a header previously read by readSegmentHeader, returning the
-// reconstructed (decompressed, if applicable) payload bytes. The result aliases
-// scratch; see segmentScratch.
-func readSegmentPayload(r io.Reader, h segmentHeader, compressor Compressor, scratch *segmentScratch) ([]byte, error) {
-	if compressor != nil {
-		return readCompressedSegmentPayload(r, h, compressor, scratch)
-	}
-	return readUncompressedSegmentPayload(r, h, scratch)
-}
-
-func readUncompressedSegmentHeader(r io.Reader) (segmentHeader, error) {
-	const headerSize = 3
-
-	var header [headerSize + crc24Size]byte
-	if _, err := io.ReadFull(r, header[:]); err != nil {
-		return segmentHeader{}, fmt.Errorf("gocql: failed to read uncompressed frame, err: %w", err)
-	}
-
-	// Compute and verify the header CRC24
-	computedHeaderCRC24 := crc.Crc24(header[:headerSize])
-	readHeaderCRC24 := uint32(header[3]) | uint32(header[4])<<8 | uint32(header[5])<<16
-	if computedHeaderCRC24 != readHeaderCRC24 {
-		return segmentHeader{}, fmt.Errorf("gocql: crc24 mismatch in frame header, computed: %d, got: %d", computedHeaderCRC24, readHeaderCRC24)
-	}
-
-	headerInt := uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16
-	return segmentHeader{
-		payloadLen:      int(headerInt & segmentPayloadLenMask),
-		isSelfContained: (headerInt & (1 << 17)) != 0,
-	}, nil
-}
-
-func readUncompressedSegmentPayload(r io.Reader, h segmentHeader, scratch *segmentScratch) ([]byte, error) {
-	payload := scratch.wireBuf(h.payloadLen)
-	if _, err := io.ReadFull(r, payload); err != nil {
-		return nil, fmt.Errorf("gocql: failed to read uncompressed frame payload, err: %w", err)
-	}
-
-	// Read and verify the payload CRC32
-	var crcBuf [crc32Size]byte
-	if _, err := io.ReadFull(r, crcBuf[:]); err != nil {
-		return nil, fmt.Errorf("gocql: failed to read payload crc32, err: %w", err)
-	}
-
-	computedPayloadCRC32 := crc.Crc32(payload)
-	readPayloadCRC32 := binary.LittleEndian.Uint32(crcBuf[:])
-	if computedPayloadCRC32 != readPayloadCRC32 {
-		return nil, fmt.Errorf("gocql: payload crc32 mismatch, computed: %d, got: %d", computedPayloadCRC32, readPayloadCRC32)
-	}
-
-	return payload, nil
-}
-
-func readCompressedSegmentHeader(r io.Reader) (segmentHeader, error) {
-	const headerSize = 5
-
-	var headerBuf [headerSize + crc24Size]byte
-	if _, err := io.ReadFull(r, headerBuf[:]); err != nil {
-		return segmentHeader{}, fmt.Errorf("gocql: failed to read compressed frame header, err: %w", err)
-	}
-
-	// Reading checksum from frame header
-	readHeaderChecksum := uint32(headerBuf[5]) | uint32(headerBuf[6])<<8 | uint32(headerBuf[7])<<16
-	if computedHeaderChecksum := crc.Crc24(headerBuf[:headerSize]); computedHeaderChecksum != readHeaderChecksum {
-		return segmentHeader{}, fmt.Errorf("gocql: crc24 mismatch in frame header, read: %d, computed: %d", readHeaderChecksum, computedHeaderChecksum)
-	}
-
-	// First 17 bits - payload size after compression
-	compressedLen := uint32(headerBuf[0]) | uint32(headerBuf[1])<<8 | uint32(headerBuf[2]&0x1)<<16
-
-	// The next 17 bits - payload size before compression
-	uncompressedLen := (uint32(headerBuf[2]) >> 1) | uint32(headerBuf[3])<<7 | uint32(headerBuf[4]&0b11)<<15
-
-	// Both fields are extracted with a 17-bit mask, so each is inherently bounded
-	// by maxSegmentPayloadSize (0x1FFFF, ~128 KiB). The payload allocations in
-	// readCompressedSegmentPayload/readUncompressedSegmentPayload are therefore
-	// bounded without an explicit check, and the int() conversions below are safe
-	// on 32-bit platforms. TestReadCompressedSegmentHeader_LengthsBoundedTo17Bits
-	// locks this invariant.
-
-	return segmentHeader{
-		payloadLen:      int(compressedLen),
-		uncompressedLen: int(uncompressedLen),
-		isSelfContained: (headerBuf[4] & 0b100) != 0,
-	}, nil
-}
-
-// asSegmentCompressor asserts that compressor supports native protocol v5
-// segment (de)compression. The ClusterConfig validation already rejects a
-// non-segment compressor on v5, so this is a defensive check whose error should
-// never surface in practice.
-func asSegmentCompressor(compressor Compressor) (SegmentCompressor, error) {
 	segComp, ok := compressor.(SegmentCompressor)
 	if !ok {
 		return nil, fmt.Errorf("gocql: compressor %q does not support protocol v5 segment compression", compressor.Name())
@@ -209,143 +53,39 @@ func asSegmentCompressor(compressor Compressor) (SegmentCompressor, error) {
 	return segComp, nil
 }
 
-func readCompressedSegmentPayload(r io.Reader, h segmentHeader, compressor Compressor, scratch *segmentScratch) ([]byte, error) {
-	compressedPayload := scratch.wireBuf(h.payloadLen)
-	if _, err := io.ReadFull(r, compressedPayload); err != nil {
-		return nil, fmt.Errorf("gocql: failed to read compressed frame payload, err: %w", err)
+// resolveSegmentCompressor narrows the negotiated compressor once, into
+// c.segCompressor, so the receive path does not repeat the assertion for every
+// segment it reads.
+//
+// It must run after the COMPRESSION negotiation in startupCoordinator.startup — the
+// last write to c.compressor, which clears it if the server refused the requested
+// algorithm — and before the first segment is exchanged. Those two points are closer
+// together than they look: an AUTHENTICATE response sets startupCompleted, so the
+// AUTH_RESPONSE exchange that follows is already written and read as v5 segments, well
+// before Conn.initFramerCache runs at the end of startupCoordinator.options. Resolving
+// alongside the other snapshots taken there would leave an authenticated, compressed
+// connection decoding its auth exchange with the uncompressed layout.
+//
+// Only v5+ resolves. Below it the segment codec is never reached, and a compressor
+// without segment support — SnappyCompressor — is a valid configuration that must not
+// be refused here.
+//
+// The error cannot fire on a connection that got this far: ClusterConfig.Validate
+// rejects a compressor without segment support on v5 before anything is dialed. It is
+// reported rather than ignored because the alternative is a connection that silently
+// reads the wrong segment layout, and failing the handshake is where a misconfigured
+// connection should die — not mid-stream, on a path whose callers can only turn it
+// into a per-request error.
+func (c *Conn) resolveSegmentCompressor() error {
+	if c.version <= protoVersion4 {
+		return nil
 	}
 
-	var crcBuf [crc32Size]byte
-	if _, err := io.ReadFull(r, crcBuf[:]); err != nil {
-		return nil, fmt.Errorf("gocql: failed to read payload crc32, err: %w", err)
-	}
-
-	// Ensuring if payload checksum matches
-	readPayloadChecksum := binary.LittleEndian.Uint32(crcBuf[:])
-	if computedPayloadChecksum := crc.Crc32(compressedPayload); readPayloadChecksum != computedPayloadChecksum {
-		return nil, fmt.Errorf("gocql: crc32 mismatch in payload, read: %d, computed: %d", readPayloadChecksum, computedPayloadChecksum)
-	}
-
-	// An uncompressed length of 0 signals that the payload is stored as-is and
-	// must not be decompressed (native_protocol_v5.spec 2.2).
-	if h.uncompressedLen == 0 {
-		return compressedPayload, nil
-	}
-
-	segComp, err := asSegmentCompressor(compressor)
+	segComp, err := asSegmentCompressor(c.compressor)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	uncompressedPayload, err := scratch.decompress(segComp, compressedPayload, h.uncompressedLen)
-	if err != nil {
-		return nil, err
-	}
-	if len(uncompressedPayload) != h.uncompressedLen {
-		return nil, fmt.Errorf("gocql: length mismatch after payload decoding, got %d, expected %d", len(uncompressedPayload), h.uncompressedLen)
-	}
+	c.segCompressor = segComp
 
-	return uncompressedPayload, nil
-}
-
-// appendUncompressedSegment encodes payload as one uncompressed transport segment
-// (header, CRC24, payload, payload CRC32) directly into dst and returns the
-// extended slice. On error the returned slice must not be used: the compressed
-// variant can fail after having written into dst.
-func appendUncompressedSegment(dst, payload []byte, isSelfContained bool) ([]byte, error) {
-	const selfContainedBit = 1 << 17
-
-	payloadLen := len(payload)
-	if payloadLen > maxSegmentPayloadSize {
-		return nil, fmt.Errorf("gocql: payload length (%d) exceeds maximum size of %d", payloadLen, maxSegmentPayloadSize)
-	}
-
-	// First 3 bytes: payload length and self-contained flag, as a single
-	// little-endian integer.
-	headerInt := uint32(payloadLen)
-	if isSelfContained {
-		headerInt |= selfContainedBit
-	}
-	var header [3]byte
-	header[0] = byte(headerInt)
-	header[1] = byte(headerInt >> 8)
-	header[2] = byte(headerInt >> 16)
-
-	// The next 3 bytes are the CRC24 of the header.
-	checksum := crc.Crc24(header[:])
-	dst = append(dst, header[0], header[1], header[2],
-		byte(checksum), byte(checksum>>8), byte(checksum>>16))
-
-	dst = append(dst, payload...)
-	return binary.LittleEndian.AppendUint32(dst, crc.Crc32(payload)), nil
-}
-
-// appendCompressedSegment encodes payload as one compressed transport segment
-// directly into dst and returns the extended slice. The compressed payload is
-// written into dst before its length is known, so the header is reserved first
-// and filled in afterwards. See appendUncompressedSegment for the error contract.
-func appendCompressedSegment(dst, payload []byte, isSelfContained bool, compressor Compressor) ([]byte, error) {
-	const (
-		headerSize       = 5
-		selfContainedBit = 1 << 34
-	)
-
-	uncompressedLen := len(payload)
-	if uncompressedLen > maxSegmentPayloadSize {
-		return nil, fmt.Errorf("gocql: payload length (%d) exceeds maximum size of %d", uncompressedLen, maxSegmentPayloadSize)
-	}
-
-	segComp, err := asSegmentCompressor(compressor)
-	if err != nil {
-		return nil, err
-	}
-
-	var reserved [headerSize + crc24Size]byte
-	headerStart := len(dst)
-	dst = append(dst, reserved[:]...)
-	payloadStart := len(dst)
-
-	dst, err = segComp.AppendCompressed(dst, payload)
-	if err != nil {
-		return nil, err
-	}
-	// SegmentCompressor requires appending to dst. A custom implementation that
-	// instead returns only its own output would leave the reserved header out of
-	// the returned slice; report that rather than slicing out of range below.
-	if len(dst) < payloadStart {
-		return nil, fmt.Errorf("gocql: compressor %q returned %d bytes, it must append to the %d bytes it was given",
-			compressor.Name(), len(dst), payloadStart)
-	}
-	compressedLen := len(dst) - payloadStart
-
-	// Fall back to sending the payload uncompressed when compression did not
-	// shrink it, or (defensively) if a SegmentCompressor returns an empty result
-	// for non-empty input. The built-in LZ4Compressor never returns empty given a
-	// CompressBlockBound-sized buffer, but a segment with compressedLen==0 and a
-	// nonzero uncompressedLen is undecodable by the peer, so guard against it for
-	// arbitrary SegmentCompressor implementations.
-	if compressedLen == 0 || uncompressedLen < compressedLen {
-		// native_protocol_v5.spec
-		// 2.2
-		//  An uncompressed length of 0 signals that the compressed payload
-		//  should be used as-is and not decompressed.
-		dst = append(dst[:payloadStart], payload...)
-		compressedLen = uncompressedLen
-		uncompressedLen = 0
-	}
-
-	// Combine compressed and uncompressed lengths and set the self-contained flag
-	// if needed. The value occupies 35 bits at most, so the 3 bytes PutUint64
-	// writes past the 5-byte header are zero and are then overwritten by the CRC24.
-	combined := uint64(compressedLen) | uint64(uncompressedLen)<<17
-	if isSelfContained {
-		combined |= selfContainedBit
-	}
-	header := dst[headerStart:payloadStart]
-	binary.LittleEndian.PutUint64(header, combined)
-	headerChecksum := crc.Crc24(header[:headerSize])
-	header[headerSize] = byte(headerChecksum)
-	header[headerSize+1] = byte(headerChecksum >> 8)
-	header[headerSize+2] = byte(headerChecksum >> 16)
-
-	return binary.LittleEndian.AppendUint32(dst, crc.Crc32(dst[payloadStart:])), nil
+	return nil
 }

--- a/segment_reassembly_test.go
+++ b/segment_reassembly_test.go
@@ -181,16 +181,16 @@ func TestRecvSplitFrameAllocatesExactlyOneFrameBuffer(t *testing.T) {
 }
 
 // TestRecvSplitFrameRejectsOversizedLength drives recvSplitFrame with a CQL
-// frame header declaring a body length beyond maxFrameSize. The declared
+// frame header declaring a body length beyond frm.MaxFrameSize. The declared
 // length is rejected before any large allocation and before processFrame.
 func TestRecvSplitFrameRejectsOversizedLength(t *testing.T) {
 	// Build a 9-byte CQL frame header (v5 response) whose length field is
-	// maxFrameSize+1, then wrap it in a single non-self-contained segment.
+	// frm.MaxFrameSize+1, then wrap it in a single non-self-contained segment.
 	header := make([]byte, 9)
 	header[0] = protoVersion5 | protoDirectionMask // version (response)
 	header[1] = 0                                  // flags
 	// header[2:4] stream, header[4] opcode left zero
-	oversized := uint32(maxFrameSize + 1)
+	oversized := uint32(frm.MaxFrameSize + 1)
 	header[5] = byte(oversized >> 24)
 	header[6] = byte(oversized >> 16)
 	header[7] = byte(oversized >> 8)
@@ -245,7 +245,7 @@ func v5ReadyFrame(bodyLen int, body []byte) []byte {
 // discovers the short read, and the io.ErrUnexpectedEOF that follows is not a
 // net.Error, so processFrameSource would keep it per-request and leave the
 // connection up for the peer to do it again. A ~20-byte segment would buy a
-// maxFrameSize allocation, repeatable.
+// frm.MaxFrameSize allocation, repeatable.
 func TestProcessAllFramesInSegmentBoundsFrameLength(t *testing.T) {
 	newConn := func(stream []byte) *Conn {
 		c := &Conn{
@@ -257,7 +257,7 @@ func TestProcessAllFramesInSegmentBoundsFrameLength(t *testing.T) {
 		return c
 	}
 
-	// Well below maxFrameSize, but far enough above the segment that the budget
+	// Well below frm.MaxFrameSize, but far enough above the segment that the budget
 	// below cannot be met by accident if the bound is removed.
 	const declared = 32 << 20
 

--- a/segment_reassembly_test.go
+++ b/segment_reassembly_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	frm "github.com/gocql/gocql/internal/frame"
+	"github.com/gocql/gocql/internal/segment"
 	"github.com/gocql/gocql/internal/streams"
 )
 
@@ -130,7 +131,7 @@ func TestRecvSplitFrameRejectsOverlongStream(t *testing.T) {
 // invisible in the output but double or triple the memory a single large response
 // occupies.
 func TestRecvSplitFrameAllocatesExactlyOneFrameBuffer(t *testing.T) {
-	const bodyLen = 3 * maxSegmentPayloadSize
+	const bodyLen = 3 * segment.MaxPayloadSize
 
 	// Enough streams to also let the framer pool warm up.
 	const runs = 4
@@ -147,7 +148,7 @@ func TestRecvSplitFrameAllocatesExactlyOneFrameBuffer(t *testing.T) {
 
 	var stream []byte
 	for src := frame; len(src) > 0; {
-		n := min(len(src), maxSegmentPayloadSize)
+		n := min(len(src), segment.MaxPayloadSize)
 		stream = append(stream, mustUncompressedSegment(t, src[:n], false)...)
 		src = src[n:]
 	}
@@ -394,4 +395,76 @@ func TestRecvSegmentObservesHeaderOverTheNetworkRead(t *testing.T) {
 				"End was not extended to when the header finished arriving", got, stall)
 		}
 	})
+}
+
+// invertingCompressor is a segment compressor that actually changes the bytes it is
+// given, unlike testSegmentCompressor's passthrough.
+//
+// That difference is the whole point of using it below: with a passthrough, a payload
+// read through the uncompressed path comes back byte-identical to one read through the
+// compressed path, so the test cannot tell which layout was used. Inverting makes the
+// two paths distinguishable, which is what lets the assertion catch a connection whose
+// header and payload readers disagree about the layout.
+type invertingCompressor struct{}
+
+func (invertingCompressor) Name() string { return "inverting" }
+
+func invertBytes(dst, src []byte) []byte {
+	for _, b := range src {
+		dst = append(dst, b^0xFF)
+	}
+	return dst
+}
+
+func (invertingCompressor) Encode(data []byte) ([]byte, error) { return invertBytes(nil, data), nil }
+func (invertingCompressor) Decode(data []byte) ([]byte, error) { return invertBytes(nil, data), nil }
+
+func (invertingCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
+	return invertBytes(dst, src), nil
+}
+
+func (invertingCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+	return invertBytes(dst, src), nil
+}
+
+// TestRecvSegmentReadsACompressedSegment drives the connection's receive path with a
+// compressor attached, which nothing else here does.
+//
+// The header reader and the payload reader take their layout from the same field, and
+// this is what holds them together: a compressed header is eight bytes where an
+// uncompressed one is six, so a connection that resolved its compressor late -- or
+// read the layout from a second source -- reads the header at the wrong width and fails
+// its CRC24 rather than mis-framing the rest of the stream quietly.
+func TestRecvSegmentReadsACompressedSegment(t *testing.T) {
+	const payload = "a compressed self-contained segment"
+
+	seg, err := newCompressedSegment([]byte(payload), true, invertingCompressor{})
+	if err != nil {
+		t.Fatalf("newCompressedSegment: %v", err)
+	}
+
+	c := &Conn{
+		r:          newSegmentReader(seg),
+		version:    protoVersion5,
+		compressor: invertingCompressor{},
+	}
+	if err := c.resolveSegmentCompressor(); err != nil {
+		t.Fatalf("resolveSegmentCompressor: %v", err)
+	}
+
+	hdr, err := c.readFirstSegmentHeader()
+	if err != nil {
+		t.Fatalf("readFirstSegmentHeader: %v", err)
+	}
+	if !hdr.IsSelfContained {
+		t.Error("a self-contained segment was read as a continuation")
+	}
+
+	got, err := c.readSegmentPayload(hdr)
+	if err != nil {
+		t.Fatalf("readSegmentPayload: %v", err)
+	}
+	if string(got) != payload {
+		t.Errorf("payload = %q, want %q", got, payload)
+	}
 }

--- a/segment_test.go
+++ b/segment_test.go
@@ -1,6 +1,3 @@
-//go:build unit
-// +build unit
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -22,261 +19,183 @@
 package gocql
 
 import (
-	"bytes"
-	"encoding/binary"
 	"io"
-	"runtime"
+	"strings"
 	"testing"
 
-	"github.com/gocql/gocql/internal/crc"
+	"github.com/gocql/gocql/internal/segment"
 )
 
-// The four helpers below build or read one whole segment in a single call, each
-// with buffers of its own. The driver itself never works a segment at a time: the
-// receive loop reads a header and a payload in two phases so it can re-arm the
-// read deadline in between (and shares one segmentScratch across segments), and
-// the send path encodes segments directly into the framer's wire buffer. So these
-// live here rather than in segment.go — they exist for the tests, and they model
-// an allocation contract the production code deliberately does not follow.
+// Segment builders for the tests in this package, which construct transport
+// segments to feed the connection's receive path (segment_reassembly_test.go,
+// conn_test.go) or to check what the send path produced (frame_test.go).
+//
+// The codec and its own tests live in internal/segment. What is left here is the
+// bridge: these take this package's Compressor, so a test can pass the same
+// compressor it configured a Conn or framer with, and narrow it the way the
+// production callers do.
+//
+// Each builds or reads one whole segment in a single call, with buffers of its own.
+// No production caller works that way — the receive loop splits header and payload
+// across two phases to re-arm its read deadline, and the send path encodes straight
+// into the framer's wire buffer — so these model an allocation contract the driver
+// deliberately does not follow.
 
 // readUncompressedSegment reads a full uncompressed segment (header + payload) in
 // one call, into a payload buffer of its own.
 func readUncompressedSegment(r io.Reader) ([]byte, bool, error) {
-	var scratch segmentScratch
+	var scratch segment.Scratch
 
-	h, err := readUncompressedSegmentHeader(r)
+	h, err := segment.ReadUncompressedHeader(r)
 	if err != nil {
 		return nil, false, err
 	}
-	payload, err := readUncompressedSegmentPayload(r, h, &scratch)
+	payload, err := segment.ReadUncompressedPayload(r, h, &scratch)
 	if err != nil {
 		return nil, false, err
 	}
-	return payload, h.isSelfContained, nil
+	return payload, h.IsSelfContained, nil
 }
 
 // readCompressedSegment reads a full compressed segment (header + payload) in one
 // call, into payload buffers of its own.
 func readCompressedSegment(r io.Reader, compressor Compressor) ([]byte, bool, error) {
-	var scratch segmentScratch
+	segComp, err := asSegmentCompressor(compressor)
+	if err != nil {
+		return nil, false, err
+	}
 
-	h, err := readCompressedSegmentHeader(r)
+	var scratch segment.Scratch
+
+	h, err := segment.ReadCompressedHeader(r)
 	if err != nil {
 		return nil, false, err
 	}
-	payload, err := readCompressedSegmentPayload(r, h, compressor, &scratch)
+	payload, err := segment.ReadCompressedPayload(r, h, segComp, &scratch)
 	if err != nil {
 		return nil, false, err
 	}
-	return payload, h.isSelfContained, nil
+	return payload, h.IsSelfContained, nil
 }
 
 // newUncompressedSegment returns payload as a standalone uncompressed segment.
 func newUncompressedSegment(payload []byte, isSelfContained bool) ([]byte, error) {
-	return appendUncompressedSegment(nil, payload, isSelfContained)
+	return segment.AppendUncompressed(nil, payload, isSelfContained)
 }
 
 // newCompressedSegment returns payload as a standalone compressed segment.
 func newCompressedSegment(payload []byte, isSelfContained bool, compressor Compressor) ([]byte, error) {
-	return appendCompressedSegment(nil, payload, isSelfContained, compressor)
-}
-
-// makeCompressedSegmentHeaderRaw builds a valid 5-byte compressed-segment
-// header (with a correct CRC24) from a raw 40-bit combined value, without any
-// clamping. It is used to feed deliberately wide inputs and observe how the
-// reader's 17-bit extraction masks them.
-func makeCompressedSegmentHeaderRaw(combined uint64) []byte {
-	const (
-		headerSize = 5
-	)
-
-	var wide [8]byte
-	binary.LittleEndian.PutUint64(wide[:], combined)
-
-	header := make([]byte, headerSize+crc24Size)
-	copy(header[:headerSize], wide[:headerSize])
-
-	checksum := crc.Crc24(header[:headerSize])
-	header[headerSize+0] = byte(checksum)
-	header[headerSize+1] = byte(checksum >> 8)
-	header[headerSize+2] = byte(checksum >> 16)
-
-	return header
-}
-
-// makeCompressedSegmentHeader builds a valid 5-byte compressed-segment header
-// (with a correct CRC24) for the given lengths and self-contained flag, using
-// the same bit layout as newCompressedSegment: compressedLen in bits 0-16,
-// uncompressedLen in bits 17-33, self-contained flag at bit 34.
-func makeCompressedSegmentHeader(compressedLen, uncompressedLen uint64, isSelfContained bool) []byte {
-	const selfContainedBit = 1 << 34
-
-	combined := compressedLen | uncompressedLen<<17
-	if isSelfContained {
-		combined |= selfContainedBit
+	segComp, err := asSegmentCompressor(compressor)
+	if err != nil {
+		return nil, err
 	}
-	return makeCompressedSegmentHeaderRaw(combined)
+	return segment.AppendCompressed(nil, payload, isSelfContained, segComp)
 }
 
-// incompressibleCompressor mimics compressors (e.g. pierrec/lz4's
-// CompressBlock) that report incompressible input by returning an empty result
-// with a nil error.
-type incompressibleCompressor struct{}
+// testSegmentCompressor is a Compressor that also supports v5 segment compression,
+// passing bytes through unchanged.
+//
+// Declared here rather than reusing frame_test.go's testMockedCompressor because this
+// file carries no build tag and that one is behind //go:build unit -- a helper taken
+// from a tagged file compiles under `go test -tags unit` and nowhere else.
+type testSegmentCompressor struct{}
 
-func (incompressibleCompressor) Name() string { return "incompressible" }
-
-func (incompressibleCompressor) AppendCompressed(dst, _ []byte) ([]byte, error) {
-	return dst, nil
-}
-
-func (incompressibleCompressor) AppendDecompressed(dst, src []byte, _ uint32) ([]byte, error) {
+func (testSegmentCompressor) Name() string                       { return "test-segment" }
+func (testSegmentCompressor) Encode(data []byte) ([]byte, error) { return data, nil }
+func (testSegmentCompressor) Decode(data []byte) ([]byte, error) { return data, nil }
+func (testSegmentCompressor) AppendCompressed(dst, src []byte) ([]byte, error) {
 	return append(dst, src...), nil
 }
 
-func (incompressibleCompressor) Encode(data []byte) ([]byte, error) {
-	return data, nil
+func (testSegmentCompressor) AppendDecompressed(dst, src []byte, decompressedLength uint32) ([]byte, error) {
+	return append(dst, src...), nil
 }
 
-func (incompressibleCompressor) Decode(data []byte) ([]byte, error) {
-	return data, nil
+// TestAsSegmentCompressor covers the narrowing every v5 segment read and write goes
+// through.
+//
+// The nil case is the one worth pinning: both callers hand it whatever compressor the
+// connection was configured with, nil included, and rely on nil narrowing to a nil
+// segment.Compressor rather than to an error -- that is how internal/segment spells
+// "the uncompressed layout". Returning an error for it instead would break every
+// uncompressed v5 connection.
+func TestAsSegmentCompressor(t *testing.T) {
+	t.Run("nil is the uncompressed layout", func(t *testing.T) {
+		comp, err := asSegmentCompressor(nil)
+		if err != nil {
+			t.Fatalf("asSegmentCompressor(nil) returned %v, want no error", err)
+		}
+		if comp != nil {
+			t.Errorf("asSegmentCompressor(nil) = %#v, want a nil segment.Compressor", comp)
+		}
+	})
+
+	t.Run("a segment compressor narrows to itself", func(t *testing.T) {
+		comp, err := asSegmentCompressor(testSegmentCompressor{})
+		if err != nil {
+			t.Fatalf("asSegmentCompressor returned %v, want no error", err)
+		}
+		if _, ok := comp.(testSegmentCompressor); !ok {
+			t.Errorf("asSegmentCompressor returned %T, want the compressor it was given", comp)
+		}
+	})
+
+	t.Run("a frame-only compressor is refused by name", func(t *testing.T) {
+		comp, err := asSegmentCompressor(SnappyCompressor{})
+		if err == nil {
+			t.Fatal("asSegmentCompressor accepted a compressor with no segment support")
+		}
+		if comp != nil {
+			t.Errorf("asSegmentCompressor returned %#v alongside its error, want nil", comp)
+		}
+		// Naming the offending compressor is the whole reason this narrowing lives in
+		// this package rather than in internal/segment, which needs only the two
+		// Append methods and so cannot reach Name.
+		if !strings.Contains(err.Error(), "snappy") {
+			t.Errorf("error %q does not name the compressor it rejected", err)
+		}
+	})
 }
 
-// TestNewCompressedSegment_IncompressiblePayloadFallsBackToRaw locks the fix for
-// the case where the compressor reports the payload as incompressible (empty
-// result). The segment must be emitted as raw (uncompressedLen==0, payloadLen
-// equal to the source length) rather than with compressedLen==0 and a nonzero
-// uncompressedLen, which the peer cannot decode.
-func TestNewCompressedSegment_IncompressiblePayloadFallsBackToRaw(t *testing.T) {
-	payload := []byte("this payload is reported as incompressible")
+// TestResolveSegmentCompressor covers the one place the narrowing now runs.
+//
+// It happens during the handshake rather than once per segment, which puts a version
+// gate on it that the per-segment call never needed: below v5 the segment codec is
+// unreachable, and a compressor without segment support is an ordinary configuration
+// there -- the driver's own integration suite runs protocol v4 with Snappy. Refusing it
+// here would fail every one of those handshakes.
+func TestResolveSegmentCompressor(t *testing.T) {
+	t.Run("v5 narrows the compressor once", func(t *testing.T) {
+		c := &Conn{version: protoVersion5, compressor: testSegmentCompressor{}}
+		if err := c.resolveSegmentCompressor(); err != nil {
+			t.Fatalf("resolveSegmentCompressor: %v", err)
+		}
+		if _, ok := c.segCompressor.(testSegmentCompressor); !ok {
+			t.Errorf("segCompressor = %#v, want the compressor the connection was given", c.segCompressor)
+		}
+	})
 
-	seg, err := newCompressedSegment(payload, true, incompressibleCompressor{})
-	if err != nil {
-		t.Fatalf("newCompressedSegment: %v", err)
-	}
+	t.Run("v4 leaves a frame-only compressor alone", func(t *testing.T) {
+		c := &Conn{version: protoVersion4, compressor: SnappyCompressor{}}
+		if err := c.resolveSegmentCompressor(); err != nil {
+			t.Fatalf("a protocol v4 connection with a frame compressor was refused: %v", err)
+		}
+		if c.segCompressor != nil {
+			t.Errorf("segCompressor = %#v, want nil: v4 never reaches the segment codec", c.segCompressor)
+		}
+	})
 
-	h, err := readCompressedSegmentHeader(bytes.NewReader(seg))
-	if err != nil {
-		t.Fatalf("readCompressedSegmentHeader: %v", err)
-	}
-	// uncompressedLen==0 signals "use the payload as-is, do not decompress".
-	if h.uncompressedLen != 0 {
-		t.Fatalf("uncompressedLen = %d, want 0 (raw fallback)", h.uncompressedLen)
-	}
-	if h.payloadLen != len(payload) {
-		t.Fatalf("payloadLen = %d, want %d", h.payloadLen, len(payload))
-	}
-	if !h.isSelfContained {
-		t.Fatalf("isSelfContained = false, want true")
-	}
-}
-
-// TestReadSegmentPayloadReusesScratch pins that reading consecutive segments with
-// one scratch does not allocate. A connection's receive loop is serialized on its
-// serve() goroutine, so the payload buffers are reused; allocating them per
-// segment costs one (uncompressed) or two (compressed) buffers of up to
-// maxSegmentPayloadSize for every segment received.
-func TestReadSegmentPayloadReusesScratch(t *testing.T) {
-	payload := bytes.Repeat([]byte{0x5A}, 8192)
-
-	for _, tc := range []struct {
-		name       string
-		compressor Compressor
-	}{
-		{"uncompressed", nil},
-		{"compressed", testMockedCompressor{}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			var (
-				seg []byte
-				err error
-			)
-			if tc.compressor != nil {
-				seg, err = newCompressedSegment(payload, true, tc.compressor)
-			} else {
-				seg, err = newUncompressedSegment(payload, true)
-			}
-			if err != nil {
-				t.Fatalf("build segment: %v", err)
-			}
-
-			var scratch segmentScratch
-			r := bytes.NewReader(seg)
-			read := func() {
-				r.Reset(seg)
-				h, err := readSegmentHeader(r, tc.compressor)
-				if err != nil {
-					t.Fatalf("readSegmentHeader: %v", err)
-				}
-				got, err := readSegmentPayload(r, h, tc.compressor, &scratch)
-				if err != nil {
-					t.Fatalf("readSegmentPayload: %v", err)
-				}
-				if len(got) != len(payload) {
-					t.Fatalf("payload length %d, want %d", len(got), len(payload))
-				}
-			}
-
-			// The first read legitimately allocates the scratch buffers.
-			read()
-
-			// Bytes rather than allocation count: reading a segment header still
-			// heap-allocates two small fixed-size buffers, which is not what this
-			// test is about. Eight reads must not add up to even one payload buffer.
-			const reads = 8
-			var before, after runtime.MemStats
-			runtime.ReadMemStats(&before)
-			for i := 0; i < reads; i++ {
-				read()
-			}
-			runtime.ReadMemStats(&after)
-
-			if allocated := after.TotalAlloc - before.TotalAlloc; allocated >= uint64(len(payload)) {
-				t.Errorf("reading %d segments allocated %d bytes, want less than one %d-byte payload buffer",
-					reads, allocated, len(payload))
-			}
-		})
-	}
-}
-
-func TestReadCompressedSegmentHeader_LengthsBoundedTo17Bits(t *testing.T) {
-	// Set every bit in the length/self-contained region. The reader extracts
-	// compressedLen and uncompressedLen with a 17-bit mask each, so both must
-	// come back clamped to maxSegmentPayloadSize regardless of the wider input.
-	// This regression-locks the inherent bound that keeps segment payload
-	// allocations safe without an explicit runtime check.
-	allBits := uint64(1)<<35 - 1 // bits 0..34 set (both 17-bit fields + self-contained bit)
-	header := makeCompressedSegmentHeaderRaw(allBits)
-
-	h, err := readCompressedSegmentHeader(bytes.NewReader(header))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if h.payloadLen != maxSegmentPayloadSize {
-		t.Fatalf("payloadLen = %d, want %d", h.payloadLen, maxSegmentPayloadSize)
-	}
-	if h.uncompressedLen != maxSegmentPayloadSize {
-		t.Fatalf("uncompressedLen = %d, want %d", h.uncompressedLen, maxSegmentPayloadSize)
-	}
-	if !h.isSelfContained {
-		t.Fatalf("isSelfContained = false, want true")
-	}
-}
-
-func TestReadCompressedSegmentHeader_AcceptsMaxLengths(t *testing.T) {
-	// The maximum in-range value for both 17-bit fields must be accepted.
-	header := makeCompressedSegmentHeader(maxSegmentPayloadSize, maxSegmentPayloadSize, false)
-
-	h, err := readCompressedSegmentHeader(bytes.NewReader(header))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if h.payloadLen != maxSegmentPayloadSize {
-		t.Fatalf("payloadLen = %d, want %d", h.payloadLen, maxSegmentPayloadSize)
-	}
-	if h.uncompressedLen != maxSegmentPayloadSize {
-		t.Fatalf("uncompressedLen = %d, want %d", h.uncompressedLen, maxSegmentPayloadSize)
-	}
-	if h.isSelfContained {
-		t.Fatalf("isSelfContained = true, want false")
-	}
+	t.Run("v5 refuses a frame-only compressor by name", func(t *testing.T) {
+		c := &Conn{version: protoVersion5, compressor: SnappyCompressor{}}
+		err := c.resolveSegmentCompressor()
+		if err == nil {
+			t.Fatal("a v5 connection with a frame-only compressor was accepted")
+		}
+		if !strings.Contains(err.Error(), "snappy") {
+			t.Errorf("error %q does not name the compressor it rejected", err)
+		}
+		if c.segCompressor != nil {
+			t.Errorf("segCompressor = %#v alongside the error, want nil", c.segCompressor)
+		}
+	})
 }


### PR DESCRIPTION
The record/replay dialers in `dialer/` wrap a `net.Conn`, so what they see is the wire.
From protocol v5 the wire carries transport segments, not CQL frames, and every fixed
offset the dialers relied on was wrong: the recorder sliced the stream on a 9-byte CQL
header, the replayer patched stream ids into bytes 2..3 — header and CRC on a segment —
and `GetFrameHash` judged v5-ness from `frame[0]`, which on a segment is the low byte of
a length. #593 refused v5 outright as a stopgap; this replaces it.

The segment codec moves to `internal/segment`, shared with the driver, so the 17-bit
length field, the two CRCs and the split threshold have one implementation instead of
drifting copies. Each connection gets a `dialer.Framing` and a decoder per direction.
`lz4` is a separate Go module, so the compressor has to be injected: both dialers take
`WithSegmentCompressor`, and a compressed v5 connection without one fails with
`ErrSegmentCompressorRequired`.

Recordings still hold bare CQL frames, unwrapped and decompressed, on every protocol
version — so the file format does not change and the checked-in v4 recordings keep
working byte for byte.

Worth a reviewer's attention: `startupCompleted` is set on READY **or** AUTHENTICATE, so
AUTH_RESPONSE and AUTH_SUCCESS are already segmented. A one-frame error there corrupts
every authenticated recording; the argument for why no single read or write can straddle
the latch is in the `dialer: latch the framing mode from the handshake` commit message.

Ten commits, each building and vetting standalone. Two gaps stay open. **#1000** — every
QUERY frame hashes to the same three zero bytes — blocks v5 QUERY replay: the correct
offset makes the checked-in recordings unmatchable, and regenerating them needs a live
node. v5 EXECUTE and the other opcodes work here. **#960** is live-server v5 integration,
which cannot be done here at all, since `discoverProtocol` pins v4 and ScyllaDB does not
speak v5; the v5 round trip is driven in process instead, recorder → temp file →
replayer.

Smaller fixes ride along: a BATCH was hashed with its per-run timestamp and so could
never match its replay; the recorder swallowed io.EOF (a server-closed connection read
as (0, nil) forever) and leaked a file descriptor when its setup failed halfway; and
`make test-bench` never ran `-C tests/bench`, so the replay benchmarks — the one gate
that panics on an unmatched request — were never executed.

Fixes: https://github.com/scylladb/gocql/issues/937
Fixes: https://scylladb.atlassian.net/browse/DRIVER-953

