### PR TITLE
fix(dialer): accept a leading empty chain segment

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1517,6 +1517,10 @@ func (c *Conn) recvSplitFrame(ctx context.Context, first []byte, netStart, netEn
 	// payload plus headSize, because a continuation segment must make progress and
 	// only headSize bytes are needed. Segment payloads alias c.segScratch, so each
 	// has to be copied before the next segment is read.
+	//
+	// first is never tested for emptiness, so a chain may open with an empty segment.
+	// Progress is owed from the second onward (readContinuationSegment) and does not
+	// stack. Observable behaviour: anything re-implementing this reader must match it.
 	if len(first) < headSize {
 		accumulated := append([]byte(nil), first...)
 		for len(accumulated) < headSize {

--- a/dialer/segment.go
+++ b/dialer/segment.go
@@ -77,6 +77,10 @@ type SegmentSplitter struct {
 	// a corrupt header is reported once rather than per chunk.
 	hdr      segment.Header
 	hdrValid bool
+	// chainOpen says a chain has consumed a segment and not yet delivered its frame.
+	// Not frames.Pending(), which answers "is a frame half-built" and differs by the
+	// one segment a chain may open empty. Chain rules read this, frame rules that.
+	chainOpen bool
 }
 
 // NewSegmentSplitter returns a splitter for a stream in the layout implied by comp:
@@ -90,11 +94,11 @@ func (s *SegmentSplitter) compressed() bool {
 	return s.comp != nil
 }
 
-// Pending reports whether the splitter holds anything incomplete: a partial segment,
-// or a chain whose frame has not finished arriving. A stream that ends here ended
-// mid-structure.
+// Pending reports whether the splitter holds anything incomplete: a partial segment, an
+// open chain, or a chain whose frame has not finished arriving. A stream that ends here
+// ended mid-structure.
 func (s *SegmentSplitter) Pending() bool {
-	return len(s.buf) > 0 || s.frames.Pending()
+	return len(s.buf) > 0 || s.chainOpen || s.frames.Pending()
 }
 
 // Feed consumes b, calling emit once for each CQL frame it recovers.
@@ -104,18 +108,15 @@ func (s *SegmentSplitter) Pending() bool {
 // Four rules govern the self-contained flag, and together they are what stops a
 // damaged stream from re-aligning silently:
 //
-//   - A self-contained segment may not arrive while a chain is in progress. This is
-//     the same rejection the driver's own reader makes, and the case that matters
-//     most: without it an over-running chain does not error, it resumes reading
-//     frames at the wrong offset.
+//   - A self-contained segment may not arrive while a chain is open. This is the same
+//     rejection the driver's own reader makes, and the case that matters most: without
+//     it an over-running chain does not error, it resumes reading frames at the wrong
+//     offset.
 //   - A self-contained segment must not end mid-frame. It promised whole frames.
-//   - A chain segment must carry a non-empty payload, so a peer cannot drive an
-//     endless chain that never progresses. An empty *self-contained* segment is
-//     accepted and yields nothing, which looks like the same defect but is not: the
-//     driver's own reader accepts it too (processAllFramesInSegment loops while bytes
-//     remain, so an empty payload is zero frames and no error), and a splitter that
-//     refused what the connection it records accepts would fail a stream gocql itself
-//     handles. Only a chain is owed progress, and recvSplitFrame enforces that there.
+//   - A chain segment must carry a non-empty payload once the chain is open, so a peer
+//     cannot drive an endless chain. Two shapes the driver accepts are exempt, because
+//     the splitter must not refuse a stream gocql itself handles: an empty
+//     self-contained segment, and the first segment of a chain.
 //   - A chain must yield exactly one frame and nothing after it, since a split frame
 //     gets a sequence of segments to itself. A chain here is bounded by the frame it
 //     carries, not by the run of continuation segments: the segment that completes a
@@ -152,11 +153,15 @@ func (s *SegmentSplitter) Feed(b []byte, emit func(frame []byte) error) error {
 			return nil
 		}
 
-		chainInProgress := s.frames.Pending()
-		if s.hdr.IsSelfContained && chainInProgress {
-			return s.fail(fmt.Errorf("gocql/dialer: received a self-contained segment while a split frame was still being reassembled"))
+		if s.hdr.IsSelfContained && s.chainOpen {
+			return s.fail(fmt.Errorf("gocql/dialer: received a self-contained segment while a segment chain was still open"))
 		}
-		if !s.hdr.IsSelfContained && s.hdr.PayloadLen == 0 {
+		// PayloadLen is the encoded length where the driver checks the decoded one. They
+		// coincide: UncompressedLen == 0 is stored as-is, anything else must decode to
+		// exactly that many bytes (segment.ReadCompressedPayload). The one shape that
+		// differs, PayloadLen == 0 with a nonzero UncompressedLen, both readers reject.
+		// Checked on the header so a stalled chain costs no decode.
+		if !s.hdr.IsSelfContained && s.chainOpen && s.hdr.PayloadLen == 0 {
 			return s.fail(fmt.Errorf("gocql/dialer: segment chain made no progress (empty payload)"))
 		}
 
@@ -180,6 +185,10 @@ func (s *SegmentSplitter) Feed(b []byte, emit func(frame []byte) error) error {
 		if !s.hdr.IsSelfContained && (emitted > 1 || (emitted == 1 && s.frames.Pending())) {
 			return s.fail(fmt.Errorf("gocql/dialer: segment chain carried more than the one frame it was split from"))
 		}
+
+		// A self-contained segment is not in a chain, and the segment that delivered the
+		// frame closed it.
+		s.chainOpen = !s.hdr.IsSelfContained && emitted == 0
 
 		// Drop the consumed segment, keeping whatever came after it. Copying the
 		// remainder down rather than re-slicing keeps the buffer from growing without

--- a/dialer/segment_test.go
+++ b/dialer/segment_test.go
@@ -125,6 +125,9 @@ func TestSegmentSplitterChain(t *testing.T) {
 				{name: "header straddles the boundary", split: []int{4, len(frame) - 4}},
 				{name: "one byte at a time in the header", split: []int{1, 1, 1, len(frame) - 3}},
 				{name: "many segments", split: []int{50, 50, 50, 50, len(frame) - 200}},
+				// The driver accepts a chain opening with an empty segment (recvSplitFrame
+				// never checks first for emptiness), so the splitter must too.
+				{name: "opens with an empty segment", split: []int{0, len(frame)}},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
 					var stream []byte
@@ -149,6 +152,35 @@ func TestSegmentSplitterChain(t *testing.T) {
 					}
 					if s.Pending() {
 						t.Error("splitter still holds something incomplete")
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSegmentSplitterPendingReportsAnOpenChain covers a stream ending right after a
+// chain's first segment. The empty case is the one worth having: buf and the inner
+// splitter are both empty, so only chainOpen marks the recording truncated.
+func TestSegmentSplitterPendingReportsAnOpenChain(t *testing.T) {
+	frame := frameV4(opQuery, 0x00, bytes.Repeat([]byte{0x5A}, 500))
+
+	for _, cc := range compressors() {
+		t.Run(cc.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name  string
+				first []byte
+			}{
+				{name: "carrying frame bytes", first: frame[:200]},
+				{name: "empty", first: nil},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					s := NewSegmentSplitter(cc.comp)
+					if got := decode(t, s, mustSegment(t, tc.first, false, cc.comp)); len(got) != 0 {
+						t.Fatalf("recovered %d frames from an unfinished chain, want 0", len(got))
+					}
+					if !s.Pending() {
+						t.Error("splitter reports a clean end of stream mid-chain")
 					}
 				})
 			}
@@ -248,7 +280,7 @@ func TestSegmentSplitterRejectsMalformedStreams(t *testing.T) {
 						s := mustSegment(t, frame[:40], false, cc.comp)
 						return append(s, mustSegment(t, other, true, cc.comp)...)
 					},
-					want: "while a split frame was still being reassembled",
+					want: "while a segment chain was still open",
 				},
 				{
 					name: "self-contained segment ends mid-frame",
@@ -258,12 +290,32 @@ func TestSegmentSplitterRejectsMalformedStreams(t *testing.T) {
 					want: "ended in the middle of a frame",
 				},
 				{
-					name: "chain segment with an empty payload",
+					name: "chain segment with an empty payload, chain already open",
 					stream: func() []byte {
 						s := mustSegment(t, frame[:40], false, cc.comp)
 						return append(s, mustSegment(t, nil, false, cc.comp)...)
 					},
 					want: "made no progress",
+				},
+				{
+					// The exemption does not stack: the first empty segment opens the
+					// chain, the second is owed progress.
+					name: "chain opens empty and then stalls",
+					stream: func() []byte {
+						s := mustSegment(t, nil, false, cc.comp)
+						return append(s, mustSegment(t, nil, false, cc.comp)...)
+					},
+					want: "made no progress",
+				},
+				{
+					// The exemption is for the chain rule only -- rule A still fires,
+					// since an empty first segment opens the chain.
+					name: "chain opens empty, then a self-contained segment",
+					stream: func() []byte {
+						s := mustSegment(t, nil, false, cc.comp)
+						return append(s, mustSegment(t, other, true, cc.comp)...)
+					},
+					want: "while a segment chain was still open",
 				},
 				{
 					name: "chain carries two frames",


### PR DESCRIPTION
`dialer.SegmentSplitter` refused a v5 chain whose first segment carried an empty payload, which the driver's own reader accepts — making the recorder stricter than the connection it records, and failing a stream gocql itself reads. Found while assessing #1021.

The cause is vocabulary rather than a missing check. `frames.Pending()` answers "is a frame half-built", but two of `Feed`'s four rules need "is a chain open", and the two differ by exactly one segment: `recvSplitFrame` accumulates until the CQL header is complete and only then calls `readContinuationSegment`, so the driver never tests its first payload for emptiness.

- `SegmentSplitter` gains `chainOpen`, read by the two chain rules; the two frame rules keep `frames.Pending()`
- `Pending()` reports it too — otherwise a stream ending after an empty leading segment looks cleanly ended and `ConnectionRecorder.Close` calls a truncated recording complete
- rule A's message no longer claims a split frame was being reassembled, which is untrue before any frame bytes arrive
- `Feed`'s doc now states the driver's first-segment exemption and that it does not stack
- `recvSplitFrame` gains a comment naming the exemption, which was unstated — and that is what let the splitter drift from it

`chainOpen` is a superset of `frames.Pending()` differing only in this case, so it is exact alignment, not a loosening: the progress rule loosens by the one segment the driver tolerates, the self-contained rule tightens by the one case it rejects. An empty chain segment delivers no bytes, so it cannot re-align anything, and progress is still owed from the second segment onward.

## Verified

`make check` (0 issues), `make test-unit` (all 22 packages), `make test-bench`, `go test ./dialer/...`, and the root package three times under `-race`. Each half of the fix was mutation-checked separately: reverting the progress rule fails the new accept row, reverting rule A fails the new self-contained row, and dropping `chainOpen` from `Pending()` fails only the `empty` subtest of the new `Pending` test — so that subtest is not redundant with its sibling. Behaviour was measured by driving `Conn.recvSegment` and `SegmentSplitter.Feed` over identical byte streams, before and after; the four boundary accepts agree on both sides, so the change is non-narrowing.

Not covered: no live-node run — `dialer/` is not linked by any integration lane (#1046) and ScyllaDB does not speak v5, so all v5 evidence is in process. Whether a real server emits such a chain was not established; the case for fixing is the asymmetry, not a sighting.

Fixes #1073
