### PR TITLE
test: remove t.Parallel() from tablet-replicas alloc regression guard

### DIFF
--- a/policies_bench_test.go
+++ b/policies_bench_test.go
@@ -17,8 +17,8 @@ import (
 // of hosts and tablets, wired up to a mock session with tabletsRoutingV1.
 // It returns the policy, session, and a slice of pre-built queries that hit
 // different tokens spread across the tablet range.
-func setupTabletAwareBench(b *testing.B, numHosts, numTablets, rf int) (HostSelectionPolicy, *Session, []*Query) {
-	b.Helper()
+func setupTabletAwareBench(tb testing.TB, numHosts, numTablets, rf int) (HostSelectionPolicy, *Session, []*Query) {
+	tb.Helper()
 
 	const keyspace = "benchks"
 	const table = "benchtbl"
@@ -83,7 +83,7 @@ func setupTabletAwareBench(b *testing.B, numHosts, numTablets, rf int) (HostSele
 			Replicas:     reps,
 		}.Build()
 		if err != nil {
-			b.Fatal(err)
+			tb.Fatal(err)
 		}
 		tabletList[i] = ti
 		firstToken = lastToken

--- a/policies_test.go
+++ b/policies_test.go
@@ -1576,37 +1576,37 @@ func TestTokenAwarePolicyReset(t *testing.T) {
 // TestTokenAwareHostPolicy_TabletReplicasPresizeAllocRegression guards the
 // tablets-path replicas slice presizing in Pick() against alloc regressions.
 func TestTokenAwareHostPolicy_TabletReplicasPresizeAllocRegression(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(), and no testing.Benchmark: both let other goroutines'
+	// allocations pollute the global counters this guard reads (#1027).
 
 	if testing.CoverMode() != "" {
 		t.Skip("skipping alloc regression guard: coverage instrumentation adds allocations of its own")
 	}
 
 	const rf = 3
-	result := testing.Benchmark(func(b *testing.B) {
-		policy, s, queries := setupTabletAwareBench(b, 10, 100, rf)
-		defer s.Close()
+	policy, s, queries := setupTabletAwareBench(t, 10, 100, rf)
+	defer s.Close()
 
-		b.ResetTimer()
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			qry := queries[i%len(queries)]
-			iter := policy.Pick(qry)
-			h := iter()
-			if h == nil {
-				b.Fatal("Pick returned nil on first call")
-			}
+	// Fixed iteration count: AllocsPerRun has a fixed divisor, unlike
+	// testing.Benchmark's adaptive b.N which can shrink and amplify noise.
+	const n = 1000
+	i := 0
+	allocsPerOp := testing.AllocsPerRun(n, func() {
+		qry := queries[i%len(queries)]
+		i++
+		h := policy.Pick(qry)()
+		if h == nil {
+			t.Fatal("Pick returned nil on first call")
 		}
 	})
 
-	t.Logf("tokenAwareHostPolicy.Pick (tablets, RF=%d): %d allocs/op, %d B/op",
-		rf, result.AllocsPerOp(), result.AllocedBytesPerOp())
+	t.Logf("tokenAwareHostPolicy.Pick (tablets, RF=%d): %.0f allocs/op", rf, allocsPerOp)
 
 	// 8 allocs/op measured after presizing (10 before); +1 headroom.
 	const maxAllocsPerOp = 9
-	if got := result.AllocsPerOp(); got > maxAllocsPerOp {
-		t.Errorf("tokenAwareHostPolicy.Pick (tablets path) allocated %d allocs/op, want <= %d "+
-			"(replicas slice presizing may have regressed)", got, maxAllocsPerOp)
+	if allocsPerOp > maxAllocsPerOp {
+		t.Errorf("tokenAwareHostPolicy.Pick (tablets path) allocated %.0f allocs/op, want <= %d "+
+			"(replicas slice presizing may have regressed)", allocsPerOp, maxAllocsPerOp)
 	}
 }
 


### PR DESCRIPTION
## What
`TestTokenAwareHostPolicy_TabletReplicasPresizeAllocRegression` measures allocs/op via `testing.Benchmark()`, which samples process-global `runtime.MemStats` counters. Those counters aren't scoped per-goroutine, so any other `t.Parallel()` test allocating memory during this test's measurement window inflates its count and flakes the assertion — exactly what real `go test -bench` avoids by never running benchmarks concurrently with each other.

Fixes #1027.

## Why not parallel
This isn't a case of "tests shouldn't race on shared state" in the generic sense — it's that this specific measurement technique (global alloc-counter delta) fundamentally requires an accounting window with no other goroutine allocating, which only serial execution can guarantee. `testing.AllocsPerRun` has the identical limitation, so there's no alternative stdlib primitive that would let this stay parallel.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- Ran the affected test 3x in isolation (previously also passed 3/3, since it only flakes under full-suite concurrent load) and confirmed it's not marked parallel anymore
- Ran the full unit suite once (`go test -tags unit -timeout=5m -race .`); the two failures present were `TestSchemaRefreshConcurrent` and `TestShardAwarePortMockedMaliciousNAT` (TLS cert parsing) — both pre-existing, unrelated to this change and to the file touched here