### PR TITLE
fix(deps): update pierrec/lz4 to v4.1.29

### DIFF
--- a/lz4/go.mod
+++ b/lz4/go.mod
@@ -25,7 +25,7 @@ module github.com/scylladb/gocql/lz4
 go 1.25.0
 
 require (
-	github.com/pierrec/lz4/v4 v4.1.27
+	github.com/pierrec/lz4/v4 v4.1.29
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/lz4/go.sum
+++ b/lz4/go.sum
@@ -1,5 +1,5 @@
-github.com/pierrec/lz4/v4 v4.1.27 h1:+PhzhWDrjRj89TH2sw43nE3+4+W8lSxIuQadEHZyjUk=
-github.com/pierrec/lz4/v4 v4.1.27/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
+github.com/pierrec/lz4/v4 v4.1.29 h1:CDQY6qZOLI4DW0Nx6R1vRrifrCeQHnNXkMb0hZWXFjg=
+github.com/pierrec/lz4/v4 v4.1.29/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=


### PR DESCRIPTION
Replacement for #984.

Updates `github.com/pierrec/lz4/v4` to v4.1.29 and removes stale v4.1.27 checksums so repository module-drift checks pass.

Validation:
- `make check`
- `go test -C lz4 -tags unit -race ./...`