### PR TITLE
feat(conn): bound the time to assemble one segmented frame

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -258,12 +258,13 @@ type ClusterConfig struct {
 	// Default: 11 Seconds
 	ReadTimeout time.Duration
 	// FrameAssemblyTimeout limits the total time spent assembling one response
-	// frame, from the moment the peer starts sending it. It exists because
-	// ReadTimeout cannot bound that: on protocol v5 a single frame may arrive
-	// across many transport segments, and every read re-arms ReadTimeout afresh,
-	// so a peer that keeps trickling bytes is never timed out however long the
-	// frame takes. It does not shorten the idle wait for the next frame, which
-	// stays unbounded.
+	// frame, measured from the first byte of its first transport segment. It exists
+	// because ReadTimeout cannot bound that: on protocol v5 a single frame may
+	// arrive across many transport segments, and every read re-arms ReadTimeout
+	// afresh, so a peer that keeps trickling bytes is never timed out however long
+	// the frame takes. It does not shorten the idle wait for the next frame, which
+	// stays unbounded, and it applies only to the segmented transport, so it has no
+	// effect below protocol v5.
 	//
 	// Set it above the time a legitimately large frame needs on the slowest link
 	// you serve: a frame may be up to 256 MiB, and exceeding the budget drops the

--- a/cluster.go
+++ b/cluster.go
@@ -257,6 +257,19 @@ type ClusterConfig struct {
 	// It has only one purpose, identify faulty connection early and drop it.
 	// Default: 11 Seconds
 	ReadTimeout time.Duration
+	// FrameAssemblyTimeout limits the total time spent assembling one response
+	// frame, from the moment the peer starts sending it. It exists because
+	// ReadTimeout cannot bound that: on protocol v5 a single frame may arrive
+	// across many transport segments, and every read re-arms ReadTimeout afresh,
+	// so a peer that keeps trickling bytes is never timed out however long the
+	// frame takes. It does not shorten the idle wait for the next frame, which
+	// stays unbounded.
+	//
+	// Set it above the time a legitimately large frame needs on the slowest link
+	// you serve: a frame may be up to 256 MiB, and exceeding the budget drops the
+	// connection rather than the request.
+	// Default: 0, unbounded
+	FrameAssemblyTimeout time.Duration
 	// Consistency for the serial part of queries, values can be either SERIAL or LOCAL_SERIAL.
 	// Default: unset
 	SerialConsistency Consistency
@@ -668,6 +681,10 @@ func (cfg *ClusterConfig) Validate() error {
 
 	if cfg.ReadTimeout < 0 {
 		return errors.New("ReadTimeout should be positive time.Duration or zero")
+	}
+
+	if cfg.FrameAssemblyTimeout < 0 {
+		return errors.New("FrameAssemblyTimeout should be positive time.Duration or zero")
 	}
 
 	if cfg.MetadataSchemaRequestTimeout < 0 {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -195,6 +195,41 @@ func TestValidate_ReadTimeout(t *testing.T) {
 	})
 }
 
+// TestValidate_FrameAssemblyTimeout covers the FrameAssemblyTimeout bound check in
+// Validate(): a negative duration is rejected; zero (disabled) and positive are
+// allowed.
+func TestValidate_FrameAssemblyTimeout(t *testing.T) {
+	t.Parallel()
+
+	newCfg := func(d time.Duration) *ClusterConfig {
+		cfg := NewCluster("10.0.0.1:9042")
+		cfg.FrameAssemblyTimeout = d
+		return cfg
+	}
+
+	t.Run("negative is rejected", func(t *testing.T) {
+		t.Parallel()
+		err := newCfg(-time.Second).Validate()
+		if err == nil || !strings.Contains(err.Error(), "FrameAssemblyTimeout should be positive") {
+			t.Fatalf("expected FrameAssemblyTimeout validation error, got: %v", err)
+		}
+	})
+
+	t.Run("zero is allowed", func(t *testing.T) {
+		t.Parallel()
+		if err := newCfg(0).Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("positive is allowed", func(t *testing.T) {
+		t.Parallel()
+		if err := newCfg(time.Second).Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 // TestValidate_HostPortNormalization covers the port-learning logic in Validate():
 // when cfg.Port is 0 (not explicitly set) the driver learns it from cfg.Hosts.
 func TestValidate_HostPortNormalization(t *testing.T) {

--- a/conn.go
+++ b/conn.go
@@ -1725,11 +1725,22 @@ type connReader struct {
 	// FrameAssemblyTimeout would wrap to an instant in the past and expire every
 	// frame at once -- the exact opposite of what such a value asks for -- and the
 	// round trip through it would also strip the monotonic reading, leaving the
-	// budget exposed to wall-clock adjustments. Ordered here, with the other
-	// pointer-bearing fields, for fieldalignment.
-	budget atomic.Pointer[time.Time]
+	// budget exposed to wall-clock adjustments.
+	//
+	// Plain, not atomic, unlike timeout/disarm below: it is written only from
+	// setReadBudget (recvSegment's deferred clear, headerReader.Read's
+	// first-byte start) and read only from armDeadline, both exclusively on the
+	// serve goroutine once dialWithoutObserver hands the connection to c.init.
+	// timeout/disarm can't make the same claim -- finalizeConnection rewrites
+	// them again later, from Session.init, concurrently with an already-running
+	// serve() (see #992/#993, the -race this same pattern caused for
+	// systemRequestTimeout). SetFrameAssemblyTimeout has exactly one call site,
+	// before serve() starts, and is never called again, so budget has no such
+	// second writer to race.
+	budget *time.Time
 	// assembly is the configured budget duration; zero disables the budget.
-	assembly atomic.Int64
+	// Plain for the same reason as budget above.
+	assembly time.Duration
 	timeout  atomic.Int64
 	disarm   atomic.Bool
 }
@@ -1835,7 +1846,7 @@ func (c *connReader) armDeadline() error {
 	// in. Whichever expires first ends the read, and because the budget is absolute
 	// it survives the re-arm that gives each attempt a fresh timeout -- which is
 	// exactly the loop that leaves a trickling peer otherwise unbounded.
-	if budget := c.budget.Load(); budget != nil {
+	if budget := c.budget; budget != nil {
 		if deadline.IsZero() || budget.Before(deadline) {
 			deadline = *budget
 		}
@@ -1852,7 +1863,7 @@ func (c *connReader) setDisarm(v bool) {
 }
 
 func (c *connReader) SetFrameAssemblyTimeout(timeout time.Duration) {
-	c.assembly.Store(int64(timeout))
+	c.assembly = timeout
 }
 
 // setReadBudget starts or clears a frame-assembly budget. Starting one with no
@@ -1860,12 +1871,12 @@ func (c *connReader) SetFrameAssemblyTimeout(timeout time.Duration) {
 // an unconfigured connection reads exactly as it did before.
 func (c *connReader) setReadBudget(v bool) {
 	if !v {
-		c.budget.Store(nil)
+		c.budget = nil
 		return
 	}
-	if d := time.Duration(c.assembly.Load()); d > 0 {
+	if d := c.assembly; d > 0 {
 		deadline := time.Now().Add(d)
-		c.budget.Store(&deadline)
+		c.budget = &deadline
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -1135,7 +1135,9 @@ func (c *Conn) readFrameHeader(r io.Reader) (frm.FrameHeader, error) {
 		defer d.setDisarm(false)
 	}
 
-	c.headerReader.reset(r, d)
+	// No budget: this is a whole-frame header off the wire (pre-v5) or out of a
+	// segment payload that has already arrived, not the start of a reassembly.
+	c.headerReader.reset(r, d, nil)
 	return readHeader(&c.headerReader, c.headerBuf[:])
 }
 
@@ -1344,10 +1346,12 @@ func (c *Conn) recvSegment(ctx context.Context) error {
 	// trickling progress is not bounded by it at all — only by the frame length
 	// recvSplitFrame enforces against the reassembled size.
 	//
-	// FrameAssemblyTimeout is what bounds the whole frame, and it starts below
-	// rather than here: until the first header has arrived this goroutine is idle,
-	// and charging a peer for the time it had nothing to say would drop healthy
-	// connections. Unset by default, in which case nothing changes.
+	// FrameAssemblyTimeout is what bounds the whole frame. It starts on the first
+	// byte of the segment header, inside headerReader -- not here, because until that
+	// byte arrives this goroutine is idle and charging a peer for the time it had
+	// nothing to say would drop healthy connections; and not after the header, which
+	// would leave the rest of it covered only by ReadTimeout. Unset by default, in
+	// which case nothing changes.
 	//
 	// netStart/netEnd bracket this read for FrameHeaderObserver. The CQL headers
 	// inside are parsed out of memory further down, so timing them there would
@@ -1355,16 +1359,17 @@ func (c *Conn) recvSegment(ctx context.Context) error {
 	// window is measured here and carried to processFrameSource instead. Sampled
 	// only when an observer is installed, so an unobserved connection pays nothing.
 	netStart := c.observedNow()
+
+	// Registered before the header read, which is what starts the budget: the clear
+	// has to cover the paths that fail partway through it as much as the ones that
+	// finish, or an absolute budget outlives its frame and expires during the next
+	// idle wait.
+	defer c.r.setReadBudget(false)
+
 	hdr, err := c.readFirstSegmentHeader()
 	if err != nil {
 		return err
 	}
-
-	// The peer is mid-frame from here: everything below is this frame's payload and,
-	// if it is split, its continuation segments. Cleared on the way out so the next
-	// idle wait is not charged against this frame's budget.
-	c.r.setReadBudget(true)
-	defer c.r.setReadBudget(false)
 
 	payload, err := c.readSegmentPayload(hdr)
 	if err != nil {
@@ -1420,12 +1425,24 @@ type headerReader struct {
 	// Nil when there is no deadline to bound: on proto v5 the CQL header is parsed
 	// out of a segment payload that has already been received.
 	disarm deadlineDisarmer
+	// budget is the reader whose frame-assembly budget starts on that same first
+	// byte, and is cleared with it. Nil for every header but a segment's first: the
+	// budget covers assembling one frame, and only readFirstSegmentHeader stands at
+	// the start of one.
+	budget readBudgeter
 	n      int
 }
 
-func (h *headerReader) reset(r io.Reader, disarm deadlineDisarmer) {
+// readBudgeter starts a frame-assembly budget; see connReadSource.setReadBudget.
+// Narrowed to the one method so headerReader cannot reach for anything else.
+type readBudgeter interface {
+	setReadBudget(bool)
+}
+
+func (h *headerReader) reset(r io.Reader, disarm deadlineDisarmer, budget readBudgeter) {
 	h.r = r
 	h.disarm = disarm
+	h.budget = budget
 	h.n = 0
 }
 
@@ -1436,11 +1453,22 @@ func (h *headerReader) Read(p []byte) (int, error) {
 	}
 	n, err := h.r.Read(p)
 	h.n += n
-	if n > 0 && h.disarm != nil {
-		// The peer has started sending: bound everything from here on. The caller's
-		// deferred re-arm still covers the paths that deliver no byte at all.
-		h.disarm.setDisarm(false)
-		h.disarm = nil
+	if n > 0 {
+		if h.disarm != nil {
+			// The peer has started sending: bound everything from here on. The caller's
+			// deferred re-arm still covers the paths that deliver no byte at all.
+			h.disarm.setDisarm(false)
+			h.disarm = nil
+		}
+		if h.budget != nil {
+			// The same instant, for the other clock. This byte is what
+			// FrameAssemblyTimeout documents as the peer starting to send the frame,
+			// and starting the budget anywhere later leaves a gap: the rest of this
+			// header is only covered by ReadTimeout, so with ReadTimeout disabled a
+			// peer could dribble it out for as long as it liked, unbounded by either.
+			h.budget.setReadBudget(true)
+			h.budget = nil
+		}
 	}
 	return n, err
 }
@@ -1470,7 +1498,7 @@ func (c *Conn) readFirstSegmentHeader() (segment.Header, error) {
 
 	// Counted rather than plumbing a byte count out of the segment header readers:
 	// the count only matters here, where the benign/fatal decision is made.
-	c.headerReader.reset(c.r, c.r)
+	c.headerReader.reset(c.r, c.r, c.r)
 
 	hdr, err := segment.ReadHeader(&c.headerReader, c.segCompressor != nil)
 	if err != nil {
@@ -1684,14 +1712,20 @@ type connReadSource interface {
 
 // connReader implements connReadSource.
 type connReader struct {
-	conn    net.Conn
-	r       *bufio.Reader
-	timeout atomic.Int64
-	// assembly is the configured budget duration, and budget the absolute deadline
-	// of the one currently running, in UnixNano. Zero means no budget in both
-	// cases: unconfigured, or configured but not started.
+	conn net.Conn
+	r    *bufio.Reader
+	// budget is the absolute deadline of the frame-assembly budget currently
+	// running, nil when none is. A time.Time rather than a UnixNano count on
+	// purpose: UnixNano is undefined past the year 2262, so a large
+	// FrameAssemblyTimeout would wrap to an instant in the past and expire every
+	// frame at once -- the exact opposite of what such a value asks for -- and the
+	// round trip through it would also strip the monotonic reading, leaving the
+	// budget exposed to wall-clock adjustments. Ordered here, with the other
+	// pointer-bearing fields, for fieldalignment.
+	budget atomic.Pointer[time.Time]
+	// assembly is the configured budget duration; zero disables the budget.
 	assembly atomic.Int64
-	budget   atomic.Int64
+	timeout  atomic.Int64
 	disarm   atomic.Bool
 }
 
@@ -1796,9 +1830,9 @@ func (c *connReader) armDeadline() error {
 	// in. Whichever expires first ends the read, and because the budget is absolute
 	// it survives the re-arm that gives each attempt a fresh timeout -- which is
 	// exactly the loop that leaves a trickling peer otherwise unbounded.
-	if budget := c.budget.Load(); budget != 0 {
-		if b := time.Unix(0, budget); deadline.IsZero() || b.Before(deadline) {
-			deadline = b
+	if budget := c.budget.Load(); budget != nil {
+		if deadline.IsZero() || budget.Before(deadline) {
+			deadline = *budget
 		}
 	}
 	return c.conn.SetReadDeadline(deadline)
@@ -1821,11 +1855,12 @@ func (c *connReader) SetFrameAssemblyTimeout(timeout time.Duration) {
 // an unconfigured connection reads exactly as it did before.
 func (c *connReader) setReadBudget(v bool) {
 	if !v {
-		c.budget.Store(0)
+		c.budget.Store(nil)
 		return
 	}
 	if d := time.Duration(c.assembly.Load()); d > 0 {
-		c.budget.Store(time.Now().Add(d).UnixNano())
+		deadline := time.Now().Add(d)
+		c.budget.Store(&deadline)
 	}
 }
 

--- a/conn.go
+++ b/conn.go
@@ -350,9 +350,6 @@ func (c *Conn) finalizeConnection() {
 	c.setSystemRequestTimeout(c.session.cfg.MetadataSchemaRequestTimeout)
 	c.w.setWriteTimeout(c.cfg.WriteTimeout)
 	c.r.SetTimeout(c.cfg.ReadTimeout)
-	// Only from here on: the budget covers segmented frames, and segments only
-	// appear after startup has negotiated the modern transport.
-	c.r.SetFrameAssemblyTimeout(c.cfg.FrameAssemblyTimeout)
 }
 
 func (c *Conn) getScyllaSupported() ScyllaConnectionFeatures {
@@ -498,6 +495,14 @@ func (s *Session) dialWithoutObserver(ctx context.Context, host *HostInfo, cfg *
 		streamObserver: s.streamObserver,
 	}
 	c.setSystemRequestTimeout(cfg.ConnectTimeout)
+	// Armed here, not in finalizeConnection: c.init below starts serve() before
+	// finalizeConnection ever runs (the control connection finalizes only at the very
+	// end of Session.init, after it has already issued system queries; a pool
+	// connection finalizes only after UseKeyspace). A segmented frame received in that
+	// window would otherwise see no budget at all. Safe this early because the value
+	// is inert until a v5 segment reassembly actually starts one (recvSegment /
+	// headerReader), which cannot happen before STARTUP has negotiated the connection.
+	c.r.SetFrameAssemblyTimeout(cfg.FrameAssemblyTimeout)
 
 	if err := c.init(ctx, dialedHost); err != nil {
 		cancel()

--- a/conn.go
+++ b/conn.go
@@ -141,20 +141,23 @@ type SslOptions struct {
 }
 
 type ConnConfig struct {
-	Dialer          Dialer
-	Logger          StdLogger
-	Authenticator   Authenticator
-	Compressor      Compressor
-	HostDialer      HostDialer
-	AuthProvider    func(h *HostInfo) (Authenticator, error)
-	tlsConfig       *tls.Config
-	CQLVersion      string
-	ConnectTimeout  time.Duration
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
-	ProtoVersion    int
-	Keepalive       time.Duration
-	disableCoalesce bool
+	Dialer         Dialer
+	Logger         StdLogger
+	Authenticator  Authenticator
+	Compressor     Compressor
+	HostDialer     HostDialer
+	AuthProvider   func(h *HostInfo) (Authenticator, error)
+	tlsConfig      *tls.Config
+	CQLVersion     string
+	ConnectTimeout time.Duration
+	ReadTimeout    time.Duration
+	WriteTimeout   time.Duration
+	// FrameAssemblyTimeout bounds the total time to assemble one response frame;
+	// see ClusterConfig.FrameAssemblyTimeout. Zero leaves it unbounded.
+	FrameAssemblyTimeout time.Duration
+	ProtoVersion         int
+	Keepalive            time.Duration
+	disableCoalesce      bool
 	// isControlConn marks the connection used by the control connection, which is
 	// the only one reporting the driver configuration on startup.
 	isControlConn bool
@@ -347,6 +350,9 @@ func (c *Conn) finalizeConnection() {
 	c.setSystemRequestTimeout(c.session.cfg.MetadataSchemaRequestTimeout)
 	c.w.setWriteTimeout(c.cfg.WriteTimeout)
 	c.r.SetTimeout(c.cfg.ReadTimeout)
+	// Only from here on: the budget covers segmented frames, and segments only
+	// appear after startup has negotiated the modern transport.
+	c.r.SetFrameAssemblyTimeout(c.cfg.FrameAssemblyTimeout)
 }
 
 func (c *Conn) getScyllaSupported() ScyllaConnectionFeatures {
@@ -1331,15 +1337,17 @@ func (c *Conn) recvSegment(ctx context.Context) error {
 	// continuation segments are all read with the deadline re-armed, so a peer that
 	// starts sending and then stalls mid-read is caught by the per-read ReadTimeout.
 	//
-	// Note the deadline is per-read (see connReader.Read), not per-frame: a
-	// single logical CQL frame may span many segments (recvSplitFrame), so
-	// ReadTimeout bounds how long any one read may stall, not the total time
-	// to assemble a frame. And a read that stalls but keeps making progress is
-	// resumed up to maxReadAttempts times, so one read can take that multiple of
-	// ReadTimeout before failing — only a read that delivers nothing fails within a
-	// single one. A peer that keeps trickling progress is therefore not bounded by
-	// time at all; it is bounded by the frame length recvSplitFrame enforces against
-	// the reassembled size.
+	// ReadTimeout is per-read (see connReader.Read), not per-frame: a single
+	// logical CQL frame may span many segments (recvSplitFrame), and a read that
+	// stalls while still making progress is resumed with a fresh deadline. So
+	// ReadTimeout bounds how long any one read may stall, and a peer that keeps
+	// trickling progress is not bounded by it at all — only by the frame length
+	// recvSplitFrame enforces against the reassembled size.
+	//
+	// FrameAssemblyTimeout is what bounds the whole frame, and it starts below
+	// rather than here: until the first header has arrived this goroutine is idle,
+	// and charging a peer for the time it had nothing to say would drop healthy
+	// connections. Unset by default, in which case nothing changes.
 	//
 	// netStart/netEnd bracket this read for FrameHeaderObserver. The CQL headers
 	// inside are parsed out of memory further down, so timing them there would
@@ -1351,6 +1359,12 @@ func (c *Conn) recvSegment(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// The peer is mid-frame from here: everything below is this frame's payload and,
+	// if it is split, its continuation segments. Cleared on the way out so the next
+	// idle wait is not charged against this frame's budget.
+	c.r.setReadBudget(true)
+	defer c.r.setReadBudget(false)
 
 	payload, err := c.readSegmentPayload(hdr)
 	if err != nil {
@@ -1655,6 +1669,16 @@ type connReadSource interface {
 	// GetTimeout returns the timeout duration.
 	GetTimeout() time.Duration
 
+	// SetFrameAssemblyTimeout sets how long a frame-assembly budget runs for once
+	// started. Zero disables the budget, which is the default.
+	SetFrameAssemblyTimeout(timeout time.Duration)
+
+	// setReadBudget starts (true) or clears (false) a budget over the reads that
+	// follow, of the duration SetFrameAssemblyTimeout configured. Unlike the
+	// per-read timeout the budget does not restart, so it is what bounds a
+	// sequence of reads rather than any one of them.
+	setReadBudget(bool)
+
 	deadlineDisarmer
 }
 
@@ -1663,7 +1687,12 @@ type connReader struct {
 	conn    net.Conn
 	r       *bufio.Reader
 	timeout atomic.Int64
-	disarm  atomic.Bool
+	// assembly is the configured budget duration, and budget the absolute deadline
+	// of the one currently running, in UnixNano. Zero means no budget in both
+	// cases: unconfigured, or configured but not started.
+	assembly atomic.Int64
+	budget   atomic.Int64
+	disarm   atomic.Bool
 }
 
 var _ connReadSource = (*connReader)(nil)
@@ -1753,14 +1782,26 @@ func (c *connReader) armDeadline() error {
 		// ConnectTimeout to ReadTimeout) is never clobbered by a restore.
 		return c.conn.SetReadDeadline(time.Time{})
 	}
+
+	// The zero deadline is net.Conn's "no deadline", and arming it is not optional:
+	// a read deadline is absolute and persists across reads, so once the timeout is
+	// disabled any deadline armed by a previous read (or during connection setup,
+	// e.g. ConnectTimeout) has to be cleared, or idle connections keep tripping the
+	// stale one.
+	var deadline time.Time
 	if timeout := c.GetTimeout(); timeout > 0 {
-		return c.conn.SetReadDeadline(time.Now().Add(timeout))
+		deadline = time.Now().Add(timeout)
 	}
-	// A read deadline is absolute and persists across reads: once the timeout is
-	// disabled we must clear any deadline armed by a previous read (or during
-	// connection setup, e.g. ConnectTimeout), otherwise idle connections keep
-	// tripping the stale deadline.
-	return c.conn.SetReadDeadline(time.Time{})
+	// The budget is a ceiling, never an extension: it only ever pulls the deadline
+	// in. Whichever expires first ends the read, and because the budget is absolute
+	// it survives the re-arm that gives each attempt a fresh timeout -- which is
+	// exactly the loop that leaves a trickling peer otherwise unbounded.
+	if budget := c.budget.Load(); budget != 0 {
+		if b := time.Unix(0, budget); deadline.IsZero() || b.Before(deadline) {
+			deadline = b
+		}
+	}
+	return c.conn.SetReadDeadline(deadline)
 }
 
 // setDisarm enables or disables the read-deadline disarm used around the
@@ -1769,6 +1810,23 @@ func (c *connReader) armDeadline() error {
 // finalizeConnection.
 func (c *connReader) setDisarm(v bool) {
 	c.disarm.Store(v)
+}
+
+func (c *connReader) SetFrameAssemblyTimeout(timeout time.Duration) {
+	c.assembly.Store(int64(timeout))
+}
+
+// setReadBudget starts or clears a frame-assembly budget. Starting one with no
+// duration configured is a no-op, so the caller needs no conditional of its own and
+// an unconfigured connection reads exactly as it did before.
+func (c *connReader) setReadBudget(v bool) {
+	if !v {
+		c.budget.Store(0)
+		return
+	}
+	if d := time.Duration(c.assembly.Load()); d > 0 {
+		c.budget.Store(time.Now().Add(d).UnixNano())
+	}
 }
 
 func (c *connReader) Close() error {

--- a/conn_test.go
+++ b/conn_test.go
@@ -3691,11 +3691,13 @@ func (s *scriptedReadSource) Read(p []byte) (int, error) {
 	return n, step.err
 }
 
-func (s *scriptedReadSource) Close() error               { return nil }
-func (s *scriptedReadSource) RemoteAddr() net.Addr       { return nil }
-func (s *scriptedReadSource) SetTimeout(_ time.Duration) {}
-func (s *scriptedReadSource) GetTimeout() time.Duration  { return 0 }
-func (s *scriptedReadSource) setDisarm(v bool)           { s.disarms = append(s.disarms, v) }
+func (s *scriptedReadSource) Close() error                          { return nil }
+func (s *scriptedReadSource) RemoteAddr() net.Addr                  { return nil }
+func (s *scriptedReadSource) SetTimeout(_ time.Duration)            {}
+func (s *scriptedReadSource) GetTimeout() time.Duration             { return 0 }
+func (s *scriptedReadSource) setDisarm(v bool)                      { s.disarms = append(s.disarms, v) }
+func (s *scriptedReadSource) SetFrameAssemblyTimeout(time.Duration) {}
+func (s *scriptedReadSource) setReadBudget(bool)                    {}
 
 // timeoutErr is a net.Error reporting a timeout, standing in for the
 // os.ErrDeadlineExceeded a real socket returns once its read deadline expires.

--- a/conn_test.go
+++ b/conn_test.go
@@ -4353,6 +4353,147 @@ func TestSystemRequestTimeoutRaceWithFinalizeConnection(t *testing.T) {
 		"finalizeConnection should publish the metadata timeout and its clause as one snapshot")
 }
 
+// TestFrameAssemblyTimeoutActiveBeforeFinalizeConnection guards a review finding on
+// #1044: dialWithoutObserver used to leave c.r's assembly budget unconfigured until
+// finalizeConnection ran, but Conn.init already starts serve() well before that --
+// finalizeConnection is deferred to the very end of Session.init for the control
+// connection (after it has issued system queries) and runs only after UseKeyspace for
+// a pool connection. A segmented frame trickled into that window saw no budget at
+// all, which is exactly what this test reproduces.
+//
+// It drives the real dialWithoutObserver/Conn.init path over a net.Pipe, answers only
+// the STARTUP handshake, and then trickles a v5 segmented frame nobody requested --
+// finalizeConnection is never called. Before the fix this hangs (the trickle
+// completes, unbounded); after it, serve() drops the connection once the budget
+// expires.
+func TestFrameAssemblyTimeoutActiveBeforeFinalizeConnection(t *testing.T) {
+	const perSegment = 64
+	body := bytes.Repeat([]byte{0x5A}, 2*perSegment)
+	frame := make([]byte, headSize)
+	// An ordinary (positive) stream with no matching call, not the reserved event
+	// stream: were the trickle ever to complete despite the budget, this lands on
+	// the harmless "no handler" discard path (processFrameSource) instead of
+	// c.session.handleEvent, which a minimal test Session cannot service.
+	const noHandlerStream = 999
+	frame[0] = protoVersion5 | protoDirectionMask
+	binary.BigEndian.PutUint16(frame[2:4], uint16(noHandlerStream))
+	frame[4] = byte(frm.OpReady)
+	binary.BigEndian.PutUint32(frame[5:headSize], uint32(len(body)))
+	frame = append(frame, body...)
+
+	var segments [][]byte
+	for src := frame; len(src) > 0; {
+		n := min(len(src), perSegment)
+		segments = append(segments, mustUncompressedSegment(t, src[:n], false))
+		src = src[n:]
+	}
+	if len(segments) < 3 {
+		t.Fatalf("the frame must need several segments to trickle, got %d", len(segments))
+	}
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	const gap = 100 * time.Millisecond
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- fakeCQLHandshakeThenTrickle(t, server, segments, gap) }()
+
+	cluster := NewCluster("127.0.0.1:1")
+	cluster.ProtoVersion = protoVersion5
+	cluster.FrameAssemblyTimeout = 120 * time.Millisecond
+	cluster.HostDialer = pipeHostDialer{conn: client}
+
+	connCfg, err := connConfig(cluster)
+	if err != nil {
+		t.Fatalf("connConfig: %v", err)
+	}
+
+	dropped := make(chan error, 1)
+	errorHandler := connErrorHandlerFn(func(_ *Conn, err error, _ bool) {
+		select {
+		case dropped <- err:
+		default:
+		}
+	})
+
+	session := &Session{ctx: context.Background(), cfg: *cluster}
+	conn, err := session.dialWithoutObserver(context.Background(), &HostInfo{}, connCfg, errorHandler, 0, 0)
+	if err != nil {
+		t.Fatalf("dialWithoutObserver: %v", err)
+	}
+	defer conn.Close()
+
+	select {
+	case err := <-dropped:
+		var netErr net.Error
+		if !errors.As(err, &netErr) || !netErr.Timeout() {
+			t.Fatalf("expected the budget to expire the trickle, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("connection was not dropped by the frame-assembly budget: finalizeConnection is never called here, so this hangs unless the budget is armed earlier")
+	}
+
+	// The fake server's own write loop is expected to fail once serve() has closed
+	// the connection out from under it -- that is the fix working, not an error.
+	<-serverErr
+}
+
+// pipeHostDialer is a HostDialer that always hands back the same pre-established
+// net.Conn, so a test can drive Conn.init/dialWithoutObserver over a net.Pipe instead
+// of a real socket.
+type pipeHostDialer struct{ conn net.Conn }
+
+func (d pipeHostDialer) DialHost(_ context.Context, _ *HostInfo) (*DialedHost, error) {
+	return &DialedHost{Conn: d.conn}, nil
+}
+
+// fakeCQLHandshakeThenTrickle answers exactly the two frames
+// startupCoordinator.setupConn sends (OPTIONS, then STARTUP) with SUPPORTED and
+// READY, then -- unlike a real peer -- starts dribbling segments nobody requested, one
+// per gap, standing in for a slow or adversarial one.
+func fakeCQLHandshakeThenTrickle(t *testing.T, conn net.Conn, segments [][]byte, gap time.Duration) error {
+	t.Helper()
+
+	for _, op := range []frm.Op{frm.OpOptions, frm.OpStartup} {
+		buf := make([]byte, headSize)
+		head, err := readHeader(conn, buf)
+		if err != nil {
+			return fmt.Errorf("reading %v: %w", op, err)
+		}
+		req := newFramer(nil, protoVersion5)
+		if err := req.readFrame(conn, &head); err != nil {
+			return fmt.Errorf("reading %v body: %w", op, err)
+		}
+		if head.Op != op {
+			return fmt.Errorf("expected %v, got %v", op, head.Op)
+		}
+
+		resp := newFramer(nil, protoVersion5)
+		if op == frm.OpOptions {
+			resp.writeHeader(0, frm.OpSupported, head.Stream)
+			resp.writeStringMultiMap(nil)
+		} else {
+			resp.writeHeader(0, frm.OpReady, head.Stream)
+		}
+		resp.buf[0] = protoVersion5 | protoDirectionMask
+		if err := resp.finish(); err != nil {
+			return err
+		}
+		if err := resp.writeTo(conn); err != nil {
+			return fmt.Errorf("writing %v response: %w", op, err)
+		}
+	}
+
+	for _, seg := range segments {
+		if _, err := conn.Write(seg); err != nil {
+			return err
+		}
+		time.Sleep(gap)
+	}
+	return nil
+}
+
 // TestSystemRequestStateClauseFollowsTimeout pins the USING TIMEOUT clause as
 // derived purely from the timeout in effect and whether the peer is ScyllaDB.
 //

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -85,19 +85,20 @@ func connConfig(cfg *ClusterConfig) (*ConnConfig, error) {
 	}
 
 	return &ConnConfig{
-		ProtoVersion:   cfg.ProtoVersion,
-		CQLVersion:     cfg.CQLVersion,
-		WriteTimeout:   cfg.WriteTimeout,
-		ReadTimeout:    cfg.ReadTimeout,
-		ConnectTimeout: cfg.ConnectTimeout,
-		Dialer:         cfg.Dialer,
-		HostDialer:     hostDialer,
-		Compressor:     cfg.Compressor,
-		Authenticator:  cfg.Authenticator,
-		AuthProvider:   cfg.AuthProvider,
-		Keepalive:      cfg.SocketKeepalive,
-		Logger:         cfg.logger(),
-		tlsConfig:      cfg.getActualTLSConfig(),
+		ProtoVersion:         cfg.ProtoVersion,
+		CQLVersion:           cfg.CQLVersion,
+		WriteTimeout:         cfg.WriteTimeout,
+		ReadTimeout:          cfg.ReadTimeout,
+		ConnectTimeout:       cfg.ConnectTimeout,
+		FrameAssemblyTimeout: cfg.FrameAssemblyTimeout,
+		Dialer:               cfg.Dialer,
+		HostDialer:           hostDialer,
+		Compressor:           cfg.Compressor,
+		Authenticator:        cfg.Authenticator,
+		AuthProvider:         cfg.AuthProvider,
+		Keepalive:            cfg.SocketKeepalive,
+		Logger:               cfg.logger(),
+		tlsConfig:            cfg.getActualTLSConfig(),
 	}, nil
 }
 

--- a/connectionpool_test.go
+++ b/connectionpool_test.go
@@ -141,7 +141,9 @@ func (e errorConn) GetTimeout() time.Duration  { return 0 }
 
 // setDisarm is required of any reader installed as Conn.r (connReadSource). This
 // mock is never read from, so there is nothing to disarm.
-func (e errorConn) setDisarm(_ bool) {}
+func (e errorConn) setDisarm(_ bool)                        {}
+func (e errorConn) SetFrameAssemblyTimeout(_ time.Duration) {}
+func (e errorConn) setReadBudget(_ bool)                    {}
 
 // TestHostConnPoolCloseDeadlock verifies that hostConnPool.Close() does not
 // self-deadlock when defaultConnPicker closes connections that trigger

--- a/docs/driver-config-schema.json
+++ b/docs/driver-config-schema.json
@@ -206,6 +206,17 @@
             }
           }
         },
+        "frame-assembly": {
+          "type": "object",
+          "description": "Settings bounding the total time to assemble one response frame out of its transport segments, measured from the first byte of its first segment.",
+          "additionalProperties": false,
+          "properties": {
+            "timeout-ms": {
+              "$ref": "#/$defs/positiveInteger",
+              "description": "Frame-assembly timeout."
+            }
+          }
+        },
         "heartbeat": {
           "type": "object",
           "description": "Reserved for CQL-level idle heartbeat settings. Optional and intentionally empty in this schema version. It is a placeholder for v2",

--- a/driver_config.go
+++ b/driver_config.go
@@ -55,16 +55,17 @@ type connectionReport struct {
 	// a query may be routed to). Omitted when nothing narrows pool membership;
 	// see buildConnectionNodePreferenceReport.
 	NodePreference any `json:"node-preference,omitempty"`
-	// Read and Write are omitted entirely when their timeout is 0 (disabled),
-	// matching the schema's "absent when unset or not applicable" convention
-	// for optional groups. write.coalescing and the sibling connection.heartbeat
-	// group are never populated: the schema declares both as
-	// additionalProperties:false with no properties, an explicit placeholder
+	// Read, Write, and FrameAssembly are omitted entirely when their timeout is
+	// 0 (disabled), matching the schema's "absent when unset or not applicable"
+	// convention for optional groups. write.coalescing and the sibling
+	// connection.heartbeat group are never populated: the schema declares both
+	// as additionalProperties:false with no properties, an explicit placeholder
 	// for a future schema version, so there is nothing a v1 report could put
 	// there even though gocql does have both features (WriteCoalesceWaitTime,
 	// the control connection's heartBeat()).
-	Read  *readWriteTimeoutReport `json:"read,omitempty"`
-	Write *readWriteTimeoutReport `json:"write,omitempty"`
+	Read          *readWriteTimeoutReport `json:"read,omitempty"`
+	Write         *readWriteTimeoutReport `json:"write,omitempty"`
+	FrameAssembly *readWriteTimeoutReport `json:"frame-assembly,omitempty"`
 	// TLS is omitted when TLS is not configured, or when a HostDialer is set:
 	// HostDialer takes over the entire connection setup and SslOpts is ignored
 	// (see ClusterConfig.SslOpts), so the effective TLS state is unknown.
@@ -398,6 +399,9 @@ func buildConnectionReport(cfg *ClusterConfig) connectionReport {
 	}
 	if ms := positiveMillis(cfg.WriteTimeout); ms != nil {
 		report.Write = &readWriteTimeoutReport{TimeoutMs: *ms}
+	}
+	if ms := positiveMillis(cfg.FrameAssemblyTimeout); ms != nil {
+		report.FrameAssembly = &readWriteTimeoutReport{TimeoutMs: *ms}
 	}
 	report.TLS = buildTLSReport(cfg)
 	report.NodePreference = buildConnectionNodePreferenceReport(cfg)

--- a/driver_config_schema_test.go
+++ b/driver_config_schema_test.go
@@ -117,6 +117,7 @@ func driverConfigCases() []struct {
 				c.MetadataSchemaRequestTimeout = 0
 				c.MaxWaitSchemaAgreement = 0
 				c.PageSize = 0
+				c.FrameAssemblyTimeout = 0
 			},
 		},
 		{
@@ -127,6 +128,7 @@ func driverConfigCases() []struct {
 				c.WriteTimeout = 500 * time.Microsecond
 				c.Timeout = 500 * time.Microsecond
 				c.MetadataSchemaRequestTimeout = 500 * time.Microsecond
+				c.FrameAssemblyTimeout = 500 * time.Microsecond
 			},
 			isScyllaConn: true,
 		},

--- a/driver_config_test.go
+++ b/driver_config_test.go
@@ -829,6 +829,7 @@ func TestBuildConnectionReport_ReadWriteTLS(t *testing.T) {
 	cfg := *NewCluster("127.0.0.1")
 	cfg.ReadTimeout = 0
 	cfg.WriteTimeout = 0
+	cfg.FrameAssemblyTimeout = 0
 	report := buildConnectionReport(&cfg)
 	if report.Read != nil {
 		t.Errorf("expected read to be omitted when ReadTimeout is 0, got %+v", report.Read)
@@ -836,12 +837,16 @@ func TestBuildConnectionReport_ReadWriteTLS(t *testing.T) {
 	if report.Write != nil {
 		t.Errorf("expected write to be omitted when WriteTimeout is 0, got %+v", report.Write)
 	}
+	if report.FrameAssembly != nil {
+		t.Errorf("expected frame-assembly to be omitted when FrameAssemblyTimeout is 0, got %+v", report.FrameAssembly)
+	}
 	if report.TLS != nil {
 		t.Errorf("expected tls to be omitted when SslOpts is nil, got %+v", report.TLS)
 	}
 
 	cfg.ReadTimeout = 5 * time.Second
 	cfg.WriteTimeout = 7 * time.Second
+	cfg.FrameAssemblyTimeout = 9 * time.Second
 	cfg.SslOpts = &SslOptions{EnableHostVerification: true}
 	report = buildConnectionReport(&cfg)
 	if report.Read == nil || report.Read.TimeoutMs != 5000 {
@@ -849,6 +854,9 @@ func TestBuildConnectionReport_ReadWriteTLS(t *testing.T) {
 	}
 	if report.Write == nil || report.Write.TimeoutMs != 7000 {
 		t.Errorf("expected write.timeout-ms 7000, got %+v", report.Write)
+	}
+	if report.FrameAssembly == nil || report.FrameAssembly.TimeoutMs != 9000 {
+		t.Errorf("expected frame-assembly.timeout-ms 9000, got %+v", report.FrameAssembly)
 	}
 	if report.TLS == nil || !report.TLS.HostnameVerification {
 		t.Errorf("expected tls.hostname-verification true, got %+v", report.TLS)

--- a/segment_reassembly_test.go
+++ b/segment_reassembly_test.go
@@ -22,12 +22,15 @@
 package gocql
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +49,13 @@ type segmentReader struct {
 	// Conn.r — a reader that could not be disarmed would silently exercise the
 	// receive path with the idle-wait handling switched off.
 	disarmed bool
+
+	// assembly, budgeted and budgets record the frame-assembly budget, for the same
+	// reason: an in-memory stream has no deadline to bound, but a reader that
+	// dropped the calls would hide whether recvSegment made them.
+	assembly time.Duration
+	budgeted bool
+	budgets  []bool
 }
 
 var _ connReadSource = (*segmentReader)(nil)
@@ -60,6 +70,11 @@ func (s *segmentReader) RemoteAddr() net.Addr       { return nil }
 func (s *segmentReader) SetTimeout(_ time.Duration) {}
 func (s *segmentReader) GetTimeout() time.Duration  { return 0 }
 func (s *segmentReader) setDisarm(v bool)           { s.disarmed = v }
+
+// There is no deadline to budget on an in-memory stream either, but the budget is
+// recorded so a test can assert recvSegment started and cleared one.
+func (s *segmentReader) SetFrameAssemblyTimeout(d time.Duration) { s.assembly = d }
+func (s *segmentReader) setReadBudget(v bool)                    { s.budgeted = v; s.budgets = append(s.budgets, v) }
 
 // mustUncompressedSegment builds a single uncompressed transport segment
 // carrying payload, failing the test on error.
@@ -102,6 +117,109 @@ func TestReadContinuationSegmentRejectsEmptyPayload(t *testing.T) {
 	_, err := c.readContinuationSegment()
 	if err == nil || !strings.Contains(err.Error(), "no progress") {
 		t.Fatalf("expected no-progress rejection, got %v", err)
+	}
+}
+
+// ReadTimeout cannot bound the time to assemble a segmented frame: every read arms
+// it afresh, so a peer that delivers one segment per interval renews its lease for as
+// long as it likes, and the only ceiling is the declared frame length. This is what
+// FrameAssemblyTimeout adds, and the two cases are the whole of it -- the same
+// trickle completes when no budget is configured, so the bound is what rejects it
+// rather than the pace.
+func TestRecvSegmentBoundsTheTimeToAssembleOneFrame(t *testing.T) {
+	// A READY frame on the event stream, split into three segments: with no session
+	// attached processFrame parses it and drops it, which is all this needs -- the
+	// assertion is about time, not contents.
+	const perSegment = 64
+	body := bytes.Repeat([]byte{0x5A}, 2*perSegment)
+	frame := make([]byte, headSize)
+	frame[0] = protoVersion5 | protoDirectionMask
+	binary.BigEndian.PutUint16(frame[2:4], uint16(0xFFFF))
+	frame[4] = byte(frm.OpReady)
+	binary.BigEndian.PutUint32(frame[5:headSize], uint32(len(body)))
+	frame = append(frame, body...)
+
+	var segments [][]byte
+	for src := frame; len(src) > 0; {
+		n := min(len(src), perSegment)
+		segments = append(segments, mustUncompressedSegment(t, src[:n], false))
+		src = src[n:]
+	}
+	if len(segments) < 3 {
+		t.Fatalf("the frame must need several segments to trickle, got %d", len(segments))
+	}
+
+	// Each segment arrives well inside ReadTimeout, so no individual read is ever
+	// close to failing; only their sum crosses the budget.
+	const gap = 100 * time.Millisecond
+
+	for _, tc := range []struct {
+		name    string
+		budget  time.Duration
+		wantErr bool
+	}{
+		{name: "no budget configured", budget: 0, wantErr: false},
+		{name: "budget shorter than the trickle", budget: 120 * time.Millisecond, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			defer client.Close()
+			defer server.Close()
+
+			go func() {
+				for _, seg := range segments {
+					if _, err := server.Write(seg); err != nil {
+						return
+					}
+					time.Sleep(gap)
+				}
+			}()
+
+			cr := &connReader{conn: client, r: bufio.NewReader(client)}
+			cr.SetTimeout(5 * time.Second)
+			cr.SetFrameAssemblyTimeout(tc.budget)
+
+			c := &Conn{r: cr, streams: streams.New(), logger: nopLogger{}}
+			c.initFramerCache()
+
+			err := c.recvSegment(context.Background())
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("a trickling peer must not be rejected without a budget: %v", err)
+				}
+				return
+			}
+
+			var netErr net.Error
+			if !errors.As(err, &netErr) || !netErr.Timeout() {
+				t.Fatalf("expected the budget to expire the read, got %v", err)
+			}
+		})
+	}
+}
+
+// The budget has to be cleared on the way out. It is absolute, so one left behind
+// would still be expiring during the next idle wait for a frame that has not started
+// arriving -- turning a healthy connection into a dropped one.
+func TestRecvSegmentClearsTheBudgetAfterEachFrame(t *testing.T) {
+	frame := make([]byte, headSize)
+	frame[0] = protoVersion5 | protoDirectionMask
+	binary.BigEndian.PutUint16(frame[2:4], uint16(0xFFFF))
+	frame[4] = byte(frm.OpReady)
+
+	r := newSegmentReader(mustUncompressedSegment(t, frame, true))
+	c := &Conn{r: r, streams: streams.New(), logger: nopLogger{}}
+	c.initFramerCache()
+
+	if err := c.recvSegment(context.Background()); err != nil {
+		t.Fatalf("recvSegment: %v", err)
+	}
+
+	if want := []bool{true, false}; !slices.Equal(r.budgets, want) {
+		t.Errorf("budget calls were %v, want %v", r.budgets, want)
+	}
+	if r.budgeted {
+		t.Error("the budget is still running after the frame was processed")
 	}
 }
 

--- a/segment_reassembly_test.go
+++ b/segment_reassembly_test.go
@@ -28,6 +28,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"net"
 	"runtime"
 	"slices"
@@ -160,6 +161,10 @@ func TestRecvSegmentBoundsTheTimeToAssembleOneFrame(t *testing.T) {
 	}{
 		{name: "no budget configured", budget: 0, wantErr: false},
 		{name: "budget shorter than the trickle", budget: 120 * time.Millisecond, wantErr: true},
+		// Held as a time.Time for this: as a UnixNano count the deadline wraps past
+		// the year 2262 into the past, and the largest budget expressible becomes the
+		// harshest one there is.
+		{name: "a budget beyond UnixNano's range", budget: math.MaxInt64, wantErr: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			client, server := net.Pipe()
@@ -195,6 +200,52 @@ func TestRecvSegmentBoundsTheTimeToAssembleOneFrame(t *testing.T) {
 				t.Fatalf("expected the budget to expire the read, got %v", err)
 			}
 		})
+	}
+}
+
+// The budget starts on the first byte of the segment header, not once the header is
+// complete. Only the wait for that byte is deliberately unbounded; the rest of the
+// header is otherwise covered by ReadTimeout alone, so with ReadTimeout disabled a
+// peer dribbling a header out would be bounded by nothing at all -- while
+// FrameAssemblyTimeout is documented to run from the moment the peer starts sending.
+func TestRecvSegmentBudgetsTheHeaderItself(t *testing.T) {
+	seg := mustUncompressedSegment(t, []byte("hello"), true)
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	// The header alone is dribbled a byte per 100ms, so it takes longer than the
+	// budget; everything after it arrives at once. That is what isolates the window
+	// under test -- a budget that started after the header instead would see only the
+	// instant payload and never expire.
+	go func() {
+		head := segment.UncompressedHeaderSize
+		for _, b := range seg[:head] {
+			if _, err := server.Write([]byte{b}); err != nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		_, _ = server.Write(seg[head:])
+	}()
+
+	cr := &connReader{conn: client, r: bufio.NewReader(client)}
+	cr.SetTimeout(0) // the case that has nothing else to fall back on
+	cr.SetFrameAssemblyTimeout(120 * time.Millisecond)
+
+	c := &Conn{r: cr, streams: streams.New(), logger: nopLogger{}}
+	c.initFramerCache()
+
+	err := c.recvSegment(context.Background())
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("expected the budget to expire during the header, got %v", err)
+	}
+	// Not the benign idle timeout: bytes were consumed, so the stream is at an
+	// unknown offset and the connection has to go down.
+	if errors.Is(err, ErrReadHeaderTimeout) {
+		t.Error("a partially-read header must not be reported as an idle timeout")
 	}
 }
 


### PR DESCRIPTION
`ReadTimeout` cannot bound the time to receive one response frame. On protocol v5 a
single CQL frame may span many transport segments, and `connReader.Read` arms a fresh
deadline for every attempt — so a peer delivering one segment per interval renews its
lease for as long as it likes. The only ceiling was the declared frame length.
`recvSegment` documents the gap in prose today; this closes it.

- `ClusterConfig.FrameAssemblyTimeout`, default 0 (unbounded), so nothing changes for
  anyone who does not set it. Validated like `ReadTimeout`, carried through
  `ConnConfig`, and armed in `dialWithoutObserver` before `c.init` starts `serve()` —
  not in `finalizeConnection`, which runs too late for a connection already live
  (receiving push events, or serving requests).
- The budget is an absolute deadline held on `connReader`, so it survives the
  per-attempt re-arm that is the whole problem, and `armDeadline` only ever lets it
  pull the deadline in.
- It starts on the header's first byte, not before (the idle wait for the next frame
  stays unbounded) or after (the header itself would otherwise be uncovered once
  `ReadTimeout` is disabled). Cleared on the way out, since an absolute budget left
  behind would expire during the next idle wait.

Verified with `make check` and `make test-unit`. The new tests trickle a three-segment
frame down a `net.Pipe` (rejected under a budget, completes without one), pin the
clear, and pin the budget being armed before `serve()` rather than at
`finalizeConnection`. Not covered: no live-node integration run.

Closes the last of #939.

Fixes #939
Fixes: DRIVER-954
