### PR TITLE
refactor(dialer): settle the frame parsers on protocol v3+

### DIFF
--- a/dialer/framesplitter.go
+++ b/dialer/framesplitter.go
@@ -10,10 +10,10 @@ import (
 // FrameHeaderLen is the CQL frame header these dialers slice on: version, flags, a
 // 2-byte stream id, the opcode and the 4-byte body length.
 //
-// It is fixed at the v3+ layout. Negotiation lands on v4 (discoverProtocol) and v5
-// keeps the same header, so the 1-byte stream id of v1/v2 only appears if a caller
-// pins ProtoVersion to one of them — which these dialers have never handled, here or
-// in the offset math they share with GetFrameHash (scylladb/gocql#1022).
+// It is the v3+ layout, and v3 is the floor this whole package parses at. Negotiation
+// lands on v4 (discoverProtocol) and v5 keeps the same header, so the 1-byte stream id
+// of v1/v2 only appears if a caller pins ProtoVersion to one of them -- which consume
+// refuses by name rather than slicing four wrong bytes as a body length.
 const FrameHeaderLen = 9
 
 // FrameBodyLen reports the body length that b's header declares, and whether b holds a
@@ -163,6 +163,42 @@ func (s *FrameSplitter) consume(b []byte, emit func(frame []byte) error) (int, e
 	s.frame = append(s.frame, b[:taken]...)
 
 	if headerShort {
+		// The version is frame[0], so the floor is checkable as soon as one byte has
+		// arrived -- and it has to be checked there rather than on a complete header.
+		// A bodyless v1/v2 frame is whole at eight bytes and so never reaches nine:
+		// behind FrameBodyLen's completeness test, the one shape this package most
+		// needs to refuse is the one shape it would never see. Feed would answer nil
+		// for it, the recorder would forward it to the server and record nothing (its
+		// Write gates the socket on the recording), and the replayer would report a
+		// successful write and then block in Read on a response it never queued. Nor
+		// is that shape exotic: OPTIONS carries no body, and the control connection
+		// heartbeats one every 30 seconds.
+		//
+		// Everything below reads the v3+ layout: the body length comes from
+		// frame[5:9], which on v1/v2 is the tail of the length plus the first body
+		// byte, and the recorder goes on to take a 2-byte stream id from frame[2:4].
+		// Refusing beats slicing, so a caller-pinned old protocol fails by name
+		// instead of recording mis-framed garbage. The refusal also precedes the
+		// length check because on such a frame the length is not the peer's number at
+		// all, and naming it would send the reader after the wrong thing.
+		//
+		// Latching on the response direction too costs the driver its protocol
+		// downgrade on a recorded connection: controlConn.discoverProtocol reads the
+		// server's version out of the ERROR frame answering a too-new STARTUP, and a
+		// v1/v2-stamped one now fails the read rather than reaching
+		// parseProtocolFromError. That is the trade, not an oversight -- the frames it
+		// gives up are ones no recording could have held correctly anyway, and it only
+		// reaches a server answering below v3.
+		//
+		// s.frame is never empty here -- Feed only calls consume with bytes to consume,
+		// and takes at least one of them while the header is short -- and
+		// FrameProtoVersion answers 0 for an empty slice anyway, so the check fails
+		// closed either way. Re-running it on each chunk of a dribbled header is the
+		// same verdict on the same byte.
+		if version := FrameProtoVersion(s.frame); version < protoVersion3 {
+			return taken, s.fail(fmt.Errorf("gocql/dialer: connection is at protocol v%d; the record and replay dialers read the protocol v3+ frame header", version))
+		}
+
 		bodyLen, ok := FrameBodyLen(s.frame)
 		if !ok {
 			return taken, nil

--- a/dialer/framesplitter_test.go
+++ b/dialer/framesplitter_test.go
@@ -3,6 +3,8 @@ package dialer
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	frm "github.com/gocql/gocql/internal/frame"
@@ -174,6 +176,56 @@ func TestFrameSplitterBoundsDeclaredLength(t *testing.T) {
 				t.Errorf("declared body length %d was rejected: %v", tc.bodyLen, err)
 			}
 		})
+	}
+}
+
+// TestFrameSplitterRefusesPreV3 pins the protocol floor. The splitter reads the body
+// length from frame[5:9] and the recorder a 2-byte stream id from frame[2:4], both of
+// which are the v3+ layout; a v1/v2 frame carries both fields a byte earlier, so every
+// one of those reads lands a byte late and slicing such a stream emits things that are
+// not frames and records them without complaint. Only a caller-pinned ProtoVersion can
+// produce one -- negotiation lands on v4 -- which is exactly the case that used to go
+// unreported.
+//
+// Every length such a frame can arrive in is checked, because the floor used to sit
+// behind FrameBodyLen's completeness test and so only ran once nine bytes had arrived.
+// A v1/v2 header is eight bytes and a bodyless frame is nothing but its header, so an
+// OPTIONS -- which the control connection heartbeats -- was a complete frame one byte
+// short of the check meant to refuse it, and Feed answered nil. See consume.
+//
+// The refusal names the version rather than the length it would otherwise have
+// believed, and it latches: a stream whose framing is in doubt cannot be resumed.
+func TestFrameSplitterRefusesPreV3(t *testing.T) {
+	for _, version := range []byte{0x01, 0x02} {
+		// A whole bodyless v1/v2 OPTIONS: version, flags, a 1-byte stream id, the
+		// opcode and a 4-byte body length of zero.
+		frame := []byte{version, 0x00, 0x00, byte(opOptions), 0x00, 0x00, 0x00, 0x00}
+
+		for _, tc := range []struct {
+			name string
+			feed []byte
+		}{
+			{name: "the version byte alone", feed: frame[:1]},
+			{name: "a whole bodyless frame", feed: frame},
+			{name: "a frame and one byte past it", feed: append(append([]byte(nil), frame...), 0x00)},
+		} {
+			t.Run(fmt.Sprintf("v%d/%s", version, tc.name), func(t *testing.T) {
+				var s FrameSplitter
+				err := s.Feed(tc.feed, mustNotEmit(t))
+				if err == nil {
+					t.Fatalf("%d bytes of a protocol v%d frame were accepted", len(tc.feed), version)
+				}
+				if want := fmt.Sprintf("protocol v%d", version); !strings.Contains(err.Error(), want) {
+					t.Errorf("error does not name the version (%q): %v", want, err)
+				}
+
+				// Including a later call carrying nothing, which is how a refused
+				// connection's zero-length write reaches here.
+				if again := s.Feed(nil, mustNotEmit(t)); again != err {
+					t.Errorf("Feed after the refusal = %v, want the latched %v", again, err)
+				}
+			})
+		}
 	}
 }
 

