### PR TITLE
fix(recorder): restrict recording file permissions

### DIFF
--- a/dialer/recorder/open_flags_other.go
+++ b/dialer/recorder/open_flags_other.go
@@ -1,0 +1,5 @@
+//go:build !unix
+
+package recorder
+
+const recordingNoFollow = 0

--- a/dialer/recorder/open_flags_unix.go
+++ b/dialer/recorder/open_flags_unix.go
@@ -1,0 +1,7 @@
+//go:build unix
+
+package recorder
+
+import "syscall"
+
+const recordingNoFollow = syscall.O_NOFOLLOW

--- a/dialer/recorder/recorder.go
+++ b/dialer/recorder/recorder.go
@@ -81,9 +81,46 @@ func (d *RecordDialer) DialContext(ctx context.Context, network, addr string) (c
 	return rec, nil
 }
 
+func openRecordingFile(fname string) (*os.File, error) {
+	const mode = 0o600
+	const flags = os.O_WRONLY | os.O_APPEND
+
+	// O_EXCL makes creation distinguishable from reuse and refuses a symlink in the
+	// final path component. A newly created file needs no follow-up Chmod, so it is
+	// never wider than mode even transiently.
+	fd, err := os.OpenFile(fname, flags|os.O_CREATE|os.O_EXCL|recordingNoFollow, mode)
+	if err == nil {
+		return fd, nil
+	}
+	if !errors.Is(err, os.ErrExist) {
+		return nil, err
+	}
+
+	// The file may disappear between the two opens, so retain O_CREATE. O_NOFOLLOW
+	// keeps an existing final-component symlink from redirecting Chmod to its target.
+	fd, err = os.OpenFile(fname, flags|os.O_CREATE|recordingNoFollow, mode)
+	if err != nil {
+		return nil, err
+	}
+
+	// Recorders intentionally append to existing files, so tighten reused files
+	// through the open descriptor before anything can be recorded.
+	if err := fd.Chmod(mode); err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("restrict recording file %q permissions: %w", fname, err),
+			fd.Close(),
+		)
+	}
+
+	return fd, nil
+}
+
 // NewConnectionRecorder wraps conn, recording every frame in both directions.
 //
 // comp may be nil; see WithSegmentCompressor for when it is needed.
+// On platforms with Unix permission bits, recording files are created with mode 0600
+// and existing files are tightened to 0600 before appending because request frames can
+// contain plaintext authentication credentials.
 //
 // # One recording directory per run
 //
