### PR TITLE
ci: name every job by both version and architecture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,21 @@ on:
       - .github/workflows/extended-ci-longevity-large-partitions-with-network-nemesis-1h-test.yml
 
 jobs:
-  build:
-    name: Build
+  build-amd64:
+    name: Build (amd64)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
+      # runner.arch qualifies the key, which it did not before. This entry is shared
+      # with the integration jobs, and the ScyllaDB one now runs on both
+      # architectures; runner.os is "Linux" on either, so an unqualified key would
+      # hand one lane the other's amd64 get-version in bin/ and x86_64 relocatables
+      # in ~/.ccm. Only the amd64 entries go cold, once.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
@@ -39,7 +46,7 @@ jobs:
             testdata/pki
             bin/
           # CCM, scylla, cassandra and java versions are in Makefile
-          key: pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}
+          key: pr-check-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -57,18 +64,25 @@ jobs:
 
       - run: sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
 
-  # Every other job here is x86-only. pierrec/lz4 ships hand-written
-  # per-architecture decode assembly (internal/lz4block/decode_arm64.s), so the
-  # code behind LZ4Compressor.Decode and AppendDecompressed -- and therefore
-  # behind every compressed native-protocol-v5 segment on a Graviton or
-  # Apple-silicon deployment -- had no gate at all. The last two bumps of that
-  # dependency both reworked exactly that file.
+  # The arm64 counterpart, and the reason it exists: pierrec/lz4 ships hand-written
+  # per-architecture decode assembly (internal/lz4block/decode_arm64.s), so the code
+  # behind LZ4Compressor.Decode and AppendDecompressed -- and therefore behind every
+  # compressed native-protocol-v5 segment on a Graviton or Apple-silicon deployment --
+  # had no gate at all before this lane existed. The last two bumps of that dependency
+  # both reworked exactly that file.
   #
-  # Only `make test-unit` runs here, not `make check`: check is golangci-lint
-  # plus `go mod tidy -diff`, both architecture-independent, and running it
-  # again would only re-download an arm64 golangci-lint to repeat the amd64
-  # result. test-unit already descends into the nested lz4 module (see its
-  # recipe in the Makefile), so the assembly above needs no separate step.
+  # It builds and tests but does not lint, which is why it is not `make check`:
+  # golangci-lint and `go mod tidy -diff` are architecture-independent, so running the
+  # whole target here would only re-download an arm64 golangci-lint to repeat the amd64
+  # result. `make build` is the one part of it that is not -- and it is not redundant
+  # with the unit tests either, since `go test` never compiles the `all`-tagged non-test
+  # files (integration_only.go, internal/ccm, internal/debug/debug_on.go).
+  #
+  # No actions/cache step, deliberately: the pr-check entry above holds CCM
+  # repositories, a JDK and amd64 binaries in bin/, and this lane uses none of them.
+  # Nothing it does need is expensive to recreate -- setup-go caches modules under its
+  # own arch-scoped key, and test-unit's .prepare-pki prerequisite regenerates the test
+  # certificates in seconds.
   build-arm64:
     name: Build (arm64)
     runs-on: ubuntu-24.04-arm
@@ -79,12 +93,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # No actions/cache step, deliberately: the other jobs' key is
-      # pr-check-${{ runner.os }}-... and runner.os is "Linux" on both
-      # architectures, so sharing it would restore amd64 binaries into bin/.
-      # Nothing this job needs is expensive to recreate -- setup-go caches
-      # modules under its own arch-scoped key, and test-unit's .prepare-pki
-      # prerequisite regenerates the test certificates in seconds.
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
@@ -93,16 +101,31 @@ jobs:
             tests/bench/go.sum
             go.sum
 
+      - name: Build
+        run: make build
+
+      # test-unit descends into the nested lz4 module (see its recipe in the
+      # Makefile), so the decode assembly above needs no separate step.
       - name: Run unit tests
         run: make test-unit
 
   test-integration-scylla:
