### PR TITLE
fix(frame): reject a short-bytes value that overflows its length

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -1442,6 +1442,22 @@ func (f *framer) validateV5Options(keyspace string, nowInSeconds *int) error {
 	return nil
 }
 
+// validateShortBytes rejects a value too long for the [short bytes] wire type, whose
+// length field is two bytes. Both values written with it -- a prepared id and a v5
+// result metadata id -- are opaque server-issued tokens far below the limit, so this
+// is about what a mis-sized one would do rather than about a value anyone expects to
+// see: writeShortBytes would truncate the length silently and emit a frame whose
+// header disagrees with its payload, desynchronising the connection.
+//
+// The single source of truth for the check, like validateV5Options above, so the
+// callers that hoist it and writeShortBytes itself cannot drift apart.
+func validateShortBytes(field string, p []byte) error {
+	if len(p) > math.MaxUint16 {
+		return fmt.Errorf("gocql: %s is %d bytes, which overflows the 2-byte length of a [short bytes] value", field, len(p))
+	}
+	return nil
+}
+
 func (f *framer) writeQueryParams(opts *queryParams) error {
 	// Validated again here, not only in the callers' buildFrame: this function is
 	// package-internal and nothing else would enforce the precondition.
@@ -1611,16 +1627,29 @@ func (f *framer) writeExecuteFrame(streamID int, preparedID, resultMetadataID []
 	if err := f.validateV5Options(params.keyspace, params.nowInSeconds); err != nil {
 		return err
 	}
+	writeResultMetadataID := f.proto > protoVersion4 || f.scyllaUseMetadataID
+	if err := validateShortBytes("prepared id", preparedID); err != nil {
+		return err
+	}
+	if writeResultMetadataID {
+		if err := validateShortBytes("result metadata id", resultMetadataID); err != nil {
+			return err
+		}
+	}
 
 	if len(*customPayload) > 0 {
 		f.payload()
 	}
 	f.writeHeader(f.flags, frm.OpExecute, streamID)
 	f.writeCustomPayload(customPayload)
-	f.writeShortBytes(preparedID)
+	if err := f.writeShortBytes(preparedID); err != nil {
+		return err
+	}
 
-	if f.proto > protoVersion4 || f.scyllaUseMetadataID {
-		f.writeShortBytes(resultMetadataID)
+	if writeResultMetadataID {
+		if err := f.writeShortBytes(resultMetadataID); err != nil {
+			return err
+		}
 	}
 
 	if err := f.writeQueryParams(params); err != nil {
@@ -1670,6 +1699,9 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 				return fmt.Errorf("gocql: named query values are not supported in batches, please see https://issues.apache.org/jira/browse/CASSANDRA-10246")
 			}
 		}
+		if err := validateShortBytes("prepared id", w.statements[i].preparedID); err != nil {
+			return err
+		}
 	}
 
 	if len(customPayload) > 0 {
@@ -1691,7 +1723,9 @@ func (f *framer) writeBatchFrame(streamID int, w *writeBatchFrame, customPayload
 			f.writeLongString(b.statement)
 		} else {
 			f.writeByte(1)
-			f.writeShortBytes(b.preparedID)
+			if err := f.writeShortBytes(b.preparedID); err != nil {
+				return err
+			}
 		}
 
 		f.writeShort(uint16(len(b.values)))
@@ -2093,9 +2127,16 @@ func (f *framer) writeBytes(p []byte) {
 	}
 }
 
-func (f *framer) writeShortBytes(p []byte) {
+// writeShortBytes writes a [short bytes] value. Validated again here, not only in the
+// callers that hoist it before writing any byte: this is package-internal and nothing
+// else would enforce the precondition, and uint16(len(p)) would otherwise truncate.
+func (f *framer) writeShortBytes(p []byte) error {
+	if err := validateShortBytes("value", p); err != nil {
+		return err
+	}
 	f.writeShort(uint16(len(p)))
 	f.buf = append(f.buf, p...)
+	return nil
 }
 
 func (f *framer) writeConsistency(cons Consistency) {

--- a/frame_test.go
+++ b/frame_test.go
@@ -721,6 +721,55 @@ func Test_framer_writeBatchFrame_unnamedValues(t *testing.T) {
 	assertDeepEqual(t, "value1", frame.statements[0].values[1].value, framer.readBytesCopy())
 }
 
+// A [short bytes] length field is two bytes, and writeShortBytes truncated
+// uint16(len(p)) with no guard: an oversized prepared id or v5 result metadata id
+// produced a frame whose declared length disagreed with its payload, desynchronising
+// the connection. Both are opaque server-issued tokens far below the limit, so what
+// is pinned here is what a mis-sized one does, not a value anyone expects to see.
+//
+// Driven through buildFrame, the entry point Conn.exec uses, so the hoisted check is
+// covered too: writeExecuteFrame writes a header and custom payload before the
+// prepared id, and writeBatchFrame writes a header, type and count before its
+// statements, so a rejection that is not hoisted leaves a partial frame behind.
+func Test_framer_shortBytesWriters_rejectOverlongValues(t *testing.T) {
+	tooLong := make([]byte, math.MaxUint16+1)
+	ok := []byte{0x01, 0x02}
+
+	for _, tc := range []struct {
+		name  string
+		proto byte
+		build frameBuilder
+	}{
+		{
+			name:  "EXECUTE prepared id",
+			proto: protoVersion4,
+			build: &writeExecuteFrame{preparedID: tooLong, params: queryParams{consistency: Quorum}},
+		},
+		{
+			name:  "EXECUTE result metadata id on v5",
+			proto: protoVersion5,
+			build: &writeExecuteFrame{preparedID: ok, resultMetadataID: tooLong, params: queryParams{consistency: Quorum}},
+		},
+		{
+			name:  "BATCH prepared id",
+			proto: protoVersion4,
+			build: &writeBatchFrame{
+				consistency: Quorum,
+				statements:  []batchStatment{{preparedID: tooLong}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			framer := newFramer(nil, tc.proto)
+
+			err := tc.build.buildFrame(framer, 1)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "overflows the 2-byte length")
+			require.Empty(t, framer.buf, "a rejected value must not leave a partial frame in the framer buffer")
+		})
+	}
+}
+
 // On protocols below v5 the keyspace override and now_in_seconds options are
 // not part of the wire format. The frame writers must reject them with an
 // explicit error (rather than silently dropping them, panicking, or leaving a


### PR DESCRIPTION
A `[short bytes]` length field is two bytes and `writeShortBytes` wrote
`uint16(len(p))` with no guard, so a value over 65535 bytes emitted a frame whose
declared length disagreed with its payload — the connection desynchronises from there
on, with nothing reporting why. The two values written this way are a prepared id and,
on v5, a result metadata id: opaque server-issued tokens far below the limit, so this
pins what a mis-sized one does rather than a value anyone expects.

- `validateShortBytes` is the single source of truth for the check, beside
  `validateV5Options`.
- EXECUTE and BATCH hoist it before writing any byte, so a rejected frame leaves no
  partial frame in the reusable framer buffer.
- `writeShortBytes` returns the error too, because it is package-internal and nothing
  else enforces its precondition — the same reasoning `writeQueryParams` already
  carries.

Verified with `make check` and `make test-unit`. The new test drives all three call
sites through `buildFrame`, the entry point `Conn.exec` uses, and all three cases pass
silently without the fix.

Refs: https://github.com/scylladb/gocql/issues/939
Refs: https://scylladb.atlassian.net/browse/DRIVER-954