--- a/dialer/framing.go
+++ b/dialer/framing.go
@@ -117,7 +117,7 @@ func (f *Framing) ObserveRequest(frame []byte) error {
 
 	if !FrameIsProtoV5OrNewer(frame) {
 		return fmt.Errorf("gocql/dialer: connection negotiated %q compression at protocol v%d, which compresses frame bodies rather than transport segments; the record and replay dialers support compression only from protocol v5",
-			algorithm, frame[0]&protoVersionMask)
+			algorithm, FrameProtoVersion(frame))
 	}
 
 	if named, ok := f.comp.(interface{ Name() string }); ok && !strings.EqualFold(named.Name(), algorithm) {
@@ -147,7 +147,7 @@ func (f *Framing) ObserveResponse(frame []byte) {
 		return
 	}
 
-	switch frameOp(frame[3+headerShift(frame)]) {
+	switch frameOp(frame[4]) {
 	case opReady, opAuthenticate:
 		f.segmented.Store(true)
 	}

--- a/dialer/recorder/recorder_test.go
+++ b/dialer/recorder/recorder_test.go
@@ -532,6 +532,91 @@ func TestConnectionRecorderAcceptsProtoV4(t *testing.T) {
 	}
 }
 
+// startupFrameV2 builds a protocol v2 STARTUP: the handshake the driver opens with, in
+// the layout that predates the 2-byte stream id, so the opcode sits at index 3 and the
+// body at index 8 rather than 4 and 9.
+func startupFrameV2() []byte {
+	body := []byte{
+		0x00, 0x01, // one option
+		0x00, 0x0B, 'C', 'Q', 'L', '_', 'V', 'E', 'R', 'S', 'I', 'O', 'N',
+		0x00, 0x05, '3', '.', '0', '.', '0',
+	}
+	header := []byte{
+		0x02,                              // version v2 (request)
+		0x00,                              // header flags
+		0x00,                              // stream id (1 byte)
+		0x01,                              // opStartup
+		0x00, 0x00, 0x00, byte(len(body)), // body length
+	}
+	return append(header, body...)
+}
+
+// optionsFrameV2 builds a body-less protocol v2 OPTIONS: eight bytes that are nothing
+// but a v1/v2 header, and therefore a complete frame one byte short of the v3+ header
+// the splitter slices on.
+//
+// This is the shape that used to slip the floor entirely, because the check ran only
+// once nine bytes had arrived. It is also the shape the driver sends most often --
+// controlConn.heartBeat sends an OPTIONS every 30 seconds, and OPTIONS carries no body.
+func optionsFrameV2() []byte {
+	return []byte{
+		0x02,                   // version v2 (request)
+		0x00,                   // header flags
+		0x00,                   // stream id (1 byte)
+		0x05,                   // opOptions
+		0x00, 0x00, 0x00, 0x00, // body length
+	}
+}
+
+// TestConnectionRecorderRefusesPreV3 is the other side of AcceptsProtoV4: a connection
+// a caller pinned to protocol v1 or v2 is refused by name, and nothing reaches the
+// recording.
+//
+// What used to happen was worse than an error. Every offset here reads the v3+ header,
+// so a v2 stream was sliced a byte late, and the write succeeded -- the file filled
+// with records whose frames were not frames, and whose stream ids came from the middle
+// of a body. Nothing said so until a replay of them failed to match anything.
+//
+// Both a bodyful frame and a bodyless one, because Write gates the socket on the
+// recording: a frame the splitter fails to refuse is forwarded to the server and
+// recorded nowhere. The bodyless case is the one that got that far.
+func TestConnectionRecorderRefusesPreV3(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		frame []byte
+	}{
+		{name: "a bodyful STARTUP", frame: startupFrameV2()},
+		{name: "a bodyless OPTIONS", frame: optionsFrameV2()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fname := filepath.Join(t.TempDir(), "conn")
+			conn := &stubConn{}
+			rec, err := NewConnectionRecorder(fname, conn, nil)
+			if err != nil {
+				t.Fatalf("NewConnectionRecorder: %v", err)
+			}
+			defer rec.Close()
+
+			n, err := rec.Write(tc.frame)
+			if err == nil {
+				t.Fatal("a protocol v2 connection was recorded")
+			}
+			if !strings.Contains(err.Error(), "protocol v2") {
+				t.Errorf("error does not name the version: %v", err)
+			}
+			if n != 0 {
+				t.Errorf("Write reported %d bytes written, want 0", n)
+			}
+			if len(conn.written) != 0 {
+				t.Errorf("%d bytes reached the server from a refused connection", len(conn.written))
+			}
+			if got := recordedFrames(t, fname+"Writes"); len(got) != 0 {
+				t.Errorf("recorded %d frames from a refused connection, want 0", len(got))
+			}
+		})
+	}
+}
+
 // TestConnectionRecorderCloseClosesEverything pins that one failing close does not
 // strand the rest. Close used to return at the first error, leaving the other
 // recording file and the socket itself open -- under the driver's redial loop, one

