### PR TITLE
ci: make Renovate tidy Go modules and update indirect deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,19 @@
   "extends": [
     "config:recommended"
   ],
-  "prConcurrentLimit": 2
+  "prConcurrentLimit": 2,
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #1008.

## Problem

`renovate.json` extended only `config:recommended`, which never runs `go mod tidy` after a bump. Renovate appends the new `go.sum` checksums and leaves the superseded ones, so its Go dependency PRs fail `check-go-mod-drift` (`Makefile:359-363`) and get re-authored by hand: #984 → #1003, #988 → #1002, and #1006 carries the same drift right now.

`gomodTidy` alone does not cover `tests/bench`. Renovate offers no standalone updates for `// indirect` deps, so it never opens that manifest and a tidy never runs there — which is how #988 left `klauspost/compress` at v1.19.1 in `tests/bench/go.mod` while the root moved to v1.19.2. Detail in #1008.

## Change

- `postUpdateOptions: ["gomodTidy"]` — tidy each module Renovate updates.
- `packageRules` entry enabling the `indirect` depType, scoped to `matchManagers: ["gomod"]` so the `uv` and `github-actions` managers are unaffected.

## Validation

- `renovate-config-validator` — passes
- `make check-go-mod-drift` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