@@ -101,14 +138,13 @@ func (d *RecordDialer) DialContext(ctx context.Context, network, addr string) (c
 // connection instead would need the replayer to stop deriving the same name from the
 // same two values, which is a different design than the one here.
 func NewConnectionRecorder(fname string, conn net.Conn, comp dialer.SegmentCompressor) (net.Conn, error) {
-	fd_writes, err := os.OpenFile(fname+"Writes", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	fd_writes, err := openRecordingFile(fname + "Writes")
 	if err != nil {
 		return nil, err
 	}
-	fd_reads, err2 := os.OpenFile(fname+"Reads", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	fd_reads, err2 := openRecordingFile(fname + "Reads")
 	if err2 != nil {
-		fd_writes.Close()
-		return nil, err2
+		return nil, errors.Join(err2, fd_writes.Close())
 	}
 	// Both directions share one Framing: the handshake fact that switches them to
 	// transport segments is carried by a response, and applies to requests too.

--- a/dialer/recorder/recorder_test.go
+++ b/dialer/recorder/recorder_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -129,6 +130,120 @@ func recordedFrames(t *testing.T, fname string) []dialer.Record {
 		records = append(records, record)
 	}
 	return records
+}
+
+// TestConnectionRecorderRestrictsRecordingFiles pins both halves of the recording
+// file permission contract: a new file starts owner-only, and reopening an older,
+// permissive file tightens it. The Writes file can hold AUTH_RESPONSE credentials in
+// plaintext, so relying on the process umask is not enough.
+func TestConnectionRecorderRestrictsRecordingFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+	const existingContents = "existing recording\n"
+	suffixes := [...]string{"Writes", "Reads"}
+
+	for _, tc := range []struct {
+		name     string
+		existing bool
+	}{
+		{name: "new files"},
+		{name: "existing permissive files", existing: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fname := filepath.Join(t.TempDir(), "conn")
+			if tc.existing {
+				for _, suffix := range suffixes {
+					path := fname + suffix
+					if err := os.WriteFile(path, []byte(existingContents), 0o666); err != nil {
+						t.Fatalf("creating %s: %v", suffix, err)
+					}
+					if err := os.Chmod(path, 0o666); err != nil {
+						t.Fatalf("making %s permissive: %v", suffix, err)
+					}
+				}
+			}
+
+			rec, err := NewConnectionRecorder(fname, &stubConn{}, nil)
+			if err != nil {
+				t.Fatalf("NewConnectionRecorder: %v", err)
+			}
+			t.Cleanup(func() {
+				if err := rec.Close(); err != nil {
+					t.Errorf("Close: %v", err)
+				}
+			})
+
+			for _, suffix := range suffixes {
+				info, err := os.Stat(fname + suffix)
+				if err != nil {
+					t.Fatalf("stat %s: %v", suffix, err)
+				}
+				if got := info.Mode().Perm(); got != 0o600 {
+					t.Errorf("%s permissions = %04o, want 0600", suffix, got)
+				}
+				if tc.existing {
+					contents, err := os.ReadFile(fname + suffix)
+					if err != nil {
+						t.Fatalf("read %s: %v", suffix, err)
+					}
+					if got := string(contents); got != existingContents {
+						t.Errorf("%s contents = %q, want %q", suffix, got, existingContents)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConnectionRecorderRefusesSymlinkRecordingFile(t *testing.T) {
+	if recordingNoFollow == 0 {
+		t.Skip("O_NOFOLLOW is not available on this platform")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	const targetContents = "must stay untouched\n"
+	if err := os.WriteFile(target, []byte(targetContents), 0o666); err != nil {
+		t.Fatalf("creating symlink target: %v", err)
+	}
+	if err := os.Chmod(target, 0o666); err != nil {
+		t.Fatalf("making symlink target permissive: %v", err)
+	}
+
+	fname := filepath.Join(dir, "conn")
+	if err := os.Symlink(target, fname+"Reads"); err != nil {
+		t.Fatalf("creating recording symlink: %v", err)
+	}
+
+	rec, err := NewConnectionRecorder(fname, &stubConn{}, nil)
+	if err == nil {
+		rec.Close()
+		t.Fatal("NewConnectionRecorder followed a recording symlink")
+	}
+	if rec != nil {
+		t.Fatalf("NewConnectionRecorder returned %T alongside error %v", rec, err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat symlink target: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o666 {
+		t.Errorf("symlink target permissions = %04o, want 0666", got)
+	}
+	contents, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read symlink target: %v", err)
+	}
+	if got := string(contents); got != targetContents {
+		t.Errorf("symlink target contents = %q, want %q", got, targetContents)
+	}
+
+	// The failed setup left no recording to keep.
+	if err := os.Remove(fname + "Writes"); err != nil {
+		t.Errorf("removing Writes file after setup failure: %v", err)
+	}
 }
 
 // TestConnectionRecorderPropagatesEOF pins that a server-closed connection reports


### PR DESCRIPTION
## Summary

- create both recorder files with owner-only mode `0600`
- tighten existing recording files to `0600` through their open descriptors before appending
- close acquired descriptors and preserve cleanup errors when setup fails
- cover new files, permissive existing files, both recording directions, and content preservation

The recorder stores raw CQL frames. Its request-side file can contain an `AUTH_RESPONSE` with plaintext credentials. Previously both files were opened with `0666`, which commonly produced world-readable `0644` files after the process umask.

Changing only the creation mode would leave old files permissive because `os.OpenFile` applies its mode argument only when creating a file. The explicit descriptor-based `Chmod` tightens files reused by the recorder without a pathname race.

The `0600` guarantee applies on platforms with Unix permission bits; Windows ACL management is outside the POSIX permission issue reported here.

Fixes #1028.

## Testing

- `go test -race ./dialer/recorder`
- `make check`
- `make test-unit`
- Windows cross-compilation of `./dialer/recorder`
