### PR TITLE
fix: keyspace CQL template always emits explicit durable_writes

### DIFF
--- a/recreate.go
+++ b/recreate.go
@@ -253,12 +253,10 @@ var keyspaceCQLTemplate = template.Must(template.New("keyspace").
 		"escape":      cqlHelpers.escape,
 		"fixStrategy": cqlHelpers.fixStrategy,
 	}).
-	Parse(`CREATE KEYSPACE {{ .Name }} WITH replication = {
-    'class': {{ escape ( fixStrategy .StrategyClass) }}
-    {{- range $key, $value := .StrategyOptions }},
-    {{ escape $key }}: {{ escape $value }}
-    {{- end }}
-}{{ if not .DurableWrites }} AND durable_writes = 'false'{{ end }};
+	// Single-line, always-explicit durable_writes to match what DESCRIBE KEYSPACE
+	// returns from Cassandra/Scylla, so this fallback stays consistent with the
+	// server-echoed CreateStmts path in ToCQL.
+	Parse(`CREATE KEYSPACE {{ .Name }} WITH replication = {'class': {{ escape ( fixStrategy .StrategyClass) }}{{ range $key, $value := .StrategyOptions }}, {{ escape $key }}: {{ escape $value }}{{ end }}} AND durable_writes = {{ .DurableWrites }};
 `))
 
 func (ks *KeyspaceMetadata) keyspaceToCQL(w io.Writer) error {


### PR DESCRIPTION
## Summary
- `ToCQL()`'s template fallback for `CREATE KEYSPACE` pretty-printed the replication map across multiple lines and only emitted `AND durable_writes = 'false'` when durable writes was disabled, silently omitting the clause when it was `true`.
- Cassandra's and Scylla's own `DESCRIBE KEYSPACE ... WITH INTERNALS` always render this single-line, with `durable_writes` explicit either way (confirmed from `KeyspaceMetadata.toCqlString()` in Cassandra 5 and `keyspace_metadata::describe()` in ScyllaDB).
- When `ToCQL()` falls back to this template instead of returning the server-echoed `CreateStmts` (e.g. `DESCRIBE` racing right after a `CREATE KEYSPACE` on Cassandra, even after schema agreement), the resulting CQL text didn't match a later DESCRIBE-sourced dump of the same keyspace, causing `TestRecreateSchema/UDT`'s round-trip comparison to fail (see failure on PR #885's Cassandra 5-LATEST job).
- Fix: render `durable_writes` unconditionally and match the single-line format both databases actually produce.

## Test plan
- [x] `go build ./...` and `go build -tags integration ./...`
- [x] Verified template output against the repo's existing `testdata/recreate/*_golden.cql` fixtures, which already expect the single-line/explicit-durable_writes format
- [x] Standalone check exercising `KeyspaceMetadata.ToCQL()` directly against both `durable_writes: true` and `false` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)