### PR TITLE
ci: add arm64 unit and integration lanes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,49 @@ jobs:
 
       - run: sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
 
+  # Every other job here is x86-only. pierrec/lz4 ships hand-written
+  # per-architecture decode assembly (internal/lz4block/decode_arm64.s), so the
+  # code behind LZ4Compressor.Decode and AppendDecompressed -- and therefore
+  # behind every compressed native-protocol-v5 segment on a Graviton or
+  # Apple-silicon deployment -- had no gate at all. The last two bumps of that
+  # dependency both reworked exactly that file.
+  #
+  # Only `make test-unit` runs here, not `make check`: check is golangci-lint
+  # plus `go mod tidy -diff`, both architecture-independent, and running it
+  # again would only re-download an arm64 golangci-lint to repeat the amd64
+  # result. test-unit already descends into the nested lz4 module (see its
+  # recipe in the Makefile), so the assembly above needs no separate step.
+  build-arm64:
+    name: Build (arm64)
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # No actions/cache step, deliberately: the other jobs' key is
+      # pr-check-${{ runner.os }}-... and runner.os is "Linux" on both
+      # architectures, so sharing it would restore amd64 binaries into bin/.
+      # Nothing this job needs is expensive to recreate -- setup-go caches
+      # modules under its own arch-scoped key, and test-unit's .prepare-pki
+      # prerequisite regenerates the test certificates in seconds.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: |
+            lz4/go.sum
+            tests/bench/go.sum
+            go.sum
+
+      - name: Run unit tests
+        run: make test-unit
+
   test-integration-scylla:
     name: Integration Tests On Scylla
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, build-arm64]
     strategy:
       matrix:
         scylla-version: [LATEST, PRIOR, LTS-LATEST, LTS-PRIOR]
@@ -129,7 +168,7 @@ jobs:
   test-integration-cassandra:
     name: Integration Tests On Cassandra
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, build-arm64]
     strategy:
       matrix:
         cassandra-version: [5-LATEST, 4-LATEST]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,6 +165,84 @@ jobs:
         if: steps.scylla-version.outputs.value != 'NOT-FOUND'
         run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla
 
