### PR TITLE
fix(client-routes): honor shard-awareness setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It also provides support for shard aware ports, a faster way to connect to all s
 - [3. Quick Start](#3-quick-start)
 - [4. Data Types](#4-data-types)
 - [5. Configuration](#5-configuration)
-  - [5.1 Shard-aware port](#51-shard-aware-port)
+  - [5.1 Advanced shard awareness (shard-aware port)](#51-advanced-shard-awareness-shard-aware-port)
   - [5.2 Client routes (PrivateLink)](#52-client-routes-privatelink)
   - [5.3 Iterator](#53-iterator)
   - [5.4 Compression](#54-compression)
@@ -171,9 +171,9 @@ if localDC != "" {
 // c.NumConns = 4
 ```
 
-### 5.1 Shard-aware port
+### 5.1 Advanced shard awareness (shard-aware port)
 
-This version of gocql supports a more robust method of establishing connection for each shard by using _shard aware port_ for native transport.
+Advanced shard awareness lets the driver choose a connection's source port so that Scylla assigns it to a desired shard. It uses the shard-aware native transport port.
 It greatly reduces time and the number of connections needed to establish a connection per shard in some cases - ex. when many clients connect at once, or when there are non-shard-aware clients connected to the same cluster.
 
 If you are using a custom Dialer and if your nodes expose the shard-aware port, it is highly recommended to update it so that it uses a specific source port when connecting.
@@ -216,7 +216,7 @@ The feature is designed to gracefully fall back to the using the non-shard-aware
 The driver will print a warning about misconfigured address translation if it detects it.
 Issues with shard-aware port not being reachable are not reported in non-debug mode, because there is no way to detect it without false positives.
 
-If you suspect that this feature is causing you problems, you can completely disable it by setting the `ClusterConfig.DisableShardAwarePort` flag to true.
+Set `ClusterConfig.DisableShardAwarePort` to true to disable advanced shard awareness. Per-shard connection pooling and token-to-shard routing remain enabled through the regular CQL port.
 
 ### 5.2 Client routes (PrivateLink)
 
@@ -237,6 +237,23 @@ cluster.WithOptions(
 ```
 
 If you also want to seed the cluster with PrivateLink hostnames, provide `ConnectionAddr` values in the endpoints list.
+
+Advanced shard awareness is disabled by default when client routes are enabled because PrivateLink paths commonly use NAT. Basic shard awareness remains enabled: the driver still maintains per-shard connections and routes requests to the appropriate shard.
+
+Opt in only when the client-route endpoint forwards to Scylla's Proxy Protocol v2 shard-aware CQL listener (`native_shard_aware_transport_port_proxy_protocol`, or `native_shard_aware_transport_port_ssl_proxy_protocol` for TLS) and the proxy sends the original client source port in the Proxy Protocol v2 header:
+
+```go
+cluster.WithOptions(
+	gocql.WithClientRoutes(
+		gocql.WithEndpoints(
+			gocql.ClientRoutesEndpoint{ConnectionID: "your-connection-id"},
+		),
+		gocql.WithShardAwareness(true),
+	),
+)
+```
+
+`ClusterConfig.DisableShardAwarePort` takes precedence over `WithShardAwareness(true)`.
 
 ### 5.3 Iterator
 

--- a/client_routes.go
+++ b/client_routes.go
@@ -63,22 +63,17 @@ type ClientRoutesConfig struct {
 	// release.
 	BlockUnknownEndpoints bool
 
-	// EnableShardAwareness controls whether the driver should use shard-aware
-	// connections when using ClientRoutes (PrivateLink).
+	// EnableShardAwareness controls advanced shard awareness for ClientRoutes:
+	// choosing a connection's source port so Scylla assigns it to a desired shard.
+	// Per-shard connection pooling and token-to-shard routing remain enabled when
+	// this option is false.
 	//
-	// By default this is false because NAT typically breaks shard-awareness.
-	// Shard-aware routing relies on the driver knowing the source port of connections,
-	// which NAT devices modify, making it impossible for the server to route
-	// requests to the correct shard.
+	// By default this is false because PrivateLink paths commonly use NAT.
 	//
-	// However, in some deployments shard-awareness can still work:
-	//   - When using PROXY Protocol v2, the original source port is preserved
-	//     in the protocol header. See https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
-	//   - When using direct connections without NAT (e.g., VPC peering)
-	//   - When the load balancer/proxy is shard-aware itself
-	//
-	// Set this to true only if your network setup preserves or correctly handles
-	// the source port information needed for shard-aware routing.
+	// Set this to true only when the client-route endpoint forwards to Scylla's
+	// Proxy Protocol v2 shard-aware CQL listener and the proxy supplies the original
+	// client source port in the Proxy Protocol v2 header. ClusterConfig's
+	// DisableShardAwarePort setting takes precedence.
 	EnableShardAwareness bool
 }
 

--- a/client_routes_config_test.go
+++ b/client_routes_config_test.go
@@ -1,0 +1,103 @@
+//go:build unit
+// +build unit
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package gocql
+
+import (
+	"testing"
+
+	"github.com/gocql/gocql/internal/tests"
+)
+
+func TestNewSessionCommonAppliesClientRoutesShardAwareness(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                  string
+		clientRoutes          *ClientRoutesConfig
+		disableShardAwarePort bool
+		wantDisabled          bool
+	}{
+		{
+			name:         "no client routes",
+			wantDisabled: false,
+		},
+		{
+			name: "client routes disable shard awareness by default",
+			clientRoutes: &ClientRoutesConfig{
+				Endpoints: ClientRoutesEndpointList{{ConnectionID: "connection-id"}},
+			},
+			wantDisabled: true,
+		},
+		{
+			name: "client routes explicitly enable shard awareness",
+			clientRoutes: &ClientRoutesConfig{
+				Endpoints:            ClientRoutesEndpointList{{ConnectionID: "connection-id"}},
+				EnableShardAwareness: true,
+			},
+			wantDisabled: false,
+		},
+		{
+			name: "cluster-wide disable overrides client routes enable",
+			clientRoutes: &ClientRoutesConfig{
+				Endpoints:            ClientRoutesEndpointList{{ConnectionID: "connection-id"}},
+				EnableShardAwareness: true,
+			},
+			disableShardAwarePort: true,
+			wantDisabled:          true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := NewCluster("127.0.0.1")
+			cfg.ClientRoutesConfig = tt.clientRoutes
+			cfg.DisableShardAwarePort = tt.disableShardAwarePort
+			session, err := newSessionCommon(*cfg)
+			if err != nil {
+				t.Fatalf("new session: %v", err)
+			}
+			t.Cleanup(session.Close)
+
+			tests.AssertEqual(t, "disable shard-aware port", tt.wantDisabled, session.cfg.DisableShardAwarePort)
+		})
+	}
+}
+
+func TestWithShardAwareness(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewCluster("127.0.0.1")
+	cfg.WithOptions(
+		WithClientRoutes(
+			WithEndpoints(ClientRoutesEndpoint{ConnectionID: "connection-id"}),
+			WithShardAwareness(true),
+		),
+	)
+
+	if cfg.ClientRoutesConfig == nil {
+		t.Fatal("expected client routes config")
+	}
+	tests.AssertEqual(t, "client routes shard awareness", true, cfg.ClientRoutesConfig.EnableShardAwareness)
+}

--- a/cluster.go
+++ b/cluster.go
@@ -313,8 +313,10 @@ type ClusterConfig struct {
 	// Default: true, and has no effect on a connection that exchanges result
 	// metadata IDs.
 	DisableSkipMetadata bool
-	// DisableShardAwarePort will prevent the driver from connecting to Scylla's shard-aware port,
-	// even if there are nodes in the cluster that support it.
+	// DisableShardAwarePort disables advanced shard awareness: the driver will not
+	// choose a source port and connect through Scylla's shard-aware port to target
+	// a desired shard. Per-shard connection pooling and token-to-shard routing remain
+	// enabled through the regular CQL port.
 	//
 	// It is generally recommended to leave this option turned off because gocql can use
 	// the shard-aware port to make the process of establishing more robust.
@@ -557,6 +559,30 @@ func WithTable(tableName string) func(*ClientRoutesConfig) {
 	}
 }
 
+// WithShardAwareness controls whether client routes use advanced shard awareness,
+// where the driver chooses a source port to target a desired shard. It is disabled
+// by default; per-shard pooling and token-to-shard routing remain enabled.
+//
+// Enable it only when the client-route endpoint forwards to Scylla's Proxy
+// Protocol v2 shard-aware CQL listener and the proxy supplies the original client
+// source port. ClusterConfig.DisableShardAwarePort takes precedence.
+func WithShardAwareness(enabled bool) func(*ClientRoutesConfig) {
+	return func(cfg *ClientRoutesConfig) {
+		cfg.EnableShardAwareness = enabled
+	}
+}
+
+// WithClientRoutes returns a cluster option that enables routing through
+// ScyllaDB Cloud private endpoints using the system.client_routes table.
+//
+// Configure at least one connection ID with WithEndpoints. If cfg.Hosts is empty
+// when this option is applied, non-empty ConnectionAddr values from the endpoints
+// are also used as initial contact points.
+//
+// Advanced shard awareness is disabled by default for client routes because
+// private endpoints commonly use NAT. Use WithShardAwareness to opt in only when
+// the endpoint targets Scylla's Proxy Protocol v2 shard-aware CQL listener and
+// preserves the original client source port. Basic shard awareness remains enabled.
 func WithClientRoutes(opts ...ClientRoutesOption) func(*ClusterConfig) {
 	pmCfg := ClientRoutesConfig{
 		TableName: "system.client_routes",
@@ -574,6 +600,12 @@ func WithClientRoutes(opts ...ClientRoutesOption) func(*ClusterConfig) {
 			}
 		}
 		// TODO: cfg.ControlConnectionOnlyToInitialNodes
+	}
+}
+
+func (cfg *ClusterConfig) applyClientRoutesConfig() {
+	if cfg.ClientRoutesConfig != nil && !cfg.ClientRoutesConfig.EnableShardAwareness {
+		cfg.DisableShardAwarePort = true
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -137,6 +137,7 @@ func resolveInitialEndpoints(resolver DNSResolver, addrs []string, defaultPort i
 }
 
 func newSessionCommon(cfg ClusterConfig) (*Session, error) {
+	cfg.applyClientRoutesConfig()
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("gocql: unable to create session: cluster config validation failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

- disable shard awareness by default when client routes are configured
- honor `ClientRoutesConfig.EnableShardAwareness` for deployments where PPv2 or the network preserves source ports
- add `WithShardAwareness(bool)` for functional client-routes configuration
- preserve an explicit cluster-wide `DisableShardAwarePort` setting

Closes #1050.
Unblocks the dependent documentation PRs #1047 and #1058.

## Testing

- `go test -tags=unit . -run 'TestNewSessionCommonAppliesClientRoutesShardAwareness|TestWithShardAwareness' -count=1`
- `go test -tags=unit ./...`
- `go test ./...`