### PR TITLE
chore(deps): update astral-sh/setup-uv action to v10

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Set up env
         run: make -C docs setupenv

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Set up env
         run: make -C docs setupenv


### PR DESCRIPTION
Replaces #1007.

Updates astral-sh/setup-uv from v9.0.0 to v10.0.1 in both documentation workflows, pinned to immutable commit 20cfd1bf945f4377ade1205e4dbc17946fc9a30d.