### PR TITLE
docs: document client routes private connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It also provides support for shard aware ports, a faster way to connect to all s
 - [4. Data Types](#4-data-types)
 - [5. Configuration](#5-configuration)
   - [5.1 Shard-aware port](#51-shard-aware-port)
-  - [5.2 Client routes (PrivateLink)](#52-client-routes-privatelink)
+  - [5.2 Client routes](#52-client-routes)
   - [5.3 Iterator](#53-iterator)
   - [5.4 Compression](#54-compression)
 - [6. Contributing](#6-contributing)
@@ -218,15 +218,21 @@ Issues with shard-aware port not being reachable are not reported in non-debug m
 
 If you suspect that this feature is causing you problems, you can completely disable it by setting the `ClusterConfig.DisableShardAwarePort` flag to true.
 
-### 5.2 Client routes (PrivateLink)
+### 5.2 Client routes
 
-Scylla Cloud exposes a `system.client_routes` table that maps hosts to PrivateLink endpoints.
-When configured, the driver can resolve and connect to the per-host PrivateLink address instead of using the public host IP.
+Use client routes when connecting to ScyllaDB Cloud through AWS PrivateLink or
+Google Cloud Private Service Connect (PSC). In these setups, cluster nodes are
+not reachable at the addresses they advertise to each other. ScyllaDB Cloud
+instead publishes the private endpoint address and port for each node in
+`system.client_routes`. This feature requires server support for both that table
+and the `CLIENT_ROUTES_CHANGE` event.
 
-Use `WithClientRoutes` to enable it and pass the connection IDs you receive from Scylla Cloud:
+Pass the connection ID supplied by ScyllaDB Cloud to `WithEndpoints`, inside
+`WithClientRoutes`. Use a private endpoint from the ScyllaDB Cloud connection
+details as the initial contact point:
 
 ```go
-cluster := gocql.NewCluster("private-link.dns.name")
+cluster := gocql.NewCluster("private-endpoint.example.com:9042")
 cluster.WithOptions(
 	gocql.WithClientRoutes(
 		gocql.WithEndpoints(
@@ -236,7 +242,72 @@ cluster.WithOptions(
 )
 ```
 
-If you also want to seed the cluster with PrivateLink hostnames, provide `ConnectionAddr` values in the endpoints list.
+For AWS PrivateLink, use the private endpoint DNS name. For GCP PSC, use the
+forwarding-rule IP address or its private DNS name. Configure every connection
+ID needed to reach the cluster nodes. Multiple IDs can cover nodes exposed
+through different private endpoints; they do not provide automatic failover
+between alternative routes for the same node:
+
+```go
+cluster := gocql.NewCluster(
+	"private-endpoint-a.example.com:19042",
+	"private-endpoint-b.example.com:19043",
+)
+cluster.WithOptions(
+	gocql.WithClientRoutes(
+		gocql.WithEndpoints(
+			gocql.ClientRoutesEndpoint{
+				ConnectionID:   "connection-id-a",
+				ConnectionAddr: "private-endpoint-a.example.com",
+			},
+			gocql.ClientRoutesEndpoint{
+				ConnectionID:   "connection-id-b",
+				ConnectionAddr: "private-endpoint-b.example.com",
+			},
+		),
+	),
+)
+```
+
+`ConnectionAddr` is optional. When set, it must be an IP address or DNS name
+without a port. It overrides the address from `system.client_routes` for that
+connection ID. If `NewCluster` has no contact points, `WithClientRoutes` also
+uses these addresses as initial contact points on `ClusterConfig.Port` (9042 by
+default). Specify contact points in `NewCluster`, as shown above, when bootstrap
+endpoints use different ports. Ports in `NewCluster` apply only when dialing
+those contact points; connections to discovered hosts use the route's `port` or
+`tls_port` from `system.client_routes`.
+
+The driver reads the route table at session startup and uses
+`CLIENT_ROUTES_CHANGE` events to refresh changed routes. Its built-in host
+dialer selects the route's `tls_port` instead of `port` when
+`ClusterConfig.SslOpts` is configured. Every selected route must provide
+`tls_port`; the driver does not fall back to `port` when it is empty.
+
+Custom `HostDialer` implementations are not supported with client routes.
+`HostInfo` exposes the translated route address, but not its translated port,
+so a custom host dialer may use the node-advertised port instead of the route
+port. Use `ClusterConfig.Dialer` when client routes require custom dialing.
+
+Shard awareness is disabled by default for client routes because private
+endpoints commonly use NAT and do not preserve source ports. Enable it only
+when the complete network path supports shard-aware source-port routing, such
+as a correctly configured Proxy Protocol v2 deployment:
+
+```go
+cluster.WithOptions(
+	gocql.WithClientRoutes(
+		gocql.WithEndpoints(endpoints...),
+		gocql.WithShardAwareness(true),
+	),
+)
+```
+
+`ClusterConfig.DisableShardAwarePort = true` overrides this opt-in.
+
+Client routes manage address translation internally and cannot be combined
+with `ClusterConfig.AddressTranslator`. Every discovered cluster node must have
+a route for at least one configured connection ID.
 
 ### 5.3 Iterator
 

--- a/client_routes.go
+++ b/client_routes.go
@@ -13,15 +13,23 @@ import (
 	"github.com/gocql/gocql/internal/eventbus"
 )
 
+// ClientRoutesEndpoint identifies one ScyllaDB Cloud private connection and
+// optionally overrides its network address.
 type ClientRoutesEndpoint struct {
-	// Scylla Cloud ConnectionID to read from `system.client_routes`
+	// ScyllaDB Cloud connection ID to read from the configured client-routes
+	// table (system.client_routes by default).
 	ConnectionID string
 
-	// Ip Address or DNS name of the AWS endpoint
-	// Could stay empty, in this case driver will pick it up from system.client_routes table
+	// ConnectionAddr optionally overrides the address from the configured
+	// client-routes table (system.client_routes by default).
+	// Set it to the IP address or DNS name, without a port, of an AWS PrivateLink
+	// or Google Cloud Private Service Connect endpoint. When ClusterConfig.Hosts
+	// is empty, WithClientRoutes also uses non-empty ConnectionAddr values as
+	// initial contact points on ClusterConfig.Port.
 	ConnectionAddr string
 }
 
+// Validate verifies that the endpoint has the required connection ID.
 func (e ClientRoutesEndpoint) Validate() error {
 	if e.ConnectionID == "" {
 		return errors.New("missing ConnectionID")
@@ -29,8 +37,10 @@ func (e ClientRoutesEndpoint) Validate() error {
 	return nil
 }
 
+// ClientRoutesEndpointList is a list of ScyllaDB Cloud private connections.
 type ClientRoutesEndpointList []ClientRoutesEndpoint
 
+// GetAllConnectionIDs returns every configured connection ID in list order.
 func (l ClientRoutesEndpointList) GetAllConnectionIDs() []string {
 	ids := make([]string, 0, len(l))
 	for _, endpoint := range l {
@@ -39,6 +49,7 @@ func (l ClientRoutesEndpointList) GetAllConnectionIDs() []string {
 	return ids
 }
 
+// Validate verifies that every endpoint is valid.
 func (l ClientRoutesEndpointList) Validate() error {
 	for id, endpoint := range l {
 		if err := endpoint.Validate(); err != nil {
@@ -48,14 +59,17 @@ func (l ClientRoutesEndpointList) Validate() error {
 	return nil
 }
 
+// ClientRoutesConfig configures routing through AWS PrivateLink or Google
+// Cloud Private Service Connect using routes from the configured client-routes
+// table (system.client_routes by default).
 type ClientRoutesConfig struct {
 	TableName string
 	Endpoints ClientRoutesEndpointList
-	// Deprecated:
+	// Deprecated: ResolveHealthyEndpointPeriod no longer has any effect.
 	ResolveHealthyEndpointPeriod time.Duration
-	// Deprecated:
+	// Deprecated: ResolverCacheDuration no longer has any effect.
 	ResolverCacheDuration time.Duration
-	// Deprecated:
+	// Deprecated: MaxResolverConcurrency no longer has any effect.
 	MaxResolverConcurrency int
 
 	// Deprecated: BlockUnknownEndpoints no longer has any effect. Unknown
@@ -63,22 +77,10 @@ type ClientRoutesConfig struct {
 	// release.
 	BlockUnknownEndpoints bool
 
-	// EnableShardAwareness controls whether the driver should use shard-aware
-	// connections when using ClientRoutes (PrivateLink).
-	//
-	// By default this is false because NAT typically breaks shard-awareness.
-	// Shard-aware routing relies on the driver knowing the source port of connections,
-	// which NAT devices modify, making it impossible for the server to route
-	// requests to the correct shard.
-	//
-	// However, in some deployments shard-awareness can still work:
-	//   - When using PROXY Protocol v2, the original source port is preserved
-	//     in the protocol header. See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
-	//   - When using direct connections without NAT (e.g., VPC peering)
-	//   - When the load balancer/proxy is shard-aware itself
-	//
-	// Set this to true only if your network setup preserves or correctly handles
-	// the source port information needed for shard-aware routing.
+	// EnableShardAwareness controls whether client routes use shard-aware
+	// connections. It is disabled by default because private endpoints commonly
+	// use NAT, which does not preserve the source port required for shard
+	// routing. Enable it only when the complete network path preserves that port.
 	EnableShardAwareness bool
 }
 
@@ -280,6 +282,10 @@ func (c *clientRouteCache) ReplaceByConnectionIDs(connectionIDs []string, incomi
 	c.rebindCurrentConnectionIDsLocked(currentIDs)
 }
 
+// ClientRoutesHandler translates discovered hosts using ScyllaDB Cloud client
+// routes. Sessions create and initialize it from ClusterConfig.ClientRoutesConfig.
+// Do not install one directly as ClusterConfig.AddressTranslator; configure
+// client routes through WithClientRoutes or ClientRoutesConfig instead.
 type ClientRoutesHandler struct {
 	log           StdLogger
 	c             controlConnection
@@ -516,6 +522,10 @@ func (p *ClientRoutesHandler) updateHostPortMapping(task updateTask) error {
 	return nil
 }
 
+// NewClientRoutesAddressTranslator constructs the client-routes handler used
+// internally when ClusterConfig.ClientRoutesConfig is set. Do not assign the
+// result directly to ClusterConfig.AddressTranslator because the session would
+// not initialize it.
 func NewClientRoutesAddressTranslator(
 	cfg ClientRoutesConfig,
 	resolver DNSResolver,

--- a/cluster.go
+++ b/cluster.go
@@ -78,6 +78,8 @@ type ClusterConfig struct {
 	// HostDialer will be used to establish all connections for this Cluster.
 	// Unlike Dialer, HostDialer is responsible for setting up the entire connection, including the TLS session.
 	// To support shard-aware port, HostDialer should implement ShardDialer.
+	// HostDialer is not supported with ClientRoutesConfig because HostInfo does
+	// not expose the translated client-route port. Use Dialer instead.
 	// If not provided, Dialer will be used instead.
 	HostDialer HostDialer
 	// StreamObserver will be notified of stream state changes.
@@ -545,12 +547,16 @@ func WithResolveHealthyEndpointPeriod(val time.Duration) func(*ClientRoutesConfi
 	return func(cfg *ClientRoutesConfig) {}
 }
 
+// WithEndpoints replaces the ScyllaDB Cloud private connection IDs and optional
+// address overrides used by client routes.
 func WithEndpoints(endpoints ...ClientRoutesEndpoint) func(*ClientRoutesConfig) {
 	return func(cfg *ClientRoutesConfig) {
 		cfg.Endpoints = endpoints
 	}
 }
 
+// WithTable overrides the client routes table name for tests. Production use
+// must use system.client_routes and should not set this option.
 func WithTable(tableName string) func(*ClientRoutesConfig) {
 	return func(cfg *ClientRoutesConfig) {
 		cfg.TableName = tableName

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -68,6 +68,47 @@ func TestNewCluster_WithHosts(t *testing.T) {
 	tests.AssertEqual(t, "cluster config host 1", "addr2", cfg.Hosts[1])
 }
 
+func TestWithClientRoutesSeedsHostsFromConnectionAddresses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seeds only non-empty connection addresses", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewCluster()
+		cfg.WithOptions(
+			WithClientRoutes(
+				WithEndpoints(
+					ClientRoutesEndpoint{ConnectionID: "conn-1", ConnectionAddr: "10.0.0.1"},
+					ClientRoutesEndpoint{ConnectionID: "conn-2", ConnectionAddr: "private-endpoint.example.com"},
+					ClientRoutesEndpoint{ConnectionID: "conn-3"},
+				),
+			),
+		)
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertDeepEqual(t, "client route connection addresses seed hosts",
+			[]string{"10.0.0.1", "private-endpoint.example.com"}, cfg.Hosts)
+		tests.AssertEqual(t, "client routes default port", 9042, cfg.Port)
+	})
+
+	t.Run("preserves existing hosts", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewCluster("existing.example.com")
+		cfg.WithOptions(
+			WithClientRoutes(
+				WithEndpoints(
+					ClientRoutesEndpoint{ConnectionID: "conn-1", ConnectionAddr: "private-endpoint.example.com"},
+				),
+			),
+		)
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		tests.AssertDeepEqual(t, "existing hosts are preserved",
+			[]string{"existing.example.com"}, cfg.Hosts)
+	})
+}
+
 func TestValidateAndInitSSLDoesNotShareTLSConfigBetweenConfigCopies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #1063. Merge #1063 before this PR.

## Summary

- document client routes for AWS PrivateLink and GCP Private Service Connect
- add single- and multi-endpoint configuration examples
- document shard awareness as disabled by default, with explicit `WithShardAwareness(true)` opt-in from #1063
- clarify `ConnectionAddr` overrides, bootstrap ports, TLS port selection, route refreshes, and configuration constraints
- improve GoDoc for the client-routes API; #1063 owns the `WithClientRoutes` and `WithShardAwareness` GoDoc
- align the existing client-routes fixture and test `ConnectionAddr` bootstrap behavior

## Testing

- `go test ./...`
- `go test -tags=unit ./...`
- `git diff --check`
- verified a conflict-free combined merge with #1063