--- a/dialer/replayer/replayer.go
+++ b/dialer/replayer/replayer.go
@@ -170,25 +170,11 @@ func (c *ConnectionReplayer) getPendingFrame() *FrameRecorded {
 	return c.frames[frameId]
 }
 
-// twoByteStreamID reports whether b's protocol version carries the 2-byte stream id of
-// v3+ rather than the single byte of v1/v2.
-//
-// dialer.FrameProtoVersion rather than b[0] directly: the top bit of a frame's first
-// byte is the request/response direction, so an unmasked comparison reads every
-// response as a far newer protocol. replaceFrameStreamID is handed exactly that -- a
-// recorded response -- where a v1/v2 frame arrives as 0x81 or 0x82, takes the v3+ branch
-// and writes the low half of the stream id over the opcode. dialer/utils.go warns about
-// this in the note above headerShift, and matchRequest already uses the masked helper.
-func twoByteStreamID(b []byte) bool {
-	return dialer.FrameProtoVersion(b) > 0x02
-}
-
+// A stream id is two bytes at frame[2:4] on every protocol this package reads. It used
+// to be one byte on v1/v2, and both functions below forked on the version to find out
+// -- dialer.FrameSplitter now refuses a connection under v3 before either can see it.
 func (c *ConnectionReplayer) pushStreamIDToReplay(b []byte, idx int) {
-	if twoByteStreamID(b) {
-		c.streamIdsToReplay = append(c.streamIdsToReplay, int(b[2])<<8|int(b[3]))
-	} else {
-		c.streamIdsToReplay = append(c.streamIdsToReplay, int(b[2]))
-	}
+	c.streamIdsToReplay = append(c.streamIdsToReplay, int(b[2])<<8|int(b[3]))
 	c.frameIdsToReplay = append(c.frameIdsToReplay, idx)
 
 	select {
@@ -216,12 +202,8 @@ func wholeFrame(b []byte) bool {
 }
 
 func replaceFrameStreamID(b []byte, stream int) {
-	if twoByteStreamID(b) {
-		b[2] = byte(stream >> 8)
-		b[3] = byte(stream)
-	} else {
-		b[2] = byte(stream)
-	}
+	b[2] = byte(stream >> 8)
+	b[3] = byte(stream)
 }
 
 // Read serves the recorded response to the request most recently matched, across as

--- a/dialer/replayer/replayer_test.go
+++ b/dialer/replayer/replayer_test.go
@@ -69,6 +69,39 @@ func TestConnectionReplayerReplaysUnsegmentedProtoV5(t *testing.T) {
 	}
 }
 
+// TestConnectionReplayerRefusesPreV3 is the replayer's half of the protocol floor, and
+// it pins the worse of the two failures it prevents. A pre-v3 frame the splitter lets
+// through is not merely unmatched: Write reports every byte written and queues no
+// response, so the driver's next Read parks on gotRequest and the connection hangs
+// instead of failing.
+//
+// A bodyless v2 OPTIONS is what reached that state -- a complete v1/v2 frame one byte
+// short of the v3+ header the splitter slices on, from the request the control
+// connection heartbeats. The error has to be the splitter's own, raised ahead of
+// matchRequest, so it names the frame's version rather than reporting a recording
+// mismatch or a hash that matched nothing.
+func TestConnectionReplayerRefusesPreV3(t *testing.T) {
+	c := newTestReplayer(0x04)
+
+	// Eight bytes: version, flags, a 1-byte stream id, opOptions, and a zero body
+	// length.
+	n, err := c.Write([]byte{0x02, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00})
+	if err == nil {
+		t.Fatal("a protocol v2 frame was replayed")
+	}
+	if !strings.Contains(err.Error(), "protocol v2") {
+		t.Errorf("error does not name the frame's version: %v", err)
+	}
+	// Distinguishes the floor from matchRequest's recording-mismatch check, which
+	// would also name v2 -- and which a frame refused here never reaches.
+	if !strings.Contains(err.Error(), "v3+ frame header") {
+		t.Errorf("refusal did not come from the protocol floor: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Write reported %d bytes written, want 0", n)
+	}
+}
+
 // TestConnectionReplayerRejectsAProtocolMismatch pins that replaying a recording at
 // the wrong protocol version says so, rather than serving responses the driver rejects
 // deep inside its own header parsing.

--- a/dialer/utils.go
+++ b/dialer/utils.go
@@ -174,6 +174,7 @@ const (
 	protoVersionMask = 0x7F
 	protoVersion1    = 0x01
 	protoVersion2    = 0x02
+	protoVersion3    = 0x03
 	protoVersion4    = 0x04
 	protoVersion5    = 0x05
 )

--- a/dialer/utils.go
+++ b/dialer/utils.go
@@ -33,11 +33,15 @@ var ErrSegmentCompressorRequired = errors.New("gocql/dialer: protocol v5 connect
 // The direction bit is masked off: the top bit of frame[0] distinguishes a request
 // from a response, and folding it into the version makes every response look like a
 // far newer protocol. It is only meaningful for bytes at a frame boundary.
+//
+// The masking is frm.ProtoVersion's rather than a second copy of it here. Every
+// version comparison in this package goes through this function for that reason: one
+// of them getting the direction bit wrong is a bug that reads as a protocol change.
 func FrameProtoVersion(b []byte) byte {
 	if len(b) == 0 {
 		return 0
 	}
-	return b[0] & protoVersionMask
+	return frm.ProtoVersion(b[0]).Version()
 }
 
 // FrameIsProtoV5OrNewer reports whether b starts a CQL frame whose protocol version is
@@ -87,13 +91,11 @@ func forEachStartupOption(frame []byte, fn func(key, value []byte) bool) bool {
 	if len(frame) < 5 {
 		return false
 	}
-	shift := headerShift(frame)
-	if frameOp(frame[3+shift]) != opStartup {
+	if frameOp(frame[4]) != opStartup {
 		return false
 	}
 
-	// Header: version, flags, stream (1 byte on v1/v2, 2 on v3+), opcode, length(4).
-	p := 8 + shift
+	p := FrameHeaderLen
 	readShort := func() (int, bool) {
 		if p+2 > len(frame) {
 			return 0, false
@@ -166,33 +168,18 @@ func StartupCompression(frame []byte) (string, bool) {
 	return algorithm, found
 }
 
-// A CQL frame carries the protocol version in the low 7 bits of frame[0]; the
-// top bit is the request/response direction. Always mask with protoVersionMask
-// before comparing a version, so the version tests in this file cannot disagree
-// with each other depending on whether the direction bit happens to be set.
-const (
-	protoVersionMask = 0x7F
-	protoVersion1    = 0x01
-	protoVersion2    = 0x02
-	protoVersion3    = 0x03
-	protoVersion4    = 0x04
-	protoVersion5    = 0x05
-)
-
-// headerShift reports the extra header byte protocol v3+ spends on its 2-byte
-// stream id: v1/v2 put the opcode at frame[3] and the body at frame[8], v3+ put
-// them at frame[4] and frame[9]. Callers must have checked that frame is non-empty.
+// The protocol versions this package names. v3 is the floor: everything here reads
+// the v3+ frame header, and FrameSplitter.consume refuses anything older, so no parser
+// below has a v1/v2 case to answer for.
 //
-// This is the single place the offset is derived, so the parsers in this file cannot
-// disagree about where a frame's opcode is. The comparison is masked per the note
-// above: the top bit of frame[0] is the request/response direction, and folding it
-// into the version makes every response look like a much newer protocol.
-func headerShift(frame []byte) int {
-	if frame[0]&protoVersionMask > protoVersion2 {
-		return 1
-	}
-	return 0
-}
+// Compare a version through FrameProtoVersion, never against frame[0] directly. The
+// top bit there is the request/response direction, and folding it in makes every
+// response look like a much newer protocol.
+const (
+	protoVersion3 = 0x03
+	protoVersion4 = 0x04
+	protoVersion5 = 0x05
+)
 
 // fits reports whether the n bytes starting at index lie inside frame.
 //
@@ -375,7 +362,7 @@ func addQueryParams(frame []byte, index int) (end, tailStart, tailEnd int, ok bo
 
 	//use query flags
 	var flags uint32
-	protoV5OrNewer := frame[0]&protoVersionMask > protoVersion4
+	protoV5OrNewer := FrameProtoVersion(frame) > protoVersion4
 	if protoV5OrNewer {
 		// For protocol v5+, flags are a 4-byte big-endian uint32
 		if !fits(frame, index, 4) {
@@ -394,14 +381,7 @@ func addQueryParams(frame []byte, index int) (end, tailStart, tailEnd int, ok bo
 		index = index + 1
 	}
 
-	names := false
-
-	// protoV3 specific things
-	if frame[0]&protoVersionMask > protoVersion2 {
-		if flags&frm.FlagValues == frm.FlagValues && flags&frm.FlagWithNameValues == frm.FlagWithNameValues {
-			names = true
-		}
-	}
+	names := flags&frm.FlagValues == frm.FlagValues && flags&frm.FlagWithNameValues == frm.FlagWithNameValues
 
 	if flags&frm.FlagValues == frm.FlagValues {
 		if !fits(frame, index, 2) {
@@ -485,10 +465,6 @@ func addQueryParams(frame []byte, index int) (end, tailStart, tailEnd int, ok bo
 	return end, tailStart, index, true
 }
 
-func addHeader(index int) int {
-	return index + 8
-}
-
 // pastCustomPayload reports the offset a request's own body fields start at, stepping
 // over the custom payload when the frame carries one, along with a canonical hash of
 // the payload's entries (0 when the frame carries none).
@@ -497,23 +473,23 @@ func addHeader(index int) int {
 // body field, so QUERY, EXECUTE and BATCH each have to step over it before walking
 // anything of their own; a frame without the flag starts where the header ends. Reading
 // frame[1] is the caller's to make safe, and GetFrameHash's arms all sit behind its
-// header-length guard.
-func pastCustomPayload(frame []byte, p int) (int, int64, bool) {
+// FrameHeaderLen guard.
+func pastCustomPayload(frame []byte) (int, int64, bool) {
 	if frame[1]&frm.FlagCustomPayload != frm.FlagCustomPayload {
-		return addHeader(p), 0, true
+		return FrameHeaderLen, 0, true
 	}
-	return addCustomPayload(frame, p)
+	return addCustomPayload(frame)
 }
 
 // addCustomPayload walks the [bytes map] a frame carries when FlagCustomPayload is
 // set, and returns the index just past it along with a canonical hash of its entries.
 //
-// It derives that map's offset from p with addHeader rather than taking it as well,
-// so the offset it reads the entry count from and the offset it walks on from cannot
-// disagree. Every caller passed addHeader(p) for both, which held only by convention:
-// a caller passing an index already advanced past something would have read the count
-// from the body start and walked from somewhere else, and the walk would be
-// plausible-but-wrong in the way the empty-map case below was.
+// It starts at the body rather than taking an index, so the offset it reads the entry
+// count from and the offset it walks on from cannot disagree. They used to be two
+// arguments that every caller passed the same value for, which held only by
+// convention: a caller handing it an index already advanced past something would have
+// read the count from the body start and walked from somewhere else, and the walk
+// would be plausible-but-wrong in the way the empty-map case below was.
 //
 // The hash sorts each entry's raw bytes before folding them together, rather than
 // folding them in wire order. writeBytesMap (frame.go) ranges directly over a Go map to
@@ -524,8 +500,8 @@ func pastCustomPayload(frame []byte, p int) (int, int64, bool) {
 // independent of which order writeBytesMap happened to produce. Ties are impossible —
 // a [bytes map]'s keys are unique, and the key is the first field of each entry, so
 // comparing the raw entries already totally orders them.
-func addCustomPayload(frame []byte, p int) (int, int64, bool) {
-	index := addHeader(p)
+func addCustomPayload(frame []byte) (int, int64, bool) {
+	index := FrameHeaderLen
 	if !fits(frame, index, 2) {
 		return 0, 0, false
 	}
@@ -661,6 +637,15 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 	// carry. Handing it segment bytes hashes a meaningless range. The record/replay
 	// dialers unwrap the segments first, which is what Decoder is for.
 	//
+	// Every offset below is the protocol v3+ header's. On a live connection nothing
+	// older reaches here: FrameSplitter.consume refuses one under v3 as soon as its
+	// version byte arrives, which is why this reads frame[4] for an opcode and blanks
+	// two stream-id bytes rather than deriving either. A recording is the other way
+	// in -- loadResponseFramesFromFiles hashes bytes straight off disk, past any
+	// splitter -- so a file holding pre-v3 frames is read at these offsets and fails
+	// to match. Every read below is bounds-checked, so that is a wrong hash, not a
+	// panic.
+	//
 	// Note the empty and short-frame guards hash the frame as given, while the
 	// raw-bytes fallbacks inside the switch hash it with the stream id already
 	// blanked. Both are stable between record and replay, which is all the hash has
@@ -678,13 +663,6 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 	// a canonical hash of the payload as well, and the header flags, for a bit of
 	// identity the body never carries; see addCustomPayload and hashParams.
 	//
-	// One exception, and it is a dead one: the protocol v1 EXECUTE path slices from
-	// past its values, so it leaves the prepared id out of the very range that is meant
-	// to carry it. It cannot be reached — its values walk advances at least four bytes
-	// per value while the bound it is checked against allows one, so every v1 EXECUTE
-	// falls back to hashing the frame whole. Left as it is because no live connection is
-	// v1 and the path is going away.
-	//
 	// STARTUP hashes the header down to the opcode and deliberately stops before the
 	// body length, for the reason its own comment gives. PREPARE, AUTH_RESPONSE,
 	// OPTIONS, REGISTER and the unknown-opcode default hash the frame whole, header
@@ -693,32 +671,23 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 		return murmur.Murmur3H1(frame)
 	}
 
-	p := headerShift(frame)
-
 	// A frame shorter than its own header — version, flags, stream id, opcode and
 	// the 4-byte body length — cannot be parsed at all: the stream-id blanking
 	// below and the opcode switch after it both index into it unconditionally.
-	if !fits(frame, 0, 8+p) {
+	if !fits(frame, 0, FrameHeaderLen) {
 		return murmur.Murmur3H1(frame)
 	}
 
-	if p == 1 {
-		streamID1 := frame[2]
-		streamID2 := frame[3]
-		defer func() {
-			frame[2] = streamID1
-			frame[3] = streamID2
-		}()
-		frame[2] = byte('0')
-		frame[3] = byte('0')
-	} else {
-		streamID1 := frame[2]
-		defer func() {
-			frame[2] = streamID1
-		}()
-		frame[2] = byte('0')
-	}
-	switch frame[3+p] {
+	streamID1 := frame[2]
+	streamID2 := frame[3]
+	defer func() {
+		frame[2] = streamID1
+		frame[3] = streamID2
+	}()
+	frame[2] = byte('0')
+	frame[3] = byte('0')
+
+	switch frame[4] {
 	case byte(opStartup):
 		// Hash the header up to and including the opcode, deliberately stopping
 		// before the 4-byte body length: a connection sends exactly one STARTUP,
@@ -729,13 +698,13 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 		// set of STARTUP options the driver sent when it was recorded, so adding
 		// one (DRIVER_CONFIG, SESSION_ID, ...) would invalidate them all and
 		// panic the replay benchmarks until they were regenerated.
-		return murmur.Murmur3H1(frame[:4+p])
+		return murmur.Murmur3H1(frame[:5])
 	case byte(opPrepare):
 		return murmur.Murmur3H1(frame)
 	case byte(opAuthResponse):
 		return murmur.Murmur3H1(frame)
 	case byte(opQuery):
-		index, payloadHash, ok := pastCustomPayload(frame, p)
+		index, payloadHash, ok := pastCustomPayload(frame)
 		if !ok {
 			return murmur.Murmur3H1(frame)
 		}
@@ -756,17 +725,16 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 
 		return hashParams(frame, index, paramsStart, payloadHash)
 	case byte(opExecute):
-		index, payloadHash, ok := pastCustomPayload(frame, p)
+		index, payloadHash, ok := pastCustomPayload(frame)
 		if !ok {
 			return murmur.Murmur3H1(frame)
 		}
 
 		endIndex := index
 
-		// Every length here is peer- or file-supplied, and this branch now runs on
-		// protocol v4 rather than being unreachable, so bound the reads: a truncated
-		// or wrongly-stamped recording must fall back to hashing the raw bytes (as the
-		// v5 guard above does) rather than panic inside loadResponseFramesFromFiles.
+		// Every length here is peer- or file-supplied, so bound the reads: a truncated
+		// or wrongly-stamped recording must fall back to hashing the raw bytes rather
+		// than panic inside loadResponseFramesFromFiles.
 		// Both the length field and the payload it announces have to be checked —
 		// a plausible length running off the end walks straight into addQueryParams.
 		if !fits(frame, index, 2) {
@@ -784,7 +752,7 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 		// query-params offset (and therefore the extracted hash) is correct. The v4
 		// case cannot be read from the frame bytes, so it is signalled by the
 		// caller via useMetadataID.
-		if frame[0]&protoVersionMask > protoVersion4 || useMetadataID {
+		if FrameProtoVersion(frame) > protoVersion4 || useMetadataID {
 			if !fits(frame, endIndex, 2) {
 				return murmur.Murmur3H1(frame)
 			}
@@ -795,31 +763,9 @@ func GetFrameHash(frame []byte, useMetadataID bool) int64 {
 			endIndex = endIndex + 2 + resultMetadataIDLen
 		}
 
-		if frame[0]&protoVersionMask > protoVersion1 {
-			return hashParams(frame, index, endIndex, payloadHash)
-		}
-
-		// Protocol v1 has no <query_parameters> block: the values follow the
-		// preparedID directly. Bounded by the preparedID length check above, which
-		// read the same two bytes at the same index: nothing between here and there
-		// moves it.
-		valuesLen := int(frame[index])<<8 | int(frame[index+1])
-		index = index + 2
-		for i := 0; i < valuesLen; i++ {
-			if index, ok = addBytes(frame, index); !ok {
-				return murmur.Murmur3H1(frame)
-			}
-		}
-		index = index + 2
-		// The walk above moves index independently of endIndex and can leave it past
-		// the end of the range, so the two still have to be ordered before the slice.
-		// endIndex itself is bounded by the helpers.
-		if index > endIndex {
-			return murmur.Murmur3H1(frame)
-		}
-		return murmur.Murmur3H1(frame[index:endIndex])
+		return hashParams(frame, index, endIndex, payloadHash)
 	case byte(opBatch):
-		index, payloadHash, ok := pastCustomPayload(frame, p)
+		index, payloadHash, ok := pastCustomPayload(frame)
 		if !ok {
 			return murmur.Murmur3H1(frame)
 		}

--- a/dialer/utils_hashlock_test.go
+++ b/dialer/utils_hashlock_test.go
@@ -157,9 +157,6 @@ func hashLockCases() []hashLockCase {
 		{name: "batch-default-timestamp", frame: frameV4(opBatch, 0x00, batchBody(0x20,
 			[]byte{0x00, 0x06, 0x26, 0x52, 0xBF, 0xD6, 0xE5, 0x3F}))},
 
-		{name: "v2-options", frame: frameV2(opOptions, nil)},
-		{name: "v2-query", frame: frameV2(opQuery, queryBody("SELECT * FROM system.local", 0x00))},
-
 		{name: "truncated-execute-prepared-id-len", frame: v4ExecuteFrame(true)[:10], useMetadataID: true},
 		{name: "truncated-execute-metadata-id-len", frame: v4ExecuteFrame(true)[:15], useMetadataID: true},
 		{name: "short-header", frame: frameV4(opQuery, 0x00, nil)[:5]},
@@ -192,6 +189,11 @@ func TestGetFrameHashIsStable(t *testing.T) {
 // v5 query-parameter support was added, and is unchanged by it: the v5 tail walk is
 // gated on v5, so nothing below v5 could reach it. The v5 cases at the bottom of the
 // map are the ones that support added.
+//
+// They are also unchanged by the package settling on a protocol v3 floor. Two v2 cases
+// used to sit here pinning the older header layout; deleting the v1/v2 walks moved
+// those two and nothing else, which is what says the fixed offsets land where the
+// derived ones did.
 var hashLockWant = map[string]int64{
 	"auth-response":                     -5612286604398787175,
 	"empty":                             0,
@@ -208,7 +210,6 @@ var hashLockWant = map[string]int64{
 	"truncated-execute-metadata-id-len": 1641695519491433123,
 	"truncated-execute-prepared-id-len": -2990148397469877668,
 	"unknown-opcode":                    -8681368666721584811,
-	"v2-options":                        2835211771060518081,
 
 	// Both BATCH values moved when the arm stopped hashing the frame whole and
 	// started walking the body to the end of the parameter block. That is the point
@@ -221,22 +222,18 @@ var hashLockWant = map[string]int64{
 	"batch-default-timestamp": -8987577148391256339,
 
 	// Every QUERY value here moved when scylladb/gocql#1000 was fixed. Before it, all
-	// eleven were Murmur3H1({0x00, 0x00, 0x00}) = 8779008611884021576: the parameter
+	// ten were Murmur3H1({0x00, 0x00, 0x00}) = 8779008611884021576: the parameter
 	// walk was handed the body start rather than the position past the query text, so
 	// it hashed the top three bytes of the text's length — zero for any query under
 	// 16 MiB — and stopped. The checked-in recordings were regenerated in the same
 	// change, because their control-connection query text had been stale since
 	// b6a9682 and only the collision hid it.
 	//
-	// Two of these still coincide, and are meant to: query-bare and v2-query both hash
-	// 669594534933358966 because the range is measured from the body, so the same
-	// statement and parameters hash alike across protocol versions.
-	//
-	// query-custom-payload used to be a third. It carries query-bare's body behind a
-	// [bytes map] and differs in nothing else, and the range began past the payload,
-	// so the two were indistinguishable — and the replayer serves the first hash it
-	// matches, so one of them got the other's response. Query.CustomPayload is public,
-	// so both are requests a caller can send. The range then started at the body.
+	// query-custom-payload carries query-bare's body behind a [bytes map] and differs
+	// in nothing else. The two used to hash alike, because the range began past the
+	// payload — and the replayer serves the first hash it matches, so one of them got
+	// the other's response. Query.CustomPayload is public, so both are requests a
+	// caller can send. The range then started at the body.
 	//
 	// execute-custom-payload and batch-custom-payload are here because the same range
 	// moved in those two arms as well, and without a payload-bearing case each, either
@@ -267,7 +264,6 @@ var hashLockWant = map[string]int64{
 	"query-serial-consistency":      -1672825478938872525,
 	"query-values":                  -2567259529754147462,
 	"query-values-page-size-serial": -6333038150028030013,
-	"v2-query":                      669594534933358966,
 
 	// A QUERY whose [long string] cannot be walked — its length field truncated, or
 	// announcing more bytes than the frame holds — is a damaged recording, so it falls

--- a/dialer/utils_test.go
+++ b/dialer/utils_test.go
@@ -23,10 +23,9 @@ func frameV4(op frameOp, headerFlags byte, body []byte) []byte {
 	return append(frame, body...)
 }
 
-// frameV2 builds the same frame on protocol v2, whose stream id is one byte, so
-// the opcode sits at index 3 and the body at index 8. Pins the shift=0 side of
-// headerShift; reading the opcode at index 4 here finds a length byte instead and
-// the frame is misclassified.
+// frameV2 builds the same frame on protocol v2, whose stream id is one byte, so the
+// opcode sits at index 3 and the body at index 8 -- a byte earlier than anything in
+// this package reads. It exists to pin that such a frame is not understood.
 func frameV2(op frameOp, body []byte) []byte {
 	frame := []byte{
 		0x02,
@@ -261,11 +260,12 @@ func TestStartupNegotiatesMetadataID(t *testing.T) {
 	if StartupNegotiatesMetadataID(frameV4(opQuery, 0x00, optIn)) {
 		t.Error("StartupNegotiatesMetadataID(QUERY with key) = true, want false")
 	}
-	if !StartupNegotiatesMetadataID(frameV2(opStartup, optIn)) {
-		t.Error("StartupNegotiatesMetadataID(v2 STARTUP with key) = false, want true")
-	}
-	if StartupNegotiatesMetadataID(frameV2(opQuery, optIn)) {
-		t.Error("StartupNegotiatesMetadataID(v2 QUERY with key) = true, want false")
+	// Below protocol v3 the opcode is a byte earlier, so index 4 holds a length byte
+	// and no v2 frame is a STARTUP as far as this is concerned. Not a gap: a
+	// connection that old is refused by FrameSplitter.consume before a STARTUP can be
+	// recorded, and reporting "no opt-in" for one is the safe way to be wrong.
+	if StartupNegotiatesMetadataID(frameV2(opStartup, optIn)) {
+		t.Error("StartupNegotiatesMetadataID(v2 STARTUP with key) = true, want false")
 	}
 	if StartupNegotiatesMetadataID(nil) {
 		t.Error("StartupNegotiatesMetadataID(nil) = true, want false")
@@ -381,9 +381,9 @@ func TestFitsRejectsOverflowingLengths(t *testing.T) {
 }
 
 // TestGetFrameHashBoundsShortFrame pins the guard for a frame shorter than its own
-// header. Everything after it indexes unconditionally — the stream-id blanking
-// reads frame[2] (and frame[3] on v3+), the switch reads the opcode at frame[3+p] —
-// so a one-byte v4 frame used to panic before the parser had looked at anything.
+// header. Everything after it indexes unconditionally — the stream-id blanking reads
+// frame[2] and frame[3], the switch reads the opcode at frame[4] — so a one-byte frame
+// used to panic before the parser had looked at anything.
 //
 // The fallback here hashes the frame as given rather than with the stream id
 // blanked, because there may be no stream id to blank. That is fine: record and
@@ -394,7 +394,6 @@ func TestGetFrameHashBoundsShortFrame(t *testing.T) {
 		full []byte
 	}{
 		{"v4", frameV4(opExecute, 0x00, nil)},
-		{"v2", frameV2(opExecute, nil)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// A header-only frame is the shortest one the parser accepts, so every


### PR DESCRIPTION
Fixes #1022.
Fixes: https://scylladb.atlassian.net/browse/DRIVER-964

The dialer half-supports protocols v1/v2, at contradictory depths.
`FrameSplitter` pins the 9-byte v3+ header and the recorder reads `frame[2..3]`
as a stream id unconditionally, while `GetFrameHash` carried full v1/v2 offset math
and the replayer forked on `b[0] > 0x02`. So a caller-pinned v1/v2 connection recorded
mis-framed garbage with no error, while the hash code suggested v1/v2 worked.

- Refuse a connection below v3 in `FrameSplitter.consume`, on the one-shot latch and
  ahead of the body-length bound — as soon as the version byte arrives, since a bodyless
  v1/v2 frame is whole at eight bytes and never reaches nine.
- Delete what the floor makes dead: `headerShift` and its offsets, the 1-byte stream-id
  blanking, the v1 EXECUTE walk, the replayer's `twoByteStreamID`, `addHeader` and
  direction-bit mask — `FrameProtoVersion` now delegates to `frm.ProtoVersion.Version()`.
- Only the two v2 cases move in `utils_hashlock_test.go`; the other 33 pinned hashes are
  byte-identical across six opcodes, v4 and v5 — proof the fixed offsets are right.
- Add `TestFrameSplitterRefusesPreV3`, `TestConnectionRecorderRefusesPreV3` and
  `TestConnectionReplayerRefusesPreV3` — refused by name at one, eight and nine bytes,
  latched, nothing written or sent.

Rebased onto master now that #1019 has merged: nine `dialer/` files, no recording
regenerated here — the `tests/bench` recapture landed with #1019.

Verified with `make check`, `make test-unit` (both modules) and `make test-bench`,
whose `tests/bench` run replays the checked-in recordings; each commit builds and vets
standalone. Re-gating on a complete header fails the new one- and eight-byte cases.
Live in Docker (ScyllaDB 2026.2.4, Cassandra 5.0.9): record-then-replay round trips at
proto 3, 4 and 5, each stamped with the pinned version, and the CRUD, batch, paging and
tracing tests re-run behind the recording dialer — 3,693 frames, 11 opcodes, none
unparseable. Not covered: multi-node topology, and no CI lane reaches a live node with
`dialer/` linked (#1046).