+  # The arm64 counterpart of the job above, pinned to one version on purpose:
+  # this lane is here to show the driver works end to end on aarch64, not to
+  # re-cover every ScyllaDB release. The second, `ccm`-tagged pass is left out
+  # for the same reason.
+  #
+  # The compressor is the suite default. The lz4 compressor lives in a nested
+  # module the root test harness cannot import -- createCluster in
+  # common_test.go knows only snappy and no-compression -- so the arm64 decode
+  # assembly that motivates these lanes stays covered by Build (arm64) alone.
+  # Once the harness can build with lz4, TEST_COMPRESSOR=lz4 belongs on this job.
+  test-integration-scylla-arm64:
+    name: Integration Tests On Scylla (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: [build, build-arm64]
+    permissions:
+      contents: read
+    env:
+      SCYLLA_VERSION: LATEST
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.11'
+
+      # Both cache keys in this job carry runner.arch, unlike their amd64
+      # counterparts: runner.os is "Linux" on either architecture, so a shared
+      # key would hand this job an amd64 get-version in bin/ and an x86_64
+      # ScyllaDB relocatable in ~/.ccm. ~/.sdkman is not cached here at all --
+      # scylla-start needs no JDK, and this image ships none for the Makefile's
+      # JAVA_HOME_11_X64 to point at.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            /home/runner/.cache/pip
+            /home/runner/.local
+            testdata/pki
+            bin/
+          # CCM and pip versions are in Makefile
+          key: pr-check-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: |
+            lz4/go.sum
+            tests/bench/go.sum
+            go.sum
+
+      - name: Get scylla version
+        id: scylla-version
+        run: make resolve-scylla-version
+
+      - name: Pull CCM image from the cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
+        id: ccm-cache
+        with:
+          path: ~/.ccm/repository
+          key: ccm-scylla-${{ runner.os }}-${{ runner.arch }}-${{ steps.scylla-version.outputs.value }}
+
+      - name: Download ScyllaDB (${{ steps.scylla-version.outputs.value }}) image
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
+        run: make download-scylla
+
+      - name: Save CCM ScyllaDB image into the cache
+        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.ccm/repository
+          key: ccm-scylla-${{ runner.os }}-${{ runner.arch }}-${{ steps.scylla-version.outputs.value }}
+
+      - name: Run integration suite with ScyllaDB LATEST(${{ steps.scylla-version.outputs.value }})
+        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
+        run: make test-integration-scylla
+
   test-integration-cassandra:
     name: Integration Tests On Cassandra
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,21 @@ BIN_DIR := "${MAKEFILE_PATH}/bin"
 CASSANDRA_VERSION ?= LATEST
 SCYLLA_VERSION ?= LATEST
 
+HOST_ARCH := $(shell uname -m)
+
 GOLANGCI_VERSION = 2.5.0
 GET_VERSION_VERSION = 0.4.5
 GET_VERSION_BIN = $(MAKEFILE_PATH)/bin/get-version
+# get-version publishes one release archive per architecture, and every
+# resolve-*-version target below depends on the binary being runnable: the
+# amd64v3 build is an "Exec format error" on aarch64.
+GET_VERSION_ARCH = $(if $(filter aarch64,$(HOST_ARCH)),arm64,amd64v3)
+
+# scylla-ccm chooses which relocatable package to download from SCYLLA_ARCH and
+# falls back to x86_64 (ccmlib/scylla_repository.py), so on an aarch64 host it
+# would fetch a package whose scylla binary cannot run. uname -m already prints
+# the two names ccm knows, x86_64 and aarch64.
+SCYLLA_ARCH ?= $(HOST_ARCH)
 
 TEST_CQL_PROTOCOL ?= 4
 TEST_COMPRESSOR ?= snappy
@@ -103,6 +115,7 @@ SCYLLA_CONFIG = "native_transport_port_ssl: 9142" \
 "experimental_features: [udf]"
 
 export JVM_EXTRA_OPTS
+export SCYLLA_ARCH
 export JAVA11_HOME=${JAVA_HOME_11_X64}
 export JAVA17_HOME=${JAVA_HOME_17_X64}
 export JAVA_HOME=${JAVA_HOME_11_X64}
@@ -117,7 +130,7 @@ print-config:
 .prepare-get-version: .prepare-bin
 	@if [[ ! -x "${GET_VERSION_BIN}" ]] || [[ "$$("${GET_VERSION_BIN}" -version 2>/dev/null)" != "${GET_VERSION_VERSION}" ]]; then
 		echo "Installing get-version ${GET_VERSION_VERSION}"
-		curl -sSLo /tmp/get-version.zip https://github.com/scylladb-actions/get-version/releases/download/v${GET_VERSION_VERSION}/get-version_${GET_VERSION_VERSION}_linux_amd64v3.zip
+		curl -sSLo /tmp/get-version.zip https://github.com/scylladb-actions/get-version/releases/download/v${GET_VERSION_VERSION}/get-version_${GET_VERSION_VERSION}_linux_${GET_VERSION_ARCH}.zip
 		unzip -o /tmp/get-version.zip get-version -d "$(MAKEFILE_PATH)/bin" >/dev/null
 	fi
 


### PR DESCRIPTION
No job ran on arm64 — every `runs-on` in `.github/workflows/*.yml` was `ubuntu-latest` and there was no `GOARCH` anywhere in the repo. `pierrec/lz4` ships hand-written per-architecture decode assembly, so `internal/lz4block/decode_arm64.s` — the code behind every `LZ4Compressor.Decode` and `AppendDecompressed` call, and therefore behind every compressed native-protocol-v5 segment — was never executed by any gate.

Not hypothetical: `master` is already on `pierrec/lz4 v4.1.29` (#1003), whose diff is `internal/lz4block/decode_arm64.s +160/-43`, and the bump before that (v4.1.27) was itself an arm64 decode rework. Upstream hit a real arm64 LZ4 failure (CASSGO-128) and fixed it in `00fc290` by bumping to v4.1.27 **and** adding a `unit-tests-arm64` job on `ubuntu-24.04-arm` wired into the downstream `needs:`. That commit isn't in this fork's master, so the lane was simply absent here.

## What this does

- `build-arm64` on `ubuntu-24.04-arm` running `make test-unit`, with both integration jobs gated on it.
- `test-integration-scylla-arm64` — a ccm ScyllaDB `LATEST` cluster on `ubuntu-24.04-arm` with the integration suite run against it (added in review).
- The two Makefile assumptions that stood in the way of that second lane.

### The unit lane

- **Only `make test-unit`, not `make check`.** `check` is `golangci-lint` plus `go mod tidy -diff`, both architecture-independent; running it again would only re-download an arm64 golangci-lint to repeat the amd64 result. `test-unit` already descends into the nested `lz4` module (`go test -C lz4 -tags unit -race`), so the assembly above needs no separate step.
- **No `actions/cache` step.** The other jobs' key is `pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}`, and `runner.os` is `Linux` on both architectures, so sharing it would restore amd64 binaries into `bin/`. Nothing this job needs is expensive to recreate: `setup-go` caches modules under its own arch-scoped key, and `test-unit`'s `.prepare-pki` prerequisite regenerates the certs in seconds.
- **`build` is not renamed.** Upstream's commit also renames `build` → `unit-tests-amd64`; porting that would invalidate the existing `Build` status-check name for no benefit, since none of this fork's other job names match upstream's anyway.

### The integration lane

`Build (arm64)` shows the unit tests pass where the lz4 assembly lives, but nothing showed the driver actually talking to a cluster there — frame codec, shard-aware routing, TLS and the pooling paths were all still amd64-only. The new job starts a 3-node ccm ScyllaDB `LATEST` cluster on `ubuntu-24.04-arm` and runs `make test-integration-scylla` against it.

- **One version, one pass.** This lane is here to show the driver works end to end on aarch64, not to re-cover every ScyllaDB release, so the version matrix and the second `ccm`-tagged run stay on the amd64 job.
- **A separate job, not a matrix axis.** GitHub appends matrix values to a job's `name:`, so an `arch` axis would rename every existing `Integration Tests On Scylla (…)` status check — the same reason `build` isn't renamed above.
- **Both cache keys carry `runner.arch`.** `runner.os` is `Linux` on either architecture, so reusing the amd64 keys would hand this job an amd64 `get-version` in `bin/` and an x86_64 ScyllaDB relocatable in `~/.ccm`. The amd64 keys are left alone so their entries stay warm. `~/.sdkman` isn't cached here at all: `scylla-start` needs no JDK (ScyllaDB ≥ 6.0 uses the native `scylla nodetool`), and this image ships no Java 11 for the Makefile's `JAVA_HOME_11_X64` to resolve to.
- **The suite's default compressor.** The lz4 compressor lives in a nested module the root test harness cannot import — `createCluster` in `common_test.go` knows only `snappy` and `no-compression` — so this lane does not exercise the arm64 decode assembly; `Build (arm64)` still does that alone. Once the harness can build with lz4 (#1023), `TEST_COMPRESSOR=lz4` belongs on this job.

### Makefile

Two spots assumed an x86_64 host, and both sit on the path the new lane has to take:

- `.prepare-get-version` downloaded the `linux_amd64v3` release archive unconditionally. That binary is an `Exec format error` on aarch64, and both `resolve-*-version` targets depend on it, so version resolution would fail before any cluster is created. get-version publishes a `linux_arm64` archive of the same release; pick it from `uname -m`.
- scylla-ccm takes the relocatable package's architecture from `SCYLLA_ARCH` and falls back to `x86_64` (`ccmlib/scylla_repository.py`), so on aarch64 it would unpack a package whose `scylla` binary cannot run. `uname -m` already prints the two names ccm recognises.

Nothing changes on x86_64: `uname -m` selects the same `amd64v3` archive as before and matches ccm's own default. Editing the Makefile does change `hashFiles('Makefile')`, so the `pr-check-*` caches are cold once on this run; the `ccm-*` image caches are keyed on the resolved version and stay warm.

## Checks

`make check` and `make test-unit` (root and `lz4` modules) pass locally, the workflow parses, and every pinned action SHA in the new job already appears in the file. The rest is runtime behaviour that only CI can show — see `Build (arm64)` and `Integration Tests On Scylla (arm64)` on this run.

Fixes #1009
Refs: https://scylladb.atlassian.net/browse/DRIVER-961