-    name: Integration Tests On Scylla
-    runs-on: ubuntu-latest
-    needs: [build, build-arm64]
+    name: Integration Tests On Scylla (${{ matrix.scylla-version }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    needs: [build-amd64]
+    permissions:
+      contents: read
     strategy:
       matrix:
         scylla-version: [LATEST, PRIOR, LTS-LATEST, LTS-PRIOR]
+        arch: [amd64]
+        # arm64 is pinned to one version on purpose: this lane is here to show the
+        # driver works end to end on aarch64, not to re-cover every ScyllaDB
+        # release. `arch` is already a matrix key, so this entry cannot merge into
+        # an existing combination and GitHub adds it as a fifth one instead.
+        include:
+          - scylla-version: LATEST
+            arch: arm64
       fail-fast: false
     env:
       SCYLLA_VERSION: ${{ matrix.scylla-version }}
@@ -115,6 +138,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      # runner.arch qualifies both cache keys in this job because runner.os is
+      # "Linux" on either architecture, so a shared key would hand one lane the
+      # other's amd64 get-version in bin/ and x86_64 ScyllaDB relocatable in
+      # ~/.ccm. ~/.sdkman is listed for the amd64 lane; the arm64 image ships no
+      # JDK, and actions/cache is content to skip a path that is not there.
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
@@ -124,88 +152,6 @@ jobs:
             testdata/pki
             bin/
           # CCM, pip and java versions are in Makefile
-          key: pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}
-
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: |
-            lz4/go.sum
-            tests/bench/go.sum
-            go.sum
-
-      - name: Get scylla version
-        id: scylla-version
-        run: make resolve-scylla-version
-
-      - name: Pull CCM image from the cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
-        id: ccm-cache
-        with:
-          path: ~/.ccm/repository
-          key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
-
-      - name: Download ScyllaDB (${{ steps.scylla-version.outputs.value }}) image
-        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
-        run: make download-scylla
-
-      - name: Save CCM ScyllaDB image into the cache
-        if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.scylla-version.outputs.value != 'NOT-FOUND'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: ~/.ccm/repository
-          key: ccm-scylla-${{ runner.os }}-${{ steps.scylla-version.outputs.value }}
-
-      - name: Run integration suite with ScyllaDB ${{ matrix.scylla-version }}(${{ steps.scylla-version.outputs.value }})
-        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
-        run: make test-integration-scylla
-
-      - name: Run CCM integration suite with ScyllaDB ${{ matrix.scylla-version }}(${{ steps.scylla-version.outputs.value }})
-        if: steps.scylla-version.outputs.value != 'NOT-FOUND'
-        run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla
-
-  # The arm64 counterpart of the job above, pinned to one version on purpose:
-  # this lane is here to show the driver works end to end on aarch64, not to
-  # re-cover every ScyllaDB release. The second, `ccm`-tagged pass is left out
-  # for the same reason.
-  #
-  # The compressor is the suite default. The lz4 compressor lives in a nested
-  # module the root test harness cannot import -- createCluster in
-  # common_test.go knows only snappy and no-compression -- so the arm64 decode
-  # assembly that motivates these lanes stays covered by Build (arm64) alone.
-  # Once the harness can build with lz4, TEST_COMPRESSOR=lz4 belongs on this job.
-  test-integration-scylla-arm64:
-    name: Integration Tests On Scylla (arm64)
-    runs-on: ubuntu-24.04-arm
-    needs: [build, build-arm64]
-    permissions:
-      contents: read
-    env:
-      SCYLLA_VERSION: LATEST
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
-        with:
-          python-version: '3.11'
-
-      # Both cache keys in this job carry runner.arch, unlike their amd64
-      # counterparts: runner.os is "Linux" on either architecture, so a shared
-      # key would hand this job an amd64 get-version in bin/ and an x86_64
-      # ScyllaDB relocatable in ~/.ccm. ~/.sdkman is not cached here at all --
-      # scylla-start needs no JDK, and this image ships none for the Makefile's
-      # JAVA_HOME_11_X64 to point at.
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: |
-            /home/runner/.cache/pip
-            /home/runner/.local
-            testdata/pki
-            bin/
-          # CCM and pip versions are in Makefile
           key: pr-check-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -239,17 +185,33 @@ jobs:
           path: ~/.ccm/repository
           key: ccm-scylla-${{ runner.os }}-${{ runner.arch }}-${{ steps.scylla-version.outputs.value }}
 
-      - name: Run integration suite with ScyllaDB LATEST(${{ steps.scylla-version.outputs.value }})
+      - name: Run integration suite with ScyllaDB ${{ matrix.scylla-version }}(${{ steps.scylla-version.outputs.value }})
         if: steps.scylla-version.outputs.value != 'NOT-FOUND'
         run: make test-integration-scylla
 
+      # amd64 only, for the same reason the arm64 lane covers one version: it is
+      # here to show the driver works end to end on aarch64, not to re-run every
+      # pass the amd64 lane already makes.
+      - name: Run CCM integration suite with ScyllaDB ${{ matrix.scylla-version }}(${{ steps.scylla-version.outputs.value }})
+        if: matrix.arch == 'amd64' && steps.scylla-version.outputs.value != 'NOT-FOUND'
+        run: TEST_INTEGRATION_TAGS="ccm gocql_debug" make test-integration-scylla
+
   test-integration-cassandra:
-    name: Integration Tests On Cassandra
-    runs-on: ubuntu-latest
-    needs: [build, build-arm64]
+    name: Integration Tests On Cassandra (${{ matrix.cassandra-version }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    needs: [build-amd64]
+    # This job had no permissions block at all, having had no arm64 counterpart to
+    # force the question, so it ran on the repository default while its neighbour was
+    # pinned -- and it is the one job that hands GITHUB_TOKEN to a make target.
+    permissions:
+      contents: read
     strategy:
       matrix:
         cassandra-version: [5-LATEST, 4-LATEST]
+        # One value today. It is spelled as a matrix dimension so this job reads the
+        # same as the ScyllaDB one above and so an arm64 lane is one entry rather
+        # than a copied job.
+        arch: [amd64]
       fail-fast: false
     env:
       CASSANDRA_VERSION: ${{ matrix.cassandra-version }}
@@ -273,7 +235,7 @@ jobs:
             testdata/pki
             bin/
           # CCM, python and java versions are in Makefile
-          key: pr-check-${{ runner.os }}-${{ hashFiles('Makefile') }}
+          key: pr-check-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -293,7 +255,7 @@ jobs:
         id: ccm-cache
         with:
           path: ~/.ccm/repository
-          key: ccm-cassandra-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}
+          key: ccm-cassandra-${{ runner.os }}-${{ runner.arch }}-${{ steps.cassandra-version.outputs.value }}
 
       - name: Download Cassandra (${{ steps.cassandra-version.outputs.value }}) image
         if: steps.ccm-cache.outputs.cache-hit != 'true' && steps.cassandra-version.outputs.value != 'NOT-FOUND'
@@ -304,7 +266,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.ccm/repository
-          key: ccm-cassandra-${{ runner.os }}-${{ steps.cassandra-version.outputs.value }}
+          key: ccm-cassandra-${{ runner.os }}-${{ runner.arch }}-${{ steps.cassandra-version.outputs.value }}
 
       - name: Run integration suite with Cassandra ${{ matrix.cassandra-version }}(${{ steps.cassandra-version.outputs.value }})
         if: steps.cassandra-version.outputs.value != 'NOT-FOUND'

--- a/Makefile
+++ b/Makefile
@@ -482,9 +482,15 @@ check-go-mod-drift:
 	go mod tidy -C lz4 -diff
 	go mod tidy -C tests/bench -diff
 
-check: .prepare-golangci check-go-mod-drift
+# The one architecture-dependent part of check, split out so the arm64 lane can run
+# it without the linters, which are not. It is not redundant with test-unit either:
+# `go test` compiles no non-test file the `all` tag guards -- integration_only.go,
+# internal/ccm, internal/debug/debug_on.go.
+build:
 	@echo "Build"
 	go build -tags all .
+
+check: build .prepare-golangci check-go-mod-drift
 	echo "Check linting"
 	${BIN_DIR}/golangci-lint run
 


### PR DESCRIPTION
Reopened at a reviewer's request to split #1023 into its CI-structure half and the protocol v5 lane. This is that half; #1023 is now stacked on this branch and carries only the v5 work.

## Problem

The checks list names one dimension per row, and a different one per job:

| today | names |
|---|---|
| `Build` / `Build (arm64)` | architecture implicit on amd64, explicit on arm64 |
| `Integration Tests On Scylla (LATEST)` | a version, no architecture |
| `Integration Tests On Scylla (arm64)` | an architecture, no version — though it only runs LATEST |

Nothing in a row tells a reader what it actually covers.

## Change

**The ScyllaDB pair folds into an `arch` matrix**, because those two jobs were near-copies: of their ten steps, **six were byte-identical**, three differed only by `runner.arch` in a cache key, and one differed only in hardcoding `LATEST` where the matrix value already says it. Exactly one step — the `ccm`-tagged pass — is genuinely amd64-only, so a 78-line job collapses behind a single guard and a future architecture is one matrix entry rather than another copied job. Every comment explaining an asymmetry moves onto whatever now carries it.

**The build pair stays two jobs**, because it is not a near-copy: three of the amd64 job's steps (cache, linters, `aio-max-nr`) are absent on arm64 rather than parameterised, so a matrix would need three guards for a quarter of the saving. They are named for what they run instead — `build-amd64` and `build-arm64` — and only `Build` has to change to say which architecture it is.

**`Build (arm64)` gains the build its name promises.** It ran `make test-unit` and nothing else, so nothing on that architecture ever compiled a non-test file the `all` tag guards: `integration_only.go`, `internal/ccm`, `internal/debug/debug_on.go`. That build is the first two lines of `make check`, and the rest of the target is architecture-independent, so it is split out as `make build`, run on both lanes, and the linters stay on amd64.

**The integration jobs wait for `build-amd64` alone**, where they waited for both build jobs.

Net −38 lines in `main.yml` (72 added, 110 removed), +6 in the `Makefile`.

### Resulting names

```
Build (amd64)                                    Build (arm64)
Integration Tests On Scylla (LATEST, amd64)      Integration Tests On Scylla (LATEST, arm64)
Integration Tests On Scylla (PRIOR, amd64)
Integration Tests On Scylla (LTS-LATEST, amd64)
Integration Tests On Scylla (LTS-PRIOR, amd64)
Integration Tests On Cassandra (5-LATEST, amd64)
Integration Tests On Cassandra (4-LATEST, amd64)
```

Same nine lanes as today — no combination added or dropped. **Eight of the nine rows change name;** `Build (arm64)` is the one that does not.

| Before | After |
|---|---|
| `Build` | `Build (amd64)` |
| `Build (arm64)` | unchanged |
| `Integration Tests On Scylla (LATEST)` | `Integration Tests On Scylla (LATEST, amd64)` |
| `Integration Tests On Scylla (PRIOR)` | `Integration Tests On Scylla (PRIOR, amd64)` |
| `Integration Tests On Scylla (LTS-LATEST)` | `Integration Tests On Scylla (LTS-LATEST, amd64)` |
| `Integration Tests On Scylla (LTS-PRIOR)` | `Integration Tests On Scylla (LTS-PRIOR, amd64)` |
| `Integration Tests On Scylla (arm64)` | `Integration Tests On Scylla (LATEST, arm64)` |
| `Integration Tests On Cassandra (5-LATEST)` | `Integration Tests On Cassandra (5-LATEST, amd64)` |
| `Integration Tests On Cassandra (4-LATEST)` | `Integration Tests On Cassandra (4-LATEST, amd64)` |

**If master's branch protection requires any of the old names, nothing will report them again:** every open pull request sits at "Expected — waiting for status to be reported" and cannot merge. The required-check list needs updating in step with this merge, by someone with admin.

## Things worth a reviewer's attention

- **`needs: [build-amd64]` is a real scheduling change,** not a rename. An arm64 unit-test failure held four ScyllaDB lanes and two Cassandra ones behind the arm64 runner queue, and five of those six run on amd64, where it says nothing about them. The sixth is the arm64 ScyllaDB entry, which will now start before its unit tests have reported — deliberately: a red arm64 lane still fails the checks list, so the cost is one CCM bring-up that could have been skipped, against a queue wait every lane pays on every run.
- **The arm64 job keeps the id `build-arm64`,** not `test-unit-arm64` as suggested: it now builds *and* tests, and `make check`'s remaining two thirds — `golangci-lint` and `go mod tidy -diff` — are architecture-independent, so running them there would only re-download an arm64 `golangci-lint` to repeat the amd64 result.
- **amd64 cache keys gain `runner.arch`,** which only the arm64 job carried. The merged ScyllaDB job has one key for two architectures and only the arch-qualified form is correct — `runner.os` is `Linux` on both, so a shared key hands one lane the other's amd64 `get-version` in `bin/` and x86_64 relocatables in `~/.ccm`. The `pr-check-` entry is shared with `build-amd64` and the Cassandra job, so their keys follow it rather than stop matching it. The arm64 keys are unchanged, so **only the amd64 entries go cold, once.**
- **Both build jobs now carry `permissions: contents: read`,** which only the arm64 one had — and so does `test-integration-cassandra`. It had none at all, having had no arm64 counterpart to force the question, so it was running on the repository default while its neighbour was pinned, and it is the one job that hands `GITHUB_TOKEN` to a make target.
- `aio-max-nr` still runs after the unit tests, where it cannot affect them. Preserved as-is; deleting it is a separate question.

## Validation

`make build`, `make check` and `make test-unit` (root and `lz4`, `-race`) pass locally with the split target; `check` still builds before it lints. The workflow parses and the matrix enumerates to exactly the nine combinations above with the expected `runs-on` per lane; a step-level diff against master confirms the six identical ScyllaDB steps came through untouched, the three cache changes are key-only, and the merged job's cache path list is a strict superset of the arm64 job's.

The rendered names are composed by GitHub, so this PR's own checks list is the real proof — please eyeball it against the table above, and check that the integration lanes start without waiting on `Build (arm64)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
